### PR TITLE
Travis now should build on pushes to any branch except gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
   # do notify immediately about it when a job of a build fails.
   fast_finish: true
 branches:
- only:
-  - master
+  except:
+  - gh-pages
 cache:
   apt: true 
   ccache: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ env:
 matrix:
   # do notify immediately about it when a job of a build fails.
   fast_finish: true
-branches:
-  except:
-  - gh-pages
 cache:
   apt: true 
   ccache: true


### PR DESCRIPTION
@lekshmideepu I patched the `.travis.yml` file as you suggested. After pushing it to my github repo, Travis did not build this branch, but maybe that is because the `.travis.yml` file in the main branch still is the old one?

Additional proposed reviewer: @apeyser 