### PR TITLE
Fix trac.730 synapse documentation

### DIFF
--- a/lib/sli/mathematica.sli
+++ b/lib/sli/mathematica.sli
@@ -1408,7 +1408,7 @@ dimensions [d1 d2 ... dn] where di gives the dimension of the
 array at level i.
 The length of the dimensions-list corresponds to the TensorRank of
 the array.
-Note: Dimensions assumes that the array is hyper-rectangular
+Remarks: Dimensions assumes that the array is hyper-rectangular
       (rectangle,cuboid, ...), i.e., all subarrays at a given level
       have the same number of elements.
       Dimensions does not check, if the array really is hyper-rectangular. It

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -1746,7 +1746,7 @@ SLI ] /iaf_neuron Create ;
 SLI ] 0 3 GetNetwork ==
 [0 1 [2 [3 4 5] [6 7 8]] 9]
 
-Note:
+Remarks:
 In parallel simulations, this function collects data across all processes
 and can thus take a lot of time and consume huge amounts of memory.
 

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -515,7 +515,7 @@ SeeAlso: over, index
  counts for all child processes.  Real time has arbitrary origin,
  i.e., only differences are meaningful.
 
- Note: results for user and system time may not be reliable if more
+ Remarks: results for user and system time may not be reliable if more
  than one thread is used.
 
  Author: Hans Ekkehard Plesser

--- a/lib/sli/unittest.sli
+++ b/lib/sli/unittest.sli
@@ -767,7 +767,7 @@ the executing process and RESULT AS STRING is present only for the
 to send_distributed.  This message is suitable for collection by
 :collect_distributed_results.
 
-Note: result can be a dict, but must not contain dicts
+Remarks: result can be a dict, but must not contain dicts
 
 SeeAlso: unittest:mpirun_self
 */

--- a/librandom/clipped_randomdev.h
+++ b/librandom/clipped_randomdev.h
@@ -61,7 +61,7 @@ Parameters:
 /low  lower bound (default: -inf)
 /high upper bound (default: +inf)
 
-Note:
+Remarks:
 - Clipped generators can be very inefficient if there is little probability
 mass in (low, high).
 - For continuous distributions, the probability of actually drawing

--- a/librandom/lognormal_randomdev.h
+++ b/librandom/lognormal_randomdev.h
@@ -42,7 +42,7 @@ Parameters:
  mu  - mean of the underlying normal distribution (default: 0.0)
  sigma - standard deviation of the underlying normal distribution (default: 1.0)
 
-Note:
+Remarks:
 Mean and variance of the lognormal numbers are given by
 
   E[X] = exp(mu + sigma^2/2)

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -108,7 +108,7 @@ class Network;
    V_m          Non-resetting membrane potential
    V_th         Two-timescale adaptive threshold
 
-   Note:
+   Remarks:
    tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
    degenerate case of the ODE describing the model [1]. For very similar values,
    numerics will be unstable.

--- a/models/cont_delay_connection.h
+++ b/models/cont_delay_connection.h
@@ -158,6 +158,11 @@ public:
       return invalid_port_;
     }
     port
+    handles_test_event( DataLoggingRequest&, rport )
+    {
+      return invalid_port_;
+    }
+    port
     handles_test_event( CurrentEvent&, rport )
     {
       return invalid_port_;

--- a/models/cont_delay_connection.h
+++ b/models/cont_delay_connection.h
@@ -33,6 +33,38 @@
   that the actual delay is given by  delay_*h - delay_offset_. This can be
   combined with off-grid spike times.
 
+  Example:
+  0 << /resolution 1.0 >> SetStatus
+
+  /sg /spike_generator << /precise_times true /spike_times [ 2.0 5.5 ] >> Create def
+  /n  /iaf_psc_delta_canon Create def
+  /sd /spike_detector << /precise_times true /record_to [ /memory ] >> Create def
+
+  /cont_delay_synapse << /weight 100. /delay 1.7 >> SetDefaults
+  sg n /cont_delay_synapse Connect
+  n sd Connect
+
+  10 Simulate
+
+  sd GetStatus /events/times :: ==   %  --> <. 3.7 7.2 .>
+
+  Remarks:
+  All delays set by the normal NEST Connect function will be rounded, even when using
+  cont_delay_connection. Set non-grid delays, you must either
+
+  1) set the delay as synapse default, as in the example above
+  2) set the delay for each synapse after the connections have been created, e.g.,
+
+       sg n 100. 1.0 /cont_delay_synapse Connect
+       << /source [ sg ] /synapse_model /cont_delay_synapse >> GetConnections
+          { << /delay 1.7 >> SetStatus }
+       forall
+
+  Alternative 1) is much more efficient, but all synapses then will have the same delay.
+  Alternative 2) is slower, but allows individual delay values.
+
+  Continuous delays cannot be shorter than the simulation resolution.
+
   Transmits: SpikeEvent, RateEvent, CurrentEvent, ConductanceEvent, DoubleDataEvent
 
   References: none
@@ -137,6 +169,16 @@ public:
     }
     port
     handles_test_event( DoubleDataEvent&, rport )
+    {
+      return invalid_port_;
+    }
+    port
+    handles_test_event( DSSpikeEvent&, rport )
+    {
+      return invalid_port_;
+    }
+    port
+    handles_test_event( DSCurrentEvent&, rport )
     {
       return invalid_port_;
     }

--- a/models/cont_delay_connection.h
+++ b/models/cont_delay_connection.h
@@ -50,7 +50,7 @@
 
   Remarks:
   All delays set by the normal NEST Connect function will be rounded, even when using
-  cont_delay_connection. Set non-grid delays, you must either
+  cont_delay_connection. To set non-grid delays, you must either
 
   1) set the delay as synapse default, as in the example above
   2) set the delay for each synapse after the connections have been created, e.g.,

--- a/models/cont_delay_connection_impl.h
+++ b/models/cont_delay_connection_impl.h
@@ -56,6 +56,7 @@ ContDelayConnection< targetidentifierT >::get_status( DictionaryDatum& d ) const
   def< double_t >( d, names::weight, weight_ );
   def< double_t >(
     d, names::delay, Time( Time::step( get_delay_steps() ) ).get_ms() - delay_offset_ );
+  def< long_t >( d, names::size_of, sizeof( *this ) );
 }
 
 template < typename targetidentifierT >

--- a/models/dc_generator.h
+++ b/models/dc_generator.h
@@ -37,7 +37,7 @@ Examples: The dc current can be altered in the following way:
    dc_gen << /amplitude 1500. >> SetStatus
    dc_gen GetStatus info                    % amplitude is now 1500.0
 
-Note: The dc_generator is rather inefficient, since it needs to
+Remarks: The dc_generator is rather inefficient, since it needs to
       send the same current information on each time step. If you
       only need a constant bias current into a neuron, you should
       set it directly in the neuron, e.g., dc_generator.

--- a/models/gamma_sup_generator.h
+++ b/models/gamma_sup_generator.h
@@ -47,7 +47,7 @@ Parameters:
    gamma_shape - shape paramter of component gamma processes. (long, var)
    n_proc - number of superimposed independent component processes. (long, var)
 
-Note:
+Remarks:
    The generator has been published in Deger, Helias, Boucsein, Rotter (2011)
    Statistical properties of superimposed stationary spike trains,
    Journal of Computational Neuroscience.

--- a/models/iaf_chs_2007.h
+++ b/models/iaf_chs_2007.h
@@ -58,7 +58,7 @@ class Network;
    grid given by the computation step size. Incoming as well as emitted
    spikes are forced to that grid.
 
-   Note:
+   Remarks:
    The way the noise term was implemented in the original model makes it
    unsuitable for simulation in NEST. The workaround was to prepare the
    noise signal externally prior to simulation. The noise signal,

--- a/models/iaf_neuron.h
+++ b/models/iaf_neuron.h
@@ -96,7 +96,7 @@ V_reset    double - Reset potential of the membrane in mV.
 tau_syn    double - Rise time of the excitatory synaptic alpha function in ms.
 I_e        double - Constant external input current in pA.
 
-Note:
+Remarks:
 tau_m != tau_syn is required by the current implementation to avoid a
 degenerate case of the ODE describing the model [1]. For very similar values,
 numerics will be unstable.

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -96,7 +96,7 @@ Parameters:
   I_e        double - Constant external input current in pA.
   V_min      double - Absolute lower value for the membrane potential.
 
-Note:
+Remarks:
   tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
   degenerate case of the ODE describing the model [1]. For very similar values,
   numerics will be unstable.

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -91,7 +91,7 @@ class Network;
    I_e          double - Constant input current in pA.
    t_spike      double - Point in time of last spike in ms.
 
-   Note:
+   Remarks:
    tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
    degenerate case of the ODE describing the model [1]. For very similar values,
    numerics will be unstable.

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -101,7 +101,7 @@ class Network;
    I_e          double - Constant input current in pA.
    t_spike      double - Point in time of last spike in ms.
 
-   Note:
+   Remarks:
    tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
    degenerate case of the ODE describing the model [1]. For very similar values,
    numerics will be unstable.

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -98,7 +98,7 @@ class Network;
    V_m          Non-resetting membrane potential
    V_th         Two-timescale adaptive threshold
 
-   Note:
+   Remarks:
    tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
    degenerate case of the ODE describing the model [1]. For very similar values,
    numerics will be unstable.

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -69,7 +69,7 @@ to memory, to screen, with GID or with weight. You must activate accumulator mod
 before simulating. Accumulator data is never written to file. You must extract it
 from the device using GetStatus.
 
-Note:
+Remarks:
  - The set of variables to record and the recording interval must be set
    BEFORE the multimeter is connected to any node, and cannot be changed
    afterwards.

--- a/models/ppd_sup_generator.h
+++ b/models/ppd_sup_generator.h
@@ -53,7 +53,7 @@ Parameters:
    frequency - rate modulation frequency. (double, var)
    amplitude - relative rate modulation amplitude. (double, var)
 
-Note:
+Remarks:
    The generator has been published in Deger, Helias, Boucsein, Rotter (2011)
    Statistical properties of superimposed stationary spike trains,
    Journal of Computational Neuroscience.

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -123,10 +123,7 @@ private:
 };
 
 inline port
-spike_dilutor::send_test_event( Node& target,
-  rport receptor_type,
-  synindex syn_id,
-  bool dummy_target )
+spike_dilutor::send_test_event( Node& target, rport receptor_type, synindex syn_id, bool )
 {
 
   device_.enforce_single_syn_type( syn_id );

--- a/models/static_connection_hom_w.h
+++ b/models/static_connection_hom_w.h
@@ -26,8 +26,13 @@
 
    Description:
      static_synapse_hom_w does not support any kind of plasticity. It simply stores
-     the parameters target, and receiver port for each connection and uses a common
-     weight and delay for all connections.
+     the parameters delay, target, and receiver port for each connection and uses a common
+     weight for all connections.
+
+   Remarks:
+     The common weight for all connections of this model must be set by SetDefaults on the model.
+     If you create copies of this model using CopyModel, each derived model can have a different
+     weight.
 
    Transmits: SpikeEvent, RateEvent, CurrentEvent, ConductanceEvent, DataLoggingRequest,
    DoubleDataEvent

--- a/models/stdp_connection_facetshw_hom.h
+++ b/models/stdp_connection_facetshw_hom.h
@@ -69,19 +69,19 @@
     a_causal     double - causal and anti-causal spike pair accumulations
     a_acausal    double
     a_thresh_th  double - two thresholds used in evaluation function.
-                          No common property, because variation of analog synapse circuitry can be
-  applied here
+                          No common property, because variation of analog synapse circuitry
+                          can be applied here
     a_thresh_tl  double
     synapse_id   long   - synapse ID, used to assign synapses to groups (synapse drivers)
 
-  Notes:
-   The synapse IDs are assigned to each synapse in an ascending order (0,1,2, ...) according their
-  first
-   presynaptic activity and is used to group synapses that are updated at once.
+  Remarks:
+   The synapse IDs are assigned to each synapse in an ascending order (0,1,2, ...) according
+   their first presynaptic activity and is used to group synapses that are updated at once.
    It is possible to avoid activity dependent synapse ID assignments by manually setting the
-  no_synapses
-   and the synapse_id(s) before running the simulation.
+   no_synapses and the synapse_id(s) before running the simulation.
    The weights will be discretized after the first presynaptic activity at a synapse.
+
+   Common properties can only be set on the synapse model using SetDefaults.
 
   Transmits: SpikeEvent
 
@@ -116,7 +116,7 @@
 namespace nest
 {
 
-// template class forward declaration required by common proterties friend definition
+// template class forward declaration required by common properties friend definition
 template < typename targetidentifierT >
 class STDPFACETSHWConnectionHom;
 

--- a/models/stdp_connection_hom.h
+++ b/models/stdp_connection_hom.h
@@ -25,12 +25,15 @@
 
 /* BeginDocumentation
   Name: stdp_synapse_hom - Synapse type for spike-timing dependent
-   plasticity using homogeneous parameters, i.e. all synapses have the same parameters.
+   plasticity using homogeneous parameters.
 
   Description:
-   stdp_synapse is a connector to create synapses with spike time
+   stdp_synapse_hom is a connector to create synapses with spike time
    dependent plasticity (as defined in [1]). Here the weight dependence
    exponent can be set separately for potentiation and depression.
+
+   Parameters controlling plasticity are identical for all synapses of the model,
+   reducing the memory required per synapse considerably.
 
   Examples:
    multiplicative STDP [2]  mu_plus = mu_minus = 1.0
@@ -46,6 +49,10 @@
    mu_plus    double - Weight dependence exponent, potentiation
    mu_minus   double - Weight dependence exponent, depression
    Wmax       double - Maximum allowed weight
+
+  Remarks:
+   The parameters are common to all synapses of the model and must be set using
+   SetDefaults on the synapse model.
 
   Transmits: SpikeEvent
 

--- a/models/stdp_dopa_connection.h
+++ b/models/stdp_dopa_connection.h
@@ -47,19 +47,27 @@
    pre_neuron post_neuron /stdp_dopamine_synapse Connect
 
    Parameters:
-   vt        long   - ID of volume_transmitter collecting the spikes from the pool of
-                      dopamine releasing neurons and transmitting the spikes
-                      to the synapse. If no volume transmitter has been
-                      assigned, a value of -1 is returned when the synapse is
-                      asked for its defaults.
-   A_plus    double - Amplitude of weight change for facilitation
-   A_minus   double - Amplitude of weight change for depression
-   tau_plus  double - STDP time constant for facilitation in ms
-   tau_c     double - Time constant of eligibility trace in ms
-   tau_n     double - Time constant of dopaminergic trace in ms
-   b         double - Dopaminergic baseline concentration
-   Wmin      double - Minimal synaptic weight
-   Wmax      double - Maximal synaptic weight
+     Common properties:
+           vt        long   - ID of volume_transmitter collecting the spikes from the pool of
+                              dopamine releasing neurons and transmitting the spikes
+                              to the synapse. A value of -1 indicates that no volume
+                              transmitter has been assigned.
+           A_plus    double - Amplitude of weight change for facilitation
+           A_minus   double - Amplitude of weight change for depression
+           tau_plus  double - STDP time constant for facilitation in ms
+           tau_c     double - Time constant of eligibility trace in ms
+           tau_n     double - Time constant of dopaminergic trace in ms
+           b         double - Dopaminergic baseline concentration
+           Wmin      double - Minimal synaptic weight
+           Wmax      double - Maximal synaptic weight
+
+         Individual properties:
+           c         double - eligibility trace
+           n         double - neuromodulator concentration
+
+   Remarks:
+     The common properties can only be set by SetDefaults and apply to all synapses of
+     the model.
 
    References:
    [1] Potjans W, Morrison A and Diesmann M (2010). Enabling

--- a/models/stdp_dopa_connection.h
+++ b/models/stdp_dopa_connection.h
@@ -61,7 +61,7 @@
            Wmin      double - Minimal synaptic weight
            Wmax      double - Maximal synaptic weight
 
-         Individual properties:
+     Individual properties:
            c         double - eligibility trace
            n         double - neuromodulator concentration
 

--- a/models/stdp_pl_connection_hom.h
+++ b/models/stdp_pl_connection_hom.h
@@ -40,6 +40,9 @@
    alpha     double - Asymmetry parameter (scales depressing increments as alpha*lambda)
    mu        double - Weight dependence exponent, potentiation
 
+  Remarks:
+   The parameters can only be set by SetDefaults and apply to all synapses of the model.
+
   References:
    [1] Morrison et al. (2007) Spike-timing dependent plasticity in balanced
        random networks. Neural Computation.

--- a/models/tsodyks2_connection.h
+++ b/models/tsodyks2_connection.h
@@ -47,7 +47,7 @@
      tau_rec    double - time constant for depression in ms, default=800 ms
      tau_fac    double - time constant for facilitation in ms, default=0 (off)
 
-  Notes:
+  Remarks:
 
      Under identical conditions, the tsodyks2_synapse produces
      slightly lower peak amplitudes than the tsodyks_synapse. However,

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -68,12 +68,12 @@
 
    Parameters:
      The following parameters can be set in the status dictionary:
-     Us         double - maximum probability of realease [0,1]
-     tau_pscs   double - time constants of synaptic current in ms
-     tau_facs   double - time constant for facilitation in ms
-     tau_recs   double - time constant for depression in ms
-     xs         double - initial fraction of synaptic vesicles in the readily releasable pool [0,1]
-     ys         double - initial fraction of synaptic vesicles in the synaptic cleft [0,1]
+     Us        double - maximum probability of realease [0,1]
+     tau_psc   double - time constants of synaptic current in ms
+     tau_fac   double - time constant for facilitation in ms
+     tau_rec   double - time constant for depression in ms
+     x         double - initial fraction of synaptic vesicles in the readily releasable pool [0,1]
+     y         double - initial fraction of synaptic vesicles in the synaptic cleft [0,1]
 
   References:
    [1] Tsodyks, Uziel, Markram (2000) Synchrony Generation in Recurrent Networks

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -68,8 +68,8 @@
 
    Parameters:
      The following parameters can be set in the status dictionary:
-     U         double - maximum probability of realease [0,1]
-     tau_psc   double - time constants of synaptic current in ms
+     U         double - maximum probability of release [0,1]
+     tau_psc   double - time constant of synaptic current in ms
      tau_fac   double - time constant for facilitation in ms
      tau_rec   double - time constant for depression in ms
      x         double - initial fraction of synaptic vesicles in the readily releasable pool [0,1]

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -68,7 +68,7 @@
 
    Parameters:
      The following parameters can be set in the status dictionary:
-     Us        double - maximum probability of realease [0,1]
+     U         double - maximum probability of realease [0,1]
      tau_psc   double - time constants of synaptic current in ms
      tau_fac   double - time constant for facilitation in ms
      tau_rec   double - time constant for depression in ms

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -854,7 +854,7 @@ NestModule::ResetKernelFunction::execute( SLIInterpreter* i ) const
    init_buffers() upon the next call to Simulate. Node parameters, such as
    time constants and threshold potentials, are not affected.
 
-   Note:
+   Remarks:
    - Time and random number generators are NOT reset.
    - Files belonging to recording devices (spike detector, voltmeter, etc)
      are closed. You must change the file name before simulating again, otherwise

--- a/precise/iaf_psc_alpha_canon.h
+++ b/precise/iaf_psc_alpha_canon.h
@@ -97,7 +97,7 @@ The following parameters can be set in the status dictionary.
   Interpol_Order  int - Interpolation order for spike time:
                         0-none, 1-linear, 2-quadratic, 3-cubic
 
-Note:
+Remarks:
   tau_m != tau_syn is required by the current implementation to avoid a
   degenerate case of the ODE describing the model [1]. For very similar values,
   numerics will be unstable.

--- a/precise/iaf_psc_alpha_presc.h
+++ b/precise/iaf_psc_alpha_presc.h
@@ -78,7 +78,7 @@
   spike_detector has to be set to true in order to record the offsets
   in addition to the on-grid spike times.
 
-  Note:
+  Remarks:
   tau_m != tau_syn is required by the current implementation to avoid a
   degenerate case of the ODE describing the model [1]. For very similar values,
   numerics will be unstable.

--- a/precise/iaf_psc_exp_ps.h
+++ b/precise/iaf_psc_exp_ps.h
@@ -83,7 +83,7 @@ Remarks:
   spike_detector has to be set to true in order to record the offsets
   in addition to the on-grid spike times.
 
-Note:
+Remarks:
   tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
   degenerate case of the ODE describing the model [1]. For very similar values,
   numerics will be unstable.

--- a/precise/poisson_generator_ps.h
+++ b/precise/poisson_generator_ps.h
@@ -48,7 +48,7 @@ Parameters:
    rate     - mean firing rate. (double, var)
    dead_time - minimal time between two spikes. (double, var)
 
-Note:
+Remarks:
    - This generator must be connected to all its targets using the
      same synapse model. Failure to do so will only be detected at
      runtime.

--- a/pynest/nest/pynest-init.sli
+++ b/pynest/nest/pynest-init.sli
@@ -29,7 +29,7 @@ Arguments: The first arg is an array containing arguments to the
 	   The second arg is SLI code that is a string containing
 	   SLI code that is executed. Anything left on the stack
 	   is stored in an array as result.
-Note: This function is for use by the python sli_func().
+Remarks: This function is for use by the python sli_func().
 SeeAlso: sli_func_litconv
  */
 /sli_func
@@ -52,7 +52,7 @@ Name: sli_func_litconv - execute sli code on array of arguments
 Synopsis: [arg1 arg2 ... argN] (function code) sli_func_litconv -> [res1 res2 ...]
 Arguments: If argn is a string and its first char is /, it is 
 	   converted to a literal before loaded onto the stack.
-Note: same as sli_func, but string args beginnig with / are converted to literals
+Remarks: same as sli_func, but string args beginnig with / are converted to literals
 SeeAlso: sli_func_litconv
  */
 /sli_func_litconv

--- a/testsuite/manualtests/ticket-737-DScallback.sli
+++ b/testsuite/manualtests/ticket-737-DScallback.sli
@@ -31,7 +31,7 @@ This tests ensures that generators relying on port information to provide target
 output via the DS-callback mechanism verify that all callback connections have a contiguous
 port range starting from 0.
 
-Note: 
+Remarks: 
 This test does not work properly until #681 is fixed, because exceptions thrown in parallel
 sections are not handled properly.
 

--- a/testsuite/mpitests/ticket-336-mpi.sli
+++ b/testsuite/mpitests/ticket-336-mpi.sli
@@ -31,7 +31,7 @@ Description:
   the same random number is generated independent of the number of MPI
   processes.
   
-Note: In response to the changes of GetStatus return values (cf #549),
+Remarks: In response to the changes of GetStatus return values (cf #549),
   this test now only checks that the first 10 RNs from its VP-RNG are
   identical independent of the number of MPI processes.
 

--- a/testsuite/mpitests/ticket-460.sli
+++ b/testsuite/mpitests/ticket-460.sli
@@ -30,7 +30,7 @@ Description:
  This test creates a network and extracts nodes, leaves and children both locally 
  and globally.
 
-Note:
+Remarks:
  This should be run with 1 and 2 MPI processes automatically.
  
 Author: Hans Ekkehard Plesser, 2010-09-24

--- a/testsuite/regressiontests/ticket-421.sli
+++ b/testsuite/regressiontests/ticket-421.sli
@@ -31,7 +31,7 @@ Description:
  checks that V_m remains constant. This is a minimal test against
  missing variable initializations, cf ticket #421.
  
-Note:
+Remarks:
    - Passing this test does not mean that all variables are properly initialized. It may just catch some cases bad cases.
    - Simulator response to initialization errors is stochastic, so if variables are not initialized properly, this test may
      fail in some runs and not in others.

--- a/testsuite/regressiontests/ticket-464.sli
+++ b/testsuite/regressiontests/ticket-464.sli
@@ -30,7 +30,7 @@ Description:
 Ensure that NEST triggers an assertion in UniversalDataLogger::record_data() instead of seg faulting
 when a frozen multimeter is connected to a node.
 
-Note:
+Remarks:
 This test has been modified (2011-02-11) to reflect the fact that NEST now protects
 multimeter against being frozen. Thus, the first test triggers an error instead of
 and assertion, and crash_or_die has been replaced by fail_or_die.

--- a/testsuite/regressiontests/ticket-903.sli
+++ b/testsuite/regressiontests/ticket-903.sli
@@ -30,7 +30,7 @@ Description:
 This test ensures that delays drawn from continuous distribution are not
 rounded up strictly.
 
-Note: This test is probabilistic, so there is a minuscule chance of it
+Remarks: This test is probabilistic, so there is a minuscule chance of it
       failing even if all is well. 
 
 Author: Hans Ekkehard Plesser

--- a/testsuite/unittests/test_cont_delay_synapse.sli
+++ b/testsuite/unittests/test_cont_delay_synapse.sli
@@ -1,0 +1,121 @@
+/*
+ *  test_cont_delay_synapse.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+ /* BeginDocumentation
+Name: testsuite::test_cont_delay_synapse - test of synapse with continuous delay
+
+Synopsis: (test_cont_delay_synapse) run -> -
+
+Description:
+
+ A minimal test for the continuous delay synapse.
+ 
+FirstVersion: June 2015
+Author: Plesser
+References:
+SeeAlso: cont_delay_synapse
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+% Case 1: Delay compatible with resolution, same result as with normal synapse expected
+{
+  ResetKernel
+  0 << /resolution 1.0 >> SetStatus
+  
+  /sg /spike_generator << /precise_times true /spike_times [ 2.0 5.5 ] >> Create def
+  /n  /iaf_psc_delta_canon Create def
+  /sd /spike_detector << /precise_times true /record_to [ /memory ] >> Create def
+  
+  sg n 100. 1.0 /cont_delay_synapse Connect
+  n sd Connect
+  
+  10 Simulate
+  
+  % expected output spike times: 3.0, 6.5
+  sd GetStatus /events/times :: cva [ 3.0 6.5 ] eq
+}
+assert_or_die
+
+
+% Case 2: Delay not compatible with resolution, set delay as default
+{
+  ResetKernel
+  0 << /resolution 1.0 >> SetStatus
+  
+  /sg /spike_generator << /precise_times true /spike_times [ 2.0 5.5 ] >> Create def
+  /n  /iaf_psc_delta_canon Create def
+  /sd /spike_detector << /precise_times true /record_to [ /memory ] >> Create def
+  
+  /cont_delay_synapse << /weight 100. /delay 1.7 >> SetDefaults
+  sg n /cont_delay_synapse Connect
+  n sd Connect
+  
+  10 Simulate
+  
+  % expected output spike times: 3.7, 7.2
+  sd GetStatus /events/times :: cva [ 3.7 7.2 ] eq
+}
+assert_or_die
+
+
+% Case 3: Delay not compatible with resolution, explicitly set delay
+{
+  ResetKernel
+  0 << /resolution 1.0 >> SetStatus
+  
+  /sg /spike_generator << /precise_times true /spike_times [ 2.0 5.5 ] >> Create def
+  /n  /iaf_psc_delta_canon Create def
+  /sd /spike_detector << /precise_times true /record_to [ /memory ] >> Create def
+  
+  sg n 100. 1.0 /cont_delay_synapse Connect
+  << /source [ sg ] /synapse_model /cont_delay_synapse >> GetConnections
+     { << /delay 1.7 >> SetStatus } 
+  forall
+
+  n sd Connect
+  
+  10 Simulate
+  
+  % expected output spike times: 3.7, 7.2
+  sd GetStatus /events/times :: cva [ 3.7 7.2 ] eq
+}
+assert_or_die
+
+
+% Case 4: Ensure NEST prohibits delays shorter than resolution
+{
+  ResetKernel
+  0 << /resolution 1.0 >> SetStatus
+  
+  /sg /spike_generator << /precise_times true /spike_times [ 2.0 5.5 ] >> Create def
+  /n  /iaf_psc_delta_canon Create def
+  
+  sg n 100. 1.0 /cont_delay_synapse Connect
+  << /source [ sg ] /synapse_model /cont_delay_synapse >> GetConnections
+     { << /delay 0.7 >> SetStatus } 
+  forall
+}
+fail_or_die

--- a/topology/topologymodule.cpp
+++ b/topology/topologymodule.cpp
@@ -1147,7 +1147,7 @@ TopologyModule::GetValue_a_PFunction::execute( SLIInterpreter* i ) const
   not as grid positions. The number of decimals can be controlled by
   calling setprecision on the output stream before calling DumpLayerNodes.
 
-  Note:
+  Remarks:
   In distributed simulations, this function should only be called for
   MPI rank 0. If you call it on several MPI ranks, you must use a
   different file name on each.
@@ -1205,7 +1205,7 @@ TopologyModule::DumpLayerNodes_os_iFunction::execute( SLIInterpreter* i ) const
   the target node. If targets do not have positions (eg spike detectors outside any layer),
   NaN is written for each displacement coordinate.
 
-  Note:
+  Remarks:
   For distributed simulations
   - this function will dump the connections with local targets only.
   - the user is responsible for writing to a different output stream (file)


### PR DESCRIPTION
Note: I mixed up two tickets, so this ended up with an incorrect branch name. This is about **trac.730**.

This pull request should fix trac.730. I mainly updated and clarified synapse model descriptions, especially wrt common synapse properties. The problems with singular and plural parameter names were a non-issue, plural was only used in the documentation of `tsodyks_synapse`, while actual parameter names were singular as everywhere else.

I also added tests for `cont_delay_synapse` and added `DS*` and `DataLoggingRequest` events, so it is now a fully-fledged static synapse and can be used to connect generators to neurons.

I also replace `Note:` with `Remarks:` in online documentation comments where necessary, so that our documentation generator sees the correct keyword.

Suggested reviewers: @abigailm