### PR TITLE
Remove last bits of model and connection unloading, fixing trac.617.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ build/
 /topology/setup.py
 
 *.kdev4
+
+### IPythonNotebook ###
+# Temporary data
+.ipynb_checkpoints/

--- a/examples/MyModule/mymodule.h
+++ b/examples/MyModule/mymodule.h
@@ -51,8 +51,7 @@ public:
   MyModule();
 
   /**
-   * @note The destructor does not do much in modules. Proper "downrigging"
-   *       is the responsibility of the unregister() method.
+   * @note The destructor does not do much in modules.
    */
   ~MyModule();
 

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -72,22 +72,6 @@ Archiving_Node::register_stdp_connection( double_t t_first_read )
   n_incoming_++;
 }
 
-void
-Archiving_Node::unregister_stdp_connection( double_t t_last_read )
-{
-  // Mark all entries in the deque we have read as unread
-  // so that we can savely decrement the incoming number of
-  // connections afterwards without loosing entries, which
-  // are still needed. For details see bug #218. MH 08-04-22
-
-  for ( std::deque< histentry >::iterator runner = history_.begin();
-        runner != history_.end() && runner->t_ <= t_last_read;
-        ++runner )
-    ( runner->access_counter_ )--;
-
-  n_incoming_--;
-}
-
 double_t
 nest::Archiving_Node::get_K_value( double_t t )
 {

--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -103,13 +103,6 @@ public:
    */
   void register_stdp_connection( double_t t_first_read );
 
-  /**
-   * Unregister this incoming connection.
-   * t_last_read: The unregistered synapse has read all history entries with t <= t_last_read.
-   */
-  void unregister_stdp_connection( double_t t_last_read );
-
-
   void get_status( DictionaryDatum& d ) const;
   void set_status( const DictionaryDatum& d );
 

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -61,7 +61,7 @@ public:
 
   /**
    * Register a synapse type. This is called by Network::register_synapse_prototype.
-   * Returns an id, which is needed to unregister the prototype later.
+   * Returns an id for the prototype.
    */
   synindex register_synapse_prototype( ConnectorModel* cf );
 
@@ -175,9 +175,9 @@ public:
 private:
   std::vector< ConnectorModel* > pristine_prototypes_; //!< The list of clean synapse prototypes
   std::vector< std::vector< ConnectorModel* > > prototypes_; //!< The list of available synapse
-                                                             //prototypes: first dimenasion one
-                                                             //entry per thread, second dimantion
-                                                             //for each synapse type
+  // prototypes: first dimenasion one
+  // entry per thread, second dimantion
+  // for each synapse type
 
   Network& net_;            //!< The reference to the network
   Dictionary* synapsedict_; //!< The synapsedict (owned by the network)

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -175,9 +175,9 @@ public:
 private:
   std::vector< ConnectorModel* > pristine_prototypes_; //!< The list of clean synapse prototypes
   std::vector< std::vector< ConnectorModel* > > prototypes_; //!< The list of available synapse
-  // prototypes: first dimenasion one
-  // entry per thread, second dimantion
-  // for each synapse type
+                                                             //!< prototypes: first dimension one
+                                                             //!< entry per thread, second dimension
+                                                             //!< for each synapse type
 
   Network& net_;            //!< The reference to the network
   Dictionary* synapsedict_; //!< The synapsedict (owned by the network)

--- a/nestkernel/network.cpp
+++ b/nestkernel/network.cpp
@@ -1949,43 +1949,6 @@ Network::register_model( Model& m, bool private_model )
   return id;
 }
 
-void
-Network::unregister_model( index m_id )
-{
-  Model* m = get_model( m_id ); // may throw UnknownModelID
-  std::string name = m->get_name();
-
-  if ( model_in_use( m_id ) )
-    throw ModelInUse( name );
-
-  modeldict_->remove( name );
-
-  // unregister from the pristine_models_ list
-  delete pristine_models_[ m_id ].first;
-  pristine_models_[ m_id ].first = 0;
-
-  // unregister from the models_ list
-  delete models_[ m_id ];
-  models_[ m_id ] = 0;
-
-  // unregister from proxy_nodes_ list
-
-  for ( thread t = 0; t < get_num_threads(); ++t )
-  {
-    delete proxy_nodes_[ t ][ m_id ];
-    proxy_nodes_[ t ][ m_id ] = 0;
-  }
-}
-
-void
-Network::try_unregister_model( index m_id )
-{
-  Model* m = get_model( m_id ); // may throw UnknownModelID
-  std::string name = m->get_name();
-
-  if ( model_in_use( m_id ) )
-    throw ModelInUse( name );
-}
 
 /**
  * This function is not thread save and has to be called inside a omp critical

--- a/nestkernel/network.h
+++ b/nestkernel/network.h
@@ -166,7 +166,7 @@ public:
    * @param   private_model  If true, model is not entered in modeldict.
    * @return void
    * @note The Network calls the Model object's destructor at exit.
-   * @see register_model, unregister_model, register_user_model
+   * @see register_model
    */
   void register_basis_model( Model& m, bool private_model = false );
 
@@ -177,20 +177,8 @@ public:
    * @param   private_model  If true, model is not entered in modeldict.
    * @return Model ID assigned by network
    * @note The Network calls the Model object's destructor at exit.
-   * @see unregister_model, register_user_model
    */
   index register_model( Model& m, bool private_model = false );
-
-  /**
-   * Unregister a previously registered model.
-   */
-  void unregister_model( index m_id );
-
-  /**
-   * Try unregistering model prototype.
-   * Throws ModelInUseException, if not possible, does not unregister.
-   */
-  void try_unregister_model( index m_id );
 
   /**
    * Copy an existing model and register it as a new model.
@@ -199,8 +187,6 @@ public:
    * @param new_name The name of the new model.
    * @retval Index, identifying the new Model object.
    * @see copy_synapse_prototype()
-   * @todo Not fully compatible with thread number changes and
-   * unregister_model() yet.
    */
   index copy_model( index old_id, std::string new_name );
 

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -193,15 +193,6 @@ void Node::register_stdp_connection( double_t )
 }
 
 /**
- * Default implementation of unregister_stdp_connection() just
- * throws IllegalConnection
- */
-void Node::unregister_stdp_connection( double_t )
-{
-  throw IllegalConnection();
-}
-
-/**
  * Default implementation of event handlers just throws
  * an UnexpectedEvent exception.
  * @see class UnexpectedEvent

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -407,14 +407,6 @@ public:
   virtual void register_stdp_connection( double_t );
 
   /**
-   * Unregister a STDP connection
-   *
-   * @throws IllegalConnection
-   *
-   */
-  virtual void unregister_stdp_connection( double_t );
-
-  /**
    * Handle incoming spike events.
    * @param thrd Id of the calling thread.
    * @param e Event object.


### PR DESCRIPTION
After #55 handled module unloading, this PR removes the last bits of the never functional model and connection unregistration code. It thus fixes trac.617, which should be closed once this PR is merged.

Potential reviewers: @abigailm @jougs 