### PR TITLE
Fixing some documentation, inspired by trac.693

### DIFF
--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -95,13 +95,13 @@ class Network;
 
    V_m        double - Membrane potential in mV
    E_L        double - Resting membrane potential in mV.
-   C_m        double - Specific capacitance of the membrane in pF/mum^2
+   C_m        double - Capacitance of the membrane in pF
    tau_m      double - Membrane time constant in ms.
    t_ref      double - Duration of refractory period in ms.
    V_th       double - Spike threshold in mV.
    V_reset    double - Reset potential of the membrane in mV.
    I_e        double - Constant input current in pA.
-   V_min      double - Absolute lower value for the membrane potential.
+   V_min      double - Absolute lower value for the membrane potential in mV
 
    refractory_input bool - If true, do not discard input during
    refractory period. Default: false.

--- a/models/pp_pop_psc_delta.h
+++ b/models/pp_pop_psc_delta.h
@@ -112,7 +112,7 @@ class Network;
 
    N                 int    - Number of represented neurons.
    tau_m             double - Membrane time constant in ms.
-   C_m               double - Specific capacitance of the membrane in pF/mum^2.
+   C_m               double - Capacitance of the membrane in pF.
    rho_0             double - Base firing rate in 1/s.
    delta_u           double - Voltage scale parameter in mV.
    I_e               double - Constant input current in pA.

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -119,7 +119,7 @@ class Network;
    The following parameters can be set in the status dictionary.
 
    V_m               double - Membrane potential in mV.
-   C_m               double - Specific capacitance of the membrane in pF/mum^2.
+   C_m               double - Capacitance of the membrane in pF.
    tau_m             double - Membrane time constant in ms.
    q_sfa             double - Adaptive threshold jump in mV.
    tau_sfa           double - Adaptive threshold time constant in ms.
@@ -139,7 +139,8 @@ class Network;
    Receives: SpikeEvent, CurrentEvent, DataLoggingRequest
 
    Author:  July 2009, Deger, Helias; January 2011, Zaytsev; May 2014, Setareh
-   SeeAlso: pp_pop_psc_delta, iaf_psc_delta, iaf_psc_alpha, iaf_psc_exp, iaf_neuron, iaf_psc_delta_canon
+   SeeAlso: pp_pop_psc_delta, iaf_psc_delta, iaf_psc_alpha, iaf_psc_exp, iaf_neuron,
+   iaf_psc_delta_canon
 */
 
 /**

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -51,7 +51,6 @@ const Name c( "c" );
 const Name c_1( "c_1" );
 const Name c_2( "c_2" );
 const Name c_3( "c_3" );
-const Name c_m( "c_m" );
 const Name C_m( "C_m" );
 const Name calibrate( "calibrate" );
 const Name calibrate_node( "calibrate_node" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -63,7 +63,6 @@ extern const Name c;                    //!< Specific to Izhikevich 2003
 extern const Name c_1;                  //!< Specific to stochastic neuron pp_psc_delta
 extern const Name c_2;                  //!< Specific to stochastic neuron pp_psc_delta
 extern const Name c_3;                  //!< Specific to stochastic neuron pp_psc_delta
-extern const Name c_m;                  //!< Capacity or specific capacitance
 extern const Name C_m;                  //!< Membrane capacitance
 extern const Name calibrate;            //!< Command to calibrate the neuron (sli_neuron)
 extern const Name calibrate_node;       //!< Command to calibrate the neuron (sli_neuron)
@@ -90,14 +89,14 @@ extern const Name dead_time; //!< Specific to ppd_sup_generator and gamma_sup_ge
 extern const Name
   dead_time_random; //!< Random dead time or fixed dead time (stochastic neuron pp_psc_delta)
 extern const Name dead_time_shape; //!< Shape parameter of the dead time distribution (stochastic
-                                   //neuron pp_psc_delta)
-extern const Name delay;           //!< Connection parameters
-extern const Name delays;          //!< Connection parameters
-extern const Name Delta_T;         //!< Specific to Brette & Gerstner 2005 (aeif_cond-*)
-extern const Name delta_tau;       //!< Specific to correlation_and correlomatrix detector
-extern const Name delta_u; //!< Specific to population point process model (pp_pop_psc_delta)
-extern const Name dg_ex;   //!< Derivative of the excitatory conductance
-extern const Name dg_in;   //!< Derivative of the inhibitory conductance
+// neuron pp_psc_delta)
+extern const Name delay;     //!< Connection parameters
+extern const Name delays;    //!< Connection parameters
+extern const Name Delta_T;   //!< Specific to Brette & Gerstner 2005 (aeif_cond-*)
+extern const Name delta_tau; //!< Specific to correlation_and correlomatrix detector
+extern const Name delta_u;   //!< Specific to population point process model (pp_pop_psc_delta)
+extern const Name dg_ex;     //!< Derivative of the excitatory conductance
+extern const Name dg_in;     //!< Derivative of the inhibitory conductance
 extern const Name dhaene_det_spikes;   //!< used for iaflossless_count_exp
 extern const Name dhaene_max_geq_V_th; //!< used for iaflossless_count_exp
 extern const Name dhaene_quick1;       //!< used for iaflossless_count_exp
@@ -256,10 +255,10 @@ extern const Name registered;       //!< Parameters for MUSIC devices
 extern const Name rho_0; //!< Specific to population point process model (pp_pop_psc_delta)
 extern const Name rms;   //!< Root mean square
 extern const Name root_finding_epsilon; //!< Accuracy of the root of the polynomial (precise timing
-                                        //neurons (Brette 2007))
-extern const Name rport;                //!< Connection parameters
-extern const Name rports;               //!< Connection parameters
-extern const Name rule;                 //!< Connectivity-related
+// neurons (Brette 2007))
+extern const Name rport;  //!< Connection parameters
+extern const Name rports; //!< Connection parameters
+extern const Name rule;   //!< Connectivity-related
 
 extern const Name S;           //!< Binary state (output) of neuron (Ginzburg neuron)
 extern const Name scientific;  //!< Recorder parameter
@@ -297,11 +296,11 @@ extern const Name tau_ahp;         //!< Specific to iaf_chxk_2008 neuron
 extern const Name tau_epsp;        //!< Specific to iaf_chs_2008 neuron
 extern const Name tau_fac;         //!< facilitation time constant (ms) (Tsodyks2_connection)
 extern const Name tau_facs;        //!< facilitation time constant (ms) (property arrays)
-extern const Name tau_lcm;   //!< Least common multiple of tau_m, tau_ex and tau_in (precise timing
-                             //neurons (Brette 2007))
-extern const Name tau_m;     //!< Membrane time constant
-extern const Name tau_max;   //!< Specific to correlation_and correlomatrix detector
-extern const Name tau_minus; //!< used for ArchivingNode
+extern const Name tau_lcm; //!< Least common multiple of tau_m, tau_ex and tau_in (precise timing
+// neurons (Brette 2007))
+extern const Name tau_m;             //!< Membrane time constant
+extern const Name tau_max;           //!< Specific to correlation_and correlomatrix detector
+extern const Name tau_minus;         //!< used for ArchivingNode
 extern const Name tau_minus_triplet; //!< used for ArchivingNode
 extern const Name tau_rec;           //!< time constant for recovery (ms) (Tsodyks2_connection)
 extern const Name tau_recs;          //!< time constant for recovery (ms) (property arrays)

--- a/precise/iaf_psc_delta_canon.h
+++ b/precise/iaf_psc_delta_canon.h
@@ -119,13 +119,13 @@ class Network;
 
    V_m        double - Membrane potential in mV
    E_L        double - Resting membrane potential in mV.
-   C_m        double - Specific capacitance of the membrane in pF/mum^2
+   C_m        double - Capacitance of the membrane in pF
    tau_m      double - Membrane time constant in ms.
    t_ref      double - Duration of refractory period in ms.
    V_th       double - Spike threshold in mV.
    V_reset    double - Reset potential of the membrane in mV.
    I_e        double - Constant input current in pA.
-   V_min      double - Absolute lower value for the membrane potential.
+   V_min      double - Absolute lower value for the membrane potential in mV.
 
    refractory_input bool - If true, do not discard input during
    refractory period. Default: false.

--- a/precise/iaf_psc_exp_ps.h
+++ b/precise/iaf_psc_exp_ps.h
@@ -66,15 +66,15 @@ between events [3].
 Parameters:
   The following parameters can be set in the status dictionary.
   E_L           double - Resting membrane potential in mV.
-  C_m           double - Specific capacitance of the membrane in pF/mum^2.
+  C_m           double - Capacitance of the membrane in pF.
   tau_m         double - Membrane time constant in ms.
   tau_syn_ex    double - Excitatory synaptic time constant in ms.
   tau_syn_in    double - Inhibitory synaptic time constant in ms.
   t_ref         double - Duration of refractory period in ms.
   V_th          double - Spike threshold in mV.
   I_e           double - Constant input current in pA.
-  V_min         double - Absolute lower value for the membrane potential.
-  V_reset       double - Reset value for the membrane potential.
+  V_min         double - Absolute lower value for the membrane potential in mV.
+  V_reset       double - Reset value for the membrane potential in mV.
 
 Remarks:
   Please note that this node is capable of sending precise spike times


### PR DESCRIPTION
This PR fixes some details in the documentation of some models and removes `names::c_m`, which was not used (only `names::C_m` is used). The actual ticket 693 appears invalid.

Suggested reviewers: @jougs @abigailm 