### PR TITLE
fix invalid string formatting for python 2.6

### DIFF
--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -75,8 +75,8 @@ def show_deprecation_warning(func_name, alt_func_name=None, text=None):
         if text is None:
             text = textwrap.dedent(
                        """\
-                       {} is deprecated and will be removed in a future version of NEST.
-                       Please use {} instead!
+                       {0} is deprecated and will be removed in a future version of NEST.
+                       Please use {1} instead!
                        For details, see the documentation at http://www.nest-simulator.org/connection_management\
                        """.format(func_name, alt_func_name)
                    )


### PR DESCRIPTION
This creates a crash when trying to use deprecated methods instead of just printing a warning