### PR TITLE
Add propagator fot tau_m==tau_syn in iaf dynamics.

### DIFF
--- a/doc/model_details/IAF_neurons_singularity.ipynb
+++ b/doc/model_details/IAF_neurons_singularity.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -20,7 +20,7 @@
     "import sympy as sp\n",
     "sp.init_printing(use_latex=True)\n",
     "from sympy.matrices import zeros\n",
-    "tau_m, C, tau_s, h = sp.symbols('tau_m, C, tau_s, h')\n"
+    "tau_m, tau_s, C, h = sp.symbols('tau_m, tau_s, C, h')"
    ]
   },
   {
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -45,31 +45,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and for exponential currents we have:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "B = sp.Matrix([[-1/tau_s, 0],[1/C, -1/tau_m]])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Non-singular case ($\\tau_m\\neq \\tau_s$) \n",
-    "The propagators are: "
+    "The propagator is: "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -118,7 +100,7 @@
        "                                             ⎦"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -132,42 +114,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "ename": "NotImplementedError",
-     "evalue": "Can't evaluate eigenvector for eigenvalue -h*(tau_m + tau_s)/(2*tau_m*tau_s) - sqrt(h**2*(tau_m - tau_s)**2)/(2*tau_m*tau_s)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-11-9929748d2ac0>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mPB\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msimplify\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mB\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mh\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mPB\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/cache.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m     89\u001b[0m             \u001b[1;32mdef\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     90\u001b[0m                 \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 91\u001b[1;33m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     92\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     93\u001b[0m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/compatibility.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwds)\u001b[0m\n\u001b[0;32m    855\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    856\u001b[0m                     \u001b[0mstats\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mMISSES\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 857\u001b[1;33m                     \u001b[1;32mreturn\u001b[0m \u001b[0muser_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    858\u001b[0m                 \u001b[1;32mwith\u001b[0m \u001b[0mlock\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    859\u001b[0m                     \u001b[0mlink\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcache_get\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/function.pyc\u001b[0m in \u001b[0;36m__new__\u001b[1;34m(cls, *args, **options)\u001b[0m\n\u001b[0;32m    373\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    374\u001b[0m         \u001b[0mevaluate\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0moptions\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'evaluate'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mglobal_evaluate\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 375\u001b[1;33m         \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mFunction\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcls\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__new__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0moptions\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    376\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mevaluate\u001b[0m \u001b[1;32mor\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcls\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    377\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/cache.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m     89\u001b[0m             \u001b[1;32mdef\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     90\u001b[0m                 \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 91\u001b[1;33m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     92\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     93\u001b[0m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/compatibility.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwds)\u001b[0m\n\u001b[0;32m    855\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    856\u001b[0m                     \u001b[0mstats\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mMISSES\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 857\u001b[1;33m                     \u001b[1;32mreturn\u001b[0m \u001b[0muser_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    858\u001b[0m                 \u001b[1;32mwith\u001b[0m \u001b[0mlock\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    859\u001b[0m                     \u001b[0mlink\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcache_get\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/function.pyc\u001b[0m in \u001b[0;36m__new__\u001b[1;34m(cls, *args, **options)\u001b[0m\n\u001b[0;32m    197\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    198\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mevaluate\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 199\u001b[1;33m             \u001b[0mevaluated\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0meval\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    200\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mevaluated\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    201\u001b[0m                 \u001b[1;32mreturn\u001b[0m \u001b[0mevaluated\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/functions/elementary/exponential.pyc\u001b[0m in \u001b[0;36meval\u001b[1;34m(cls, arg)\u001b[0m\n\u001b[0;32m    273\u001b[0m         \u001b[1;32melif\u001b[0m \u001b[0marg\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mis_Matrix\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    274\u001b[0m             \u001b[1;32mfrom\u001b[0m \u001b[0msympy\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mMatrix\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 275\u001b[1;33m             \u001b[1;32mreturn\u001b[0m \u001b[0marg\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    276\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    277\u001b[0m     \u001b[1;33m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36mexp\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m   1924\u001b[0m                 \"Exponentiation is valid only for square matrices\")\n\u001b[0;32m   1925\u001b[0m         \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1926\u001b[1;33m             \u001b[0mP\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcells\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mjordan_cells\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1927\u001b[0m         \u001b[1;32mexcept\u001b[0m \u001b[0mMatrixError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1928\u001b[0m             \u001b[1;32mraise\u001b[0m \u001b[0mNotImplementedError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Exponentiation is implemented only for matrices for which the Jordan normal form can be computed\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36mjordan_cells\u001b[1;34m(self, calc_transformation)\u001b[0m\n\u001b[0;32m   3702\u001b[0m         \u001b[0mJcells\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m[\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3703\u001b[0m         \u001b[0mPcols_new\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m[\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 3704\u001b[1;33m         \u001b[0mjordan_block_structures\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_jordan_block_structure\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   3705\u001b[0m         \u001b[1;32mfrom\u001b[0m \u001b[0msympy\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmatrices\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mMutableMatrix\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3706\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36m_jordan_block_structure\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m   3442\u001b[0m         \u001b[1;31m# that will eventually be used to form the transformation P\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3443\u001b[0m         \u001b[0mjordan_block_structures\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m{\u001b[0m\u001b[1;33m}\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 3444\u001b[1;33m         \u001b[0m_eigenvects\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0meigenvects\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   3445\u001b[0m         \u001b[0mev\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0meigenvals\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3446\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mev\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m==\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36meigenvects\u001b[1;34m(self, **flags)\u001b[0m\n\u001b[0;32m   3000\u001b[0m                 \u001b[1;32mif\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mbasis\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3001\u001b[0m                     raise NotImplementedError(\n\u001b[1;32m-> 3002\u001b[1;33m                         \"Can't evaluate eigenvector for eigenvalue %s\" % r)\n\u001b[0m\u001b[0;32m   3003\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mprimitive\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3004\u001b[0m                 \u001b[1;31m# the relationship A*e = lambda*e will still hold if we change the\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mNotImplementedError\u001b[0m: Can't evaluate eigenvector for eigenvalue -h*(tau_m + tau_s)/(2*tau_m*tau_s) - sqrt(h**2*(tau_m - tau_s)**2)/(2*tau_m*tau_s)"
-     ]
-    }
-   ],
-   "source": [
-    "PB = sp.simplify(sp.exp(B*h))\n",
-    "PB"
+    "Note that the entry in the third line and the second column $A_{32}$ would also appear in the propagator matrix in case of an exponentially shaped current"
    ]
   },
   {
@@ -180,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -205,7 +152,7 @@
        "⎣      C   τ_m⎦"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,52 +166,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and"
+    "The propagator is"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHYAAAA3BAMAAAArjaPrAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMA74lUMhDN3buZqyJ2\nRGaQSGKPAAACDElEQVRIDe2Wv0vDQBTHn6ZnqNUq1N0uOohg6uLYFFrQySIi/gGCa3GwgkM7O0nF\nHwiCgyKCs+AidVBQB/sfWDcnRTcLEi+0yeXd5a5JLbj4oPTde+9z73qX5nsAvM3ygeDjubPgtULl\njBAJHgjBjlqfeN6A7JT1AYlsLihLKvemW7uYTcGIO2o58r59Btn0VGfCsC8A452yWwDpPIN9+qZY\nlvMaAM8Gi4nsVemCpZFHvihbZSGRZTnei9HDnE+y6K9Zslqktm6yKX09QvvK12wx86Pp700r98oP\nasU2AN7VZySHbwD2PNkwewW6QbxPcCiWTD6Ynfb1cLaL+8ZKllXjKuRDzEZzp559lFPNDGbzUG4H\nePKYhcGkJ9fO5dhoHeI7b0fTZjvOznOsboJ2Bwkt2QlLmRNS6DU6YG09KWjbuiZnI2Unh9ds6wk5\nHqj1Pzp54TtyWHBimAX5+9UBQPtnm3vxV3sl1xN2RsOOi89XridOPcT2G9XWALNuRSCnW+xQUxXE\nnku25BRXAJhsWLSqW33pVK/nY/K/EL8g3PeyDsvuEfClwhixkW+AeFmokQUQ25MEiFRlpUIcsU95\n+tqgH6lh3UAs1Ve1Yd1ALNV1tWHdQOwaJa+VNNINxB5QblfJIt1ArF6HBVPJIt3IoDvwROVWiYJO\n0y3dsO/Awt1bTbu6Yd+9w5pHN34AeJuPHUKPhrYAAAAASUVORK5CYII=\n",
-      "text/latex": [
-       "$$\\left[\\begin{matrix}- \\frac{1}{\\tau_{m}} & 0\\\\\\frac{1}{C} & - \\frac{1}{\\tau_{m}}\\end{matrix}\\right]$$"
-      ],
-      "text/plain": [
-       "⎡-1      ⎤\n",
-       "⎢───   0 ⎥\n",
-       "⎢τ_m     ⎥\n",
-       "⎢        ⎥\n",
-       "⎢ 1   -1 ⎥\n",
-       "⎢ ─   ───⎥\n",
-       "⎣ C   τ_m⎦"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Bs = sp.Matrix([[-1/tau_m,0],[1/C, -1/tau_m]])\n",
-    "Bs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The propagators are"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -294,7 +201,7 @@
        "⎣  2⋅C      C         ⎦"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,55 +212,18 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJgAAAA/BAMAAADu9RxEAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARM1UEIl2mSLd7zKr\nZruhia6uAAADIElEQVRYCe2YQWgTQRSG/3Qnm6ZJm4gnLzZH8bQQar1oF6QUQUrR0oseapFWxGi1\nVgqCBMGLKEaoUi8iFA8qQvDoxeKhgiLkIBbE1h5EPIgoKh4U4qTu7L7ZzOwkJhfBgbLv/e9/38xs\n0u100Vut5tCG0VOtfkVvPp9VsdJNThHL5zlMReKaNa0p6OVFLSzh6Ls0FT0sWZjT9GhlPSxTLmi7\nNAU9bCs+aHq0sh5WQKnZu6aHzWHZ1a5BXdDD1H6qstmpMs0Rglmf+HiHTNUfkltOOhy2ICkhmFQz\nJa+B/ZKnFdhHYMCltFZgv4Be6QMnMDY2VRTzPLx3U5pT6PTKfnDYOFUIbEuxc0SUnE0i0l87vwOP\n/Y6aL4B1LmIo+KRH0T2zeqovEOqhUbD0g8mXQUcO1gQWLWnioLoRMb4y3TYzS8TM1oHnrBR3iFYX\n8ns2IBmCbWbCqyhZ00mrjkCEW8Bbl+TknnVx2DgpsSU7mz5KhLrwGHBaEoOV2TkMFaWaKUk67L7k\nCWCYKlSkkjFhY8fLkonAJP2vkv+w5m/bP3vPnpj3SiyGbfabYcRigM2YYcRigN1YKZpwxCJg9h1l\n00/b+PtKLAKGaypYbL3HtDJqETD2TQWzK9GPR95DLQIWK6lgiWL6iEonGrUIWPzFG/nZRPwNhwLW\nMW8vhZr8s0v1c6jipyGLgGWyiRHh2V07CrkiU17VFgF7hKSjbGtGFLATuJpqpk/pFbD3WIsrDc2I\nArYNl0drfYOT/uk/tf3uvAqltwiY1xVbwEUBsGJZEdJrhCUEu+Swc35n3MXKrpXNB31hI4iw/IF5\nB2Lg2auC6/d2ADtyXU6fL2wEEZbQyvjJMhjDQLq8FwcCpRZFWHzY2tNRfkrhRy5pJNEf/kclwiJg\nFyoYvg3wp5pNaftwGMtFqkRZPFjqC9C9DkyA+V8NCREkERYPVjucpcb5ss6uBm3qKMLiwU66AOM/\nrQ0Pxk+UbRgejJ912zA82HWOutIyzoOd56Az7YIlKxgstwuGQ7OmP0MNTOVtswFnAxYOa+eLpT2a\nF0sNrESy8BdLO38DVoXxfxr9m2sAAAAASUVORK5CYII=\n",
-      "text/latex": [
-       "$$\\left[\\begin{matrix}e^{- \\frac{h}{\\tau_{m}}} & 0\\\\\\frac{h}{C} e^{- \\frac{h}{\\tau_{m}}} & e^{- \\frac{h}{\\tau_{m}}}\\end{matrix}\\right]$$"
-      ],
-      "text/plain": [
-       "⎡  -h        ⎤\n",
-       "⎢  ───       ⎥\n",
-       "⎢  τ_m       ⎥\n",
-       "⎢ ℯ       0  ⎥\n",
-       "⎢            ⎥\n",
-       "⎢   -h       ⎥\n",
-       "⎢   ───   -h ⎥\n",
-       "⎢   τ_m   ───⎥\n",
-       "⎢h⋅ℯ      τ_m⎥\n",
-       "⎢──────  ℯ   ⎥\n",
-       "⎣  C         ⎦"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "PBs = sp.simplify(sp.exp(Bs*h))\n",
-    "PBs"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Numeric stability of propagator elements\n",
-    "For the limes $ \\tau_s\\rightarrow\\tau_m $ the entry $PA_{32}=PB_{21}$ becomes numerically unstable, since denominator and enumerator go to zero.\n",
+    "For the limes $ \\tau_s\\rightarrow\\tau_m $ the entry $PA_{32}$ becomes numerically unstable, since denominator and enumerator go to zero.\n",
     "\n",
     "$1.$ We show that $PAs_{32}$ is the limit of $PA_{32}(\\tau_s)$ for $\\tau_s\\rightarrow\\tau_m$.:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -373,7 +243,7 @@
        "  C   "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -392,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -413,7 +283,7 @@
        "               2⋅C⋅τ_m                                     "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -452,13 +322,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The entry $A_{31}$ is numerically unstable, too and we treat it analogously."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Tests and examples\n",
     "We will now show that the stability criterion explained above leads to a reasonable behavior for $\\tau_s\\rightarrow\\tau_m$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -478,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -487,7 +364,7 @@
     "taum = 10.\n",
     "C_m = 250.\n",
     "# array of distances between tau_m and tau_ex\n",
-    "epsilon_array = np.hstack(([0.],10.**(np.arange(-5.,1.,1.))))[::-1]\n",
+    "epsilon_array = np.hstack(([0.],10.**(np.arange(-6.,1.,1.))))[::-1]\n",
     "dt = 0.1\n",
     "fig = pl.figure(1)\n",
     "NUM_COLORS = len(epsilon_array)\n",
@@ -504,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -512,10 +389,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x55372d0>"
+       "<matplotlib.text.Text at 0x598b510>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -554,7 +431,7 @@
     "\n",
     "    # plot voltage trace\n",
     "    if epsilon == 0.:\n",
-    "        pl.plot(times,voltage,'--',color='black')\n",
+    "        pl.plot(times,voltage,'--',color='black',label='singular')\n",
     "    else:\n",
     "        pl.plot(times,voltage,color = cmap(1.*i/NUM_COLORS),label=str(epsilon))\n",
     "\n",
@@ -572,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -580,10 +457,10 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.text.Text at 0x5deeed0>"
+       "<matplotlib.legend.Legend at 0x6799350>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -591,13 +468,16 @@
    "source": [
     "fig = pl.figure(2)\n",
     "pl.semilogx(epsilon_array,maxVs,color='red',label='maxV')\n",
+    "#show singular solution as horizontal line\n",
+    "pl.semilogx(epsilon_array,np.ones(len(epsilon_array))*maxVs[-1],color='black',label='singular')\n",
     "pl.xlabel('epsilon')\n",
-    "pl.ylabel('max(voltage V) (mV)')"
+    "pl.ylabel('max(voltage V) (mV)')\n",
+    "pl.legend()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 12,
    "metadata": {
     "collapsed": true
    },
@@ -610,7 +490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The maximum of the voltage traces show that the non-singular case nicely converges to the singular one and no numeric instabilities occur "
+    "The maximum of the voltage traces show that the non-singular case nicely converges to the singular one and no numeric instabilities occur. "
    ]
   }
  ],

--- a/doc/model_details/IAF_neurons_singularity.ipynb
+++ b/doc/model_details/IAF_neurons_singularity.ipynb
@@ -1,0 +1,638 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# IAF neurons singularity\n",
+    "\n",
+    "This notebook describes how NEST handles the singularities appearing in the ODE's of integrate-and-fire model neurons with alpha- or exponentially-shaped current, when the membrane and the synaptic time-constants are identical.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import sympy as sp\n",
+    "sp.init_printing(use_latex=True)\n",
+    "from sympy.matrices import zeros\n",
+    "tau_m, C, tau_s, h = sp.symbols('tau_m, C, tau_s, h')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For alpha-shaped currents we have:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "A = sp.Matrix([[-1/tau_s,0,0],[1,-1/tau_s,0],[0,1/C,-1/tau_m]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and for exponential currents we have:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "B = sp.Matrix([[-1/tau_s, 0],[1/C, -1/tau_m]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Non-singular case ($\\tau_m\\neq \\tau_s$) \n",
+    "The propagators are: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA5UAAABnCAMAAACnxJZuAAAANlBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABHL6OuAAAAEXRSTlMAMquZdlQQ\nQN0iRInvZs27fFd4iKMAABDJSURBVHgB7V3ZoqsqDNU6nFpre/v/P3sZVKZAQAVrd3xoBUMSFoky\naaqKDhyB2wunIQpC4DAE6o84bocx/EVGXfOLtaI6fRsCd+mMVVV/mpYd3bcp+FX6NATPV7XHryoz\ncVe8fbhX1r9ax+PqdW+nZjiOHXEiBPwITOSVfnD0K+zO1U56Bp0TArkQIK+MQ/bxrqo3PSvjwCKq\nnQiQV8YByJ+T94rGlnFoEdU+BMgr4/DjY8pb28cRExUhsAsB8spd8FFhQiADAuSVEKjdezn401Gu\nIKlfqATlnYpA34xtc5mVBFRb8spTrYmEH4PAi434+/tVZuNQbckrjzEL4nImAtOTSx8vsikS15a8\n8kxrItnHIPAWu0W7zzVm43BtySsj7KJ+PZ/3+zWaPKI6v0fyEV75+Fxj5QrXlrxSt9F+bFtgX11X\nPR46GZ1/FwL9R7w68Pi036UXrE2EtuSVGnQPPl8wjFrOcjqKB+Vjmi7R7ovWf+V/+Ig2q+Xft9c6\nQlvyStWIw5PP5IET7HIe4Tb0tBVW4fU1ZxF2/jW6sts+fg8hr1TtdXuy12gmaPjYs12w7Kib12XW\nxFS1fv+sl3Z+mR6seLKHtCWvVEYrR+EqbZ+NQ9VD3VubjtKlEZDjyu4qsz1iFBzSlrxSWRA2LJnY\nsBJ6kioOdHYOAnfRl5kusjKCa0teqezoKR+ENKGjILnIWSt2ETQX2UWAa0teqQyv5a3aAysjioTO\nvhOBO5+ne15l0I9qS16pmVnbtBNNsmqAXOaULzTfruKUbHYC0Za88jKWR4r+GQTIK/9MU1NFL4MA\neeVlmooU/TMIkFf+maamil4GAfLKyzQVKfpnECCv/DNNTRW9DALklUlNRTGAkuA6hfgH2oi8Msly\nKAZQElynEP9AG5FXJlkOxQBKgusU4h9oI/LKJMuhGEBJcJ1C/ANtRF6ZZDkUAygJrlOIf6CNyCtT\nLIdiAKWgdQ7tL7QReWWK7VAMoBS0zqH9hTYir0yxHYoBlILWObS/0EbklefYDkklBPwIcK/suz//\n3Yv+/bz7QaIrhMCRCKDRfwb2EnfNZq3+/PESnzgyYKDIXAYcX5m4ZBtR9J9YW7rI99Fiq0N034sA\nRf+JbZvHRb6PFlsfovteBCj6T2zbjDSsjIWK6HYiQNF/YgF8Nd3UvmVYUk8MIIrMFQtmAboLtxFF\n/4m1j/7zYh55kwHXPDGAKDJXLJr56Xxxmq7QRhRnJNY+OjEN/eaf4A7EAKLIXLF4Zqa7dBuRV8Za\nh/zs9pN/Nt0fA6iiyFyxeGamu3QbRcQqor09woDuPJjBIB6Y/hhAFJkrs7NFs792G+GxisgruSn0\nHx7LeWTRKvoKiwFEkbminScb4bXbiKL/xBkGvzdVFYv+w6JXYjGAKDJXHKY5qa7dRhT9J8425AeY\n2AOTdWQpBlAcZmdSXbyNoqL//Pv8OxPiL5D9FjF/xkaEyqMYQF/QIogK124jNPrPf6zvRrvTERug\ny4RAUQRotqco3CSMEIhAgLwyAiQiIQSKIkBeWRRuEkYIRCBAXhkBEpEQAkURIK8sCjcJIwQiECCv\njACJSAiBoggU80o8UhJOURQZEnY6ArhF4BSnV2KLAsW8Eo+UhFNsqSCVuS4CuEXgFJesfTGvxCMl\n4RSXRJiU3owAbhE4xWbhZxYs5pV4pCSc4kygSHZ5BHCLwCnKa32ARO6VfVvgK814pCSc4oD6EosL\nIYBbBE5xoeoqVQf2+n3NP1ST+cAjJeEUmVUk9l+GAG4ROMWXVSlSnY59cbHE7nQ8UhJOoao0iXc8\nVJrOsiPQiy+NZRejC8AtAqXIbCi5QCk1rsQjJeEUa4uJ1+vWVNpJzrn0nLyNWpYRZEp5yK8WGXrk\nTeAWgVH4DMWsWVItzKL7QTH5zaqU8sqkmiPEj+eOcXDOufScvA1MygiypLTln5ZGpdMTXkOxapbC\n2Sq6GxSLn1Qlk1f2jTxYbKGq+lgHm18KXRbUAaD6555gRTnn0nPyNgApI8iW8so7bggaxRab8RuK\nXTMD3HDCLroXFJufkJ7JK8M123f15kbPSmCYcy49J2+jimUE2VKGi8Vi8RuKXTMD3HDCLroXFJuf\nkH49r6z32UbOufScvA1bKSPIkSK/LW9o8sWJgKE4NYuvhlN0JygOP65KEa9EInQgly3EgECTFkUo\nmXMuPSdvo05lBLlSAnZu6HdEAjEK5DLXwG8obs2iNXaL7gPF5cdVKeKVSPQH5LKJ2PDZtbiKzqWb\n0pJSOXkbipQRBEh58Y/LlzkQo0AuMx0DhgLULLZSQNFdoAD8mCrxXjncxTQM/5yxOpxM/vkuoOlk\nhA5VzjpDLuvUzb6Qdthcui4q9Twnb0OXMoIAKTIeqqFLMOGYB6d2MvPYTMBQgJoFq6FdBIqmgqJx\nqyqAH7se75VN3d96e0nCzuxffQUtrcq1rsc0AR7LtBCXJxasbmoe3RicYhWxQIyKUaIYAoP4xny8\nONs8REk7M5PNFDOUVFAi4Iv2Su6PPGSVcTiZt1vLn8n2MUfouA09cJFNegvGHV/zfXZVJ77KarOY\n0zIWCE/072fKY9NanZFJj5AlO1bEFt6LjKT/UoJsOauS80fL13T4xDEPTu5k5rEZZSiajna9RFq7\nHj61Sy/UcaB07+XgCNi8TE2ivZJxekDuYmY+zQ7uovf8Xzev0HPwVlc9c7RRLHJaRZck13c5/MP5\nhWL3fwERu3UsyQDciRJSwDSPmdLMzGMzuqGEFDzgWjIoqMwUr2zEg87qaMrMau6csnleeTeEBGNx\nc5hH8p0O9yrglvpo4ROgg+RvyDtORL9rkmqD6lmKtNpNMUrAaTajG0qUptuJkkFBRaV45V086KyO\npsys5s7pmzkKNK4UeiBxc3i5lj1rb23AgGU8I8HusW/hEoWGERwoooNH1DFafBFNlzoDfprNaIaS\nG79kUFCFkrxScjM7mvPYbu6c9mxcmdX8ZOw/ociYMqxkb8a8ns/7nffp449YERG8j/HKCEHxtQtQ\n+uTUqZ2HuY3K24xmKFo9ffXSSAKnntLJoHARHl5SeopXzvpCHU2sczoX3f/3UT7/YnO27Vs8V9t5\n8KwuLpL4rDuffWad4+oRHPQuJfT/sIgk3rZXelUGLiQJ0vXn5wA/QQLk43L6DzhdZ8t00uVtRjOU\nCq+Xo7DKUIV9JhQGRSuvmCLmmO6VYEcT6Zzq6uw61wDoPy/mbWK/0zjWw60eBrfn++AvdA/zLJVY\nFbWGxUFtwiLSeFte6VUZuJAmyKoRwE9QAPmunGW6QPHUjV3lYmflbUYzlMqtV4IRGIUrubBur/CF\nQDHL60AFzDHdK3XGxc8Hda/uxMzSmy2q1HzWx1m14boNbKGFvaAyT/yKVVFrWBysQVBEIm/TK70q\nAxcSBZk1AvgJAiAfkLNMFyieWJRlRXnumWYoQL3ijcAsLBfWHVQCoFjldVAC5mh4Zf+6r4dYwwBX\nVU7IXCujdeEbUatlrbgGX/67PSe2fjqPJZdFU2j9xam5kBgUEc1bKm96Jc+DVXYvRAuCK+EXZCkA\nyXHWsuDhmqiiK/5ES9EMBaqXOc4V6rPbt23+LN8oPC+sVzYqAVDM8rMgCZd8joCaGF6pF4LPjU5i\nPY5yWAfT7spdeFuLH7V6Vt55v3RdKx7B8c4H8FVoiONRNSgimvf44sf9Kf60t9BglZkq1oVoQZ5a\n2PxWMlyOO10QMMCVb9KJYVHRJS2zcMtphrILP6iwg0oAFKi8oS1ojhFeOb1vzdiL5Yre2EfAnP3B\nmALH2LybtNlOm8nCuza9TXVMerH5a3zOy6NyBn5qpprN7lRt+xa9VqBrAQ5xbOkyDYpgTtO23CgS\nebvPSlhlxnlebNooyK2LTxAux50uAGrtCsRyvBaFFVyvW2ax5q8nylBSG2plIU6g+jqoQEQzm8Al\nQQGbI+qVg3jZmu0940zehquxLmQPrhmym0mVtuHBmR1deZu7Yvt1YM0VZxv0xkp0UAe5uj09+LP0\neesr+eWGeS+UOzXLy6IHKKJqHlXNOx+JvB2v9KjMn/9Ss42CnGr5BG2So/oqjpzYjIBFxbJgt8Z5\nrsBXQhlKakOZHKNaOQBKVHlTJEthXlnP+5EnbogPx7z5J/Lcg0981knrzZy7fUje82hwubjee6TX\nM+3E47sVegy9+OcqNzKbjz17uTKycIj/h0SwO9O7E5v0xZea4nk7XulRmS1lzJhuFOTUzydoi5wh\ndb3S0YYZhrwFeyzKLQDmWGbh0qyGUiU2lMkqpnAIlJjypkSewrxy9vWq5g7pjCJ7vjjhHnxnY9pO\nesArF96yL7oIeS4jxbfo2o7S+9h+IEnA/2v+WL/LkUfbtNs/PgiLqG8fMftbpfF2vNKn8lqXjYIW\npNZ/n6AlP0XO4lIr8/STsEVF8zPNwi22Ggq7ze0xgojCQVAiyrvKI17ZLj1U8XiQN3H1fhx7tcvl\nOOd0rKSi1Mmg3MUr1bWVt7lX6C1mXnV2xjn/0FbLmLHeGdLFMYolJDreO3f6DDgDxyuXIj6Vtwpa\n+Dr/HkFJcnir7jsAi1KN7mXtkphm4RZEDMUtsD1nPyi2bMQrjd2EtfSI9f041n0zp3905ndmuSul\nfgHMXbxyLaF4d8vTUTDh0zv+QwyVuM+w7pExMeUvknqFT5EsC6ApZR/mtNVa1KvyVkErZ+vEJyhJ\nThh+SyKYBCxqbXSwgMh0SUyzcEvu19Tl6ck5XhTilcacL//GiJzylE7EP04AjisZ1ciWAPhtdXE3\nXlIeYO5Mpq4p3lLqUjp8X3pwD+a96uGW8HmDhXfU/9ROfAv9YYdX5VKCkuS8jVvkFhBci1KN7uUH\nkJhm4ZYMG4pLvyNnPyi2cMQrxYodKzPwO70wIM7AfD+O51TmO53VNK/LAZR2+RtfxxOLeeJp4pSY\nn9BCCp/09Txz5uv0lxWB/eiDFuU0OquEZVE2iWkWbqULGsp+UGz1Ea9s5oeYWH0UCwKcwfxOpc1L\npTmEDz6wA1+vW8pr2wnVI9Xhvd4LJPvjb0xKbTpDEEibWAeZgRYFm4lRfraL1WYsszBoRaKYoRwA\niq094pXVnT+aerk6xD8UII5l+XlOOn/1q+s6sbYpKe1th3N57YMhyisd3pM5QNz17SJHU8pIQmAM\nz7VF8YIsCjYTg51tM5ZZGLQiUcxQjgDFUh/zympkG3uW+JbL24nSO/0b759iAySXNPuxtdlvztW2\nE2peKRVc74nVzRzF9ftXzCwIKBmNwPOI4QNgUbCZGGrZNmOZhUErEsUM5RBQTP1Rr9TJzQ9l2U9A\nndI6Z5C63/7QtxMqr5xLqueofXsW67IWf0oWQaALToBvUcG0KNBMDLbKZmyzMMhEopChHA8KvovA\nrKzpPNYT0CTVU57Nfuw7lHxyjR/apm2ZsT5HO+f2vCv4j+ROv5sQEJ3PTSW9hXSLgs3EKLpuQXXN\nwqATiTKGkgEUdG+PWVdz0Q2/tZmlE1LrPZG3lHVM+G3SKkHJQxDIAbxpUdFqAmbhls2hryMli5Ck\nHizrh2o7ZiJubU4dYjPWe+L6NNVKvjdsrdGK0+k2BIYnuL1yG7O1lG5RayZ6ApmFW6iAoeQBRXql\nmJ1xn0puPb8ip3fmab9CrR9Xop+3Fl+omvkN5XhQZNwQ9tpQz75Lxw5zrvObwR/4Syl0lEVA7tUv\nK3OvtOyGcjwo7OMZ/Nhb8zPKD1pH+gz5f1Bmf52bttY6mQ0lIyj/AwbqsbYzxLseAAAAAElFTkSu\nQmCC\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}e^{- \\frac{h}{\\tau_{s}}} & 0 & 0\\\\h e^{- \\frac{h}{\\tau_{s}}} & e^{- \\frac{h}{\\tau_{s}}} & 0\\\\- \\frac{\\tau_{m} \\tau_{s} e^{- \\frac{h}{\\tau_{s}} - \\frac{h}{\\tau_{m}}}}{C \\left(\\tau_{m}^{2} - 2 \\tau_{m} \\tau_{s} + \\tau_{s}^{2}\\right)} \\left(h \\tau_{m} e^{\\frac{h}{\\tau_{m}}} - h \\tau_{s} e^{\\frac{h}{\\tau_{m}}} + \\tau_{m} \\tau_{s} e^{\\frac{h}{\\tau_{m}}} - \\tau_{m} \\tau_{s} e^{\\frac{h}{\\tau_{s}}}\\right) & - \\frac{\\tau_{m} \\tau_{s} e^{- \\frac{h}{\\tau_{s}} - \\frac{h}{\\tau_{m}}}}{C \\left(\\tau_{m} - \\tau_{s}\\right)} \\left(e^{\\frac{h}{\\tau_{m}}} - e^{\\frac{h}{\\tau_{s}}}\\right) & e^{- \\frac{h}{\\tau_{m}}}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡                                      -h                                     \n",
+       "⎢                                      ───                                    \n",
+       "⎢                                      τ_s                                    \n",
+       "⎢                                     ℯ                                       \n",
+       "⎢                                                                             \n",
+       "⎢                                       -h                                    \n",
+       "⎢                                       ───                                   \n",
+       "⎢                                       τ_s                                   \n",
+       "⎢                                    h⋅ℯ                                      \n",
+       "⎢                                                                             \n",
+       "⎢         ⎛        h            h              h              h ⎞     h     h \n",
+       "⎢         ⎜       ───          ───            ───            ───⎟  - ─── - ───\n",
+       "⎢         ⎜       τ_m          τ_m            τ_m            τ_s⎟    τ_s   τ_m\n",
+       "⎢-τ_m⋅τ_s⋅⎝h⋅τ_m⋅ℯ    - h⋅τ_s⋅ℯ    + τ_m⋅τ_s⋅ℯ    - τ_m⋅τ_s⋅ℯ   ⎠⋅ℯ           \n",
+       "⎢─────────────────────────────────────────────────────────────────────────────\n",
+       "⎢                           ⎛   2                  2⎞                         \n",
+       "⎣                         C⋅⎝τ_m  - 2⋅τ_m⋅τ_s + τ_s ⎠                         \n",
+       "\n",
+       "                                             ⎤\n",
+       "                                             ⎥\n",
+       "                                             ⎥\n",
+       "                    0                     0  ⎥\n",
+       "                                             ⎥\n",
+       "                    -h                       ⎥\n",
+       "                    ───                      ⎥\n",
+       "                    τ_s                      ⎥\n",
+       "                   ℯ                      0  ⎥\n",
+       "                                             ⎥\n",
+       "            ⎛  h      h ⎞     h     h        ⎥\n",
+       "            ⎜ ───    ───⎟  - ─── - ───    -h ⎥\n",
+       "            ⎜ τ_m    τ_s⎟    τ_s   τ_m    ───⎥\n",
+       "   -τ_m⋅τ_s⋅⎝ℯ    - ℯ   ⎠⋅ℯ               τ_m⎥\n",
+       "─  ────────────────────────────────────  ℯ   ⎥\n",
+       "              C⋅(τ_m - τ_s)                  ⎥\n",
+       "                                             ⎦"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PA = sp.simplify(sp.exp(A*h))\n",
+    "PA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "NotImplementedError",
+     "evalue": "Can't evaluate eigenvector for eigenvalue -h*(tau_m + tau_s)/(2*tau_m*tau_s) - sqrt(h**2*(tau_m - tau_s)**2)/(2*tau_m*tau_s)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNotImplementedError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-11-9929748d2ac0>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mPB\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msimplify\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mB\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mh\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m \u001b[0mPB\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/cache.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m     89\u001b[0m             \u001b[1;32mdef\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     90\u001b[0m                 \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 91\u001b[1;33m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     92\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     93\u001b[0m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/compatibility.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwds)\u001b[0m\n\u001b[0;32m    855\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    856\u001b[0m                     \u001b[0mstats\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mMISSES\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 857\u001b[1;33m                     \u001b[1;32mreturn\u001b[0m \u001b[0muser_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    858\u001b[0m                 \u001b[1;32mwith\u001b[0m \u001b[0mlock\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    859\u001b[0m                     \u001b[0mlink\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcache_get\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/function.pyc\u001b[0m in \u001b[0;36m__new__\u001b[1;34m(cls, *args, **options)\u001b[0m\n\u001b[0;32m    373\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    374\u001b[0m         \u001b[0mevaluate\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0moptions\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'evaluate'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mglobal_evaluate\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 375\u001b[1;33m         \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mFunction\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcls\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__new__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0moptions\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    376\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mevaluate\u001b[0m \u001b[1;32mor\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mresult\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcls\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    377\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/cache.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m     89\u001b[0m             \u001b[1;32mdef\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     90\u001b[0m                 \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 91\u001b[1;33m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     92\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     93\u001b[0m                     \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/compatibility.pyc\u001b[0m in \u001b[0;36mwrapper\u001b[1;34m(*args, **kwds)\u001b[0m\n\u001b[0;32m    855\u001b[0m                 \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    856\u001b[0m                     \u001b[0mstats\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mMISSES\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 857\u001b[1;33m                     \u001b[1;32mreturn\u001b[0m \u001b[0muser_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    858\u001b[0m                 \u001b[1;32mwith\u001b[0m \u001b[0mlock\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    859\u001b[0m                     \u001b[0mlink\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcache_get\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/core/function.pyc\u001b[0m in \u001b[0;36m__new__\u001b[1;34m(cls, *args, **options)\u001b[0m\n\u001b[0;32m    197\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    198\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mevaluate\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 199\u001b[1;33m             \u001b[0mevaluated\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0meval\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    200\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mevaluated\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    201\u001b[0m                 \u001b[1;32mreturn\u001b[0m \u001b[0mevaluated\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/functions/elementary/exponential.pyc\u001b[0m in \u001b[0;36meval\u001b[1;34m(cls, arg)\u001b[0m\n\u001b[0;32m    273\u001b[0m         \u001b[1;32melif\u001b[0m \u001b[0marg\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mis_Matrix\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    274\u001b[0m             \u001b[1;32mfrom\u001b[0m \u001b[0msympy\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mMatrix\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 275\u001b[1;33m             \u001b[1;32mreturn\u001b[0m \u001b[0marg\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    276\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    277\u001b[0m     \u001b[1;33m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36mexp\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m   1924\u001b[0m                 \"Exponentiation is valid only for square matrices\")\n\u001b[0;32m   1925\u001b[0m         \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1926\u001b[1;33m             \u001b[0mP\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mcells\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mjordan_cells\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1927\u001b[0m         \u001b[1;32mexcept\u001b[0m \u001b[0mMatrixError\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1928\u001b[0m             \u001b[1;32mraise\u001b[0m \u001b[0mNotImplementedError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Exponentiation is implemented only for matrices for which the Jordan normal form can be computed\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36mjordan_cells\u001b[1;34m(self, calc_transformation)\u001b[0m\n\u001b[0;32m   3702\u001b[0m         \u001b[0mJcells\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m[\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3703\u001b[0m         \u001b[0mPcols_new\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m[\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 3704\u001b[1;33m         \u001b[0mjordan_block_structures\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_jordan_block_structure\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   3705\u001b[0m         \u001b[1;32mfrom\u001b[0m \u001b[0msympy\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mmatrices\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mMutableMatrix\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3706\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36m_jordan_block_structure\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m   3442\u001b[0m         \u001b[1;31m# that will eventually be used to form the transformation P\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3443\u001b[0m         \u001b[0mjordan_block_structures\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m{\u001b[0m\u001b[1;33m}\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 3444\u001b[1;33m         \u001b[0m_eigenvects\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0meigenvects\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   3445\u001b[0m         \u001b[0mev\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0meigenvals\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3446\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mev\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;33m==\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/usr/local/lib/python2.7/dist-packages/sympy/matrices/matrices.pyc\u001b[0m in \u001b[0;36meigenvects\u001b[1;34m(self, **flags)\u001b[0m\n\u001b[0;32m   3000\u001b[0m                 \u001b[1;32mif\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mbasis\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3001\u001b[0m                     raise NotImplementedError(\n\u001b[1;32m-> 3002\u001b[1;33m                         \"Can't evaluate eigenvector for eigenvalue %s\" % r)\n\u001b[0m\u001b[0;32m   3003\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mprimitive\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   3004\u001b[0m                 \u001b[1;31m# the relationship A*e = lambda*e will still hold if we change the\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mNotImplementedError\u001b[0m: Can't evaluate eigenvector for eigenvalue -h*(tau_m + tau_s)/(2*tau_m*tau_s) - sqrt(h**2*(tau_m - tau_s)**2)/(2*tau_m*tau_s)"
+     ]
+    }
+   ],
+   "source": [
+    "PB = sp.simplify(sp.exp(B*h))\n",
+    "PB"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Singular case ($\\tau_m = \\tau_s$) \n",
+    "We have"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALkAAABSBAMAAAD6AGguAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAMquZdlQQ3SJEzbvv\niWYEN0CTAAADrUlEQVRYCd2ZT0gUURzHv7ruzKq5LhR16LBKUkf/UESBITVBhtBCQZfMwSwhCrcg\njIJciOiYl46RHaJbiF2D7NAx2sAunQSPRYr9gQ4xvUVn3r95781rBgPnsr/3+73fZ96+mVm++x1A\nOvZKmQwTOw9kCJNR5+VUhpks6eUgWOeXlg3dDYIAKB/0TiamX1rq5+fyI2fwRCnMFD2vl9CjcZjX\nrP05JmvhtJjPtopzm0mv2tGLi+iYY9rF8CvwmclZ0tu7kP/FtIvhAjDm02Qs/QKtC1FnF1p/Cjl2\nSG6PpxWaiKPfn+mhE/hoqg+tP/gUO3K+E/oQzcTRaVWKHtXR9EfKRokCqZXr0RBbQndeTJPjjnRv\n0mVsRFN1/c6Qtet2ppM8YJvHmogm484+5HVXlez7mOGqxlDDlDuPou6OvAus+uFkEsc9TbQsRi2L\nyM2JSWY8AhxlhpZ03MI13cVxK87bFPTrXjfTLYXO0nH25LZrl3jahER/GAS/tR02RYneP37Fpl8/\nV6Q7aNc3WFVFOvDEql8/WaYfA1Yurjz+qO9LVpXpN4Bzczsqo8n69bNkehVoLk3ik74vWVWmkz4X\nZ1FlfoxEVGIlGEsfxzB6aiIzGidXgrH0iKMINIqE79hW9Daf/3JxI/XOsEqPdIo7U3iTiq5Xes6r\n3lR0k9I7k4puUnpJ6GolaFJ6CehqJWhUegno5GZQHEal9z/oVxtCcPoZEAo18hmzfkdWepd9dl6q\ntUNQeg+APbXs6ILSIw81/68s3dpHDEovHd2g9AY+3FxmN8oyTqn0CjNBMJv4lOJvpKkxt3u/b5pD\n67Z0H/O02RjZ0tFaNzLpBGt6bhnFQ9+OjJYoQx1Z090S8qfxLp/oK9jTyUq7nWpHRb1iWrGmN1qr\n+T43TxnqyJpOVJ7T1TLbfErNbJoPa7b0BCqvaaD6r3SotUyIRH5b0g2eHdLtjMGzS0c3eXbp6CbP\nLh3d5NkBapVH78jFMBSeJoNnB6hVXkhE4fD60OZAoBs8u4iQMNhSusGz29B5a/LKQyUomHbC2k2e\nnczVZgS6ybNDcWFwoqYlskWBbvLsCi/hvGb79bFAN3l25Vngi57IVkW6wbN7T3p3sf36WKTrZ7c0\nfFStb8abdnZ0ctENB2/a2dHJDas/BNPOju7WgcKy9gScaWdHz5GdyflaOmfaNejSuzJ1+z04BrOP\nmnYb78omPG9YzeMrHfuWfD4jjqqRaUfelXliNYOxybRLdwrWtPsLgF4+IP8NYNIAAAAASUVORK5C\nYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}- \\frac{1}{\\tau_{m}} & 0 & 0\\\\1 & - \\frac{1}{\\tau_{m}} & 0\\\\0 & \\frac{1}{C} & - \\frac{1}{\\tau_{m}}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡-1           ⎤\n",
+       "⎢───   0    0 ⎥\n",
+       "⎢τ_m          ⎥\n",
+       "⎢             ⎥\n",
+       "⎢     -1      ⎥\n",
+       "⎢ 1   ───   0 ⎥\n",
+       "⎢     τ_m     ⎥\n",
+       "⎢             ⎥\n",
+       "⎢      1   -1 ⎥\n",
+       "⎢ 0    ─   ───⎥\n",
+       "⎣      C   τ_m⎦"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "As = sp.Matrix([[-1/tau_m,0,0],[1,-1/tau_m,0],[0,1/C,-1/tau_m]])\n",
+    "As"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAHYAAAA3BAMAAAArjaPrAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMA74lUMhDN3buZqyJ2\nRGaQSGKPAAACDElEQVRIDe2Wv0vDQBTHn6ZnqNUq1N0uOohg6uLYFFrQySIi/gGCa3GwgkM7O0nF\nHwiCgyKCs+AidVBQB/sfWDcnRTcLEi+0yeXd5a5JLbj4oPTde+9z73qX5nsAvM3ygeDjubPgtULl\njBAJHgjBjlqfeN6A7JT1AYlsLihLKvemW7uYTcGIO2o58r59Btn0VGfCsC8A452yWwDpPIN9+qZY\nlvMaAM8Gi4nsVemCpZFHvihbZSGRZTnei9HDnE+y6K9Zslqktm6yKX09QvvK12wx86Pp700r98oP\nasU2AN7VZySHbwD2PNkwewW6QbxPcCiWTD6Ynfb1cLaL+8ZKllXjKuRDzEZzp559lFPNDGbzUG4H\nePKYhcGkJ9fO5dhoHeI7b0fTZjvOznOsboJ2Bwkt2QlLmRNS6DU6YG09KWjbuiZnI2Unh9ds6wk5\nHqj1Pzp54TtyWHBimAX5+9UBQPtnm3vxV3sl1xN2RsOOi89XridOPcT2G9XWALNuRSCnW+xQUxXE\nnku25BRXAJhsWLSqW33pVK/nY/K/EL8g3PeyDsvuEfClwhixkW+AeFmokQUQ25MEiFRlpUIcsU95\n+tqgH6lh3UAs1Ve1Yd1ALNV1tWHdQOwaJa+VNNINxB5QblfJIt1ArF6HBVPJIt3IoDvwROVWiYJO\n0y3dsO/Awt1bTbu6Yd+9w5pHN34AeJuPHUKPhrYAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}- \\frac{1}{\\tau_{m}} & 0\\\\\\frac{1}{C} & - \\frac{1}{\\tau_{m}}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡-1      ⎤\n",
+       "⎢───   0 ⎥\n",
+       "⎢τ_m     ⎥\n",
+       "⎢        ⎥\n",
+       "⎢ 1   -1 ⎥\n",
+       "⎢ ─   ───⎥\n",
+       "⎣ C   τ_m⎦"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Bs = sp.Matrix([[-1/tau_m,0],[1/C, -1/tau_m]])\n",
+    "Bs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The propagators are"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPMAAABgCAMAAAD/2rTgAAAAP1BMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADFBd4eAAAAFHRS\nTlMAMquZdlQQQO0wRIki3e9mzbt8bDjT79EAAAX9SURBVHgB7VzZgqQqDEVFesbdGf//W28CtbKI\nQGJbc5uHri41hxyRhOKAQqSXekm3+XSLtvl0Bun+N226zadbjHJuhk8nkej/Vgk5J9pc6vJq06U+\n7lS3CrF+YjuPhqoQ1dZIKAldFNt4FAkGx28n75UzEq035Fwl1oR9uZYq0eoql89ZnK/ifZ4fiZxN\nd7D+5tX8tFJNL5vUR+1pbv8XhYtybtd7YXuUFwgMaiQLiVG4KGf7LtJ/nyfE7KlGs3G4C3BedZJs\nN6LnKA53Ac6b5txtRKkvDhfkrHopPcPLapmmcSRqEt1P1KZ/r3SbJOk2B+BCnDuMKUPvuNGKrnMO\nFh0YNl1LZT6KoND4AFyA8zBhLPUmkB4beW7aeW66ti9PMQecTLkRB+ACnOsJRmmz9xHW8bWV8AH3\npXWfhBQH8VplGpju2dYu7cEFOJtA4HNfwc8LKHUFKRUyDEHgMf25JYthOjzswYU4x9oP+OJcCcUP\njVHfxZkqV8XhApwnwzkYShXkFwnBrJblwyepxyQN1ZgkDhfgjN0VYlg5Id0RIn9GjJdTeTS8VROF\nC3AWspHzWRMhOBSA+EBVonAhzlQOXBHnh/MVW4Xep592pr+nV0T8aecrtgq9T0XtzKBOMkA6N62I\nM4M6yQBJy5lBnWSApOXMoE4yQNJyZlAnGSBJOTOokwyQDmVREsMY1EkGSFrODOokA+QRzmqdYOLn\ng0uWRre4i4LelTpLl7xr92n3iQHSOJCl0VHNQKbdA6qrszS6jmoGkopFGs4xje5r+3qF7T+7O8c1\nuj/u2ooFdBl5WxXEoNQxQL62WJZGp7YFpnhrI5DSK3Xc4l+WXtXqVUQrigsMSh0D5GsrZ+qSRlCY\nUMJgUOoYIN85H5D83LHniLLNoBubQaljgHznLOKSn8NZbaip96AhKRGVwdOVOgZIi3OGRoc3AaTl\nXoD6zKDUMUBanDM0OjMhBY0NjziDUscAaXEW6RrdqpW5vtFiLINSxwBpkf7R6Kwbgl+dGOa55l87\nhJy/fv3+12jt8vn7K2f99i7k5U/+X5/t9HX6l2/KXQd/2nn39nhOnqGoeaotPFTWzmcoaoUEPeZl\nnM9Q1DxOFx4q43yGolZI0GNexvkMRc3jdOGhIs6nKGqFBD3mRZxPUdQ8ThceCnOu+j62DZRTUaNJ\ng16UMGeY+Oy+cXafJg16UcKcYTWzelFxVGOKXphPItLtP6E0adCL4nCWtxkr9KilbedX6H3CcJYm\nDXpRHM5ifOwlUihoUJYndByVJg16URzOz+dZ1d59N3F3Q1c8oUNXPI/TpEE/isP5EbdgZ4IyuzKe\nnjz+y9pO94B+wIT/oUmDfhSHc1/Ps94ogFv/sT/jNKKzFyVrO90DOkz1cYYmDfpRHM4LbIaUWpQ0\n9atFCdxlY5eM7XQ2tA151neHM0o3ZnLbuFDXsKHO443eGpS2nc6GvqHSLCxJQLE5V7jZCZWAe5ke\nYfx+RH9mbKdzoN8AT/xic5Yw/Bo28dz5owXKYABPEekc6BNpvlVlc14hXM0rilW3suKGL09/1qeT\nttM50Pcqzv60OeMwZKh1gDKuKOjPTtjO8tKB9qNkpUEHag/F5uwY8x0ILKZJTIMZKN/HObSYBgT/\nhF3lOSjfxnlnMU1CGsxCsTh7fyQmHAz2hDcMvCq8mCYlDWahWJyDPpOfCC+muVV1KA1moRzj3Ddr\nc8vR81o3vcrb6v1qG1tMcywNZqEc4tzjwkDdy4YFx6GwxDuj3d9tY4tpjlWQhXKIM66ArDb9x4xE\nYdSSXCq9CEuPeNCWZjFNFsohzjjmHtDl+7xRlTFKsW1pFtPkoBzijO2C70CS9zlBFRyA46XeUmLr\nBcw/aDjrTBIaVBvwEZrWLLHLq6zENq9Gn9XjHYgKXwwo8dUb4dLjHg2zlDJ80d6ZEts93LRz+h2I\nB38/zHpbil7+CpUMvkmESOUlthFontMd/LbsKtHcwvU9V6dUVmKbUg/VtdXStu0KcWvU2TnvZVIl\ntlREEnAmHePQoIdBWO57PUtsE5w9dOl/jfFV4X8oDk8AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}e^{- \\frac{h}{\\tau_{m}}} & 0 & 0\\\\h e^{- \\frac{h}{\\tau_{m}}} & e^{- \\frac{h}{\\tau_{m}}} & 0\\\\\\frac{h^{2} e^{- \\frac{h}{\\tau_{m}}}}{2 C} & \\frac{h}{C} e^{- \\frac{h}{\\tau_{m}}} & e^{- \\frac{h}{\\tau_{m}}}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡  -h                 ⎤\n",
+       "⎢  ───                ⎥\n",
+       "⎢  τ_m                ⎥\n",
+       "⎢ ℯ         0      0  ⎥\n",
+       "⎢                     ⎥\n",
+       "⎢   -h      -h        ⎥\n",
+       "⎢   ───     ───       ⎥\n",
+       "⎢   τ_m     τ_m       ⎥\n",
+       "⎢h⋅ℯ       ℯ       0  ⎥\n",
+       "⎢                     ⎥\n",
+       "⎢    -h      -h       ⎥\n",
+       "⎢    ───     ───   -h ⎥\n",
+       "⎢ 2  τ_m     τ_m   ───⎥\n",
+       "⎢h ⋅ℯ     h⋅ℯ      τ_m⎥\n",
+       "⎢───────  ──────  ℯ   ⎥\n",
+       "⎣  2⋅C      C         ⎦"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PAs = sp.simplify(sp.exp(As*h))\n",
+    "PAs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJgAAAA/BAMAAADu9RxEAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMARM1UEIl2mSLd7zKr\nZruhia6uAAADIElEQVRYCe2YQWgTQRSG/3Qnm6ZJm4gnLzZH8bQQar1oF6QUQUrR0oseapFWxGi1\nVgqCBMGLKEaoUi8iFA8qQvDoxeKhgiLkIBbE1h5EPIgoKh4U4qTu7L7ZzOwkJhfBgbLv/e9/38xs\n0u100Vut5tCG0VOtfkVvPp9VsdJNThHL5zlMReKaNa0p6OVFLSzh6Ls0FT0sWZjT9GhlPSxTLmi7\nNAU9bCs+aHq0sh5WQKnZu6aHzWHZ1a5BXdDD1H6qstmpMs0Rglmf+HiHTNUfkltOOhy2ICkhmFQz\nJa+B/ZKnFdhHYMCltFZgv4Be6QMnMDY2VRTzPLx3U5pT6PTKfnDYOFUIbEuxc0SUnE0i0l87vwOP\n/Y6aL4B1LmIo+KRH0T2zeqovEOqhUbD0g8mXQUcO1gQWLWnioLoRMb4y3TYzS8TM1oHnrBR3iFYX\n8ns2IBmCbWbCqyhZ00mrjkCEW8Bbl+TknnVx2DgpsSU7mz5KhLrwGHBaEoOV2TkMFaWaKUk67L7k\nCWCYKlSkkjFhY8fLkonAJP2vkv+w5m/bP3vPnpj3SiyGbfabYcRigM2YYcRigN1YKZpwxCJg9h1l\n00/b+PtKLAKGaypYbL3HtDJqETD2TQWzK9GPR95DLQIWK6lgiWL6iEonGrUIWPzFG/nZRPwNhwLW\nMW8vhZr8s0v1c6jipyGLgGWyiRHh2V07CrkiU17VFgF7hKSjbGtGFLATuJpqpk/pFbD3WIsrDc2I\nArYNl0drfYOT/uk/tf3uvAqltwiY1xVbwEUBsGJZEdJrhCUEu+Swc35n3MXKrpXNB31hI4iw/IF5\nB2Lg2auC6/d2ADtyXU6fL2wEEZbQyvjJMhjDQLq8FwcCpRZFWHzY2tNRfkrhRy5pJNEf/kclwiJg\nFyoYvg3wp5pNaftwGMtFqkRZPFjqC9C9DkyA+V8NCREkERYPVjucpcb5ss6uBm3qKMLiwU66AOM/\nrQ0Pxk+UbRgejJ912zA82HWOutIyzoOd56Az7YIlKxgstwuGQ7OmP0MNTOVtswFnAxYOa+eLpT2a\nF0sNrESy8BdLO38DVoXxfxr9m2sAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\left[\\begin{matrix}e^{- \\frac{h}{\\tau_{m}}} & 0\\\\\\frac{h}{C} e^{- \\frac{h}{\\tau_{m}}} & e^{- \\frac{h}{\\tau_{m}}}\\end{matrix}\\right]$$"
+      ],
+      "text/plain": [
+       "⎡  -h        ⎤\n",
+       "⎢  ───       ⎥\n",
+       "⎢  τ_m       ⎥\n",
+       "⎢ ℯ       0  ⎥\n",
+       "⎢            ⎥\n",
+       "⎢   -h       ⎥\n",
+       "⎢   ───   -h ⎥\n",
+       "⎢   τ_m   ───⎥\n",
+       "⎢h⋅ℯ      τ_m⎥\n",
+       "⎢──────  ℯ   ⎥\n",
+       "⎣  C         ⎦"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PBs = sp.simplify(sp.exp(Bs*h))\n",
+    "PBs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Numeric stability of propagator elements\n",
+    "For the limes $ \\tau_s\\rightarrow\\tau_m $ the entry $PA_{32}=PB_{21}$ becomes numerically unstable, since denominator and enumerator go to zero.\n",
+    "\n",
+    "$1.$ We show that $PAs_{32}$ is the limit of $PA_{32}(\\tau_s)$ for $\\tau_s\\rightarrow\\tau_m$.:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEEAAAArBAMAAADVtvhKAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAELvv3c2ZVESJZnYi\nqzKqLvLVAAABg0lEQVQ4Ea2TvUvDQBjGn7Rpm5i2huIiIkpxVOjQRV3qKDoUBCeHKkgVRYtDQQXb\nzbVbN4lLBjs5CKJLwMlZnKSQPyGCoKJWL8a8PWk+KPSFkN/zcSE5cgAyeYTNalgBr2EN6TmsIRfC\nGrFya9qr80jmxBraJDioEtdMZElwUCbeBOZJcLCkG39qEckOFxB2FM1h4Q1yTiCfQJqMGI4YshBt\nnFNAoGhiwhGpIobrDQoI4kbq0hERDfI2+YOAgywbFd801iCe2t8zRm933QXplfyCy927tIx7VyWk\nuovc/a4i7JGUVehH+ukZGTY8tG5UMmLAcTFaOWSG++EWvihmkAFS5giavIf3fwoQUUWhwpuzgMLr\ncVzjyeCdKwj0tbzfZWXnoiv6pbGZtkZ75bVYmQOq7PIdYYrtU/zTNwdi9sGWcgGNfXtT0iX/RvLF\nzgTTvyF/+GdOInqeSH5V1LKVx6mkkvjbOCHdC85OlHoDcpL2b8H+uYCpaUisB+TsJTfaW0GFH7To\nVTvpgivnAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\frac{h}{C} e^{- \\frac{h}{\\tau_{m}}}$$"
+      ],
+      "text/plain": [
+       "   -h \n",
+       "   ───\n",
+       "   τ_m\n",
+       "h⋅ℯ   \n",
+       "──────\n",
+       "  C   "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PA_32 = PA.row(2).col(1)[0]\n",
+    "sp.limit(PA_32, tau_s, tau_m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$2.$ The Taylor-series up to the second order of the function $PA_{32}(\\tau_s)$ is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAhoAAAA4BAMAAABJbEwBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAELvv3c2ZVESJZnYi\nqzKqLvLVAAAIuUlEQVRoBeVZfYwkRRV/PV89PdPTM3JAQtDseDFKLnysEYMiklFRQyQwRhaIEhgI\neKfewWjMGdTIBMGvRG/5gzNIgFbixnCGrBfuxN0jNB8xQo7sEILGXO7oQMREIbuXGF3u8NZXVV1f\n3dUz23OzxGVfslWvfu/3ftVV013dVQswPqu1x6e1/pXszvofw/hGUOqOT2v9KxXmtq//QYw0gt3v\nbyTy6uFcAtsQgBMYlsw74OwNMfjEIAuB91YCnIPWxlw58j13OTEb2+FQ8vFJsN6RgH30HTksOOX8\nTOOK6IVZLau+IkzD11/jqmyXzOi7oyR7M9p7syn8X7P/k+3qKL3SyZa0btjlbCsAo/8YfrZuBpjp\nQp1Wdrp39bfexqej4me6wpHIVp+lFbfuMX41vWRWpfT8ysoSgHXf/oCT/vahSxrcH3e9b9yCJr27\nGDhxLRw2hXeaQACFfmfgTnNS90fcG3td/uDYJQ2C1T4Fbw9hsyEKW00ggKS7F8DpoSDdDZWtD2+7\nTQIicrLOppE0TTupgVfyRRq9GeBjJtrnZgITLOm1C+d/KRltsPfBBba4WWTkZL0/jyJg3EkNFFqg\nT/ql4J4w0U5UfRMs6XV2bzGS1QQ4YrWcrinnpDAv2zsv6su4kxp4HTUyHGsZnEkrySs3c0ESVen1\n6Vi8ZXcKdgw7+WaxM4qGcSc1UIjOemUJ8tPKHc8zqr5xZAo9j7Mxy+lYW/1qr3ZAAcbjLgSj6WTe\nSX0J+8GDinov/isjXgpqvzNchkKvtuH0wEAZM3TTiHqxndRwlYeQkvPB+cpwKmeo9P1zPoeT9T+S\nUCrySDJSvuGMK66hMFviPT/JSUMqIYnwnVQaK4Ev9BIQA8SGlHxkjWRuM0NaLUyQHy+f9dpKD+Fo\niX8qwRgAHMFY9p0UefJ1+wbZkjZ0bKRWMZNIO95Hbfb7DXiCwLhQEfs8LVdZFJGXfSdlONxM6+/d\naYEU/A8pOIUTYpxtBVHaDusjAHUyEaUWgarTpEyxhByyR9hJVdm8p3Siwd/RWsMbFw2iJMQ2RWx7\nljnlo6UmQJF8aRTQAcgHpEyxhJw1CWwnlZIAB0wB+y0TasQSPRpZAiy3hGtwEmLFLmPx2Sh0bARy\n5Meqd0joTlKkWUIOrk6jRrhxD+ZpBz1nzIv/DnlfOP8TumCyRz0eazkdCVRxTT4um+hFYjLA6Xw2\ndoWEn5vEok5vF/UF8QTqUZBwiPFrkwFBL/QxLnFKx6LAHD1gHeNhrMuXwbO8aZd73I1q3mMMTmvi\ni1jYva8fORiIFnEiMRmotFmcz8atDdLOd7CY8LGALaRg5jzw/OsHeYPWkZwS+DWPb0JhBeew3SRe\nPHCch7F+umvdIppOA2a+PfPDBwSQcTYKXZHpdaEpGsxhYkrAbrEAn43zaHOxh9WCT/zPkoLZ3yHH\n3aiOrk0JfFNlKLiA95LpjgfeBLzrqC3Bi3vm6C9CM4r4A7bz3dtEOp8Nzh9QL2FSvgdw2iXErgPw\n+kKGOVxMBDySg8Zn43p6JTcTaLFLSnzDWFcSuU+HAG8QRDEuJwOLShRdmVAiGmhXLFOGDJDmvynG\niv8qPpyCn+zhqfBzht0zNfWpqamrVMIQn8yGMMcXLjqKmAjQ2XCmpq788NRUBzkvh1i4dI1f9NEl\nsyHtF9LV5EAEYrMhcJF4V4+6ekCdjTcFlTkF2Kn8K1HMf4yV0lSeFFyzQqh89Z/7q3vDiM3FMADO\nPP745RaL8HvjwT62T+sRMPGkAFwOMPPIfGf+XBJH43IkAPf9HovYK0jghE3Miz7mdCV1Bj6K3ziM\ny8r3wGNwKOCI6JED8Vo/a1JXUVjAL8pdfv6FKhkjMS6GAdjmNTHcJrB8UiaO4a1xFoUmZkm1hfqs\ncJcAfnMMPt54PAK5HAmUeq8gKlZRypB4lADFQAQUJexU2D6wtotGwuE9JgIREDtrcvoK8VGAJx/F\nnXJpOgK5GAZg89cbOIYOi/B7o7Lylz/tCCjGTlHuZ3FaVlvgntmCZeCbTS6HAch94F1I+jKnb2qi\nJ3EO/4A5upKrfm9Uv/YwJxtq3qMhRKHYWRO/9WnsEJaH4FUQjw8XI4E3VkL86uyhh8ZnA+5Y+UxI\nEcjTeVVv/dosLmqz3qR40XA5EvBeJgd517BcfEgn0ZM4h29hjq7kLRP0zHMO+89yXlrNe2TxP954\nLnGUzPhZ02UxoYthLyx4EaiI2QG5pKejgJgNmZ1rE78QSIR4+bDadJdCBipy8F2cd3DJHDBDcWoU\nj3ytkkr0eKh6IcBO/BtsP1HDVh8e7OEdqGXqZ00zKh+vbwmv8ldOBCpihbAU4tIXBcp+5MjKoSOr\ndCRCvAX8wSvNaQYqcriQ4u/u8DmQh3MU1zVYSyqRnqz3NfC5Xf2GhWjUGpCfjGfqZ025gHUWleU+\nXAvP361htFGZewyvoZ0McCSa5LN5m9U/xYXQ/Steedz27Onh20iglh+5FBew4kilXD/aKJYnlfhw\nN9+C2gm2xZSZu7U8t6k1BzdiU6eRo93DUxo4pCGnrjKEqYbrPsCtXUS8jgoP9XGrjbOhZ8bv5eeG\nqkjCb6Wb9M6hkOsnI2lIJUiLDMQXA3D/RRhWOJBnCBaOiky2Fc1+1mRQNUEPmcC1wO7BBef4aMK7\npkUm3YqOcNa0yo4nyM37dhi+Ewrk9TyCfVJksq3o4LOmEToQKdW2cNfUsXHtzC+RLqys/ZSaSqbX\nz5qeiX9xJvbI5IKP9wadje9l1cAtgsx0UGcNTd90rFlHpBv2pdHJ2IfdgYMyk2xF19Bys2soLqTd\ni9B1yTbWaQhwdc5rAAdkJtmKrqFZl6+huJA+tUvc232wbxDY6hz30nt3tGQmbkX184vVqaya9Uyw\nauroxC001brx8LasGkU8B2yByMR9kn5+kVVvCN8NhxDGELZ6YxDhEvr5BUc3bK2dX2zYWeAD184v\nOLhRa/38YqPOAh936vkFJ6yL+n+kem1jDpDuygAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$$\\frac{h}{C} e^{- \\frac{h}{\\tau_{m}}} + \\frac{h^{2} e^{- \\frac{h}{\\tau_{m}}}}{2 C \\tau_{m}^{2}} \\left(- \\tau_{m} + \\tau_{s}\\right) + \\mathcal{O}\\left(\\left(- \\tau_{m} + \\tau_{s}\\right)^{2}; \\tau_{s}\\rightarrow\\tau_{m}\\right)$$"
+      ],
+      "text/plain": [
+       "   -h                     -h                               \n",
+       "   ───                    ───                              \n",
+       "   τ_m    2               τ_m                              \n",
+       "h⋅ℯ      h ⋅(-τ_m + τ_s)⋅ℯ       ⎛            2           ⎞\n",
+       "────── + ──────────────────── + O⎝(-τ_m + τ_s) ; τ_s → τ_m⎠\n",
+       "  C                   2                                    \n",
+       "               2⋅C⋅τ_m                                     "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PA_32_series = PA_32.series(x=tau_s,x0=tau_m,n=2)\n",
+    "PA_32_series "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Therefore we have \n",
+    " \n",
+    "$T(PA_{32}(\\tau_s,\\tau_m))=PAs_{32}+PA_{32}^{lin}+O(2)$ where $PA_{32}^{lin}=h^2(-\\tau_m + \\tau_s)*exp(-h/\\tau_m)/(2C\\tau_m^2)$\n",
+    " \n",
+    "$3.$ We define\n",
+    "\n",
+    "$dev:=|PA_{32}-PAs_{32}|$\n",
+    " \n",
+    "We also define $PA_{32}^{real}$ which is the correct value of P32 without misscalculation (instability).\n",
+    " \n",
+    "In the following we assume $0<|\\tau_s-\\tau_m|<0.1$. We consider two different cases\n",
+    " \n",
+    "a) When $dev \\geq 2|PA_{32}^{lin}|$ we do not trust the numeric evaluation of $PA_{32}$, since it strongly deviates from the first order correction. In this case the error we make is\n",
+    " \n",
+    "$|PAs_{32}-PA_{32}^{real}|\\approx |P_{32}^{lin}|$\n",
+    "        \n",
+    "b) When $dev \\le |2PA_{32}^{lin}|$ we trust the numeric evaluation of $PA_{32}$. In this case the maximal error occurs when $dev\\approx 2 PA_{32}^{lin}$ due to numeric instabilities. The order of the error is again\n",
+    "\n",
+    "$|PAs_{32}-PA_{32}^{real}|\\approx |P_{32}^{lin}|$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tests and examples\n",
+    "We will now show that the stability criterion explained above leads to a reasonable behavior for $\\tau_s\\rightarrow\\tau_m$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import nest\n",
+    "import numpy as np\n",
+    "import pylab as pl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Neuron, simulation and plotting parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "taum = 10.\n",
+    "C_m = 250.\n",
+    "# array of distances between tau_m and tau_ex\n",
+    "epsilon_array = np.hstack(([0.],10.**(np.arange(-5.,1.,1.))))[::-1]\n",
+    "dt = 0.1\n",
+    "fig = pl.figure(1)\n",
+    "NUM_COLORS = len(epsilon_array)\n",
+    "cmap = pl.get_cmap('gist_ncar')\n",
+    "maxVs = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Loop through epsilon array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x55372d0>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for i,epsilon in enumerate(epsilon_array):\n",
+    "    nest.ResetKernel() # reset simulation kernel \n",
+    "    nest.SetKernelStatus({'resolution':dt})\n",
+    "\n",
+    "    # Current based alpha neuron \n",
+    "    neuron = nest.Create('iaf_psc_alpha') \n",
+    "    nest.SetStatus(neuron,{'C_m':C_m,'tau_m':taum,'t_ref':0.,'V_reset':-70.,'V_th':1e32,\n",
+    "                           'tau_syn_ex':taum+epsilon,'tau_syn_in':taum+epsilon,'I_e':0.})\n",
+    "   \n",
+    "    # create a spike generator\n",
+    "    spikegenerator_ex=nest.Create('spike_generator')\n",
+    "    nest.SetStatus(spikegenerator_ex,{'spike_times': [50.]})\n",
+    "    \n",
+    "    # create a voltmeter\n",
+    "    vm = nest.Create('voltmeter',params={'interval':dt})\n",
+    "\n",
+    "    ## connect spike generator and voltmeter to the neuron\n",
+    "\n",
+    "    nest.Connect(spikegenerator_ex, neuron,'all_to_all',{'weight':100.})\n",
+    "    nest.Connect(vm, neuron)\n",
+    "\n",
+    "    # run simulation for 200ms\n",
+    "    nest.Simulate(200.) \n",
+    "\n",
+    "    # read out recording time and voltage from voltmeter\n",
+    "    times=nest.GetStatus(vm)[0]['events']['times']\n",
+    "    voltage=nest.GetStatus(vm)[0]['events']['V_m']\n",
+    "    \n",
+    "    # store maximum value of voltage trace in array\n",
+    "    maxVs.append(np.max(voltage))\n",
+    "\n",
+    "    # plot voltage trace\n",
+    "    if epsilon == 0.:\n",
+    "        pl.plot(times,voltage,'--',color='black')\n",
+    "    else:\n",
+    "        pl.plot(times,voltage,color = cmap(1.*i/NUM_COLORS),label=str(epsilon))\n",
+    "\n",
+    "pl.legend()\n",
+    "pl.xlabel('time t (ms)')\n",
+    "pl.ylabel('voltage V (mV)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show maximum values of voltage traces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x5deeed0>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fig = pl.figure(2)\n",
+    "pl.semilogx(epsilon_array,maxVs,color='red',label='maxV')\n",
+    "pl.xlabel('epsilon')\n",
+    "pl.ylabel('max(voltage V) (mV)')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pl.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The maximum of the voltage traces show that the non-singular case nicely converges to the singular one and no numeric instabilities occur "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/libnestutil/Makefile.am
+++ b/libnestutil/Makefile.am
@@ -16,6 +16,7 @@ libnestutil_la_SOURCES= \
 		stopwatch.h stopwatch.cpp \
 		numerics.h numerics.cpp \
 		allocator.h allocator.cpp \
+		propagator_stability.h propagator_stability.cpp \
 		instance.h \
 		lockptr.h \
 		sparseconfig.h \

--- a/libnestutil/Makefile.am
+++ b/libnestutil/Makefile.am
@@ -16,7 +16,7 @@ libnestutil_la_SOURCES= \
 		stopwatch.h stopwatch.cpp \
 		numerics.h numerics.cpp \
 		allocator.h allocator.cpp \
-		propagator_stability.h propagator_stability.cpp \
+		propagators.h propagators.cpp \
 		instance.h \
 		lockptr.h \
 		sparseconfig.h \

--- a/libnestutil/Makefile.am
+++ b/libnestutil/Makefile.am
@@ -16,7 +16,7 @@ libnestutil_la_SOURCES= \
 		stopwatch.h stopwatch.cpp \
 		numerics.h numerics.cpp \
 		allocator.h allocator.cpp \
-		propagators.h propagators.cpp \
+		propagator_stability.h propagator_stability.cpp \
 		instance.h \
 		lockptr.h \
 		sparseconfig.h \

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -1,5 +1,5 @@
 /*
- *  propagators.cpp
+ *  propagator_stability.cpp
  *
  *  This file is part of NEST.
  *
@@ -20,20 +20,22 @@
  *
  */
 
-#include "propagators.h"
+#include "propagator_stability.h"
 #include <cmath>
 #include "numerics.h"
 
 double
 propagator_31( double tau_syn, double tau, double C, double h )
 {
+  const double P31_linear =
+    1 / ( 3. * C * tau * tau ) * h * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
   const double P31 = 1 / C * ( std::exp( -h / tau_syn ) * numerics::expm1( -h / tau + h / tau_syn )
-                                 / tau * ( tau / tau_syn - 1 )
-                               - h * std::exp( -h / tau_syn ) ) / tau * ( -1 - -tau / tau_syn );
-
+                                 / ( tau / tau_syn - 1 ) * tau
+                               - h * std::exp( -h / tau_syn ) ) / ( -1 - -tau / tau_syn ) * tau;
   const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
+  const double dev_P31 = std::abs( P31 - P31_singular );
 
-  if ( std::abs( tau - tau_syn ) < std::pow( 1., -15 ) )
+  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * P31_linear ) )
   {
     return P31_singular;
   }
@@ -46,11 +48,15 @@ propagator_31( double tau_syn, double tau, double C, double h )
 double
 propagator_32( double tau_syn, double tau, double C, double h )
 {
+  const double P32_linear =
+    1 / ( 2. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
   const double P32_singular = h / C * std::exp( -h / tau );
   const double P32 = -tau / ( C * ( 1 - tau / tau_syn ) ) * std::exp( -h / tau_syn )
     * numerics::expm1( h * ( 1 / tau_syn - 1 / tau ) );
 
-  if ( std::abs( tau - tau_syn ) < std::pow( 1., -15 ) )
+  const double dev_P32 = std::abs( P32 - P32_singular );
+
+  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear ) )
   {
     return P32_singular;
   }

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -51,7 +51,7 @@ double
 propagator_31( double tau_syn, double tau, double C, double h )
 {
   const double P31_linear =
-    h / ( 3. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
+    1 / ( 3. * C * tau * tau ) * h * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
   const double P31 =
     1 / C * ( ( std::exp( -h / tau_syn ) - std::exp( -h / tau ) ) / ( -1 / tau_syn - -1 / tau )
               - h * std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -54,7 +54,7 @@ propagator_32( double tau_syn, double tau, double C, double h )
     1 / C * ( std::exp( -h / tau ) - std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
   const double dev_P32 = std::abs( P32 - P32_singular );
 
-  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P31_linear ) )
+  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear ) )
   {
     return P32_singular;
   }

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -1,0 +1,73 @@
+/*
+ *  propagator_stability.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "propagator_stability.h"
+#include <cmath>
+
+double
+propagator_32( double tau_syn, double tau, double C, double h )
+{
+  const double P32_linear =
+    1 / ( 2. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
+  const double P32_singular = h / C * std::exp( -h / tau );
+  const double P32 =
+    1 / C * ( std::exp( -h / tau ) - std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
+  const double dev_P32 = std::abs( P32 - P32_singular );
+
+  if ( tau == tau_syn )
+  {
+    return P32_singular;
+  }
+  else if ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear )
+  {
+    return P32_singular;
+  }
+  else
+  {
+    return P32;
+  }
+}
+
+double
+propagator_31( double tau_syn, double tau, double C, double h )
+{
+  const double P31_linear =
+    h / ( 3. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
+  const double P31 =
+    1 / C * ( ( std::exp( -h / tau_syn ) - std::exp( -h / tau ) ) / ( -1 / tau_syn - -1 / tau )
+              - h * std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
+  const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
+  const double dev_P31 = std::abs( P31 - P31_singular );
+
+  if ( tau == tau_syn )
+  {
+    return P31_singular;
+  }
+  else if ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * P31_linear )
+  {
+    return P31_singular;
+  }
+  else
+  {
+    return P31;
+  }
+}

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -24,30 +24,6 @@
 #include <cmath>
 
 double
-propagator_32( double tau_syn, double tau, double C, double h )
-{
-  const double P32_linear =
-    1 / ( 2. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
-  const double P32_singular = h / C * std::exp( -h / tau );
-  const double P32 =
-    1 / C * ( std::exp( -h / tau ) - std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
-  const double dev_P32 = std::abs( P32 - P32_singular );
-
-  if ( tau == tau_syn )
-  {
-    return P32_singular;
-  }
-  else if ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear )
-  {
-    return P32_singular;
-  }
-  else
-  {
-    return P32;
-  }
-}
-
-double
 propagator_31( double tau_syn, double tau, double C, double h )
 {
   const double P31_linear =
@@ -69,5 +45,29 @@ propagator_31( double tau_syn, double tau, double C, double h )
   else
   {
     return P31;
+  }
+}
+
+double
+propagator_32( double tau_syn, double tau, double C, double h )
+{
+  const double P32_linear =
+    1 / ( 2. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
+  const double P32_singular = h / C * std::exp( -h / tau );
+  const double P32 =
+    1 / C * ( std::exp( -h / tau ) - std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
+  const double dev_P32 = std::abs( P32 - P32_singular );
+
+  if ( tau == tau_syn )
+  {
+    return P32_singular;
+  }
+  else if ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear )
+  {
+    return P32_singular;
+  }
+  else
+  {
+    return P32;
   }
 }

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -35,7 +35,8 @@ propagator_31( double tau_syn, double tau, double C, double h )
   const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
   const double dev_P31 = std::abs( P31 - P31_singular );
 
-  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * P31_linear ) )
+  if ( tau == tau_syn
+    or ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * std::abs( P31_linear ) ) )
   {
     return P31_singular;
   }
@@ -56,7 +57,8 @@ propagator_32( double tau_syn, double tau, double C, double h )
 
   const double dev_P32 = std::abs( P32 - P32_singular );
 
-  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear ) )
+  if ( tau == tau_syn
+    or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * std::abs( P32_linear ) ) )
   {
     return P32_singular;
   }

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -34,11 +34,7 @@ propagator_31( double tau_syn, double tau, double C, double h )
   const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
   const double dev_P31 = std::abs( P31 - P31_singular );
 
-  if ( tau == tau_syn )
-  {
-    return P31_singular;
-  }
-  else if ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * P31_linear )
+  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * P31_linear ) )
   {
     return P31_singular;
   }
@@ -58,11 +54,7 @@ propagator_32( double tau_syn, double tau, double C, double h )
     1 / C * ( std::exp( -h / tau ) - std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
   const double dev_P32 = std::abs( P32 - P32_singular );
 
-  if ( tau == tau_syn )
-  {
-    return P32_singular;
-  }
-  else if ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear )
+  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P31_linear ) )
   {
     return P32_singular;
   }

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -23,7 +23,7 @@
 #ifndef PROPAGATOR_STABILITY_H
 #define PROPAGATOR_STABILITY_H
 
-double propagator_32( double tau_syn, double tau, double C, double h );
 double propagator_31( double tau_syn, double tau, double C, double h );
+double propagator_32( double tau_syn, double tau, double C, double h );
 
 #endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -1,0 +1,29 @@
+/*
+ *  propagator_stability.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PROPAGATOR_STABILITY_H
+#define PROPAGATOR_STABILITY_H
+
+double propagator_32( double tau_syn, double tau, double C, double h );
+double propagator_31( double tau_syn, double tau, double C, double h );
+
+#endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -1,5 +1,5 @@
 /*
- *  propagators.h
+ *  propagator_stability.h
  *
  *  This file is part of NEST.
  *
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef PROPAGATORS_H
-#define PROPAGATORS_H
+#ifndef PROPAGATOR_STABILITY_H
+#define PROPAGATOR_STABILITY_H
 
 double propagator_31( double tau_syn, double tau, double C, double h );
 double propagator_32( double tau_syn, double tau, double C, double h );

--- a/libnestutil/propagators.cpp
+++ b/libnestutil/propagators.cpp
@@ -1,5 +1,5 @@
 /*
- *  propagator_stability.cpp
+ *  propagators.cpp
  *
  *  This file is part of NEST.
  *
@@ -20,21 +20,20 @@
  *
  */
 
-#include "propagator_stability.h"
+#include "propagators.h"
 #include <cmath>
+#include "numerics.h"
 
 double
 propagator_31( double tau_syn, double tau, double C, double h )
 {
-  const double P31_linear =
-    1 / ( 3. * C * tau * tau ) * h * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
-  const double P31 =
-    1 / C * ( ( std::exp( -h / tau_syn ) - std::exp( -h / tau ) ) / ( -1 / tau_syn - -1 / tau )
-              - h * std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
-  const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
-  const double dev_P31 = std::abs( P31 - P31_singular );
+  const double P31 = 1 / C * ( std::exp( -h / tau_syn ) * numerics::expm1( -h / tau + h / tau_syn )
+                                 / tau * ( tau / tau_syn - 1 )
+                               - h * std::exp( -h / tau_syn ) ) / tau * ( -1 - -tau / tau_syn );
 
-  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * P31_linear ) )
+  const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
+
+  if ( std::abs( tau - tau_syn ) < std::pow( 1., -15 ) )
   {
     return P31_singular;
   }
@@ -47,14 +46,11 @@ propagator_31( double tau_syn, double tau, double C, double h )
 double
 propagator_32( double tau_syn, double tau, double C, double h )
 {
-  const double P32_linear =
-    1 / ( 2. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
   const double P32_singular = h / C * std::exp( -h / tau );
-  const double P32 =
-    1 / C * ( std::exp( -h / tau ) - std::exp( -h / tau_syn ) ) / ( -1 / tau - -1 / tau_syn );
-  const double dev_P32 = std::abs( P32 - P32_singular );
+  const double P32 = -tau / ( C * ( 1 - tau / tau_syn ) ) * std::exp( -h / tau_syn )
+    * numerics::expm1( h * ( 1 / tau_syn - 1 / tau ) );
 
-  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P32 > 2 * P32_linear ) )
+  if ( std::abs( tau - tau_syn ) < std::pow( 1., -15 ) )
   {
     return P32_singular;
   }

--- a/libnestutil/propagators.h
+++ b/libnestutil/propagators.h
@@ -1,5 +1,5 @@
 /*
- *  propagator_stability.h
+ *  propagators.h
  *
  *  This file is part of NEST.
  *
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef PROPAGATOR_STABILITY_H
-#define PROPAGATOR_STABILITY_H
+#ifndef PROPAGATORS_H
+#define PROPAGATORS_H
 
 double propagator_31( double tau_syn, double tau, double C, double h );
 double propagator_32( double tau_syn, double tau, double C, double h );

--- a/models/iaf_neuron.h
+++ b/models/iaf_neuron.h
@@ -97,9 +97,11 @@ tau_syn    double - Rise time of the excitatory synaptic alpha function in ms.
 I_e        double - Constant external input current in pA.
 
 Remarks:
-tau_m != tau_syn is required by the current implementation to avoid a
-degenerate case of the ODE describing the model [1]. For very similar values,
-numerics will be unstable.
+If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+will numerically behave as if tau_m is equal to tau_syn_ex or
+tau_syn_in, respectively, to avoid numerical instabilities.
+For details, please see IAF_Neruons_Singularity.ipynb in
+the NEST source code (docs/model_details).
 
 References:
 [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -241,7 +241,7 @@ iaf_psc_alpha::calibrate()
 
   // exact propagator, linear approximation and singular case for excitatory synaptic event
 
-  const double P32_ex_linear = 1 / 2. / P_.C_ / P_.Tau_ / P_.Tau_ * h * h * ( P_.tau_ex_ - P_.Tau_ )
+  const double P32_ex_linear = 1 / ( 2. * P_.C_ * P_.Tau_ * P_.Tau_ ) * h * h * ( P_.tau_ex_ - P_.Tau_ )
     * std::exp( -h / P_.Tau_ );
   const double P32_ex_singular = h / P_.C_ * V_.P33_;
   const double P32_ex = 1 / P_.C_ * ( V_.P33_ - V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -31,7 +31,6 @@
 #include "universal_data_logger_impl.h"
 #include "propagator_stability.h"
 
-
 #include <limits>
 
 nest::RecordablesMap< nest::iaf_psc_alpha > nest::iaf_psc_alpha::recordablesMap_;
@@ -227,7 +226,6 @@ iaf_psc_alpha::calibrate()
   B_.logger_.init(); // ensures initialization in case mm connected after Simulate
 
   const double h = Time::get_resolution().get_ms();
-
 
   // these P are independent
   V_.P11_ex_ = V_.P22_ex_ = std::exp( -h / P_.tau_ex_ );

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -29,6 +29,8 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
+#include "propagator_stability.h"
+
 
 #include <limits>
 
@@ -226,6 +228,7 @@ iaf_psc_alpha::calibrate()
 
   const double h = Time::get_resolution().get_ms();
 
+
   // these P are independent
   V_.P11_ex_ = V_.P22_ex_ = std::exp( -h / P_.tau_ex_ );
   V_.P11_in_ = V_.P22_in_ = std::exp( -h / P_.tau_in_ );
@@ -239,82 +242,11 @@ iaf_psc_alpha::calibrate()
   V_.P21_ex_ = h * V_.P11_ex_;
   V_.P21_in_ = h * V_.P11_in_;
 
-  // exact propagator, linear approximation and singular case for excitatory synaptic event
-
-  const double P32_ex_linear = 1 / ( 2. * P_.C_ * P_.Tau_ * P_.Tau_ ) * h * h
-    * ( P_.tau_ex_ - P_.Tau_ ) * std::exp( -h / P_.Tau_ );
-  const double P32_ex_singular = h / P_.C_ * V_.P33_;
-  const double P32_ex = 1 / P_.C_ * ( V_.P33_ - V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
-  const double P31_ex_linear = h * 2 / 3. * P32_ex_linear;
-  const double P31_ex = 1 / P_.C_ * ( ( V_.P11_ex_ - V_.P33_ ) / ( -1 / P_.tau_ex_ - -1 / P_.Tau_ )
-                                      - h * V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
-  const double P31_ex_singular = h * h / 2 / P_.C_ * V_.P33_;
-  const double dev_P31_ex = P31_ex - P31_ex_singular;
-  const double dev_P32_ex = P32_ex - P32_ex_singular;
-  const double dev_norm_ex = std::pow( dev_P31_ex, 2 ) + std::pow( dev_P32_ex, 2 );
-  const double error_linear_ex =
-    std::pow( std::fabs( P32_ex_linear ), 2 ) + std::pow( std::fabs( P31_ex_linear ), 2 );
-
-  if ( P_.Tau_ == P_.tau_ex_ )
-  {
-    net_->message( SLIInterpreter::M_INFO,
-      "iaf_psc_alpha::calibrate",
-      "singular solution for excitatory synaptic events is used." );
-    V_.P31_ex_ = P31_ex_singular;
-    V_.P32_ex_ = P32_ex_singular;
-  }
-  else if ( std::abs( P_.Tau_ - P_.tau_ex_ ) < 0.1 and dev_norm_ex > 4 * error_linear_ex )
-  {
-    net_->message( SLIInterpreter::M_INFO,
-      "iaf_psc_alpha::calibrate",
-      "singular solution for excitatory synaptic events is used." );
-    V_.P31_ex_ = P31_ex_singular;
-    V_.P32_ex_ = P32_ex_singular;
-  }
-  else
-  {
-    V_.P32_ex_ = P32_ex;
-    V_.P31_ex_ = P31_ex;
-  }
-
-  // exact propagator, linear approximation and singular case for inhibitory synaptic event
-
-  const double P32_in_linear = 1 / 2. / P_.C_ / P_.Tau_ / P_.Tau_ * h * h * ( P_.tau_in_ - P_.Tau_ )
-    * std::exp( -h / P_.Tau_ );
-  const double P32_in_singular = h / P_.C_ * V_.P33_;
-  const double P32_in = 1 / P_.C_ * ( V_.P33_ - V_.P11_in_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_in_ );
-  const double P31_in_linear = h * 2 / 3. * P32_in_linear;
-  const double P31_in = 1 / P_.C_ * ( ( V_.P11_in_ - V_.P33_ ) / ( -1 / P_.tau_in_ - -1 / P_.Tau_ )
-                                      - h * V_.P11_in_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_in_ );
-  const double P31_in_singular = h * h / 2 / P_.C_ * V_.P33_;
-  const double dev_P31_in = std::fabs( P31_in - P31_in_singular );
-  const double dev_P32_in = std::fabs( P32_in - P32_in_singular );
-
-  const double dev_norm_in = std::sqrt( std::pow( dev_P31_in, 2 ) + std::pow( dev_P32_in, 2 ) );
-  const double error_linear_in = std::sqrt(
-    std::pow( std::fabs( P32_in_linear ), 2 ) + std::pow( std::fabs( P31_in_linear ), 2 ) );
-
-  if ( P_.Tau_ == P_.tau_in_ )
-  {
-    net_->message( SLIInterpreter::M_INFO,
-      "iaf_psc_alpha::calibrate",
-      "singular solution for excitatory synaptic events is used." );
-    V_.P31_in_ = P31_in_singular;
-    V_.P32_in_ = P32_in_singular;
-  }
-  else if ( std::abs( P_.Tau_ - P_.tau_in_ ) < 0.1 and dev_norm_in > 2 * error_linear_in )
-  {
-    net_->message( SLIInterpreter::M_INFO,
-      "iaf_psc_alpha::calibrate",
-      "singular solution for excitatory synaptic events is used." );
-    V_.P31_in_ = P31_in_singular;
-    V_.P32_in_ = P32_in_singular;
-  }
-  else
-  {
-    V_.P32_in_ = P32_in;
-    V_.P31_in_ = P31_in;
-  }
+  // these are determined according to a numeric stability criterion
+  V_.P31_ex_ = propagator_31( P_.tau_ex_, P_.Tau_, P_.C_, h );
+  V_.P32_ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
+  V_.P31_in_ = propagator_31( P_.tau_in_, P_.Tau_, P_.C_, h );
+  V_.P32_in_ = propagator_32( P_.tau_in_, P_.Tau_, P_.C_, h );
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
   V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -29,7 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
-#include "propagators.h"
+#include "propagator_stability.h"
 
 #include <limits>
 
@@ -240,7 +240,7 @@ iaf_psc_alpha::calibrate()
   V_.P21_ex_ = h * V_.P11_ex_;
   V_.P21_in_ = h * V_.P11_in_;
 
-  // these are determined depending on the relation of the time constants
+  // these are determined according to a numeric stability criterion
   V_.P31_ex_ = propagator_31( P_.tau_ex_, P_.Tau_, P_.C_, h );
   V_.P32_ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
   V_.P31_in_ = propagator_31( P_.tau_in_, P_.Tau_, P_.C_, h );

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -29,7 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
-#include "propagator_stability.h"
+#include "propagators.h"
 
 #include <limits>
 
@@ -240,7 +240,7 @@ iaf_psc_alpha::calibrate()
   V_.P21_ex_ = h * V_.P11_ex_;
   V_.P21_in_ = h * V_.P11_in_;
 
-  // these are determined according to a numeric stability criterion
+  // these are determined depending on the relation of the time constants
   V_.P31_ex_ = propagator_31( P_.tau_ex_, P_.Tau_, P_.C_, h );
   V_.P32_ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
   V_.P31_in_ = propagator_31( P_.tau_in_, P_.Tau_, P_.C_, h );

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -241,83 +241,80 @@ iaf_psc_alpha::calibrate()
 
   // exact propagator, linear approximation and singular case for excitatory synaptic event
 
-  const double P32_ex_linear = 1 / 2. / P_.C_ / P_.Tau_ / P_.Tau_  
-                               * h * h * ( P_.tau_ex_ - P_.Tau_ ) * std::exp( -h / P_.Tau_ );
+  const double P32_ex_linear = 1 / 2. / P_.C_ / P_.Tau_ / P_.Tau_ * h * h * ( P_.tau_ex_ - P_.Tau_ )
+    * std::exp( -h / P_.Tau_ );
   const double P32_ex_singular = h / P_.C_ * V_.P33_;
   const double P32_ex = 1 / P_.C_ * ( V_.P33_ - V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
   const double P31_ex_linear = h * 2 / 3. * P32_ex_linear;
   const double P31_ex = 1 / P_.C_ * ( ( V_.P11_ex_ - V_.P33_ ) / ( -1 / P_.tau_ex_ - -1 / P_.Tau_ )
-                              - h * V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
+                                      - h * V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
   const double P31_ex_singular = h * h / 2 / P_.C_ * V_.P33_;
   const double dev_P31_ex = std::fabs( P31_ex - P31_ex_singular );
   const double dev_P32_ex = std::fabs( P32_ex - P32_ex_singular );
-    
-  const double dev_norm_ex = std::sqrt( std::pow( dev_P31_ex , 2 ) + std::pow( dev_P32_ex , 2 ) );
-  const double error_linear_ex = std::sqrt( std::pow( std::fabs( P32_ex_linear ) , 2 )
-					   +std::pow( std::fabs( P31_ex_linear ) , 2 ) );
+  const double dev_norm_ex = std::sqrt( std::pow( dev_P31_ex, 2 ) + std::pow( dev_P32_ex, 2 ) );
+  const double error_linear_ex = std::sqrt(
+    std::pow( std::fabs( P32_ex_linear ), 2 ) + std::pow( std::fabs( P31_ex_linear ), 2 ) );
 
-  if (P_.Tau_ == P_.tau_ex_)
-    {
-      net_->message(
-	SLIInterpreter::M_INFO, "iaf_psc_alpha::calibrate",
-	"singular solution for excitatory synaptic events is used." );
-      V_.P31_ex_ = P31_ex_singular;
-      V_.P32_ex_ = P32_ex_singular;
-    }
+  if ( P_.Tau_ == P_.tau_ex_ )
+  {
+    net_->message( SLIInterpreter::M_INFO,
+      "iaf_psc_alpha::calibrate",
+      "singular solution for excitatory synaptic events is used." );
+    V_.P31_ex_ = P31_ex_singular;
+    V_.P32_ex_ = P32_ex_singular;
+  }
+  else if ( std::abs( P_.Tau_ - P_.tau_ex_ ) < 0.1 and dev_norm_ex > 2 * error_linear_ex )
+  {
+    net_->message( SLIInterpreter::M_INFO,
+      "iaf_psc_alpha::calibrate",
+      "singular solution for excitatory synaptic events is used." );
+    V_.P31_ex_ = P31_ex_singular;
+    V_.P32_ex_ = P32_ex_singular;
+  }
   else
-    if (std::abs(P_.Tau_ - P_.tau_ex_) < 0.1 and dev_norm_ex  >  2 * error_linear_ex )
-    {
-      net_->message(
-	SLIInterpreter::M_INFO, "iaf_psc_alpha::calibrate",
-	"singular solution for excitatory synaptic events is used." );
-      V_.P31_ex_ = P31_ex_singular;
-      V_.P32_ex_ = P32_ex_singular;
-    }
-    else
-    {
-      V_.P32_ex_ = P32_ex;
-      V_.P31_ex_ = P31_ex;
-    }
+  {
+    V_.P32_ex_ = P32_ex;
+    V_.P31_ex_ = P31_ex;
+  }
 
   // exact propagator, linear approximation and singular case for inhibitory synaptic event
 
-  const double P32_in_linear = 1 / 2. / P_.C_ / P_.Tau_ / P_.Tau_  
-                               * h * h * ( P_.tau_in_ - P_.Tau_ ) * std::exp( -h / P_.Tau_ );
+  const double P32_in_linear = 1 / 2. / P_.C_ / P_.Tau_ / P_.Tau_ * h * h * ( P_.tau_in_ - P_.Tau_ )
+    * std::exp( -h / P_.Tau_ );
   const double P32_in_singular = h / P_.C_ * V_.P33_;
   const double P32_in = 1 / P_.C_ * ( V_.P33_ - V_.P11_in_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_in_ );
   const double P31_in_linear = h * 2 / 3. * P32_in_linear;
   const double P31_in = 1 / P_.C_ * ( ( V_.P11_in_ - V_.P33_ ) / ( -1 / P_.tau_in_ - -1 / P_.Tau_ )
-                              - h * V_.P11_in_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_in_ );
+                                      - h * V_.P11_in_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_in_ );
   const double P31_in_singular = h * h / 2 / P_.C_ * V_.P33_;
   const double dev_P31_in = std::fabs( P31_in - P31_in_singular );
   const double dev_P32_in = std::fabs( P32_in - P32_in_singular );
-    
-  const double dev_norm_in = std::sqrt( std::pow( dev_P31_in , 2 ) + std::pow( dev_P32_in , 2 ) );
-  const double error_linear_in = std::sqrt( std::pow( std::fabs( P32_in_linear ) , 2 )
-					   +std::pow( std::fabs( P31_in_linear ) , 2 ) );
 
-  if (P_.Tau_ == P_.tau_in_)
-    {
-      net_->message(
-	SLIInterpreter::M_INFO, "iaf_psc_alpha::calibrate",
-	"singular solution for excitatory synaptic events is used." );
-      V_.P31_in_ = P31_in_singular;
-      V_.P32_in_ = P32_in_singular;
-    }
+  const double dev_norm_in = std::sqrt( std::pow( dev_P31_in, 2 ) + std::pow( dev_P32_in, 2 ) );
+  const double error_linear_in = std::sqrt(
+    std::pow( std::fabs( P32_in_linear ), 2 ) + std::pow( std::fabs( P31_in_linear ), 2 ) );
+
+  if ( P_.Tau_ == P_.tau_in_ )
+  {
+    net_->message( SLIInterpreter::M_INFO,
+      "iaf_psc_alpha::calibrate",
+      "singular solution for excitatory synaptic events is used." );
+    V_.P31_in_ = P31_in_singular;
+    V_.P32_in_ = P32_in_singular;
+  }
+  else if ( std::abs( P_.Tau_ - P_.tau_in_ ) < 0.1 and dev_norm_in > 2 * error_linear_in )
+  {
+    net_->message( SLIInterpreter::M_INFO,
+      "iaf_psc_alpha::calibrate",
+      "singular solution for excitatory synaptic events is used." );
+    V_.P31_in_ = P31_in_singular;
+    V_.P32_in_ = P32_in_singular;
+  }
   else
-    if (std::abs(P_.Tau_ - P_.tau_in_) < 0.1 and dev_norm_in  >  2 * error_linear_in )
-    {
-      net_->message(
-	SLIInterpreter::M_INFO, "iaf_psc_alpha::calibrate",
-	"singular solution for excitatory synaptic events is used." );
-      V_.P31_in_ = P31_in_singular;
-      V_.P32_in_ = P32_in_singular;
-    }
-    else
-    {
-      V_.P32_in_ = P32_in;
-      V_.P31_in_ = P31_in;
-    }
+  {
+    V_.P32_in_ = P32_in;
+    V_.P31_in_ = P31_in;
+  }
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
   V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -241,19 +241,19 @@ iaf_psc_alpha::calibrate()
 
   // exact propagator, linear approximation and singular case for excitatory synaptic event
 
-  const double P32_ex_linear = 1 / ( 2. * P_.C_ * P_.Tau_ * P_.Tau_ ) * h * h * ( P_.tau_ex_ - P_.Tau_ )
-    * std::exp( -h / P_.Tau_ );
+  const double P32_ex_linear = 1 / ( 2. * P_.C_ * P_.Tau_ * P_.Tau_ ) * h * h
+    * ( P_.tau_ex_ - P_.Tau_ ) * std::exp( -h / P_.Tau_ );
   const double P32_ex_singular = h / P_.C_ * V_.P33_;
   const double P32_ex = 1 / P_.C_ * ( V_.P33_ - V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
   const double P31_ex_linear = h * 2 / 3. * P32_ex_linear;
   const double P31_ex = 1 / P_.C_ * ( ( V_.P11_ex_ - V_.P33_ ) / ( -1 / P_.tau_ex_ - -1 / P_.Tau_ )
                                       - h * V_.P11_ex_ ) / ( -1 / P_.Tau_ - -1 / P_.tau_ex_ );
   const double P31_ex_singular = h * h / 2 / P_.C_ * V_.P33_;
-  const double dev_P31_ex = std::fabs( P31_ex - P31_ex_singular );
-  const double dev_P32_ex = std::fabs( P32_ex - P32_ex_singular );
-  const double dev_norm_ex = std::sqrt( std::pow( dev_P31_ex, 2 ) + std::pow( dev_P32_ex, 2 ) );
-  const double error_linear_ex = std::sqrt(
-    std::pow( std::fabs( P32_ex_linear ), 2 ) + std::pow( std::fabs( P31_ex_linear ), 2 ) );
+  const double dev_P31_ex = P31_ex - P31_ex_singular;
+  const double dev_P32_ex = P32_ex - P32_ex_singular;
+  const double dev_norm_ex = std::pow( dev_P31_ex, 2 ) + std::pow( dev_P32_ex, 2 );
+  const double error_linear_ex =
+    std::pow( std::fabs( P32_ex_linear ), 2 ) + std::pow( std::fabs( P31_ex_linear ), 2 );
 
   if ( P_.Tau_ == P_.tau_ex_ )
   {
@@ -263,7 +263,7 @@ iaf_psc_alpha::calibrate()
     V_.P31_ex_ = P31_ex_singular;
     V_.P32_ex_ = P32_ex_singular;
   }
-  else if ( std::abs( P_.Tau_ - P_.tau_ex_ ) < 0.1 and dev_norm_ex > 2 * error_linear_ex )
+  else if ( std::abs( P_.Tau_ - P_.tau_ex_ ) < 0.1 and dev_norm_ex > 4 * error_linear_ex )
   {
     net_->message( SLIInterpreter::M_INFO,
       "iaf_psc_alpha::calibrate",

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -96,10 +96,20 @@ Parameters:
   I_e        double - Constant external input current in pA.
   V_min      double - Absolute lower value for the membrane potential.
 
-Remarks:
-  tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
-  degenerate case of the ODE describing the model [1]. For very similar values,
-  numerics will be unstable.
+Note: 
+For very similar values of tau_m and tau_syn_{ex,in} the
+evaluation of the propagator entries P_31 and P_32 is numerically
+unstable.  Consider a first order taylor approximation in tau_s around tau_m
+P_31 = P_31_0 + P_31_lin + O(2) ; P_32 = P_32_0 + P_32_lin + O(2).  
+If tau_m == tau_syn_{ex,in} the singular solutions P_31_0 and P_32_0 are used.
+If tau_m and tau_syn_{ex,in} are close to each other we calculate the
+deviation of the propagator to the singular case 
+P_31_dev = P_31 - P_31_0 ; P_32_dev = P_32 - P_32_0 
+and if 
+||(P_31_dev,P_32_dev)|| > 2 * ||(P_31_1,P_32_1)|| 
+we assume that the deviations in the propagators are due to numeric 
+instabilities and we use the singular solutions. Here || || is the euclidean norm.
+With this criterion the maximal error is of order ||(P_31_1,P_32_1)||.
 
 References:
   [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -97,13 +97,12 @@ Parameters:
   V_min      double - Absolute lower value for the membrane potential.
 
 Remarks: 
-If tau_m is very close to tau_syn_ex or tau_syn_in, the model
-will numerically behave as if tau_m is equal to tau_syn_ex or
-tau_syn_in, respectively, to avoid numerical instabilities. The status
-dictionary provides information about which propagators are used
-through the /propagator_info entry. For details, please see
-IAF_Neruons_Singularity.ipynb in the NEST source code
-(docs/model_details).
+
+  If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+  will numerically behave as if tau_m is equal to tau_syn_ex or
+  tau_syn_in, respectively, to avoid numerical instabilities.
+  For details, please see IAF_Neruons_Singularity.ipynb in the
+  NEST source code (docs/model_details).
 
 References:
   [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -99,17 +99,8 @@ Parameters:
 Note:
 For very similar values of tau_m and tau_syn_{ex,in} the
 evaluation of the propagator entries P_31 and P_32 is numerically
-unstable.  Consider a first order taylor approximation in tau_s around tau_m
-P_31 = P_31_0 + P_31_lin + O(2) ; P_32 = P_32_0 + P_32_lin + O(2).
-If tau_m == tau_syn_{ex,in} the singular solutions P_31_0 and P_32_0 are used.
-If tau_m and tau_syn_{ex,in} are close to each other we calculate the
-deviation of the propagator to the singular case
-P_31_dev = P_31 - P_31_0 ; P_32_dev = P_32 - P_32_0
-and if
-||(P_31_dev,P_32_dev)|| > 2 * ||(P_31_1,P_32_1)||
-we assume that the deviations in the propagators are due to numeric
-instabilities and we use the singular solutions. Here || || is the euclidean norm.
-With this criterion the maximal error is of order ||(P_31_1,P_32_1)||.
+unstable. For details, please see IAF_Neruons_Singularity.ipynb in the
+NEST source code (docs/model_details)
 
 References:
   [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -100,9 +100,8 @@ Remarks:
 
   If tau_m is very close to tau_syn_ex or tau_syn_in, the model
   will numerically behave as if tau_m is equal to tau_syn_ex or
-  tau_syn_in, respectively, to avoid numerical instabilities.
-  For details, please see IAF_Neruons_Singularity.ipynb in the
-  NEST source code (docs/model_details).
+  tau_syn_in, respectively. For details, please see
+  IAF_Neruons_Singularity.ipynb in the NEST source code (docs/model_details).
 
 References:
   [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -96,18 +96,18 @@ Parameters:
   I_e        double - Constant external input current in pA.
   V_min      double - Absolute lower value for the membrane potential.
 
-Note: 
+Note:
 For very similar values of tau_m and tau_syn_{ex,in} the
 evaluation of the propagator entries P_31 and P_32 is numerically
 unstable.  Consider a first order taylor approximation in tau_s around tau_m
-P_31 = P_31_0 + P_31_lin + O(2) ; P_32 = P_32_0 + P_32_lin + O(2).  
+P_31 = P_31_0 + P_31_lin + O(2) ; P_32 = P_32_0 + P_32_lin + O(2).
 If tau_m == tau_syn_{ex,in} the singular solutions P_31_0 and P_32_0 are used.
 If tau_m and tau_syn_{ex,in} are close to each other we calculate the
-deviation of the propagator to the singular case 
-P_31_dev = P_31 - P_31_0 ; P_32_dev = P_32 - P_32_0 
-and if 
-||(P_31_dev,P_32_dev)|| > 2 * ||(P_31_1,P_32_1)|| 
-we assume that the deviations in the propagators are due to numeric 
+deviation of the propagator to the singular case
+P_31_dev = P_31 - P_31_0 ; P_32_dev = P_32 - P_32_0
+and if
+||(P_31_dev,P_32_dev)|| > 2 * ||(P_31_1,P_32_1)||
+we assume that the deviations in the propagators are due to numeric
 instabilities and we use the singular solutions. Here || || is the euclidean norm.
 With this criterion the maximal error is of order ||(P_31_1,P_32_1)||.
 

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -96,7 +96,7 @@ Parameters:
   I_e        double - Constant external input current in pA.
   V_min      double - Absolute lower value for the membrane potential.
 
-Remarks: 
+Remarks:
 
   If tau_m is very close to tau_syn_ex or tau_syn_in, the model
   will numerically behave as if tau_m is equal to tau_syn_ex or

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -100,8 +100,9 @@ Remarks:
 
   If tau_m is very close to tau_syn_ex or tau_syn_in, the model
   will numerically behave as if tau_m is equal to tau_syn_ex or
-  tau_syn_in, respectively. For details, please see
-  IAF_Neruons_Singularity.ipynb in the NEST source code (docs/model_details).
+  tau_syn_in, respectively, to avoid numerical instabilities.
+  For details, please see IAF_Neruons_Singularity.ipynb in
+  the NEST source code (docs/model_details).
 
 References:
   [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -96,11 +96,14 @@ Parameters:
   I_e        double - Constant external input current in pA.
   V_min      double - Absolute lower value for the membrane potential.
 
-Note:
-For very similar values of tau_m and tau_syn_{ex,in} the
-evaluation of the propagator entries P_31 and P_32 is numerically
-unstable. For details, please see IAF_Neruons_Singularity.ipynb in the
-NEST source code (docs/model_details)
+Remarks: 
+If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+will numerically behave as if tau_m is equal to tau_syn_ex or
+tau_syn_in, respectively, to avoid numerical instabilities. The status
+dictionary provides information about which propagators are used
+through the /propagator_info entry. For details, please see
+IAF_Neruons_Singularity.ipynb in the NEST source code
+(docs/model_details).
 
 References:
   [1] Rotter S & Diesmann M (1999) Exact simulation of time-invariant linear

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -29,7 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
-#include "propagators.h"
+#include "propagator_stability.h"
 
 #include <limits>
 
@@ -267,7 +267,7 @@ iaf_psc_alpha_multisynapse::calibrate()
     V_.P11_syn_[ i ] = V_.P22_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     V_.P21_syn_[ i ] = h * V_.P11_syn_[ i ];
 
-    // these are determined depending on the relation of the time constants
+    // these are determined according to a numeric stability criterion
     V_.P31_syn_[ i ] = propagator_31( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
     V_.P32_syn_[ i ] = propagator_32( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
 

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -29,7 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
-#include "propagator_stability.h"
+#include "propagators.h"
 
 #include <limits>
 
@@ -267,7 +267,7 @@ iaf_psc_alpha_multisynapse::calibrate()
     V_.P11_syn_[ i ] = V_.P22_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     V_.P21_syn_[ i ] = h * V_.P11_syn_[ i ];
 
-    // these are determined according to a numeric stability criterion
+    // these are determined depending on the relation of the time constants
     V_.P31_syn_[ i ] = propagator_31( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
     V_.P32_syn_[ i ] = propagator_32( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -29,7 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
-#include "propagators.h"
+#include "propagator_stability.h"
 
 #include <limits>
 
@@ -231,7 +231,7 @@ nest::iaf_psc_exp::calibrate()
   V_.P22_ = std::exp( -h / P_.Tau_ );
   // P22_ = 1.0-h/Tau_;
 
-  // these are determined depending on the relation of the time constants
+  // these are determined according to a numeric stability criterion
   V_.P21ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
   V_.P21in_ = propagator_32( P_.tau_in_, P_.Tau_, P_.C_, h );
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -29,7 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
-#include "propagator_stability.h"
+#include "propagators.h"
 
 #include <limits>
 
@@ -231,7 +231,7 @@ nest::iaf_psc_exp::calibrate()
   V_.P22_ = std::exp( -h / P_.Tau_ );
   // P22_ = 1.0-h/Tau_;
 
-  // these are determined according to a numeric stability criterion
+  // these are determined depending on the relation of the time constants
   V_.P21ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
   V_.P21in_ = propagator_32( P_.tau_in_, P_.Tau_, P_.C_, h );
 

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -91,10 +91,13 @@ class Network;
    I_e          double - Constant input current in pA.
    t_spike      double - Point in time of last spike in ms.
 
-   Remarks:
-   tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
-   degenerate case of the ODE describing the model [1]. For very similar values,
-   numerics will be unstable.
+Remarks:
+
+   If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+   will numerically behave as if tau_m is equal to tau_syn_ex or
+   tau_syn_in, respectively, to avoid numerical instabilities.
+   For details, please see IAF_Neruons_Singularity.ipynb in the
+   NEST source code (docs/model_details).
 
    References:
    [1] Misha Tsodyks, Asher Uziel, and Henry Markram (2000) Synchrony Generation in Recurrent

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -29,6 +29,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
+#include "propagator_stability.h"
 
 #include <limits>
 
@@ -251,8 +252,8 @@ nest::iaf_psc_exp_multisynapse::calibrate()
   for ( size_t i = 0; i < P_.num_of_receptors_; i++ )
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
-    V_.P21_syn_[ i ] = P_.Tau_ / ( P_.C_ * ( 1.0 - P_.Tau_ / P_.tau_syn_[ i ] ) ) * V_.P11_syn_[ i ]
-      * ( 1.0 - std::exp( h * ( 1.0 / P_.tau_syn_[ i ] - 1.0 / P_.Tau_ ) ) );
+    // these are determined according to a numeric stability criterion
+    V_.P21_syn_[ i ] = propagator_32( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
 
     B_.spikes_[ i ].resize();
   }

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -102,9 +102,11 @@ class Network;
    t_spike      double - Point in time of last spike in ms.
 
    Remarks:
-   tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
-   degenerate case of the ODE describing the model [1]. For very similar values,
-   numerics will be unstable.
+   If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+   will numerically behave as if tau_m is equal to tau_syn_ex or
+   tau_syn_in, respectively, to avoid numerical instabilities.
+   For details, please see IAF_Neruons_Singularity.ipynb in
+   the NEST source code (docs/model_details).
 
    References:
    [1] Misha Tsodyks, Asher Uziel, and Henry Markram (2000) Synchrony Generation in Recurrent

--- a/precise/iaf_psc_alpha_canon.cpp
+++ b/precise/iaf_psc_alpha_canon.cpp
@@ -30,6 +30,7 @@
 #include "dictutils.h"
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
+#include "propagator_stability.h"
 
 #include <limits>
 
@@ -159,11 +160,6 @@ nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d )
   if ( tau_m_ <= 0 || tau_syn_ <= 0 )
     throw BadProperty( "All time constants must be strictly positive." );
 
-  if ( tau_m_ == tau_syn_ )
-    throw BadProperty(
-      "Membrane and synapse time constant(s) must differ."
-      "See note in documentation." );
-
   return delta_EL;
 }
 
@@ -261,9 +257,9 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.expm1_tau_m_ = numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
   V_.expm1_tau_syn_ = numerics::expm1( -V_.h_ms_ / P_.tau_syn_ );
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
-  V_.P31_ = V_.gamma_sq_ * V_.expm1_tau_m_ - V_.gamma_sq_ * V_.expm1_tau_syn_
-    - V_.h_ms_ * V_.gamma_ * V_.expm1_tau_syn_ - V_.h_ms_ * V_.gamma_;
-  V_.P32_ = V_.gamma_ * V_.expm1_tau_m_ - V_.gamma_ * V_.expm1_tau_syn_;
+  // these are determined according to a numeric stability criterion
+  V_.P31_ = propagator_31( P_.tau_syn_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  V_.P32_ = propagator_32( P_.tau_syn_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/precise/iaf_psc_alpha_canon.h
+++ b/precise/iaf_psc_alpha_canon.h
@@ -98,9 +98,11 @@ The following parameters can be set in the status dictionary.
                         0-none, 1-linear, 2-quadratic, 3-cubic
 
 Remarks:
-  tau_m != tau_syn is required by the current implementation to avoid a
-  degenerate case of the ODE describing the model [1]. For very similar values,
-  numerics will be unstable.
+If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+will numerically behave as if tau_m is equal to tau_syn_ex or
+tau_syn_in, respectively, to avoid numerical instabilities.
+For details, please see IAF_Neruons_Singularity.ipynb in
+the NEST source code (docs/model_details).
 
 References:
 [1] Morrison A, Straube S, Plesser H E, & Diesmann M (2006) Exact Subthreshold

--- a/precise/iaf_psc_alpha_presc.h
+++ b/precise/iaf_psc_alpha_presc.h
@@ -79,9 +79,11 @@
   in addition to the on-grid spike times.
 
   Remarks:
-  tau_m != tau_syn is required by the current implementation to avoid a
-  degenerate case of the ODE describing the model [1]. For very similar values,
-  numerics will be unstable.
+  If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+  will numerically behave as if tau_m is equal to tau_syn_ex or
+  tau_syn_in, respectively, to avoid numerical instabilities.
+  For details, please see IAF_Neruons_Singularity.ipynb in
+  the NEST source code (docs/model_details).
 
   References:
   [1] Morrison A, Straube S, Plesser H E, & Diesmann M (2006) Exact Subthreshold

--- a/precise/iaf_psc_exp_ps.h
+++ b/precise/iaf_psc_exp_ps.h
@@ -84,9 +84,11 @@ Remarks:
   in addition to the on-grid spike times.
 
 Remarks:
-  tau_m != tau_syn_{ex,in} is required by the current implementation to avoid a
-  degenerate case of the ODE describing the model [1]. For very similar values,
-  numerics will be unstable.
+  If tau_m is very close to tau_syn_ex or tau_syn_in, the model
+  will numerically behave as if tau_m is equal to tau_syn_ex or
+  tau_syn_in, respectively, to avoid numerical instabilities.
+  For details, please see IAF_Neruons_Singularity.ipynb in the
+  NEST source code (docs/model_details).
 
 References:
   [1] Morrison A, Straube S, Plesser HE & Diesmann M (2007) Exact subthreshold


### PR DESCRIPTION
This fixes the ticket for the 'iaf_psc_alpha' neuron model. In the singular case the degenerate solution is used and in case of numeric instabilities a switching criterion is used. The latter is described in the documentation.
See https://trac.nest-initiative.org/trac/ticket/618 for the detailed discussion. 

I suggest @heplesser @mhelias as code reviewers.