### PR TITLE
Fix for the copyright check under regression tests and a minor change in the email notification section of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,12 +115,19 @@ before_script:
 
 script: ./build.sh  
 
-after_failure:
-  - cd $TRAVIS_BUILD_DIR/build
-  - |
-    for i in $(find reports -type f); do
-      echo "###########################"
-      echo "File: $i"
-      cat $i
-    done
+#S3 deployment    
+
+deploy:
+  provider: s3
+  access_key_id: AKIAIGKKBSJAWDMB34IA
+  secret_access_key:
+    secure: CARBlB16Up/ZyrMJty32nolnBfSKvlBYJ9HD7KXEOqCL4L95QJdpH0XtfxwTfOYJ5XuTjVMOvnUmB6F/PKzVO01VTP5Fa9iRBo2UNHYP6zxKNW++z5658iPoFPVTag47M9grWDCfp7A/+1pFna7mHHJ0Iq/+pUPYblYTNMFfqJg=
+  bucket: "nest-travis-artefacts"
+  skip_cleanup: true
+  local-dir: "$TRAVIS_BUILD_DIR/build"
+  acl: bucket_owner_full_control
+  on:
+    repo: nest/nest-simulator
+
+
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,19 +115,6 @@ before_script:
 
 script: ./build.sh  
 
-notifications:
-  email:
-    recipients:
-      - r.deepu@fz-juelich.de
-      - t.zito@fz-juelich.de
-      - a.peyser@fz-juelich.de
-      - a.morrison@fz-juelich.de
-      - j.eppler@fz-juelich.de
-      - t.ippen@fz-juelich.de
-    on_success: change
-    on_failure: always
-    #on_start: false
-
 after_failure:
   - cd $TRAVIS_BUILD_DIR/build
   - |

--- a/testsuite/regressiontests/ticket-659-copyright.py
+++ b/testsuite/regressiontests/ticket-659-copyright.py
@@ -55,6 +55,7 @@ exclude_files = [
     'nest/static_modules.h',
     'pynest/pynestkernel.cpp',
     'rcsinfo.sli',
+    'get-pip.py'
 ]
 
 templates = {


### PR DESCRIPTION
Error:  'regressiontests/ticket-659-copyright.py'... Failed: inconsistent copyright header(s) in get-pip.py.
Fix: Added get-pip.py in the exclude section of ticket-659-copyright.py

By using default notification in .travis.yml file, email notification will be sent to all the people who has admin rights to the github repository.