### PR TITLE
Some improvements to module infrastructure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -730,7 +730,7 @@ SLI_USER_MODULES=""
 # SLI_USER_MODULES_LDADD collects what needs to be added to LDADD
 SLI_USER_MODULES_LDADD=""
 
-AC_ARG_WITH(modules,[  --with-modules=MODULES  external modules to be linked in],
+AC_ARG_WITH(modules,[  --with-modules=MODULES external modules to be linked in],
 [
 if test "$withval" != no; then
   for mod in $withval; do

--- a/configure.ac
+++ b/configure.ac
@@ -730,11 +730,11 @@ SLI_USER_MODULES=""
 # SLI_USER_MODULES_LDADD collects what needs to be added to LDADD
 SLI_USER_MODULES_LDADD=""
 
-AC_ARG_WITH(modules,[  --with-modules = external modules to be linked in],
+AC_ARG_WITH(modules,[  --with-modules=MODULES  external modules to be linked in],
 [
 if test "$withval" != no; then
   for mod in $withval; do
-    SLI_USER_MODULES_LDADD=" $prefix/lib/nest/lib$mod.la"
+    SLI_USER_MODULES_LDADD="$SLI_USER_MODULES_LDADD $prefix/lib/nest/lib$mod.la"
     SLI_USER_MODULES="$SLI_USER_MODULES $mod"
   done
 fi

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -38,6 +38,7 @@
 
 #include <ltdl.h>
 
+#include "sliconfig.h"
 #include "network.h"
 #include "interpret.h"
 #include "integerdatum.h"
@@ -165,6 +166,15 @@ DynamicLoaderModule::LoadModuleFunction::execute( SLIInterpreter* i ) const
 
   // call lt_dlerror() to reset any error messages hanging around
   lt_dlerror();
+  int searchpath_result = lt_dlsetsearchpath( SLI_PREFIX "/lib/nest" );
+  if ( searchpath_result != 0 )
+  {
+    char* errstr = ( char* ) lt_dlerror();
+    std::string msg = "Could not set user search path: " SLI_PREFIX "/lib/nest";
+    if ( errstr )
+      msg += "\nThe dynamic loader returned the following error: '" + std::string( errstr ) + "'.";
+    throw DynamicModuleManagementError( msg );
+  }
 
   // try to open the module
   const lt_dlhandle hModule = lt_dlopenext( new_module.name.c_str() );


### PR DESCRIPTION
Regards #56 and trac.526.

With this PR the user of modules does not have to set `LD_LIBRARY_PATH` anymore. When modules are opened dynamically, NEST first looks in the user-defined search path, which is set to the standard install directory for modules 

    SLI_PREFIX "/lib/nest"
Afterwards it still looks for modules in the libltdl's search path (`LTDL_LIBRARY_PATH `) and the system library search path (`LD_LIBRARY_PATH`).

Further, this PR fixes some formatting and variable assignment in `configure.ac` .