### PR TITLE
Remove arguments in value_()-function of ConnParameter class

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -273,8 +273,7 @@ nest::ConnBuilder::single_connect_( index sgid,
     if ( default_weight_and_delay_ )
       net_.connect( sgid, &target, target_thread, synapse_model_ );
     else if ( default_weight_ )
-      net_.connect(
-        sgid, &target, target_thread, synapse_model_, delay_->value_double( rng ) );
+      net_.connect( sgid, &target, target_thread, synapse_model_, delay_->value_double( rng ) );
     else
     {
       double delay = delay_->value_double( rng );

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -274,11 +274,11 @@ nest::ConnBuilder::single_connect_( index sgid,
       net_.connect( sgid, &target, target_thread, synapse_model_ );
     else if ( default_weight_ )
       net_.connect(
-        sgid, &target, target_thread, synapse_model_, delay_->value_double( sgid, tgid, rng ) );
+        sgid, &target, target_thread, synapse_model_, delay_->value_double( rng ) );
     else
     {
-      double delay = delay_->value_double( sgid, tgid, rng );
-      double weight = weight_->value_double( sgid, tgid, rng );
+      double delay = delay_->value_double( rng );
+      double weight = weight_->value_double( rng );
       net_.connect( sgid, &target, target_thread, synapse_model_, delay, weight );
     }
   }
@@ -297,7 +297,7 @@ nest::ConnBuilder::single_connect_( index sgid,
           // change value of dictionary entry without allocating new datum
           IntegerDatum* id = static_cast< IntegerDatum* >(
             ( ( *param_dicts_[ target_thread ] )[ it->first ] ).datum() );
-          ( *id ) = it->second->value_int( sgid, tgid, rng );
+          ( *id ) = it->second->value_int( rng );
         }
         catch ( KernelException& e )
         {
@@ -309,7 +309,7 @@ nest::ConnBuilder::single_connect_( index sgid,
         // change value of dictionary entry without allocating new datum
         DoubleDatum* dd = static_cast< DoubleDatum* >(
           ( ( *param_dicts_[ target_thread ] )[ it->first ] ).datum() );
-        ( *dd ) = it->second->value_double( sgid, tgid, rng );
+        ( *dd ) = it->second->value_double( rng );
       }
     }
 
@@ -321,11 +321,11 @@ nest::ConnBuilder::single_connect_( index sgid,
         target_thread,
         synapse_model_,
         param_dicts_[ target_thread ],
-        delay_->value_double( sgid, tgid, rng ) );
+        delay_->value_double( rng ) );
     else
     {
-      double delay = delay_->value_double( sgid, tgid, rng );
-      double weight = weight_->value_double( sgid, tgid, rng );
+      double delay = delay_->value_double( rng );
+      double weight = weight_->value_double( rng );
       net_.connect( sgid,
         &target,
         target_thread,

--- a/nestkernel/conn_parameter.h
+++ b/nestkernel/conn_parameter.h
@@ -69,8 +69,8 @@ public:
    * @param rng   random number generator pointer
    * will be ignored except for random parameters.
    */
-  virtual double value_double( index, index, librandom::RngPtr& ) const = 0;
-  virtual long_t value_int( index, index, librandom::RngPtr& ) const = 0;
+  virtual double value_double( librandom::RngPtr& ) const = 0;
+  virtual long_t value_int( librandom::RngPtr& ) const = 0;
 
   /**
    * Returns number of values available.
@@ -101,12 +101,12 @@ public:
   }
 
   double
-  value_double( index, index, librandom::RngPtr& ) const
+  value_double( librandom::RngPtr& ) const
   {
     return value_;
   }
   long_t
-  value_int( index, index, librandom::RngPtr& ) const
+  value_int( librandom::RngPtr& ) const
   {
     throw KernelException( "ConnParameter calls value function with false return type." );
   }
@@ -129,12 +129,12 @@ public:
   }
 
   double
-  value_double( index, index, librandom::RngPtr& ) const
+  value_double( librandom::RngPtr& ) const
   {
     throw KernelException( "ConnParameter calls value function with false return type." );
   }
   long_t
-  value_int( index, index, librandom::RngPtr& ) const
+  value_int( librandom::RngPtr& ) const
   {
     return value_;
   }
@@ -167,9 +167,9 @@ public:
     return values_.size();
   }
 
-  // double value(index sgid, index tgid, librandom::RngPtr&) const
+  // double value(librandom::RngPtr&) const
   double
-  value_double( index, index, librandom::RngPtr& ) const
+  value_double( librandom::RngPtr& ) const
 
   {
     // return values_[sgid];
@@ -179,7 +179,7 @@ public:
       throw KernelException( "Parameter values exhausted." );
   }
   long_t
-  value_int( index, index, librandom::RngPtr& ) const
+  value_int( librandom::RngPtr& ) const
   {
     throw KernelException( "ConnParameter calls value function with false return type." );
   }
@@ -201,12 +201,12 @@ public:
   RandomParameter( const DictionaryDatum& );
 
   double
-  value_double( index, index, librandom::RngPtr& rng ) const
+  value_double( librandom::RngPtr& rng ) const
   {
     return ( *rdv_ )( rng );
   }
   long_t
-  value_int( index, index, librandom::RngPtr& rng ) const
+  value_int( librandom::RngPtr& rng ) const
   {
     return ( *rdv_ )( rng );
   }


### PR DESCRIPTION
The arguments sgid and tgid describing the indices of potentially inserted parameter containers have been removed since the functionality is not yet implemented as discussed in PR #66 .