### PR TITLE
Fix issue #59 in hl_api.py: Invalid URL in deprecation warning

### DIFF
--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -77,7 +77,7 @@ def show_deprecation_warning(func_name, alt_func_name=None, text=None):
                        """\
                        {} is deprecated and will be removed in a future version of NEST.
                        Please use {} instead!
-                       For details, see the documentation at http://nest-initiative.org/Connection_Management\
+                       For details, see the documentation at http://www.nest-simulator.org/connection_management\
                        """.format(func_name, alt_func_name)
                    )
 
@@ -1093,9 +1093,9 @@ def Connect(pre, post, conn_spec=None, syn_spec=None, model=None):
 
     if model is not None:
         deprecation_text = "".join(["The argument 'model' is there for backward compatibility with the old ",
-                                    "Connect function and will be removed in NEST 2.6. Please change the name ",
+                                    "Connect function and will be removed in a future version of NEST. Please change the name ",
                                     "of the keyword argument from 'model' to 'syn_spec'. For details, see the ",
-                                    "documentation at:\nhttp://nest-initiative.org/Connection_Management"])
+                                    "documentation at:\nhttp://www.nest-simulator.org/connection_management"])
         show_deprecation_warning("BackwardCompatibilityConnect", 
                                  text=deprecation_text)
 


### PR DESCRIPTION
The deprecation warning in hl_api.py points to an outdated URL:
http://nest-initiative.org/Connection_Management
Changed to http://www.nest-simulator.org/connection_management/

And fixed wording from "will be removed in NEST 2.6"
to
"will be removed in a future version of NEST"