### PR TITLE
Warn about too few local neurons for recording in hpc_benchmark.sli [ci skip] 

### DIFF
--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -244,11 +244,11 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
 
     local_neurons Nrec lt
     {
-      M_WARNING (BuildNetwork)
+      M_ERROR (BuildNetwork)
       (Spikes can only be recorded from local neurons, but the number of local 
 neurons is smaller than the number of neurons spikes should be recorded from. 
-Hence, the number of recorded neurons is reduced.) message
-      /Nrec local_neurons def
+Aborting the simulation!) message
+      1 quit_i
     } if
 
     M_INFO (BuildNetwork)

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -240,10 +240,21 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
 
   record_spikes true eq 
   {
+    E_net GetLocalNodes size /local_neurons Set
+
+    local_neurons Nrec lt
+    {
+      M_WARNING (BuildNetwork)
+      (Spikes can only be recorded from local neurons, but the number of local 
+neurons is smaller than the number of neurons spikes should be recorded from. 
+Hence, the number of recorded neurons is reduced.) message
+      /Nrec local_neurons def
+    } if
+
     M_INFO (BuildNetwork)
     (Connecting spike detectors.) message
     E_net GetLocalNodes Nrec Take [E_detector] << /rule (all_to_all) >> << /model /syn_std >> Connect
-  } if    
+  } if
 
   % read out time used for building    
   toc /BuildEdgeTime Set


### PR DESCRIPTION
When running the hpc_benchmark.sli script with MPI and the number of local neurons is smaller than the number of recorded neurons, this results in an undescriptive out of range exception. With this PR a descriptive warning message is printed and the number of recorded neurons is reduced.