### PR TITLE
Modify .gitignore file so that project files created by kdevelop are …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ build/
 /sli/sli
 /testsuite/do_tests.sh
 /topology/setup.py
+
+*.kdev4


### PR DESCRIPTION
…ignored as well

This is just a trivial addition to the .gitignore file to make life easier for people working with kdevelop.
