### PR TITLE
First Structural Plasticity Pull request

### DIFF
--- a/nestkernel/Makefile.am
+++ b/nestkernel/Makefile.am
@@ -78,8 +78,8 @@ libnest_la_SOURCES=\
 		conn_parameter.h conn_parameter.cpp\
 		conn_builder.h conn_builder.cpp\
 		conn_builder_factory.h\
-		music_event_handler.h music_event_handler.cpp
-
+		music_event_handler.h music_event_handler.cpp\
+                synaptic_element.h synaptic_element.cpp
 libnest_la_LIBADD= @LIBLTDL@ @LIBADD_DL@
 
 EXTRA_DIST= README.md

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -28,7 +28,9 @@
  */
 
 #include "archiving_node.h"
+#include "synaptic_element.h"
 #include "dictutils.h"
+#include "network.h"
 
 namespace nest
 {
@@ -42,6 +44,11 @@ nest::Archiving_Node::Archiving_Node()
   , tau_minus_( 20.0 )
   , tau_minus_triplet_( 110.0 )
   , last_spike_( -1.0 )
+  , Ca_t_( 0.0 )
+  , Ca_minus_( 0.0 )
+  , tau_Ca_( 10000.0 )
+  , beta_Ca_( 0.001 )
+  , synaptic_elements_map_()
 {
 }
 
@@ -53,6 +60,11 @@ nest::Archiving_Node::Archiving_Node( const Archiving_Node& n )
   , tau_minus_( n.tau_minus_ )
   , tau_minus_triplet_( n.tau_minus_triplet_ )
   , last_spike_( n.last_spike_ )
+  , Ca_t_( n.Ca_t_ )
+  , Ca_minus_( n.Ca_minus_ )
+  , tau_Ca_( n.tau_Ca_ )
+  , beta_Ca_( n.beta_Ca_ )
+  , synaptic_elements_map_( n.synaptic_elements_map_ )
 {
 }
 
@@ -164,6 +176,9 @@ nest::Archiving_Node::get_history( double_t t1,
 void
 nest::Archiving_Node::set_spiketime( Time const& t_sp )
 {
+  update_synaptic_element( t_sp.get_ms() );
+  Ca_minus_ += beta_Ca_;
+
   if ( n_incoming_ )
   {
     // prune all spikes from history which are no longer needed
@@ -191,12 +206,29 @@ nest::Archiving_Node::set_spiketime( Time const& t_sp )
 void
 nest::Archiving_Node::get_status( DictionaryDatum& d ) const
 {
+  DictionaryDatum synaptic_elements_d;
+  DictionaryDatum synaptic_element_d;
+
   def< double >( d, names::t_spike, get_spiketime_ms() );
   def< double >( d, names::tau_minus, tau_minus_ );
+  def< double >( d, names::Ca, Ca_minus_ );
+  def< double >( d, names::tau_Ca, tau_Ca_ );
+  def< double >( d, names::beta_Ca, beta_Ca_ );
   def< double >( d, names::tau_minus_triplet, tau_minus_triplet_ );
 #ifdef DEBUG_ARCHIVER
   def< int >( d, names::archiver_length, history_.size() );
 #endif
+
+  synaptic_elements_d = DictionaryDatum( new Dictionary );
+  def< DictionaryDatum >( d, "synaptic_elements", synaptic_elements_d );
+  for ( std::map< Name, SynapticElement >::const_iterator it = synaptic_elements_map_.begin();
+        it != synaptic_elements_map_.end();
+        ++it )
+  {
+    synaptic_element_d = DictionaryDatum( new Dictionary );
+    def< DictionaryDatum >( synaptic_elements_d, it->first, synaptic_element_d );
+    ( it->second ).get( synaptic_element_d );
+  }
 }
 
 void
@@ -205,20 +237,55 @@ nest::Archiving_Node::set_status( const DictionaryDatum& d )
   // We need to preserve values in case invalid values are set
   double_t new_tau_minus = tau_minus_;
   double_t new_tau_minus_triplet = tau_minus_triplet_;
+  double_t new_tau_Ca = tau_Ca_;
+  double_t new_beta_Ca = beta_Ca_;
   updateValue< double_t >( d, names::tau_minus, new_tau_minus );
   updateValue< double_t >( d, names::tau_minus_triplet, new_tau_minus_triplet );
+  updateValue< double_t >( d, names::tau_Ca, new_tau_Ca );
+  updateValue< double_t >( d, names::beta_Ca, new_beta_Ca );
 
-  if ( new_tau_minus <= 0 || new_tau_minus_triplet <= 0 )
+  if ( new_tau_minus <= 0.0 || new_tau_minus_triplet <= 0.0 )
     throw BadProperty( "All time constants must be strictly positive." );
 
   tau_minus_ = new_tau_minus;
   tau_minus_triplet_ = new_tau_minus_triplet;
+
+  if ( new_tau_Ca <= 0.0 )
+    throw BadProperty( "All time constants must be strictly positive." );
+  tau_Ca_ = new_tau_Ca;
+
+  if ( new_beta_Ca <= 0.0 )
+    throw BadProperty(
+      "For Ca to function as an integrator of the electrical activity, beta_ca needs to be greater "
+      "than 0." );
+  beta_Ca_ = new_beta_Ca;
 
   // check, if to clear spike history and K_minus
   bool clear = false;
   updateValue< bool >( d, names::clear, clear );
   if ( clear )
     clear_history();
+
+  if ( !d->known( "synaptic_elements" ) )
+    return;
+
+  // we replace the existing synaptic_elements_map_ by the new one
+  DictionaryDatum synaptic_elements_d;
+  DictionaryDatum synaptic_element_d;
+  std::pair< std::map< Name, SynapticElement >::iterator, bool > insert_result;
+
+  synaptic_elements_map_ = std::map< Name, SynapticElement >();
+  synaptic_elements_d = getValue< DictionaryDatum >( d, "synaptic_elements" );
+
+  for ( Dictionary::const_iterator i = synaptic_elements_d->begin();
+        i != synaptic_elements_d->end();
+        ++i )
+  {
+    synaptic_element_d = getValue< DictionaryDatum >( synaptic_elements_d, i->first );
+    insert_result = synaptic_elements_map_.insert(
+      std::pair< Name, SynapticElement >( i->first, SynapticElement() ) );
+    ( insert_result.first->second ).set( synaptic_element_d );
+  }
 }
 
 void
@@ -228,6 +295,124 @@ nest::Archiving_Node::clear_history()
   Kminus_ = 0.0;
   triplet_Kminus_ = 0.0;
   history_.clear();
+  Ca_minus_ = 0.0;
+  Ca_t_ = 0.0;
+}
+
+
+/* ----------------------------------------------------------------
+* Get the number of synaptic_elements
+* ---------------------------------------------------------------- */
+double_t
+nest::Archiving_Node::get_synaptic_element( Name n ) const
+{
+  std::map< Name, SynapticElement >::const_iterator se_it;
+  se_it = synaptic_elements_map_.find( n );
+  double_t z_value;
+
+  if ( se_it != synaptic_elements_map_.end() )
+  {
+    z_value = ( se_it->second ).get_z_minus();
+    if ( ( se_it->second ).continuous() )
+      return z_value;
+    else
+      return std::floor( z_value );
+  }
+  else
+  {
+    return 0.0;
+  }
+}
+
+int_t
+nest::Archiving_Node::get_synaptic_element_vacant( Name n ) const
+{
+  std::map< Name, SynapticElement >::const_iterator se_it;
+  se_it = synaptic_elements_map_.find( n );
+
+  if ( se_it != synaptic_elements_map_.end() )
+  {
+    return ( se_it->second ).get_z_vacant();
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+int_t
+nest::Archiving_Node::get_synaptic_element_connected( Name n ) const
+{
+  std::map< Name, SynapticElement >::const_iterator se_it;
+  se_it = synaptic_elements_map_.find( n );
+
+  if ( se_it != synaptic_elements_map_.end() )
+  {
+    return ( se_it->second ).get_z_connected();
+  }
+  else
+  {
+    return 0;
+  }
+}
+
+std::map< Name, double_t >
+nest::Archiving_Node::get_synaptic_elements() const
+{
+  std::map< Name, double_t > n_map;
+
+  for ( std::map< Name, SynapticElement >::const_iterator it = synaptic_elements_map_.begin();
+        it != synaptic_elements_map_.end();
+        ++it )
+  {
+    n_map.insert( std::pair< Name, double_t >( it->first, get_synaptic_element( it->first ) ) );
+  }
+  return n_map;
+}
+
+void
+nest::Archiving_Node::update_synaptic_element( double_t t )
+{
+  if ( t < Ca_t_ )
+  {
+    throw KernelException( "Synaptic elements already updated" );
+  }
+
+  for ( std::map< Name, SynapticElement >::iterator it = synaptic_elements_map_.begin();
+        it != synaptic_elements_map_.end();
+        ++it )
+  {
+    ( it->second ).update( t, Ca_t_, Ca_minus_, tau_Ca_ );
+  }
+  // Update calcium concentration
+  Ca_minus_ = Ca_minus_ * std::exp( ( Ca_t_ - t ) / tau_Ca_ );
+  Ca_t_ = t;
+}
+
+void
+nest::Archiving_Node::decay_synaptic_element_vacant( double_t p )
+{
+  double_t z, z_vacant;
+  for ( std::map< Name, SynapticElement >::iterator it = synaptic_elements_map_.begin();
+        it != synaptic_elements_map_.end();
+        ++it )
+  {
+    z = ( it->second ).get_z_minus();
+    z_vacant = ( it->second ).get_z_vacant();
+    ( it->second ).set_z_minus( z - ( z_vacant * p ) );
+  }
+}
+
+void
+nest::Archiving_Node::connect_synaptic_element( Name name, int_t n )
+{
+  std::map< Name, SynapticElement >::iterator se_it;
+  se_it = synaptic_elements_map_.find( name );
+
+  if ( se_it != synaptic_elements_map_.end() )
+  {
+    ( se_it->second ).connect( n );
+  }
 }
 
 } // of namespace nest

--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -37,6 +37,7 @@
 #include "nest_time.h"
 #include "histentry.h"
 #include <deque>
+#include "synaptic_element.h"
 
 #define DEBUG_ARCHIVER 1
 
@@ -64,6 +65,36 @@ public:
    */
   Archiving_Node( const Archiving_Node& );
 
+  /**
+   * \fn double_t get_Ca_value()
+   * return the Ca_minus value
+   */
+  double_t
+  get_Ca_value() const
+  {
+    return Ca_minus_;
+  }
+
+  /**
+   * \fn double_t get_synaptic_element(Name n, double_t t)
+   * get the number of synaptic element for the current Node
+   */
+  double_t get_synaptic_element( Name n ) const;
+
+  int_t get_synaptic_element_vacant( Name n ) const;
+  int_t get_synaptic_element_connected( Name n ) const;
+
+  /**
+   * \fn std::map<Name, double_t> get_synaptic_elements()
+   * get the number of all synaptic elements for the current Node
+   */
+  std::map< Name, double_t > get_synaptic_elements() const;
+
+  void update_synaptic_element( double_t t );
+
+  void decay_synaptic_element_vacant( double_t p );
+
+  void connect_synaptic_element( Name name, int_t n );
 
   /**
    * \fn double_t get_K_value(long_t t)
@@ -113,6 +144,12 @@ public:
   void get_status( DictionaryDatum& d ) const;
   void set_status( const DictionaryDatum& d );
 
+  double_t
+  get_tau_Ca() const
+  {
+    return tau_Ca_;
+  };
+
 protected:
   /**
    * \fn void set_spiketime(Time const & t_sp)
@@ -131,7 +168,6 @@ protected:
    * clear spike history
    */
   void clear_history();
-
 
 private:
   // number of incoming connections from stdp connectors.
@@ -154,6 +190,25 @@ private:
 
   // spiking history needed by stdp synapses
   std::deque< histentry > history_;
+
+  /*
+   * Structural plasticity
+   */
+
+  // Time of the last update of the Calcium concentration
+  double_t Ca_t_;
+
+  //  Value of the calcium concentration at Ca_t_
+  double_t Ca_minus_;
+
+  // time constant for exponential decay of the intracellular calcium concentration
+  double_t tau_Ca_;
+
+  // increase in calcium concentration for each spike of the neuron
+  double_t beta_Ca_;
+
+  // Map of the synaptic elements
+  std::map< Name, SynapticElement > synaptic_elements_map_;
 };
 
 inline double_t

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -25,6 +25,9 @@ namespace nest
 {
 namespace names
 {
+const Name Ca( "Ca" );
+const Name tau_Ca( "tau_Ca" );
+const Name beta_Ca( "beta_Ca" );
 const Name a( "a" );
 const Name A( "A" );
 const Name A_lower( "A_lower" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -130,6 +130,9 @@ extern const Name events;          //!< Recorder parameter
 extern const Name ex_spikes;       //!< Number of arriving excitatory spikes
 extern const Name exc_conductance; //!< Recorder parameter
 
+extern const Name Ca;
+extern const Name tau_Ca;
+extern const Name beta_Ca;
 extern const Name F_lower;
 extern const Name F_mean;
 extern const Name F_std;

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -477,6 +477,59 @@ public:
   virtual void handle( DoubleDataEvent& e );
 
   /**
+   * return the Ca_minus value at t (in ms).
+   * return 0.0 if not overridden
+   */
+  virtual double_t
+  get_Ca_value() const
+  {
+    return 0.0;
+  }
+
+  /**
+   * get the number of synaptic element for the current Node at t (in ms)
+   * return 0.0 if not overridden
+   */
+  virtual double_t get_synaptic_element( Name ) const
+  {
+    return 0.0;
+  }
+
+  /**
+   * get the number of vacant synaptic element for the current Node
+   * return 0.0 if not overridden
+   */
+  virtual int_t get_synaptic_element_vacant( Name ) const
+  {
+    return 0.0;
+  }
+
+  /**
+   * get the number of connected synaptic element for the current Node
+   * return 0.0 if not overridden
+   */
+  virtual int_t get_synaptic_element_connected( Name ) const
+  {
+    return 0.0;
+  }
+
+  /**
+   * get the number of all synaptic elements for the current Node at t (in ms)
+   * return an empty map if not overridden
+   */
+  virtual std::map< Name, double_t >
+  get_synaptic_elements()
+  {
+    return std::map< Name, double >();
+  }
+
+  virtual void update_synaptic_element( double_t ){};
+
+  virtual void decay_synaptic_element_vacant( double_t ){};
+
+  virtual void connect_synaptic_element( Name, int_t ){};
+
+  /**
    * return the Kminus value at t (in ms).
    * @throws UnexpectedEvent
    */

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -1,0 +1,265 @@
+/*
+ *  synaptic_element.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \file synaptic_element.cpp
+ * Implementation of synaptic_element and growth_curve
+ * \author Mikael Naveau
+ * \date July 2013
+ */
+
+#include "synaptic_element.h"
+#include "dictutils.h"
+#include "exceptions.h"
+#include "archiving_node.h"
+#include "network.h"
+
+/* ----------------------------------------------------------------
+* GrowthCurveLinear
+* ---------------------------------------------------------------- */
+nest::GrowthCurveLinear::GrowthCurveLinear()
+  : eps( 0.7 )
+{
+  name = "linear";
+}
+
+void
+nest::GrowthCurveLinear::get( DictionaryDatum& d ) const
+{
+  def< std::string >( d, "growth_curve", name );
+  def< double_t >( d, "eps", eps );
+}
+
+void
+nest::GrowthCurveLinear::set( const DictionaryDatum& d )
+{
+  updateValue< double_t >( d, "eps", eps );
+}
+
+nest::double_t
+nest::GrowthCurveLinear::update( double_t t,
+  double_t t_minus,
+  double_t Ca_minus,
+  double_t z_minus,
+  double_t tau_Ca,
+  double_t growth_rate ) const
+{
+  double_t Ca, z_value;
+  Ca = Ca_minus * std::exp( ( t_minus - t ) / tau_Ca );
+  z_value =
+    growth_rate * tau_Ca * ( Ca - Ca_minus ) / eps + growth_rate * ( t - t_minus ) + z_minus;
+
+  if ( z_value > 0 )
+    return z_value;
+  else
+    return 0.0;
+}
+
+/* ----------------------------------------------------------------
+* GrowthCurveGaussian
+* ---------------------------------------------------------------- */
+nest::GrowthCurveGaussian::GrowthCurveGaussian()
+  : eta( 0.1 )
+  , eps( 0.7 )
+{
+  name = "gaussian";
+}
+
+void
+nest::GrowthCurveGaussian::get( DictionaryDatum& d ) const
+{
+  def< std::string >( d, "growth_curve", name );
+  def< double_t >( d, "eps", eps );
+  def< double_t >( d, "eta", eta );
+}
+
+void
+nest::GrowthCurveGaussian::set( const DictionaryDatum& d )
+{
+  updateValue< double_t >( d, "eps", eps );
+  updateValue< double_t >( d, "eta", eta );
+}
+
+nest::double_t
+nest::GrowthCurveGaussian::update( double_t t,
+  double_t t_minus,
+  double_t Ca_minus,
+  double_t z_minus,
+  double_t tau_Ca,
+  double_t growth_rate ) const
+{
+  double_t lag, dz, zeta, xi, Ca, z_value;
+  const double_t h = Time::get_resolution().get_ms();
+
+  // Numerical integration from t_minus to t
+  // use standard forward Euler numerics
+  zeta = ( eta - eps ) / ( 2.0 * sqrt( log( 2.0 ) ) );
+  xi = ( eta + eps ) / 2.0;
+
+  z_value = z_minus;
+  Ca = Ca_minus;
+
+  for ( lag = t_minus; lag < ( t - h / 2.0 ); lag += h )
+  {
+    Ca = Ca - ( ( Ca / tau_Ca ) * h );
+    dz = h * growth_rate * ( 2.0 * exp( -pow( ( Ca - xi ) / zeta, 2 ) ) - 1.0 );
+    z_value = z_value + dz;
+  }
+
+  //  return z_value;
+  if ( z_value > 0 )
+    return z_value;
+  else
+    return 0.0;
+}
+
+
+/* ----------------------------------------------------------------
+* SynapticElement
+* Default constructors defining default parameters and state
+* ---------------------------------------------------------------- */
+
+nest::SynapticElement::SynapticElement()
+  : z_minus_( 0.0 )
+  , z_minus_t_( 0.0 )
+  , z_connected_( 0 )
+  , continuous_( true )
+  , growth_rate_( 1.0 )
+  , tau_vacant_( 10.0 )
+  , growth_curve_( new GrowthCurveLinear )
+{
+}
+
+nest::SynapticElement::SynapticElement( const SynapticElement& se )
+  : z_minus_( se.z_minus_ )
+  , z_minus_t_( se.z_minus_t_ )
+  , z_connected_( se.z_connected_ )
+  , continuous_( se.continuous_ )
+  , growth_rate_( se.growth_rate_ )
+  , tau_vacant_( se.tau_vacant_ )
+{
+  growth_curve_ = new_growth_curve( se.growth_curve_->get_name() );
+  DictionaryDatum gc_parameters = DictionaryDatum( new Dictionary );
+  se.get( gc_parameters );
+  growth_curve_->set( gc_parameters );
+}
+
+nest::SynapticElement& nest::SynapticElement::operator=( const SynapticElement& other )
+{
+  if ( this != &other )
+  {
+    // 1: allocate new memory and copy the elements
+    GrowthCurve* new_gc = new_growth_curve( other.growth_curve_->get_name() );
+    DictionaryDatum gc_parameters = DictionaryDatum( new Dictionary );
+
+    other.get( gc_parameters );
+    new_gc->set( gc_parameters );
+
+    delete growth_curve_;
+    growth_curve_ = new_gc;
+
+    z_minus_ = other.z_minus_;
+    z_minus_t_ = other.z_minus_t_;
+    z_connected_ = other.z_connected_;
+    continuous_ = other.continuous_;
+    growth_rate_ = other.growth_rate_;
+    tau_vacant_ = other.tau_vacant_;
+  }
+  return *this;
+}
+
+nest::GrowthCurve*
+nest::SynapticElement::new_growth_curve( std::string name )
+{
+  if ( !name.compare( "gaussian" ) )
+  {
+    return new GrowthCurveGaussian;
+  }
+  if ( !name.compare( "linear" ) )
+  {
+    return new GrowthCurveLinear;
+  }
+  throw BadProperty( "Unknown growth curve. Available growth curve are: linear, gaussian." );
+}
+
+/* ----------------------------------------------------------------
+* get function to store current values in dictionary
+* ---------------------------------------------------------------- */
+void
+nest::SynapticElement::get( DictionaryDatum& d ) const
+{
+  // Store current values in the dictionary
+  def< double_t >( d, "growth_rate", growth_rate_ );
+  def< double_t >( d, "tau_vacant", tau_vacant_ );
+  def< bool >( d, "continuous", continuous_ );
+  def< double_t >( d, "z", z_minus_ );
+  def< int_t >( d, "z_connected", z_connected_ );
+
+  // Store growth curve
+  growth_curve_->get( d );
+}
+
+/* ----------------------------------------------------------------
+* set function to store dictionary values in the SynaticElement
+* ---------------------------------------------------------------- */
+void
+nest::SynapticElement::set( const DictionaryDatum& d )
+{
+  double_t new_tau_vacant = tau_vacant_;
+
+  // Store values
+  updateValue< double_t >( d, "growth_rate", growth_rate_ );
+  updateValue< double_t >( d, "tau_vacant", new_tau_vacant );
+  updateValue< bool >( d, "continuous", continuous_ );
+  updateValue< double_t >( d, "z", z_minus_ );
+
+  if ( d->known( "growth_curve" ) )
+  {
+    std::string growth_curve_name = getValue< std::string >( d, "growth_curve" );
+    if ( !growth_curve_->is( growth_curve_name ) )
+    {
+      growth_curve_ = new_growth_curve( growth_curve_name );
+    }
+  }
+  growth_curve_->set( d );
+
+  if ( new_tau_vacant <= 0.0 )
+    throw BadProperty( "All time constants must be strictly positive." );
+  tau_vacant_ = new_tau_vacant;
+}
+
+
+/* ----------------------------------------------------------------
+* Update the number of element at the time t (in ms)
+* ---------------------------------------------------------------- */
+void
+nest::SynapticElement::update( double_t t, double_t t_minus, double_t Ca_minus, double_t tau_Ca )
+{
+  if ( z_minus_t_ != t_minus )
+  {
+    throw KernelException(
+      "Last update of the calcium concentration does not match the last update of the synaptic "
+      "element" );
+  }
+  z_minus_ = growth_curve_->update( t, t_minus, Ca_minus, z_minus_, tau_Ca, growth_rate_ );
+  z_minus_t_ = t;
+}

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -1,0 +1,242 @@
+/*
+ *  synaptic_element.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * \file synaptic_element.h
+ * Definition of SynapticElement which is capable of
+ * managing a synaptic element of a node.
+ * \author Mikael Naveau
+ * \date July 2013
+ */
+
+#ifndef SYNAPTIC_ELEMENT_H
+#define SYNAPTIC_ELEMENT_H
+
+#include "dictdatum.h"
+#include "dictutils.h"
+#include "histentry.h"
+
+namespace nest
+{
+
+class SynapticElement;
+class Archiving_Node;
+
+/**
+ * \class GrowthCurve
+ */
+class GrowthCurve
+{
+public:
+  virtual ~GrowthCurve()
+  {
+  }
+  virtual void get( DictionaryDatum& d ) const = 0;
+  virtual void set( const DictionaryDatum& d ) = 0;
+  virtual double_t update( double_t t,
+    double_t t_minus,
+    double_t Ca_minus,
+    double_t z_minus,
+    double_t tau_Ca,
+    double_t growth_rate ) const = 0;
+  virtual bool
+  is( std::string n )
+  {
+    return !n.compare( name );
+  }
+  std::string
+  get_name()
+  {
+    return name;
+  }
+
+protected:
+  std::string name;
+};
+
+/**
+ * \class GrowthCurveLinear
+ */
+class GrowthCurveLinear : public GrowthCurve
+{
+public:
+  GrowthCurveLinear();
+  void get( DictionaryDatum& d ) const;
+  void set( const DictionaryDatum& d );
+  double_t update( double_t t,
+    double_t t_minus,
+    double_t Ca_minus,
+    double_t z_minus,
+    double_t tau_Ca,
+    double_t growth_rate ) const;
+
+private:
+  double_t eps;
+};
+
+/**
+ * \class GrowthCurveGaussian
+ */
+class GrowthCurveGaussian : public GrowthCurve
+{
+public:
+  GrowthCurveGaussian();
+  void get( DictionaryDatum& d ) const;
+  void set( const DictionaryDatum& d );
+  double_t update( double_t t,
+    double_t t_minus,
+    double_t Ca_minus,
+    double_t z_minus,
+    double_t tau_Ca,
+    double_t growth_rate ) const;
+
+private:
+  double_t eta;
+  double_t eps;
+};
+
+
+/**
+ * \class SynapticElement
+ * Synaptic element of a node (like Axon or dendrite) for the purposes
+ * of synaptic plasticity
+ */
+class SynapticElement
+{
+
+public:
+  /**
+  * \fn SynapticElement()
+  * Constructor.
+  */
+  SynapticElement();
+
+  /**
+  * \fn SynapticElement(const SynapticElement& se)
+  * Copy Constructor.
+  * @param se SynapticElement
+  */
+  SynapticElement( const SynapticElement& se );
+
+  /**
+  * \fn SynapticElement(const SynapticElement& se)
+  * copy assignment operator.
+  * @param other SynapticElement
+  */
+  SynapticElement& operator=( const SynapticElement& other );
+
+  /**
+  * \fn SynapticElement()
+  * Destructor.
+  */
+  ~SynapticElement()
+  {
+    delete growth_curve_;
+  }
+
+  /**
+   * \fn GrowthCurve* new_growth_curve(std::string name);
+   * @param name linear, gaussian
+   * @return pointer to a new GrowthCurve
+   */
+  GrowthCurve* new_growth_curve( std::string name );
+
+  /**
+  * \fn void get(DictionaryDatum&) const
+  * Store current values in a dictionary.
+  * @param d to write data
+  */
+  void get( DictionaryDatum& d ) const;
+
+  /**
+  * \fn void set(const DictionaryDatum&)
+  * Set values from a dictionary.
+  * @param d to take data from
+  */
+  void set( const DictionaryDatum& d );
+
+  /**
+  * \fn double_t get_z_value(Archiving_Node const *a, double_t t) const
+  * Get the number of synaptic_element at the time t (in ms)
+  * @param a node of this synaptic_element
+  * @param t Current time (in ms)
+  */
+  void update( double_t t, double_t t_minus, double_t Ca_minus, double_t tau_Ca );
+  int_t
+  get_z_vacant() const
+  {
+    return std::floor( z_minus_ ) - z_connected_;
+  }
+  int_t
+  get_z_connected() const
+  {
+    return z_connected_;
+  }
+  void
+  connect( int_t n )
+  {
+    z_connected_ += n;
+  }
+
+  void
+  set_growth_curve( GrowthCurve* g )
+  {
+    delete growth_curve_;
+    growth_curve_ = g;
+  }
+
+  double_t
+  get_growth_rate() const
+  {
+    return growth_rate_;
+  }
+
+  void
+  set_z_minus( const double_t z )
+  {
+    z_minus_ = z;
+  }
+  double_t
+  get_z_minus() const
+  {
+    return z_minus_;
+  }
+
+  bool
+  continuous() const
+  {
+    return continuous_;
+  }
+
+private:
+  double_t z_minus_;
+  double_t z_minus_t_;
+  int_t z_connected_;
+  bool continuous_;
+  double_t growth_rate_;
+  double_t tau_vacant_;
+  GrowthCurve* growth_curve_;
+};
+
+} // of namespace
+
+#endif

--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -44,6 +44,7 @@ from . import test_networks
 from . import test_threads
 from . import test_csa
 from . import test_quantal_stp_synapse
+from . import test_msp
 
 
 def suite():
@@ -68,8 +69,9 @@ def suite():
     suite.addTest(test_events.suite())
     suite.addTest(test_networks.suite())
     suite.addTest(test_threads.suite())    
-    suite.addTest(test_csa.suite())    
-    suite.addTest(test_quantal_stp_synapse.suite())    
+    suite.addTest(test_csa.suite())
+    suite.addTest(test_quantal_stp_synapse.suite())
+    suite.addTest(test_msp.suite())
     
     return suite
 

--- a/pynest/nest/tests/test_msp/__init__.py
+++ b/pynest/nest/tests/test_msp/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# __init__.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+__author__ = 'naveau'
+
+from . import test_all
+
+suite = test_all.suite

--- a/pynest/nest/tests/test_msp/synaptic_elements.py
+++ b/pynest/nest/tests/test_msp/synaptic_elements.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# synaptic_elements.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+__author__ = 'naveau'
+
+import nest
+import unittest
+
+
+class TestSynapticElements(unittest.TestCase):
+
+    def setUp(self):
+        nest.ResetKernel()
+
+    def test_set_status(self):
+        synaptic_element_dict = {u'SE': {u'z': 15.0, u'growth_curve': u'linear'}}
+
+        neuron = nest.Create('iaf_neuron', 1)
+        nest.SetStatus(neuron, {'synaptic_elements': synaptic_element_dict})
+        neuron_synaptic_elements = nest.GetStatus(neuron, 'synaptic_elements')[0]
+        self.assertIn('SE', neuron_synaptic_elements)
+        self.assertDictContainsSubset(synaptic_element_dict[u'SE'], neuron_synaptic_elements[u'SE'])
+
+    def test_set_status_overwrite(self):
+        synaptic_element_dict1 = {u'SE1': {u'z': 15.0, u'growth_curve': u'linear'}}
+        synaptic_element_dict2 = {u'SE2': {u'z': 10.0, u'growth_curve': u'gaussian'}}
+
+        neuron = nest.Create('iaf_neuron', 1)
+        nest.SetStatus(neuron, {'synaptic_elements': synaptic_element_dict1})
+        nest.SetStatus(neuron, {'synaptic_elements': synaptic_element_dict2})
+
+        neuron_synaptic_elements = nest.GetStatus(neuron, 'synaptic_elements')[0]
+        self.assertNotIn('SE1', neuron_synaptic_elements)
+        self.assertIn('SE2', neuron_synaptic_elements)
+        self.assertDictContainsSubset(synaptic_element_dict2[u'SE2'], neuron_synaptic_elements[u'SE2'])
+
+    def test_set_defaults(self):
+        synaptic_element_dict = {u'SE': {u'z': 15.0, u'growth_curve': u'linear'}}
+
+        nest.SetDefaults('iaf_neuron', {'synaptic_elements': synaptic_element_dict})
+        neuron = nest.Create('iaf_neuron', 1)
+        neuron_synaptic_elements = nest.GetStatus(neuron, 'synaptic_elements')[0]
+        self.assertIn('SE', neuron_synaptic_elements)
+        self.assertDictContainsSubset(synaptic_element_dict[u'SE'], neuron_synaptic_elements[u'SE'])
+
+    def test_set_defaults_overwrite(self):
+        synaptic_element_dict1 = {u'SE1': {u'z': 15.0, u'growth_curve': u'linear'}}
+        synaptic_element_dict2 = {u'SE2': {u'z': 10.0, u'growth_curve': u'gaussian'}}
+
+        nest.SetDefaults('iaf_neuron', {'synaptic_elements': synaptic_element_dict1})
+        nest.SetDefaults('iaf_neuron', {'synaptic_elements': synaptic_element_dict2})
+        neuron = nest.Create('iaf_neuron', 1)
+
+        neuron_synaptic_elements = nest.GetStatus(neuron, 'synaptic_elements')[0]
+        self.assertNotIn('SE1', neuron_synaptic_elements)
+        self.assertIn('SE2', neuron_synaptic_elements)
+        self.assertDictContainsSubset(synaptic_element_dict2[u'SE2'], neuron_synaptic_elements[u'SE2'])
+
+
+def suite():
+    test_suite = unittest.makeSuite(TestSynapticElements, 'test')
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pynest/nest/tests/test_msp/test_all.py
+++ b/pynest/nest/tests/test_msp/test_all.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# test_all.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+__author__ = 'naveau'
+
+import unittest
+import nest
+
+from . import synaptic_elements
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+
+    test_suite.addTest(synaptic_elements.suite())
+
+    return test_suite
+
+
+if __name__ == "__main__":
+    nest.set_verbosity('M_WARNING')
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/pynest/setup.py.in
+++ b/pynest/setup.py.in
@@ -29,7 +29,7 @@ setup(
     author_email='nest_user@nest-initiative.org',
     url='http://www.nest-initiative.org',
     license='GPLv2+',
-    packages=['nest', 'nest.tests'],
+    packages=['nest', 'nest.tests', 'nest.tests.test_msp'],
     package_dir={'nest': '@PKGSRCDIR@/pynest/nest'},
     package_data={'nest': ['pynest-init.sli']},
 )


### PR DESCRIPTION
These changes include the first step in order to enable structural plasticity in NEST. The implementation corresponds to the formalism described in: M. Butz and A. van Ooyen. A simple rule for dendritic spine and axonal bouton formation can account for cortical reorganization after focal retinal lesions. PLoS Comput. Biol., 9(10):e1003259, Oct 2013. 

This Model of Structural Plasticity (MSP) considers synapses to be not just a weighted link between two neurons but as consisting of two connected parts, a presynaptic axonal element and a postsynaptic dendritic element. Matching synaptic elements develop independently from each other, only depending on the level of activity of the hosting neuron. 
Once new synaptic elements are formed, they are first considered as vacant. From that moment on, they can be connected with a matching counterpart to form a new synapse in a random process. 
Synapses can break apart when a bound synaptic element is deleted. The remaining and now freed synaptic element of the broken synapse can then rebind with a different synaptic element. 
Breaking of synapses and rebinding of synaptic elements causes the rewiring of the network until a homoeostatic point is reached.

This first request includes only the implementation of classes and data structures to represent synaptic elements and their dynamics within the network. No changes in the connectivity are present at this point. 
