### PR TITLE
Fix #89 by making `do_tests.sh` return non-zero exit code in case of failing tests

### DIFF
--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -627,4 +627,8 @@ if test "x${INFO_OS}" = xDarwin ; then
     defaults write com.apple.CrashReporter DialogType "${TEST_CRSTATE}"
 fi
 
-exit 0
+if test ${TEST_FAILED} -gt 0 ; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
Until the PR #91 fixing #88 is merged, the Travis tests including Python should fail once this PR is merged. This failure with and success without Python is expected behavior, because #88 makes one PyNEST test fail.

Potential reviewers: @tammoippen @jougs @lekshmideepu 