### PR TITLE
Fix travis commit range issue 64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ before_install:
   # used for building cppcheck-1.69
   - sudo apt-get install -y libpcre3 libpcre3-dev
 
+  # process json output from github api
+  - sudo apt-get install -y jq
+
 install: 
   - cython --version
   - python --version

--- a/build.sh
+++ b/build.sh
@@ -125,7 +125,7 @@ cd ..
 
 # Extracting changed files in PR / push
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  file_names=`curl "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST/files" | jq '.[] | .filename'`
+  file_names=`curl "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST/files" | jq '.[] | .filename' | tr '\n' ' ' | tr '"' ' '`
 else
   # extract filenames via git => has some problems with history rewrites
   # see https://github.com/travis-ci/travis-ci/issues/2668

--- a/build.sh
+++ b/build.sh
@@ -123,8 +123,14 @@ cppcheck --version
 # go back to NEST sources
 cd ..
 
-# Extracting changed files between two commits
-file_names=`git diff --name-only $TRAVIS_COMMIT_RANGE`
+# Extracting changed files in PR / push
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  file_names=`curl "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST/files" | jq '.[] | .filename'`
+else
+  # extract filenames via git => has some problems with history rewrites
+  # see https://github.com/travis-ci/travis-ci/issues/2668
+  file_names=`(git diff --name-only $TRAVIS_COMMIT_RANGE || echo "") | tr '\n' ' '`
+fi
 format_error_files=""
 
 for f in $file_names; do


### PR DESCRIPTION
Using the `$TRAVIS_COMMIT_RANGE` variable in `build.sh` on the TravisCI has some issues, when some history rewrites happened on your branch (see [here](https://github.com/travis-ci/travis-ci/issues/2668) and issue #64  ). With this PR the issue should be fixed with respect to pull requests (by using the [github api](https://developer.github.com/v3/pulls/#list-pull-requests-files) ). 

Using TravisCI on your own repository still uses `$TRAVIS_COMMIT_RANGE` for commits pushed to it: if history rewrites happened, the script will not be able to get all changed files and thus cannot perform the static code analyses – it will just omit it.