### PR TITLE
Fix PyNEST test failures

### DIFF
--- a/pynest/nest/tests/compatibility.py
+++ b/pynest/nest/tests/compatibility.py
@@ -20,6 +20,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+import numpy
 import inspect
 
 
@@ -65,3 +66,10 @@ if not hasattr(unittest.TestCase, 'assertIsInstance'):
 if not hasattr(unittest.TestCase, 'assertGreater'):
     unittest.TestCase.assertGreater = lambda self, a, b, **kwargs: \
         unittest.TestCase.assertTrue(self, a > b, **kwargs)
+
+# NumPy 1.4.0-
+if not hasattr(numpy, 'fill_diagonal'):
+    def fill_diagonal(a, b):
+        diagonal = numpy.arange(a.shape[0])
+        a[diagonal, diagonal] = b
+    numpy.fill_diagonal = fill_diagonal

--- a/pynest/nest/tests/compatibility.py
+++ b/pynest/nest/tests/compatibility.py
@@ -70,6 +70,6 @@ if not hasattr(unittest.TestCase, 'assertGreater'):
 # NumPy 1.4.0-
 if not hasattr(numpy, 'fill_diagonal'):
     def fill_diagonal(a, b):
-        diagonal = numpy.arange(a.shape[0])
-        a[diagonal, diagonal] = b
+        diagonal = [ numpy.arange( min( a.shape ) ) ] * a.ndim
+        a[diagonal] = b
     numpy.fill_diagonal = fill_diagonal

--- a/pynest/nest/tests/test_connect_all_to_all.py
+++ b/pynest/nest/tests/test_connect_all_to_all.py
@@ -117,7 +117,7 @@ class TestAllToAll(TestParams):
             frequencies = scipy.stats.itemfreq(M)
             self.assertTrue(np.array_equal(frequencies[:, 0], np.arange(1, n_rport+1)), 'Missing or invalid rports')
             chi, p = scipy.stats.chisquare(frequencies[:, 1])
-            self.assertGreater(p, self.pval, 'Chi2 test failed.')
+            self.assertGreater(p, self.pval)
 
 
 def suite():

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -545,7 +545,7 @@ fi
 
 if test "x${TEST_PYNEST}" = xtrue ; then
 
-    if command -v nosetests >/dev/null 2>&1; then
+    if command -v nosetests >/dev/null 2>&1 && nosetests --with-xunit --xunit-file=/dev/null >/dev/null 2>&1; then
 
 	echo
 	echo "Phase 6: Running PyNEST tests."


### PR DESCRIPTION
This PR does three things compared to test failures with older Python and NumPy versions:
* Check if the nosetests executable supports the `--with-xunit` switch. If it does not, we use our own test harness instead.
* Remove the error message given to `assertGreater`, as this leads to problems with Python <= 2.6. This fixes #6 .
* Add a simple implementation for `numpy.fill_diagonal` if it is not there (NumPy <= 1.4.0)