### PR TITLE
Fix TravisCI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -115,7 +115,7 @@ for f in $file_names; do
   case $f in
     *.h | *.c | *.cc | *.hpp | *.cpp )
       echo "Static analysis on file $f:"
-      f_base=reports/`basename $f`
+      f_base=$NEST_VPATH/reports/`basename $f`
       # Vera++ checks the specified list of rules given in the profile 
       # nest which is placed in the <vera++ root>/lib/vera++/profile
       vera++ --root ./vera_home --profile nest $f > ${f_base}_vera.txt


### PR DESCRIPTION
Apparently, TravisCI accept my pull request #29, but it was erroneous.
The important line is this in the builds was something like this:

    ./build.sh: 121: ./build.sh: cannot create reports/uniformint_randomdev.cpp_vera.txt: Directory nonexistent

I got confused about in what directory we perform the lint-checks – in the source directory.
But the ‘reports’ directory is in the build-directory.