### PR TITLE
Fix formatting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,6 +109,7 @@ EOF
 
 # Extracting changed files between two commits
 file_names=`git diff --name-only $TRAVIS_COMMIT_RANGE`
+format_error_files=""
 
 for f in $file_names; do
   if [ ! -f "$f" ]; then
@@ -139,9 +140,21 @@ for f in $file_names; do
 
       # remove temporary files
       rm ${f_base}_formatted_$TRAVIS_COMMIT.txt
+
+      if [ -s ${f_base}_clang_format.txt ]; then 
+        # file exists and has size greater than zero
+        format_error_files="$format_error_files $f"
+      fi
+
       ;;
     *)
       echo "$f : not a C/CPP file. Do not do static analysis / formatting checking."
       continue
   esac
 done
+
+if [ "$format_error_files" != "" ]; then
+  echo "There are files with a formatting error: $format_error_files ."
+  exit 42
+fi
+

--- a/examples/MyModule/pif_psc_alpha.cpp
+++ b/examples/MyModule/pif_psc_alpha.cpp
@@ -60,17 +60,12 @@ RecordablesMap< mynest::pif_psc_alpha >::create()
  * ---------------------------------------------------------------- */
 
 mynest::pif_psc_alpha::Parameters_::Parameters_()
-  : C_m( 250.0 )
-  , // pF
-  I_e( 0.0 )
-  , // nA
-  tau_syn( 2.0 )
-  , // ms
-  V_th( -55.0 )
-  , // mV
-  V_reset( -70.0 )
-  ,            // mV
-  t_ref( 2.0 ) // ms
+  : C_m( 250.0 )     // pF
+  , I_e( 0.0 )       // nA
+  , tau_syn( 2.0 )   // ms
+  , V_th( -55.0 )    // mV
+  , V_reset( -70.0 ) // mV
+  , t_ref( 2.0 )     // ms
 {
 }
 

--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -36,13 +36,10 @@
  * ---------------------------------------------------------------- */
 
 nest::ac_generator::Parameters_::Parameters_()
-  : amp_( 0.0 )
-  , // pA
-  offset_( 0.0 )
-  , // pA
-  freq_( 0.0 )
-  ,               // Hz
-  phi_deg_( 0.0 ) // degree
+  : amp_( 0.0 )     // pA
+  , offset_( 0.0 )  // pA
+  , freq_( 0.0 )    // Hz
+  , phi_deg_( 0.0 ) // degree
 {
 }
 

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -120,39 +120,23 @@ nest::aeif_cond_alpha_dynamics( double, const double y[], double f[], void* pnod
  * ---------------------------------------------------------------- */
 
 nest::aeif_cond_alpha::Parameters_::Parameters_()
-  : V_peak_( 0.0 )
-  , // mV, should not be larger that V_th+10
-  V_reset_( -60.0 )
-  , // mV
-  t_ref_( 0.0 )
-  , // ms
-  g_L( 30.0 )
-  , // nS
-  C_m( 281.0 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -85.0 )
-  , // mV
-  E_L( -70.6 )
-  , // mV
-  Delta_T( 2.0 )
-  , // mV
-  tau_w( 144.0 )
-  , // ms
-  a( 4.0 )
-  , // nS
-  b( 80.5 )
-  , // pA
-  V_th( -50.4 )
-  , // mV
-  tau_syn_ex( 0.2 )
-  , // ms
-  tau_syn_in( 2.0 )
-  , // ms
-  I_e( 0.0 )
-  , // pA
-  gsl_error_tol( 1e-6 )
+  : V_peak_( 0.0 )    // mV, should not be larger that V_th+10
+  , V_reset_( -60.0 ) // mV
+  , t_ref_( 0.0 )     // ms
+  , g_L( 30.0 )       // nS
+  , C_m( 281.0 )      // pF
+  , E_ex( 0.0 )       // mV
+  , E_in( -85.0 )     // mV
+  , E_L( -70.6 )      // mV
+  , Delta_T( 2.0 )    // mV
+  , tau_w( 144.0 )    // ms
+  , a( 4.0 )          // nS
+  , b( 80.5 )         // pA
+  , V_th( -50.4 )     // mV
+  , tau_syn_ex( 0.2 ) // ms
+  , tau_syn_in( 2.0 ) // ms
+  , I_e( 0.0 )        // pA
+  , gsl_error_tol( 1e-6 )
 {
 }
 

--- a/models/aeif_cond_alpha_RK5.cpp
+++ b/models/aeif_cond_alpha_RK5.cpp
@@ -66,41 +66,24 @@ RecordablesMap< aeif_cond_alpha_RK5 >::create()
  * ---------------------------------------------------------------- */
 
 nest::aeif_cond_alpha_RK5::Parameters_::Parameters_()
-  : V_peak_( 0.0 )
-  , // mV, should not be larger that V_th+10
-  V_reset_( -60.0 )
-  , // mV
-  t_ref_( 0.0 )
-  , // ms
-  g_L( 30.0 )
-  , // nS
-  C_m( 281.0 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -85.0 )
-  , // mV
-  E_L( -70.6 )
-  , // mV
-  Delta_T( 2.0 )
-  , // mV
-  tau_w( 144.0 )
-  , // ms
-  a( 4.0 )
-  , // nS
-  b( 80.5 )
-  , // pA
-  V_th( -50.4 )
-  , // mV
-  tau_syn_ex( 0.2 )
-  , // ms
-  tau_syn_in( 2.0 )
-  , // ms
-  I_e( 0.0 )
-  , // pA
-  MAXERR( 1.0e-10 )
-  ,              // mV
-  HMIN( 1.0e-3 ) // ms
+  : V_peak_( 0.0 )    // mV, should not be larger that V_th+10
+  , V_reset_( -60.0 ) // mV
+  , t_ref_( 0.0 )     // ms
+  , g_L( 30.0 )       // nS
+  , C_m( 281.0 )      // pF
+  , E_ex( 0.0 )       // mV
+  , E_in( -85.0 )     // mV
+  , E_L( -70.6 )      // mV
+  , Delta_T( 2.0 )    // mV
+  , tau_w( 144.0 )    // ms
+  , a( 4.0 )          // nS
+  , b( 80.5 )         // pA
+  , V_th( -50.4 )     // mV
+  , tau_syn_ex( 0.2 ) // ms
+  , tau_syn_in( 2.0 ) // ms
+  , I_e( 0.0 )        // pA
+  , MAXERR( 1.0e-10 ) // mV
+  , HMIN( 1.0e-3 )    // ms
 {
 }
 

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -60,39 +60,23 @@ RecordablesMap< aeif_cond_alpha_multisynapse >::create()
  * ---------------------------------------------------------------- */
 
 aeif_cond_alpha_multisynapse::Parameters_::Parameters_()
-  : V_peak_( 0.0 )
-  , // mV, should not be larger that V_th+10
-  V_reset_( -60.0 )
-  , // mV
-  t_ref_( 0.0 )
-  , // ms
-  g_L( 30.0 )
-  , // nS
-  C_m( 281.0 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -85.0 )
-  , // mV
-  E_L( -70.6 )
-  , // mV
-  Delta_T( 2.0 )
-  , // mV
-  tau_w( 144.0 )
-  , // ms
-  a( 4.0 )
-  , // nS
-  b( 80.5 )
-  , // pA
-  V_th( -50.4 )
-  , // mV
-  I_e( 0.0 )
-  , // pA
-  MAXERR( 1.0e-10 )
-  , // mV
-  HMIN( 1.0e-3 )
-  , // ms
-  has_connections_( false )
+  : V_peak_( 0.0 )    // mV, should not be larger that V_th+10
+  , V_reset_( -60.0 ) // mV
+  , t_ref_( 0.0 )     // ms
+  , g_L( 30.0 )       // nS
+  , C_m( 281.0 )      // pF
+  , E_ex( 0.0 )       // mV
+  , E_in( -85.0 )     // mV
+  , E_L( -70.6 )      // mV
+  , Delta_T( 2.0 )    // mV
+  , tau_w( 144.0 )    // ms
+  , a( 4.0 )          // nS
+  , b( 80.5 )         // pA
+  , V_th( -50.4 )     // mV
+  , I_e( 0.0 )        // pA
+  , MAXERR( 1.0e-10 ) // mV
+  , HMIN( 1.0e-3 )    // ms
+  , has_connections_( false )
 {
   taus_syn.clear();
 }

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -121,39 +121,23 @@ nest::aeif_cond_exp_dynamics( double, const double y[], double f[], void* pnode 
  * ---------------------------------------------------------------- */
 
 nest::aeif_cond_exp::Parameters_::Parameters_()
-  : V_peak_( 0.0 )
-  , // mV
-  V_reset_( -60.0 )
-  , // mV
-  t_ref_( 0.0 )
-  , // ms
-  g_L( 30.0 )
-  , // nS
-  C_m( 281.0 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -85.0 )
-  , // mV
-  E_L( -70.6 )
-  , // mV
-  Delta_T( 2.0 )
-  , // mV
-  tau_w( 144.0 )
-  , // ms
-  a( 4.0 )
-  , // nS
-  b( 80.5 )
-  , // pA
-  V_th( -50.4 )
-  , // mV
-  tau_syn_ex( 0.2 )
-  , // ms
-  tau_syn_in( 2.0 )
-  , // ms
-  I_e( 0.0 )
-  , // pA
-  gsl_error_tol( 1e-6 )
+  : V_peak_( 0.0 )    // mV
+  , V_reset_( -60.0 ) // mV
+  , t_ref_( 0.0 )     // ms
+  , g_L( 30.0 )       // nS
+  , C_m( 281.0 )      // pF
+  , E_ex( 0.0 )       // mV
+  , E_in( -85.0 )     // mV
+  , E_L( -70.6 )      // mV
+  , Delta_T( 2.0 )    // mV
+  , tau_w( 144.0 )    // ms
+  , a( 4.0 )          // nS
+  , b( 80.5 )         // pA
+  , V_th( -50.4 )     // mV
+  , tau_syn_ex( 0.2 ) // ms
+  , tau_syn_in( 2.0 ) // ms
+  , I_e( 0.0 )        // pA
+  , gsl_error_tol( 1e-6 )
 {
 }
 

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -61,35 +61,22 @@ RecordablesMap< amat2_psc_exp >::create()
  * ---------------------------------------------------------------- */
 
 nest::amat2_psc_exp::Parameters_::Parameters_()
-  : Tau_( 10.0 )
-  , // in ms
-  C_( 200.0 )
-  , // in pF (R=50MOhm)
-  tau_ref_( 2.0 )
-  , // in ms
-  U0_( -70.0 )
-  , // in mV
-  I_e_( 0.0 )
-  , // in pA
-  tau_ex_( 1.0 )
-  , // in ms
-  tau_in_( 3.0 )
-  , // in ms
-  tau_1_( 10.0 )
-  , // in ms
-  tau_2_( 200.0 )
-  , // in ms
-  alpha_1_( 10.0 )
-  , // in mV
-  alpha_2_( 0.0 )
-  , // in mV
-  beta_( 0.0 )
-  , // in mV
-  tau_v_( 5.0 )
-  ,             // in ms
-  omega_( 5.0 ) // resting threshold relative to U0_ in mV
-                // state V_th_ is initialized with the
-                // same value
+  : Tau_( 10.0 )     // in ms
+  , C_( 200.0 )      // in pF (R=50MOhm)
+  , tau_ref_( 2.0 )  // in ms
+  , U0_( -70.0 )     // in mV
+  , I_e_( 0.0 )      // in pA
+  , tau_ex_( 1.0 )   // in ms
+  , tau_in_( 3.0 )   // in ms
+  , tau_1_( 10.0 )   // in ms
+  , tau_2_( 200.0 )  // in ms
+  , alpha_1_( 10.0 ) // in mV
+  , alpha_2_( 0.0 )  // in mV
+  , beta_( 0.0 )     // in mV
+  , tau_v_( 5.0 )    // in ms
+  , omega_( 5.0 )    // resting threshold relative to U0_ in mV
+                     // state V_th_ is initialized with the
+                     // same value
 {
 }
 
@@ -98,11 +85,9 @@ nest::amat2_psc_exp::State_::State_()
   , i_syn_ex_( 0.0 )
   , i_syn_in_( 0.0 )
   , V_m_( 0.0 )
-  , V_th_1_( 0.0 )
-  , // relative to omega_
-  V_th_2_( 0.0 )
-  , // relative to omega_
-  V_th_dv_( 0.0 )
+  , V_th_1_( 0.0 ) // relative to omega_
+  , V_th_2_( 0.0 ) // relative to omega_
+  , V_th_dv_( 0.0 )
   , V_th_v_( 0.0 )
   , r_( 0 )
 {

--- a/models/binary_neuron_impl.h
+++ b/models/binary_neuron_impl.h
@@ -59,9 +59,8 @@ binary_neuron< TGainfunction >::State_::State_()
   : y_( false )
   , h_( 0.0 )
   , last_in_gid_( 0 )
-  , t_next_( Time::neg_inf() )
-  ,                                   // mark as not initialized
-  t_last_in_spike_( Time::neg_inf() ) // mark as not intialized
+  , t_next_( Time::neg_inf() )          // mark as not initialized
+  , t_last_in_spike_( Time::neg_inf() ) // mark as not intialized
 {
 }
 

--- a/models/gamma_sup_generator.cpp
+++ b/models/gamma_sup_generator.cpp
@@ -110,9 +110,8 @@ nest::gamma_sup_generator::Internal_states_::update( double_t transition_prob,
  * ---------------------------------------------------------------- */
 
 nest::gamma_sup_generator::Parameters_::Parameters_()
-  : rate_( 0.0 )
-  , // Hz
-  gamma_shape_( 1 )
+  : rate_( 0.0 ) // Hz
+  , gamma_shape_( 1 )
   , n_proc_( 1 )
   , num_targets_( 0 )
 {

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -119,27 +119,19 @@ hh_cond_exp_traub_dynamics( double, const double y[], double f[], void* pnode )
  * ---------------------------------------------------------------- */
 
 nest::hh_cond_exp_traub::Parameters_::Parameters_()
-  : g_Na( 20000.0 )
-  , // Sodium Conductance (nS)
-  g_K( 6000.0 )
-  , // K Conductance      (nS)
-  g_L( 10.0 )
-  , // Leak Conductance   (nS)
-  C_m( 200.0 )
-  , // Membrane Capacitance (pF)
-  E_Na( 50.0 )
-  , // Reversal potentials (mV)
-  E_K( -90.0 )
+  : g_Na( 20000.0 ) // Sodium Conductance (nS)
+  , g_K( 6000.0 )   // K Conductance      (nS)
+  , g_L( 10.0 )     // Leak Conductance   (nS)
+  , C_m( 200.0 )    // Membrane Capacitance (pF)
+  , E_Na( 50.0 )    // Reversal potentials (mV)
+  , E_K( -90.0 )
   , E_L( -60.0 )
-  , V_T( -63.0 )
-  , // adjusts threshold to around -50 mV
-  E_ex( 0.0 )
+  , V_T( -63.0 ) // adjusts threshold to around -50 mV
+  , E_ex( 0.0 )
   , E_in( -80.0 )
-  , tau_synE( 5.0 )
-  , // Synaptic Time Constant Excitatory Synapse (ms)
-  tau_synI( 10.0 )
-  ,          // Synaptic Time Constant Excitatory Synapse (ms)
-  I_e( 0.0 ) // Stimulus Current (pA)
+  , tau_synE( 5.0 )  // Synaptic Time Constant Excitatory Synapse (ms)
+  , tau_synI( 10.0 ) // Synaptic Time Constant Excitatory Synapse (ms)
+  , I_e( 0.0 )       // Stimulus Current (pA)
 {
 }
 

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -120,27 +120,17 @@ hh_psc_alpha_dynamics( double, const double y[], double f[], void* pnode )
  * ---------------------------------------------------------------- */
 
 nest::hh_psc_alpha::Parameters_::Parameters_()
-  : t_ref_( 2.0 )
-  , // ms
-  g_Na( 12000.0 )
-  , // nS
-  g_K( 3600.0 )
-  , // nS
-  g_L( 30.0 )
-  , // nS
-  C_m( 100.0 )
-  , // pF
-  E_Na( 50.0 )
-  , // mV
-  E_K( -77.0 )
-  , // mV
-  E_L( -54.402 )
-  , // mV
-  tau_synE( 0.2 )
-  , // ms
-  tau_synI( 2.0 )
-  ,          // ms
-  I_e( 0.0 ) // pA
+  : t_ref_( 2.0 )   // ms
+  , g_Na( 12000.0 ) // nS
+  , g_K( 3600.0 )   // nS
+  , g_L( 30.0 )     // nS
+  , C_m( 100.0 )    // pF
+  , E_Na( 50.0 )    // mV
+  , E_K( -77.0 )    // mV
+  , E_L( -54.402 )  // mV
+  , tau_synE( 0.2 ) // ms
+  , tau_synI( 2.0 ) // ms
+  , I_e( 0.0 )      // pA
 {
 }
 

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -173,66 +173,40 @@ ht_neuron_dynamics( double, const double y[], double f[], void* pnode )
  * ---------------------------------------------------------------- */
 
 nest::ht_neuron::Parameters_::Parameters_()
-  : E_Na( 30.0 )
-  , // 30 mV
-  E_K( -90.0 )
-  , // -90 mV
-  g_NaL( 0.2 )
-  , // 0.2
-  g_KL( 1.0 )
-  , // 1.0 - 1.85
-  Tau_m( 16.0 )
-  , // ms
-  Theta_eq( -51.0 )
-  , // mV
-  Tau_theta( 2.0 )
-  , // ms
-  Tau_spike( 1.75 )
-  , // ms
-  t_spike( 2.0 )
-  , // ms
-  AMPA_g_peak( 0.1 )
-  , AMPA_Tau_1( 0.5 )
-  , // ms
-  AMPA_Tau_2( 2.4 )
-  , // ms
-  AMPA_E_rev( 0.0 )
-  , // mV
-  NMDA_g_peak( 0.075 )
-  , NMDA_Tau_1( 4.0 )
-  , // ms
-  NMDA_Tau_2( 40.0 )
-  , // ms
-  NMDA_E_rev( 0.0 )
-  , // mV
-  NMDA_Vact( -58.0 )
-  , // mV
-  NMDA_Sact( 2.5 )
-  , // mV
-  GABA_A_g_peak( 0.33 )
-  , GABA_A_Tau_1( 1.0 )
-  , // ms
-  GABA_A_Tau_2( 7.0 )
-  , // ms
-  GABA_A_E_rev( -70.0 )
-  , // mV
-  GABA_B_g_peak( 0.0132 )
-  , GABA_B_Tau_1( 60.0 )
-  , // ms
-  GABA_B_Tau_2( 200.0 )
-  , // ms
-  GABA_B_E_rev( -90.0 )
-  , // mV
-  NaP_g_peak( 1.0 )
-  , NaP_E_rev( 30.0 )
-  , // mV
-  KNa_g_peak( 1.0 )
-  , KNa_E_rev( -90.0 )
-  , // mV
-  T_g_peak( 1.0 )
-  , T_E_rev( 0.0 )
-  , // mV
-  h_g_peak( 1.0 )
+  : E_Na( 30.0 )      // 30 mV
+  , E_K( -90.0 )      // -90 mV
+  , g_NaL( 0.2 )      // 0.2
+  , g_KL( 1.0 )       // 1.0 - 1.85
+  , Tau_m( 16.0 )     // ms
+  , Theta_eq( -51.0 ) // mV
+  , Tau_theta( 2.0 )  // ms
+  , Tau_spike( 1.75 ) // ms
+  , t_spike( 2.0 )    // ms
+  , AMPA_g_peak( 0.1 )
+  , AMPA_Tau_1( 0.5 ) // ms
+  , AMPA_Tau_2( 2.4 ) // ms
+  , AMPA_E_rev( 0.0 ) // mV
+  , NMDA_g_peak( 0.075 )
+  , NMDA_Tau_1( 4.0 )  // ms
+  , NMDA_Tau_2( 40.0 ) // ms
+  , NMDA_E_rev( 0.0 )  // mV
+  , NMDA_Vact( -58.0 ) // mV
+  , NMDA_Sact( 2.5 )   // mV
+  , GABA_A_g_peak( 0.33 )
+  , GABA_A_Tau_1( 1.0 )   // ms
+  , GABA_A_Tau_2( 7.0 )   // ms
+  , GABA_A_E_rev( -70.0 ) // mV
+  , GABA_B_g_peak( 0.0132 )
+  , GABA_B_Tau_1( 60.0 )  // ms
+  , GABA_B_Tau_2( 200.0 ) // ms
+  , GABA_B_E_rev( -90.0 ) // mV
+  , NaP_g_peak( 1.0 )
+  , NaP_E_rev( 30.0 ) // mV
+  , KNa_g_peak( 1.0 )
+  , KNa_E_rev( -90.0 ) // mV
+  , T_g_peak( 1.0 )
+  , T_E_rev( 0.0 ) // mV
+  , h_g_peak( 1.0 )
   , h_E_rev( -40.0 ) // mV
 {
 }

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -56,23 +56,15 @@ RecordablesMap< iaf_chs_2007 >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_chs_2007::Parameters_::Parameters_()
-  : tau_epsp_( 8.5 )
-  , // in ms
-  tau_reset_( 15.4 )
-  , // in ms
-  E_L_( 0.0 )
-  , // normalized
-  U_th_( 1.0 )
-  , // normalized
-  U_epsp_( 0.77 )
-  , // normalized
-  U_reset_( 2.31 )
-  , // normalized
-  C_( 1.0 )
-  , // Should not be modified
-  U_noise_( 0.0 )
-  , // normalized
-  noise_()
+  : tau_epsp_( 8.5 )   // in ms
+  , tau_reset_( 15.4 ) // in ms
+  , E_L_( 0.0 )        // normalized
+  , U_th_( 1.0 )       // normalized
+  , U_epsp_( 0.77 )    // normalized
+  , U_reset_( 2.31 )   // normalized
+  , C_( 1.0 )          // Should not be modified
+  , U_noise_( 0.0 )    // normalized
+  , noise_()
 
 {
 }

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -114,35 +114,21 @@ nest::iaf_chxk_2008_dynamics( double, const double y[], double f[], void* pnode 
  * ---------------------------------------------------------------- */
 
 nest::iaf_chxk_2008::Parameters_::Parameters_()
-  :
-
-  // Default values chosen based on values found in
+  : // Default values chosen based on values found in
   // Alex Casti's simulator
-  V_th( -45.0 )
-  , // mV
-  g_L( 100.0 )
-  , // nS
-  C_m( 1000.0 )
-  , // pF
-  E_ex( 20.0 )
-  , // mV
-  E_in( -90.0 )
-  , // mV
-  E_L( -60.0 )
-  , // mV
-  tau_synE( 1.0 )
-  , // ms
-  tau_synI( 1.0 )
-  , // ms
-  I_e( 0.0 )
-  , // pA
-  tau_ahp( 0.5 )
-  , // ms
-  g_ahp( 443.8 )
-  , // nS
-  E_ahp( -95.0 )
-  , // mV
-  ahp_bug( false )
+  V_th( -45.0 )     // mV
+  , g_L( 100.0 )    // nS
+  , C_m( 1000.0 )   // pF
+  , E_ex( 20.0 )    // mV
+  , E_in( -90.0 )   // mV
+  , E_L( -60.0 )    // mV
+  , tau_synE( 1.0 ) // ms
+  , tau_synI( 1.0 ) // ms
+  , I_e( 0.0 )      // pA
+  , tau_ahp( 0.5 )  // ms
+  , g_ahp( 443.8 )  // nS
+  , E_ahp( -95.0 )  // mV
+  , ahp_bug( false )
 
 {
   recordablesMap_.create();

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -106,27 +106,17 @@ nest::iaf_cond_alpha_dynamics( double, const double y[], double f[], void* pnode
  * ---------------------------------------------------------------- */
 
 nest::iaf_cond_alpha::Parameters_::Parameters_()
-  : V_th( -55.0 )
-  , // mV
-  V_reset( -60.0 )
-  , // mV
-  t_ref( 2.0 )
-  , // ms
-  g_L( 16.6667 )
-  , // nS
-  C_m( 250.0 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -85.0 )
-  , // mV
-  E_L( -70.0 )
-  , // mV
-  tau_synE( 0.2 )
-  , // ms
-  tau_synI( 2.0 )
-  ,          // ms
-  I_e( 0.0 ) // pA
+  : V_th( -55.0 )    // mV
+  , V_reset( -60.0 ) // mV
+  , t_ref( 2.0 )     // ms
+  , g_L( 16.6667 )   // nS
+  , C_m( 250.0 )     // pF
+  , E_ex( 0.0 )      // mV
+  , E_in( -85.0 )    // mV
+  , E_L( -70.0 )     // mV
+  , tau_synE( 0.2 )  // ms
+  , tau_synI( 2.0 )  // ms
+  , I_e( 0.0 )       // pA
 {
 }
 

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -156,11 +156,9 @@ nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pn
  * ---------------------------------------------------------------- */
 
 nest::iaf_cond_alpha_mc::Parameters_::Parameters_()
-  : V_th( -55.0 )
-  , // mV
-  V_reset( -60.0 )
-  ,            // mV
-  t_ref( 2.0 ) // ms
+  : V_th( -55.0 )    // mV
+  , V_reset( -60.0 ) // mV
+  , t_ref( 2.0 )     // ms
 {
   // conductances between compartments
   g_conn[ SOMA ] = 2.5; // nS, soma-proximal

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -94,27 +94,17 @@ nest::iaf_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
  * ---------------------------------------------------------------- */
 
 nest::iaf_cond_exp::Parameters_::Parameters_()
-  : V_th_( -55.0 )
-  , // mV
-  V_reset_( -60.0 )
-  , // mV
-  t_ref_( 2.0 )
-  , // ms
-  g_L( 16.6667 )
-  , // nS
-  C_m( 250.0 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -85.0 )
-  , // mV
-  E_L( -70.0 )
-  , // mV
-  tau_synE( 0.2 )
-  , // ms
-  tau_synI( 2.0 )
-  ,          // ms
-  I_e( 0.0 ) // pA
+  : V_th_( -55.0 )    // mV
+  , V_reset_( -60.0 ) // mV
+  , t_ref_( 2.0 )     // ms
+  , g_L( 16.6667 )    // nS
+  , C_m( 250.0 )      // pF
+  , E_ex( 0.0 )       // mV
+  , E_in( -85.0 )     // mV
+  , E_L( -70.0 )      // mV
+  , tau_synE( 0.2 )   // ms
+  , tau_synI( 2.0 )   // ms
+  , I_e( 0.0 )        // pA
 {
 }
 

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -103,39 +103,23 @@ nest::iaf_cond_exp_sfa_rr_dynamics( double, const double y[], double f[], void* 
  * ---------------------------------------------------------------- */
 
 nest::iaf_cond_exp_sfa_rr::Parameters_::Parameters_()
-  : V_th_( -57.0 )
-  , // mV
-  V_reset_( -70.0 )
-  , // mV
-  t_ref_( 0.5 )
-  , // ms
-  g_L( 28.95 )
-  , // nS
-  C_m( 289.5 )
-  , // pF
-  E_ex( 0.0 )
-  , // mV
-  E_in( -75.0 )
-  , // mV
-  E_L( -70.0 )
-  , // mV
-  tau_synE( 1.5 )
-  , // ms
-  tau_synI( 10.0 )
-  , // ms
-  I_e( 0.0 )
-  , // pA
-  tau_sfa( 110.0 )
-  , // ms
-  tau_rr( 1.97 )
-  , // ms
-  E_sfa( -70.0 )
-  , // mV
-  E_rr( -70.0 )
-  , // mV
-  q_sfa( 14.48 )
-  ,              // nS
-  q_rr( 3214.0 ) // nS
+  : V_th_( -57.0 )    // mV
+  , V_reset_( -70.0 ) // mV
+  , t_ref_( 0.5 )     // ms
+  , g_L( 28.95 )      // nS
+  , C_m( 289.5 )      // pF
+  , E_ex( 0.0 )       // mV
+  , E_in( -75.0 )     // mV
+  , E_L( -70.0 )      // mV
+  , tau_synE( 1.5 )   // ms
+  , tau_synI( 10.0 )  // ms
+  , I_e( 0.0 )        // pA
+  , tau_sfa( 110.0 )  // ms
+  , tau_rr( 1.97 )    // ms
+  , E_sfa( -70.0 )    // mV
+  , E_rr( -70.0 )     // mV
+  , q_sfa( 14.48 )    // nS
+  , q_rr( 3214.0 )    // nS
 {
 }
 

--- a/models/iaf_neuron.cpp
+++ b/models/iaf_neuron.cpp
@@ -56,21 +56,14 @@ RecordablesMap< iaf_neuron >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_neuron::Parameters_::Parameters_()
-  : C_( 250.0 )
-  , // pF
-  Tau_( 10.0 )
-  , // ms
-  tau_syn_( 2.0 )
-  , // ms
-  TauR_( 2.0 )
-  , // ms
-  U0_( -70.0 )
-  , // mV
-  V_reset_( -70.0 - U0_ )
-  , // mV, rel to U0_
-  Theta_( -55.0 - U0_ )
-  ,           // mV, rel to U0_
-  I_e_( 0.0 ) // pA
+  : C_( 250.0 )             // pF
+  , Tau_( 10.0 )            // ms
+  , tau_syn_( 2.0 )         // ms
+  , TauR_( 2.0 )            // ms
+  , U0_( -70.0 )            // mV
+  , V_reset_( -70.0 - U0_ ) // mV, rel to U0_
+  , Theta_( -55.0 - U0_ )   // mV, rel to U0_
+  , I_e_( 0.0 )             // pA
 {
 }
 

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -58,24 +58,16 @@ RecordablesMap< iaf_psc_alpha >::create()
  * ---------------------------------------------------------------- */
 
 iaf_psc_alpha::Parameters_::Parameters_()
-  : Tau_( 10.0 )
-  , // ms
-  C_( 250.0 )
-  , // pF
-  TauR_( 2.0 )
-  , // ms
-  U0_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  V_reset_( -70.0 - U0_ )
-  , // mV, rel to U0_
-  Theta_( -55.0 - U0_ )
-  , // mV, rel to U0_
-  LowerBound_( -std::numeric_limits< double_t >::infinity() )
-  , tau_ex_( 2.0 )
-  ,              // ms
-  tau_in_( 2.0 ) // ms
+  : Tau_( 10.0 )            // ms
+  , C_( 250.0 )             // pF
+  , TauR_( 2.0 )            // ms
+  , U0_( -70.0 )            // mV
+  , I_e_( 0.0 )             // pA
+  , V_reset_( -70.0 - U0_ ) // mV, rel to U0_
+  , Theta_( -55.0 - U0_ )   // mV, rel to U0_
+  , LowerBound_( -std::numeric_limits< double_t >::infinity() )
+  , tau_ex_( 2.0 ) // ms
+  , tau_in_( 2.0 ) // ms
 {
 }
 

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -58,21 +58,14 @@ RecordablesMap< iaf_psc_alpha_multisynapse >::create()
  * ---------------------------------------------------------------- */
 
 iaf_psc_alpha_multisynapse::Parameters_::Parameters_()
-  : Tau_( 10.0 )
-  , // ms
-  C_( 250.0 )
-  , // pF
-  TauR_( 2.0 )
-  , // ms
-  U0_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  V_reset_( -70.0 - U0_ )
-  , // mV, rel to U0_
-  Theta_( -55.0 - U0_ )
-  , // mV, rel to U0_
-  LowerBound_( -std::numeric_limits< double_t >::infinity() )
+  : Tau_( 10.0 )            // ms
+  , C_( 250.0 )             // pF
+  , TauR_( 2.0 )            // ms
+  , U0_( -70.0 )            // mV
+  , I_e_( 0.0 )             // pA
+  , V_reset_( -70.0 - U0_ ) // mV, rel to U0_
+  , Theta_( -55.0 - U0_ )   // mV, rel to U0_
+  , LowerBound_( -std::numeric_limits< double_t >::infinity() )
   , has_connections_( false )
 {
   tau_syn_.clear();

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -57,22 +57,14 @@ RecordablesMap< iaf_psc_delta >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_delta::Parameters_::Parameters_()
-  : tau_m_( 10.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  t_ref_( 2.0 )
-  , // ms
-  E_L_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  V_th_( -55.0 - E_L_ )
-  , // mV, rel to U0_
-  V_min_( -std::numeric_limits< double_t >::max() )
-  ,
-  // relative U0_-55.0-U0_),  // mV, rel to U0_
-  V_reset_( -70.0 - E_L_ )
+  : tau_m_( 10.0 )                                    // ms
+  , c_m_( 250.0 )                                     // pF
+  , t_ref_( 2.0 )                                     // ms
+  , E_L_( -70.0 )                                     // mV
+  , I_e_( 0.0 )                                       // pA
+  , V_th_( -55.0 - E_L_ )                             // mV, rel to U0_
+  , V_min_( -std::numeric_limits< double_t >::max() ) // relative U0_-55.0-U0_
+  , V_reset_( -70.0 - E_L_ )                          // mV, rel to U0_
   , with_refr_input_( false )
 {
 }

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -60,23 +60,15 @@ RecordablesMap< iaf_psc_exp >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_exp::Parameters_::Parameters_()
-  : Tau_( 10.0 )
-  , // in ms
-  C_( 250.0 )
-  , // in pF
-  t_ref_( 2.0 )
-  , // in ms
-  U0_( -70.0 )
-  , // in mV
-  I_e_( 0.0 )
-  , // in pA
-  Theta_( -55.0 - U0_ )
-  , // relative U0_
-  V_reset_( -70.0 - U0_ )
-  , // in mV
-  tau_ex_( 2.0 )
-  ,              // in ms
-  tau_in_( 2.0 ) // in ms
+  : Tau_( 10.0 )            // in ms
+  , C_( 250.0 )             // in pF
+  , t_ref_( 2.0 )           // in ms
+  , U0_( -70.0 )            // in mV
+  , I_e_( 0.0 )             // in pA
+  , Theta_( -55.0 - U0_ )   // relative U0_
+  , V_reset_( -70.0 - U0_ ) // in mV
+  , tau_ex_( 2.0 )          // in ms
+  , tau_in_( 2.0 )          // in ms
 {
 }
 

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -57,21 +57,14 @@ RecordablesMap< iaf_psc_exp_multisynapse >::create()
  * ---------------------------------------------------------------- */
 
 iaf_psc_exp_multisynapse::Parameters_::Parameters_()
-  : Tau_( 10.0 )
-  , // in ms
-  C_( 250.0 )
-  , // in pF
-  t_ref_( 2.0 )
-  , // in ms
-  U0_( -70.0 )
-  , // in mV
-  I_e_( 0.0 )
-  , // in pA
-  V_reset_( -70.0 - U0_ )
-  , // in mV
-  Theta_( -55.0 - U0_ )
-  , // relative U0_
-  has_connections_( false )
+  : Tau_( 10.0 )            // in ms
+  , C_( 250.0 )             // in pF
+  , t_ref_( 2.0 )           // in ms
+  , U0_( -70.0 )            // in mV
+  , I_e_( 0.0 )             // in pA
+  , V_reset_( -70.0 - U0_ ) // in mV
+  , Theta_( -55.0 - U0_ )   // relative U0_
+  , has_connections_( false )
 {
   tau_syn_.clear();
 }

--- a/models/iaf_tum_2000.cpp
+++ b/models/iaf_tum_2000.cpp
@@ -58,25 +58,16 @@ RecordablesMap< iaf_tum_2000 >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_tum_2000::Parameters_::Parameters_()
-  : Tau_( 10.0 )
-  , // in ms
-  C_( 250.0 )
-  , // in pF
-  tau_ref_tot_( 2.0 )
-  , // in ms
-  tau_ref_abs_( 2.0 )
-  , // in ms
-  U0_( -70.0 )
-  , // in mV
-  I_e_( 0.0 )
-  , // in pA
-  Theta_( -55.0 - U0_ )
-  , // relative U0_
-  V_reset_( -70.0 - U0_ )
-  , // in mV
-  tau_ex_( 2.0 )
-  ,              // in ms
-  tau_in_( 2.0 ) // in ms
+  : Tau_( 10.0 )            // in ms
+  , C_( 250.0 )             // in pF
+  , tau_ref_tot_( 2.0 )     // in ms
+  , tau_ref_abs_( 2.0 )     // in ms
+  , U0_( -70.0 )            // in mV
+  , I_e_( 0.0 )             // in pA
+  , Theta_( -55.0 - U0_ )   // relative U0_
+  , V_reset_( -70.0 - U0_ ) // in mV
+  , tau_ex_( 2.0 )          // in ms
+  , tau_in_( 2.0 )          // in ms
 {
 }
 

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -57,30 +57,21 @@ RecordablesMap< izhikevich >::create()
  * ---------------------------------------------------------------- */
 
 nest::izhikevich::Parameters_::Parameters_()
-  : a_( 0.02 )
-  , // a
-  b_( 0.2 )
-  , // b
-  c_( -65.0 )
-  , // c without unit
-  d_( 8.0 )
-  , // d
-  I_e_( 0.0 )
-  , // pA
-  V_th_( 30.0 )
-  , // mV
-  V_min_( -std::numeric_limits< double_t >::max() )
-  , // mV
-  consistent_integration_( true )
+  : a_( 0.02 )                                        // a
+  , b_( 0.2 )                                         // b
+  , c_( -65.0 )                                       // c without unit
+  , d_( 8.0 )                                         // d
+  , I_e_( 0.0 )                                       // pA
+  , V_th_( 30.0 )                                     // mV
+  , V_min_( -std::numeric_limits< double_t >::max() ) // mV
+  , consistent_integration_( true )
 {
 }
 
 nest::izhikevich::State_::State_()
-  : v_( -65.0 )
-  , // membrane potential
-  u_( 0.0 )
-  ,         // membrane recovery variable
-  I_( 0.0 ) // input current
+  : v_( -65.0 ) // membrane potential
+  , u_( 0.0 )   // membrane recovery variable
+  , I_( 0.0 )   // input current
 {
 }
 

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -60,31 +60,20 @@ RecordablesMap< mat2_psc_exp >::create()
  * ---------------------------------------------------------------- */
 
 nest::mat2_psc_exp::Parameters_::Parameters_()
-  : Tau_( 5.0 )
-  , // in ms
-  C_( 100.0 )
-  , // in pF
-  tau_ref_( 2.0 )
-  , // in ms
-  U0_( -70.0 )
-  , // in mV
-  I_e_( 0.0 )
-  , // in pA
-  tau_ex_( 1.0 )
-  , // in ms
-  tau_in_( 3.0 )
-  , // in ms
-  tau_1_( 10.0 )
-  , // in ms
-  tau_2_( 200.0 )
-  , // in ms
-  alpha_1_( 37.0 )
-  , // in mV
-  alpha_2_( 2.0 )
-  ,              // in mV
-  omega_( 19.0 ) // resting threshold relative to U0_ in mV
-                 // state V_th_ is initialized with the
-                 // same value
+  : Tau_( 5.0 )      // in ms
+  , C_( 100.0 )      // in pF
+  , tau_ref_( 2.0 )  // in ms
+  , U0_( -70.0 )     // in mV
+  , I_e_( 0.0 )      // in pA
+  , tau_ex_( 1.0 )   // in ms
+  , tau_in_( 3.0 )   // in ms
+  , tau_1_( 10.0 )   // in ms
+  , tau_2_( 200.0 )  // in ms
+  , alpha_1_( 37.0 ) // in mV
+  , alpha_2_( 2.0 )  // in mV
+  , omega_( 19.0 )   // resting threshold relative to U0_ in mV
+                     // state V_th_ is initialized with the
+                     // same value
 {
 }
 
@@ -93,11 +82,9 @@ nest::mat2_psc_exp::State_::State_()
   , i_syn_ex_( 0.0 )
   , i_syn_in_( 0.0 )
   , V_m_( 0.0 )
-  , V_th_1_( 0.0 )
-  , // relative to omega_
-  V_th_2_( 0.0 )
-  , // relative to omega_
-  r_( 0 )
+  , V_th_1_( 0.0 ) // relative to omega_
+  , V_th_2_( 0.0 ) // relative to omega_
+  , r_( 0 )
 {
 }
 

--- a/models/mip_generator.cpp
+++ b/models/mip_generator.cpp
@@ -33,9 +33,8 @@
  * ---------------------------------------------------------------- */
 
 nest::mip_generator::Parameters_::Parameters_()
-  : rate_( 0.0 )
-  , // Hz
-  p_copy_( 1.0 )
+  : rate_( 0.0 ) // Hz
+  , p_copy_( 1.0 )
   , mother_seed_( 0 )
 {
   rng_ = librandom::RandomGen::create_knuthlfg_rng( mother_seed_ );

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -33,17 +33,12 @@
  * ---------------------------------------------------------------- */
 
 nest::noise_generator::Parameters_::Parameters_()
-  : mean_( 0.0 )
-  , // pA
-  std_( 0.0 )
-  , // pA / sqrt(s)
-  std_mod_( 0.0 )
-  , // pA / sqrt(s)
-  freq_( 0.0 )
-  , // Hz
-  phi_deg_( 0.0 )
-  , // degree
-  dt_( Time::ms( 1.0 ) )
+  : mean_( 0.0 )    // pA
+  , std_( 0.0 )     // pA / sqrt(s)
+  , std_mod_( 0.0 ) // pA / sqrt(s)
+  , freq_( 0.0 )    // Hz
+  , phi_deg_( 0.0 ) // degree
+  , dt_( Time::ms( 1.0 ) )
   , num_targets_( 0 )
 {
 }

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -64,15 +64,11 @@ RecordablesMap< pp_pop_psc_delta >::create()
 
 nest::pp_pop_psc_delta::Parameters_::Parameters_()
   : N_( 100 )
-  , tau_m_( 10.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  rho_0_( 10.0 )
-  , // 1/s
-  delta_u_( 1.0 )
-  , // mV
-  len_kernel_( 5.0 )
+  , tau_m_( 10.0 )  // ms
+  , c_m_( 250.0 )   // pF
+  , rho_0_( 10.0 )  // 1/s
+  , delta_u_( 1.0 ) // mV
+  , len_kernel_( 5.0 )
   , I_e_( 0.0 ) // pA
 {
   taus_eta_.push_back( 10.0 );

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -65,29 +65,20 @@ RecordablesMap< pp_psc_delta >::create()
  * ---------------------------------------------------------------- */
 
 nest::pp_psc_delta::Parameters_::Parameters_()
-  : tau_m_( 10.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  dead_time_( 1.0 )
-  , // ms
-  dead_time_random_( 0 )
+  : tau_m_( 10.0 )    // ms
+  , c_m_( 250.0 )     // pF
+  , dead_time_( 1.0 ) // ms
+  , dead_time_random_( 0 )
   , dead_time_shape_( 1 )
   , with_reset_( 1 )
-  , tau_sfa_( 34.0 )
-  , // ms
-  q_sfa_( 0.0 )
-  , // mV, reasonable default is 7 mV [2]
-  multi_param_( 1 )
-  , c_1_( 0.0 )
-  , // Hz / mV
-  c_2_( 1.238 )
-  , // Hz / mV
-  c_3_( 0.25 )
-  , // 1.0 / mV
-  I_e_( 0.0 )
-  ,                       // pA
-  t_ref_remaining_( 0.0 ) // ms
+  , tau_sfa_( 34.0 ) // ms
+  , q_sfa_( 0.0 )    // mV, reasonable default is 7 mV [2]
+  , multi_param_( 1 )
+  , c_1_( 0.0 )             // Hz / mV
+  , c_2_( 1.238 )           // Hz / mV
+  , c_3_( 0.25 )            // 1.0 / mV
+  , I_e_( 0.0 )             // pA
+  , t_ref_remaining_( 0.0 ) // ms
 {
   tau_sfa_.clear();
   q_sfa_.clear();

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -98,16 +98,12 @@ nest::ppd_sup_generator::Age_distribution_::update( double_t hazard_step, libran
  * ---------------------------------------------------------------- */
 
 nest::ppd_sup_generator::Parameters_::Parameters_()
-  : rate_( 0.0 )
-  , // Hz
-  dead_time_( 0.0 )
-  , // ms
-  n_proc_( 1 )
-  , frequency_( 0.0 )
-  , // Hz
-  amplitude_( 0.0 )
-  , // percentage
-  num_targets_( 0 )
+  : rate_( 0.0 )      // Hz
+  , dead_time_( 0.0 ) // ms
+  , n_proc_( 1 )
+  , frequency_( 0.0 ) // Hz
+  , amplitude_( 0.0 ) // percentage
+  , num_targets_( 0 )
 {
 }
 

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -53,16 +53,12 @@ RecordablesMap< sinusoidal_gamma_generator >::create()
 
 
 nest::sinusoidal_gamma_generator::Parameters_::Parameters_()
-  : om_( 0.0 )
-  , // radian/s
-  phi_( 0.0 )
-  , // radian
-  order_( 1.0 )
-  , dc_( 0.0 )
-  , // spikes/s
-  ac_( 0.0 )
-  , // spikes/s
-  individual_spike_trains_( true )
+  : om_( 0.0 )  // radian/s
+  , phi_( 0.0 ) // radian
+  , order_( 1.0 )
+  , dc_( 0.0 ) // spikes/s
+  , ac_( 0.0 ) // spikes/s
+  , individual_spike_trains_( true )
   , num_trains_( 0 )
 {
 }

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -51,15 +51,11 @@ RecordablesMap< sinusoidal_poisson_generator >::create()
  * ---------------------------------------------------------------- */
 
 nest::sinusoidal_poisson_generator::Parameters_::Parameters_()
-  : om_( 0.0 )
-  , // radian/s
-  phi_( 0.0 )
-  , // radian
-  dc_( 0.0 )
-  , // spikes/s
-  ac_( 0.0 )
-  , // spikes/s
-  individual_spike_trains_( true )
+  : om_( 0.0 )  // radian/s
+  , phi_( 0.0 ) // radian
+  , dc_( 0.0 )  // spikes/s
+  , ac_( 0.0 )  // spikes/s
+  , individual_spike_trains_( true )
 {
 }
 

--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -33,9 +33,8 @@
 
 nest::spike_detector::spike_detector()
   : Node()
-  , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true )
-  , // record time and gid
-  user_set_precise_times_( false )
+  , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true ) // record time and gid
+  , user_set_precise_times_( false )
   , has_proxies_( false )
   , local_receiver_( true )
 {

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -33,9 +33,13 @@
 
 nest::spin_detector::spin_detector()
   : Node()
-  , device_( *this, RecordingDevice::SPIN_DETECTOR, "gdf", true, true, true )
-  , // record time, gid and weight (used for spin)
-  last_in_gid_( 0 )
+  , device_( *this,
+      RecordingDevice::SPIN_DETECTOR,
+      "gdf",
+      true,
+      true,
+      true ) // record time, gid and weight (used for spin)
+  , last_in_gid_( 0 )
   , t_last_in_spike_( Time::neg_inf() )
   , user_set_precise_times_( false )
 {
@@ -45,9 +49,8 @@ nest::spin_detector::spin_detector( const spin_detector& n )
   : Node( n )
   , device_( *this, n.device_ )
   , last_in_gid_( 0 )
-  , t_last_in_spike_( Time::neg_inf() )
-  , // mark as not initialized
-  user_set_precise_times_( n.user_set_precise_times_ )
+  , t_last_in_spike_( Time::neg_inf() ) // mark as not initialized
+  , user_set_precise_times_( n.user_set_precise_times_ )
 {
 }
 

--- a/models/stdp_connection_facetshw_hom_impl.h
+++ b/models/stdp_connection_facetshw_hom_impl.h
@@ -36,20 +36,13 @@ namespace nest
 template < typename targetidentifierT >
 STDPFACETSHWHomCommonProperties< targetidentifierT >::STDPFACETSHWHomCommonProperties()
   : CommonSynapseProperties()
-  ,
-
-  tau_plus_( 20.0 )
+  , tau_plus_( 20.0 )
   , tau_minus_( 20.0 )
-  ,
-
-  Wmax_( 100.0 )
-  ,
-
-  no_synapses_( 0 )
-  , synapses_per_driver_( 50 )
-  , // hardware efficiency of 50/256=20%,
-  // which is comparable to Fieres et al. (2008)
-  driver_readout_time_( 15.0 ) // in ms; measured on hardware
+  , Wmax_( 100.0 )
+  , no_synapses_( 0 )
+  , synapses_per_driver_( 50 )   // hardware efficiency of 50/256=20%,
+                                 // which is comparable to Fieres et al. (2008)
+  , driver_readout_time_( 15.0 ) // in ms; measured on hardware
 
 {
   lookuptable_0_.resize( 16 );

--- a/models/step_current_generator.cpp
+++ b/models/step_current_generator.cpp
@@ -32,9 +32,8 @@
  * ---------------------------------------------------------------- */
 
 nest::step_current_generator::Parameters_::Parameters_()
-  : amp_times_()
-  ,             // ms
-  amp_values_() // pA
+  : amp_times_()  // ms
+  , amp_values_() // pA
 {
 }
 

--- a/nestkernel/communicator.cpp
+++ b/nestkernel/communicator.cpp
@@ -376,7 +376,7 @@ nest::Communicator::communicate( std::vector< OffGridSpike >& send_buffer,
     }
     recv_buffer.swap( send_buffer );
   }
-  else 
+  else
   {
     communicate_Allgather( send_buffer, recv_buffer, displacements );
   }

--- a/nestkernel/communicator.h
+++ b/nestkernel/communicator.h
@@ -80,7 +80,7 @@ public:
   {
   public:
     //! We defined this type explicitly, so that the assert function below always tests the correct
-    //type.
+    //! type.
     typedef uint_t gid_external_type;
 
     OffGridSpike()
@@ -294,7 +294,6 @@ private:
     std::vector< T >& recv_buffer,
     std::vector< int >& displacements );
 };
-
 }
 
 #else  /* #ifdef HAVE_MPI */

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -175,9 +175,9 @@ public:
 private:
   std::vector< ConnectorModel* > pristine_prototypes_; //!< The list of clean synapse prototypes
   std::vector< std::vector< ConnectorModel* > > prototypes_; //!< The list of available synapse
-                                                             //prototypes: first dimenasion one
-                                                             //entry per thread, second dimantion
-                                                             //for each synapse type
+                                                             //!< prototypes: first dimenasion one
+                                                             //!< entry per thread, second dimantion
+                                                             //!< for each synapse type
 
   Network& net_;            //!< The reference to the network
   Dictionary* synapsedict_; //!< The synapsedict (owned by the network)

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -38,11 +38,10 @@
 namespace nest
 {
 Event::Event()
-  : sender_gid_( 0 )
-  , // initializing to 0 as this is an unsigned type
-    // gid 0 is network, can never send an event, so
-    // this is safe
-  sender_( NULL )
+  : sender_gid_( 0 ) // initializing to 0 as this is an unsigned type
+                     // gid 0 is network, can never send an event, so
+                     // this is safe
+  , sender_( NULL )
   , receiver_( NULL )
   , p_( -1 )
   , rp_( 0 )

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -84,19 +84,19 @@ extern const Name D_lower;
 extern const Name D_mean;
 extern const Name D_std;
 extern const Name D_upper;
-extern const Name dc;        //!< Specific to sinusoidally modulated generators
-extern const Name dead_time; //!< Specific to ppd_sup_generator and gamma_sup_generator
-extern const Name
-  dead_time_random; //!< Random dead time or fixed dead time (stochastic neuron pp_psc_delta)
-extern const Name dead_time_shape; //!< Shape parameter of the dead time distribution (stochastic
-// neuron pp_psc_delta)
-extern const Name delay;     //!< Connection parameters
-extern const Name delays;    //!< Connection parameters
-extern const Name Delta_T;   //!< Specific to Brette & Gerstner 2005 (aeif_cond-*)
-extern const Name delta_tau; //!< Specific to correlation_and correlomatrix detector
-extern const Name delta_u;   //!< Specific to population point process model (pp_pop_psc_delta)
-extern const Name dg_ex;     //!< Derivative of the excitatory conductance
-extern const Name dg_in;     //!< Derivative of the inhibitory conductance
+extern const Name dc;               //!< Specific to sinusoidally modulated generators
+extern const Name dead_time;        //!< Specific to ppd_sup_generator and gamma_sup_generator
+extern const Name dead_time_random; //!< Random dead time or fixed dead time
+                                    //!< (stochastic neuron pp_psc_delta)
+extern const Name dead_time_shape;  //!< Shape parameter of the dead time distribution (stochastic
+                                    //!< neuron pp_psc_delta)
+extern const Name delay;            //!< Connection parameters
+extern const Name delays;           //!< Connection parameters
+extern const Name Delta_T;          //!< Specific to Brette & Gerstner 2005 (aeif_cond-*)
+extern const Name delta_tau;        //!< Specific to correlation_and correlomatrix detector
+extern const Name delta_u; //!< Specific to population point process model (pp_pop_psc_delta)
+extern const Name dg_ex;   //!< Derivative of the excitatory conductance
+extern const Name dg_in;   //!< Derivative of the inhibitory conductance
 extern const Name dhaene_det_spikes;   //!< used for iaflossless_count_exp
 extern const Name dhaene_max_geq_V_th; //!< used for iaflossless_count_exp
 extern const Name dhaene_quick1;       //!< used for iaflossless_count_exp
@@ -104,10 +104,10 @@ extern const Name dhaene_quick2;       //!< used for iaflossless_count_exp
 extern const Name dhaene_tmax_lt_t1;   //!< used for iaflossless_count_exp
 extern const Name distribution;        //!< Connectivity-related
 extern const Name dt;                  //!< Miscellaneous parameters
-extern const Name dU; //!< Unit increment of the utilization for a facilitating synapse [0...1]
-                      //(Tsodyks2_connection)
-extern const Name
-  dUs; //!< Unit increment of the utilization for a facilitating synapse [0...1] (property arrays)
+extern const Name dU;  //!< Unit increment of the utilization for a facilitating synapse [0...1]
+                       //!< (Tsodyks2_connection)
+extern const Name dUs; //!< Unit increment of the utilization for a facilitating synapse [0...1]
+                       //!< (property arrays)
 
 extern const Name E_ahp;        //!< Specific to iaf_chxk_2008 neuron
 extern const Name E_ex;         //!< Excitatory reversal potential
@@ -158,13 +158,13 @@ extern const Name gamma_shape;   //!< Specific to ppd_sup_generator and gamma_su
 extern const Name global_id;     //!< Node parameter
 extern const Name gsl_error_tol; //!< GSL integrator tolerance
 
-extern const Name h; //!< Summed input to a neuron (Ginzburg neuron)
-extern const Name
-  has_connections; //!< Specific to iaf_psc_exp_multisynapse and iaf_psc_alpha_multisynapse
+extern const Name h;                    //!< Summed input to a neuron (Ginzburg neuron)
+extern const Name has_connections;      //!< Specific to iaf_psc_exp_multisynapse and
+                                        //!< iaf_psc_alpha_multisynapse
 extern const Name histogram;            //!< Specific to correlation_detector
 extern const Name histogram_correction; //!< Specific to correlation_detector
-extern const Name
-  HMIN; //!< Smallest integration step for adaptive stepsize (Brette & Gerstner 2005)
+extern const Name HMIN;                 //!< Smallest integration step for adaptive stepsize
+                                        //!< (Brette & Gerstner 2005)
 
 extern const Name I;         //!< Specific to mirollo_strogatz_ps
 extern const Name I_adapt;   //!< Goal of current homeostasis (current homeostasis)
@@ -188,15 +188,16 @@ extern const Name Interpol_Order;          //!< Interpolation order (precise tim
 extern const Name interval;                //!< Recorder parameter
 extern const Name is_refractory;           //!< Neuron is in refractory period (debugging)
 
-extern const Name label;      //!< Miscellaneous parameters
-extern const Name len_kernel; //!< Specific to population point process model (pp_pop_psc_delta)
+extern const Name label;             //!< Miscellaneous parameters
+extern const Name len_kernel;        //!< Specific to population point process model
+                                     //!< (pp_pop_psc_delta)
 extern const Name lin_left_geq_V_th; //!< used for iaflossless_count_exp
 extern const Name lin_max_geq_V_th;  //!< used for iaflossless_count_exp
 extern const Name local;             //!< Node parameter
 extern const Name local_id;          //!< Node
 
-extern const Name
-  MAXERR; //!< Largest permissible error for adaptive stepsize (Brette & Gerstner 2005)
+extern const Name MAXERR;        //!< Largest permissible error for adaptive stepsize
+                                 //!< (Brette & Gerstner 2005)
 extern const Name mean;          //!< Miscellaneous parameters
 extern const Name memory;        //!< Recorder parameter
 extern const Name model;         //!< Node parameter
@@ -242,23 +243,24 @@ extern const Name published;          //!< Parameters for MUSIC devices
 extern const Name q_rr;  //!< Other adaptation
 extern const Name q_sfa; //!< Other adaptation
 
-extern const Name rate;             //!< Specific to ppd_sup_generator and gamma_sup_generator
-extern const Name receptor_type;    //!< Connection parameters
-extern const Name receptor_types;   //!< Connection parameters
-extern const Name record_from;      //!< Recorder parameter
-extern const Name record_to;        //!< Recorder parameter
-extern const Name recordables;      //!< List of recordable state data (Device parameters)
-extern const Name recorder;         //!< Node type
-extern const Name refractory_input; //!< Spikes arriving during refractory period are counted
-                                    //(precise timing neurons)
-extern const Name registered;       //!< Parameters for MUSIC devices
-extern const Name rho_0; //!< Specific to population point process model (pp_pop_psc_delta)
-extern const Name rms;   //!< Root mean square
+extern const Name rate;                 //!< Specific to ppd_sup_generator and gamma_sup_generator
+extern const Name receptor_type;        //!< Connection parameters
+extern const Name receptor_types;       //!< Connection parameters
+extern const Name record_from;          //!< Recorder parameter
+extern const Name record_to;            //!< Recorder parameter
+extern const Name recordables;          //!< List of recordable state data (Device parameters)
+extern const Name recorder;             //!< Node type
+extern const Name refractory_input;     //!< Spikes arriving during refractory period are counted
+                                        //!< (precise timing neurons)
+extern const Name registered;           //!< Parameters for MUSIC devices
+extern const Name rho_0;                //!< Specific to population point process model
+                                        //!< (pp_pop_psc_delta)
+extern const Name rms;                  //!< Root mean square
 extern const Name root_finding_epsilon; //!< Accuracy of the root of the polynomial (precise timing
-// neurons (Brette 2007))
-extern const Name rport;  //!< Connection parameters
-extern const Name rports; //!< Connection parameters
-extern const Name rule;   //!< Connectivity-related
+                                        //!< neurons (Brette 2007))
+extern const Name rport;                //!< Connection parameters
+extern const Name rports;               //!< Connection parameters
+extern const Name rule;                 //!< Connectivity-related
 
 extern const Name S;           //!< Binary state (output) of neuron (Ginzburg neuron)
 extern const Name scientific;  //!< Recorder parameter
@@ -280,24 +282,24 @@ extern const Name synapse;         //!< Node type
 extern const Name synapse_model;   //!< Connection parameters
 extern const Name synapse_modelid; //!< Connection parameters
 
-extern const Name t_lag;           //!< Lag within a time slice
-extern const Name t_origin;        //!< Origin of a time-slice
-extern const Name t_ref;           //!< Refractory period
-extern const Name t_ref_abs;       //!< Absolute refractory period
-extern const Name t_ref_remaining; //!< Time remaining till end of refractory state
-extern const Name t_ref_tot;       //!< Total refractory period
-extern const Name t_spike;         //!< Time of last spike
-extern const Name target;          //!< Connection parameters
-extern const Name target_thread;   //!< Connection parameters
-extern const Name targets;         //!< Connection parameters
-extern const Name tau_1;           //!< Specific to Kobayashi, Tsubo, Shinomoto 2009
-extern const Name tau_2;           //!< Specific to Kobayashi, Tsubo, Shinomoto 2009
-extern const Name tau_ahp;         //!< Specific to iaf_chxk_2008 neuron
-extern const Name tau_epsp;        //!< Specific to iaf_chs_2008 neuron
-extern const Name tau_fac;         //!< facilitation time constant (ms) (Tsodyks2_connection)
-extern const Name tau_facs;        //!< facilitation time constant (ms) (property arrays)
-extern const Name tau_lcm; //!< Least common multiple of tau_m, tau_ex and tau_in (precise timing
-// neurons (Brette 2007))
+extern const Name t_lag;             //!< Lag within a time slice
+extern const Name t_origin;          //!< Origin of a time-slice
+extern const Name t_ref;             //!< Refractory period
+extern const Name t_ref_abs;         //!< Absolute refractory period
+extern const Name t_ref_remaining;   //!< Time remaining till end of refractory state
+extern const Name t_ref_tot;         //!< Total refractory period
+extern const Name t_spike;           //!< Time of last spike
+extern const Name target;            //!< Connection parameters
+extern const Name target_thread;     //!< Connection parameters
+extern const Name targets;           //!< Connection parameters
+extern const Name tau_1;             //!< Specific to Kobayashi, Tsubo, Shinomoto 2009
+extern const Name tau_2;             //!< Specific to Kobayashi, Tsubo, Shinomoto 2009
+extern const Name tau_ahp;           //!< Specific to iaf_chxk_2008 neuron
+extern const Name tau_epsp;          //!< Specific to iaf_chs_2008 neuron
+extern const Name tau_fac;           //!< facilitation time constant (ms) (Tsodyks2_connection)
+extern const Name tau_facs;          //!< facilitation time constant (ms) (property arrays)
+extern const Name tau_lcm;           //!< Least common multiple of tau_m, tau_ex and tau_in
+                                     //!< (precise timing neurons (Brette 2007))
 extern const Name tau_m;             //!< Membrane time constant
 extern const Name tau_max;           //!< Specific to correlation_and correlomatrix detector
 extern const Name tau_minus;         //!< used for ArchivingNode
@@ -312,19 +314,20 @@ extern const Name tau_syn_ex;        //!< Excitatory synaptic time constant
 extern const Name tau_syn_in;        //!< Inhibitory synaptic time constant
 extern const Name tau_v;             //!< Specific to amat2_*
 extern const Name tau_w;             //!< Specific to Brette & Gerstner 2005 (aeif_cond-*)
-extern const Name taus_eta; //!< Specific to population point process model (pp_pop_psc_delta)
-extern const Name taus_syn; //!< Synapse time constants (array)
-extern const Name theta;    //!< Did not compile without (theta neuron problem)
-extern const Name thread;   //!< Node parameter
-extern const Name thread_local_id; //!< Thead-local ID of node, see Kunkel et al 2014, Sec 3.3.2
-extern const Name time_in_steps;   //!< Recorder parameter
-extern const Name times;           //!< Recorder parameter
-extern const Name to_accumulator;  //!< Recorder parameter
-extern const Name to_file;         //!< Recorder parameter
-extern const Name to_memory;       //!< Recorder parameter
-extern const Name to_screen;       //!< Recorder parameter
-extern const Name Tstart;          //!< Specific to correlation_and correlomatrix detector
-extern const Name Tstop;           //!< Specific to correlation_and correlomatrix detector
+extern const Name taus_eta;          //!< Specific to population point process model
+                                     //!< (pp_pop_psc_delta)
+extern const Name taus_syn;          //!< Synapse time constants (array)
+extern const Name theta;             //!< Did not compile without (theta neuron problem)
+extern const Name thread;            //!< Node parameter
+extern const Name thread_local_id;   //!< Thead-local ID of node, see Kunkel et al 2014, Sec 3.3.2
+extern const Name time_in_steps;     //!< Recorder parameter
+extern const Name times;             //!< Recorder parameter
+extern const Name to_accumulator;    //!< Recorder parameter
+extern const Name to_file;           //!< Recorder parameter
+extern const Name to_memory;         //!< Recorder parameter
+extern const Name to_screen;         //!< Recorder parameter
+extern const Name Tstart;            //!< Specific to correlation_and correlomatrix detector
+extern const Name Tstop;             //!< Specific to correlation_and correlomatrix detector
 
 extern const Name u; //!< probability of release [0...1] (Tsodyks2_connection)
 extern const Name U_lower;
@@ -356,15 +359,15 @@ extern const Name weighted_spikes_ex; //!< Weighted incoming excitatory spikes
 extern const Name weighted_spikes_in; //!< Weighted incoming inhibitory spikes
 extern const Name weights;            //!< Connection parameters
 extern const Name with_noise;
-extern const Name
-  with_reset; //!< Shall the pp_neuron reset after each spike? (stochastic neuron pp_psc_delta)
+extern const Name with_reset; //!< Shall the pp_neuron reset after each spike?
+                              //!< (stochastic neuron pp_psc_delta)
 extern const Name withgid;    //!< Recorder parameter
 extern const Name withpath;   //!< Recorder parameter
 extern const Name withtime;   //!< Recorder parameter
 extern const Name withweight; //!< Recorder parameter
 
-extern const Name
-  x; //!< current scaling factor of the synaptic weight [0...1] (Tsodyks2_connection)
+extern const Name x;  //!< current scaling factor of the synaptic weight [0...1]
+                      //!< (Tsodyks2_connection)
 extern const Name xs; //!< current scaling factor of the synaptic weight [0...1] (property arrays)
 }
 }

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -57,9 +57,8 @@ nest::RecordingDevice::Parameters_::Parameters_( const std::string& file_ext,
   , precision_( 3 )
   , scientific_( false )
   , binary_( false )
-  , fbuffer_size_( BUFSIZ )
-  , // default buffer size as defined in <cstdio>
-  label_()
+  , fbuffer_size_( BUFSIZ ) // default buffer size as defined in <cstdio>
+  , label_()
   , file_ext_( file_ext )
   , filename_()
   , close_after_simulate_( false )

--- a/nestkernel/scheduler.cpp
+++ b/nestkernel/scheduler.cpp
@@ -1506,7 +1506,7 @@ nest::Scheduler::print_progress_()
   {
     long t_real_s = ( t_slice_end_.tv_sec - t_slice_begin_.tv_sec ) * 1e6;   // usec
     t_real_ += t_real_s + ( t_slice_end_.tv_usec - t_slice_begin_.tv_usec ); // usec
-    double_t t_real_acc = ( t_real_ ) / 1000.; // ms
+    double_t t_real_acc = ( t_real_ ) / 1000.;                               // ms
     double_t t_sim_acc = ( to_do_total_ - to_do_ ) * Time::get_resolution().get_ms();
     rt_factor = t_sim_acc / t_real_acc;
   }

--- a/nestkernel/scheduler.cpp
+++ b/nestkernel/scheduler.cpp
@@ -85,16 +85,14 @@ nest::Scheduler::Scheduler( Network& net )
   , entry_counter_( 0 )
   , exit_counter_( 0 )
   , nodes_vec_( n_threads_ )
-  , nodes_vec_network_size_( 0 )
-  , // zero to force update
-  clock_( Time::tic( 0L ) )
+  , nodes_vec_network_size_( 0 ) // zero to force update
+  , clock_( Time::tic( 0L ) )
   , slice_( 0L )
   , to_do_( 0L )
   , to_do_total_( 0L )
   , from_step_( 0L )
-  , to_step_( 0L )
-  , // consistent with to_do_ == 0
-  terminate_( false )
+  , to_step_( 0L ) // consistent with to_do_ == 0
+  , terminate_( false )
   , off_grid_spiking_( false )
   , print_time_( false )
   , rng_()

--- a/nestkernel/scheduler.h
+++ b/nestkernel/scheduler.h
@@ -402,7 +402,7 @@ private:
   index n_sim_procs_; //!< MPI processes used for simulation
 
   index n_gsd_; //!< Total number of global spike detectors, used for distributing them over
-                //recording processes
+                //!< recording processes
 
   volatile index entry_counter_; //!< Counter for entry barrier.
   volatile index exit_counter_;  //!< Counter for exit barrier.
@@ -427,7 +427,7 @@ private:
   bool print_time_;       //!< Indicates whether time should be printed during simulations (or not)
 
   std::vector< long_t > rng_seeds_; //!< The seeds of the local RNGs. These do not neccessarily
-                                    //describe the state of the RNGs.
+                                    //!< describe the state of the RNGs.
   long_t
     grng_seed_; //!< The seed of the global RNG, not neccessarily describing the state of the GRNG.
 

--- a/precise/iaf_psc_alpha_canon.cpp
+++ b/precise/iaf_psc_alpha_canon.cpp
@@ -61,25 +61,16 @@ RecordablesMap< iaf_psc_alpha_canon >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_alpha_canon::Parameters_::Parameters_()
-  : tau_m_( 10.0 )
-  , // ms
-  tau_syn_( 2.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  t_ref_( 2.0 )
-  , // ms
-  E_L_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  U_th_( -55.0 - E_L_ )
-  , // mV, rel to E_L_
-  U_min_( -std::numeric_limits< double_t >::infinity() )
-  , // mV
-  U_reset_( -70.0 - E_L_ )
-  , // mV, rel to E_L_
-  Interpol_( iaf_psc_alpha_canon::LINEAR )
+  : tau_m_( 10.0 )                                         // ms
+  , tau_syn_( 2.0 )                                        // ms
+  , c_m_( 250.0 )                                          // pF
+  , t_ref_( 2.0 )                                          // ms
+  , E_L_( -70.0 )                                          // mV
+  , I_e_( 0.0 )                                            // pA
+  , U_th_( -55.0 - E_L_ )                                  // mV, rel to E_L_
+  , U_min_( -std::numeric_limits< double_t >::infinity() ) // mV
+  , U_reset_( -70.0 - E_L_ )                               // mV, rel to E_L_
+  , Interpol_( iaf_psc_alpha_canon::LINEAR )
 {
 }
 

--- a/precise/iaf_psc_alpha_presc.cpp
+++ b/precise/iaf_psc_alpha_presc.cpp
@@ -59,21 +59,14 @@ RecordablesMap< iaf_psc_alpha_presc >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_alpha_presc::Parameters_::Parameters_()
-  : tau_m_( 10.0 )
-  , // ms
-  tau_syn_( 2.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  t_ref_( 2.0 )
-  , // ms
-  E_L_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  U_th_( -55.0 - E_L_ )
-  , // mV, rel to E_L_
-  U_min_( -std::numeric_limits< double_t >::infinity() )
+  : tau_m_( 10.0 )        // ms
+  , tau_syn_( 2.0 )       // ms
+  , c_m_( 250.0 )         // pF
+  , t_ref_( 2.0 )         // ms
+  , E_L_( -70.0 )         // mV
+  , I_e_( 0.0 )           // pA
+  , U_th_( -55.0 - E_L_ ) // mV, rel to E_L_
+  , U_min_( -std::numeric_limits< double_t >::infinity() )
   , U_reset_( -70.0 - E_L_ )
   , Interpol_( iaf_psc_alpha_presc::LINEAR )
 {

--- a/precise/iaf_psc_delta_canon.cpp
+++ b/precise/iaf_psc_delta_canon.cpp
@@ -61,28 +61,20 @@ RecordablesMap< iaf_psc_delta_canon >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_delta_canon::Parameters_::Parameters_()
-  : tau_m_( 10.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  t_ref_( 2.0 )
-  , // ms
-  E_L_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  U_th_( -55.0 - E_L_ )
-  , // mV, rel to E_L_
-  U_min_( -std::numeric_limits< double_t >::max() )
-  ,                        // mV
-  U_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
+  : tau_m_( 10.0 )                                    // ms
+  , c_m_( 250.0 )                                     // pF
+  , t_ref_( 2.0 )                                     // ms
+  , E_L_( -70.0 )                                     // mV
+  , I_e_( 0.0 )                                       // pA
+  , U_th_( -55.0 - E_L_ )                             // mV, rel to E_L_
+  , U_min_( -std::numeric_limits< double_t >::max() ) // mV
+  , U_reset_( -70.0 - E_L_ )                          // mV, rel to E_L_
 {
 }
 
 nest::iaf_psc_delta_canon::State_::State_()
-  : U_( 0.0 )
-  , //  or U_ = U_reset_;
-  I_( 0. )
+  : U_( 0.0 ) //  or U_ = U_reset_;
+  , I_( 0. )
   , last_spike_step_( -1 )
   , last_spike_offset_( 0.0 )
   , is_refractory_( false )

--- a/precise/iaf_psc_exp_ps.cpp
+++ b/precise/iaf_psc_exp_ps.cpp
@@ -57,25 +57,16 @@ RecordablesMap< iaf_psc_exp_ps >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_exp_ps::Parameters_::Parameters_()
-  : tau_m_( 10.0 )
-  , // ms
-  tau_ex_( 2.0 )
-  , // ms
-  tau_in_( 2.0 )
-  , // ms
-  c_m_( 250.0 )
-  , // pF
-  t_ref_( 2.0 )
-  , // ms
-  E_L_( -70.0 )
-  , // mV
-  I_e_( 0.0 )
-  , // pA
-  U_th_( -55.0 - E_L_ )
-  , // mV, rel to E_L_
-  U_min_( -std::numeric_limits< double_t >::infinity() )
-  ,                        // mV
-  U_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
+  : tau_m_( 10.0 )                                         // ms
+  , tau_ex_( 2.0 )                                         // ms
+  , tau_in_( 2.0 )                                         // ms
+  , c_m_( 250.0 )                                          // pF
+  , t_ref_( 2.0 )                                          // ms
+  , E_L_( -70.0 )                                          // mV
+  , I_e_( 0.0 )                                            // pA
+  , U_th_( -55.0 - E_L_ )                                  // mV, rel to E_L_
+  , U_min_( -std::numeric_limits< double_t >::infinity() ) // mV
+  , U_reset_( -70.0 - E_L_ )                               // mV, rel to E_L_
 {
 }
 

--- a/precise/poisson_generator_ps.cpp
+++ b/precise/poisson_generator_ps.cpp
@@ -36,11 +36,9 @@
  * ---------------------------------------------------------------- */
 
 nest::poisson_generator_ps::Parameters_::Parameters_()
-  : rate_( 0.0 )
-  , // Hz
-  dead_time_( 0.0 )
-  , // ms
-  num_targets_( 0 )
+  : rate_( 0.0 )      // Hz
+  , dead_time_( 0.0 ) // ms
+  , num_targets_( 0 )
 {
 }
 

--- a/sli/processes.cc
+++ b/sli/processes.cc
@@ -460,8 +460,8 @@ Processes::KillFunction::execute( SLIInterpreter* i ) const
     i->raiseerror( systemerror( i ) );
   }
   else
-  { // no error
-    i->EStack.pop(); // pop command from execution stack
+  {                     // no error
+    i->EStack.pop();    // pop command from execution stack
     i->OStack.pop( 2 ); // pop arguments from operand stack
   }
 }
@@ -519,8 +519,8 @@ Processes::Dup2_is_isFunction::execute( SLIInterpreter* i ) const
     i->raiseerror( systemerror( i ) );
   }
   else
-  { // no error
-    i->EStack.pop(); // pop command from execution stack
+  {                     // no error
+    i->EStack.pop();    // pop command from execution stack
     i->OStack.pop( 2 ); // pop operands from operand stack
   }
 }
@@ -547,8 +547,8 @@ Processes::Dup2_os_osFunction::execute( SLIInterpreter* i ) const
     i->raiseerror( systemerror( i ) );
   }
   else
-  { // no error
-    i->EStack.pop(); // pop command from execution stack
+  {                     // no error
+    i->EStack.pop();    // pop command from execution stack
     i->OStack.pop( 2 ); // pop operands from operand stack
   }
 }
@@ -579,8 +579,8 @@ Processes::Dup2_is_osFunction::execute( SLIInterpreter* i ) const
     i->raiseerror( systemerror( i ) );
   }
   else
-  { // no error
-    i->EStack.pop(); // pop command from execution stack
+  {                     // no error
+    i->EStack.pop();    // pop command from execution stack
     i->OStack.pop( 2 ); // pop operands from operand stack
   }
 }
@@ -607,8 +607,8 @@ Processes::Dup2_os_isFunction::execute( SLIInterpreter* i ) const
     i->raiseerror( systemerror( i ) );
   }
   else
-  { // no error
-    i->EStack.pop(); // pop command from execution stack
+  {                     // no error
+    i->EStack.pop();    // pop command from execution stack
     i->OStack.pop( 2 ); // pop operands from operand stack
   }
 }
@@ -787,7 +787,7 @@ Processes::MkfifoFunction::execute( SLIInterpreter* i ) const
     i->raiseerror( systemerror( i ) );
   }
   else
-  { // no error
+  {                  // no error
     i->EStack.pop(); // pop command from execution stack
     i->OStack.pop(); // pop operand from operand stack
   }


### PR DESCRIPTION
1) There was a problem with the previous (pre-git) formatting of constructor initialization lists with comments: when clang-format processed them, comments and member variables were mixed. This fixes all those problems I found.

2) Apparently there were some further format errors introduced via pull requests. They are corrected with this PR. 

3) Updated `build.sh` so that future PR will make TravisCI fail, if the committed files do not conform to the clang-format formatting.