### PR TITLE
Add a script that checks static analysis from TravisCI locally.

### DIFF
--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+# static code analysis
+START_SHA=master
+END_SHA=HEAD
+
+NEST_SRC=.
+CPPCHECK=cppcheck
+VERA=vera++
+VERA_HOME=/usr/local/lib/vera++
+
+CLANG_FORMAT=clang-format
+INCREMENTAL=false
+
+ONLY_FILE=
+
+#
+# usage [exit_code bad_option]
+#
+usage ()
+{
+    if test $1 -ne 0 ; then
+        echo "Unknown option: $2"
+    fi
+
+    cat <<EOF
+Usage: check_code_style.sh [options ...]"
+
+Setup of Tooling is explained here: 
+    https://nest.github.io/nest-simulator/coding_guidelines_c++
+
+Options:
+
+    --help               Print program options and exit
+    --incremental        Do analysis one file after another.
+    --file=/path/to/file Perform the static analysis on this file only.
+    --git-start=SHA      Enter the default SHA for git to start the diff
+                         (default=master)
+    --git-end=SHA        Enter the default SHA for git to end the diff
+                         (default=HEAD)
+    --nest-src=/path     The base directory for the NEST sources
+                         (default=. assuming you execute check_code_style.sh 
+                         from the base directory.)
+    --cppcheck=exe       Enter the executable that is used for cppcheck.
+                         (default=cppcheck)
+    --clang-format=exe   Enter the executable that is used for clang-format.
+                         (default=clang-format)
+    --vera++=exe         Enter the executable that is used for vera++.
+                         (default=vera++)
+EOF
+
+    exit $1
+}
+
+#
+# bail_out message
+#
+bail_out ()
+{
+    echo "$1"
+    exit 1
+}
+
+while test $# -gt 0 ; do
+    case "$1" in
+        --help)
+            usage 0
+            ;;
+        --incremental)
+            INCREMENTAL=true
+            ;;
+        --file=*)
+            ONLY_FILE="$( echo "$1" | sed 's/^--file=//' )"
+            if [ ! -f $ONLY_FILE ]; then
+              bail_out "This is not a valid file: $ONLY_FILE"
+            fi
+            ;;
+        --git-start=*)
+            START_SHA="$( echo "$1" | sed 's/^--git-start=//' )"
+            ;;
+        --git-end=*)
+            END_SHA="$( echo "$1" | sed 's/^--git-end=//' )"
+            ;;
+        --nest-src=*)
+            NEST_SRC="$( echo "$1" | sed 's/^--nest-src=//' )"
+            ;;
+        --cppcheck=*)
+            CPPCHECK="$( echo "$1" | sed 's/^--cppcheck=//' )"
+            ;;
+        --vera++=*)
+            VERA="$( echo "$1" | sed 's/^--vera++=//' )"
+            ;;
+        --clang-format=*)
+            CLANG_FORMAT="$( echo "$1" | sed 's/^--clang-format=//' )"
+            ;;
+        *)
+            usage 1 "$1"
+            ;;
+    esac
+    shift
+done
+
+#
+# sed has different syntax for extended regular expressions
+# on different operating systems:
+# BSD: -E
+# other: -r
+#
+EXTENDED_REGEX_PARAM=r
+/bin/sh -c "echo 'hello' | sed -${EXTENDED_REGEX_PARAM} 's/[aeou]/_/g' "  >/dev/null 2>&1 || EXTENDED_REGEX_PARAM=E
+
+echo "Executing check_code_style.sh"
+echo "Tooling:"
+
+# check vera++ is set up appropriately
+$VERA $NEST_SRC/nest/main.cpp >/dev/null 2>&1 || usage 1 "Executable $VERA for vera++ is not working!"
+$VERA --profile nest $NEST_SRC/nest/main.cpp >/dev/null 2>&1 ||  bail_out "No profile called nest for vera++ installed. See https://nest.github.io/nest-simulator/coding_guidelines_c++#vera-profile-nest"
+echo "vera++ version: `vera++ --version`"
+
+# check cppcheck 1.69 is installed correctly
+$CPPCHECK --enable=all --inconclusive --std=c++03 $NEST_SRC/nest/main.cpp >/dev/null 2>&1 || usage 1 "Executable $CPPCHECK for cppcheck is not working!"
+cppcheck_version=`$CPPCHECK --version | sed 's/^Cppcheck //'`
+echo "cppcheck version: $cppcheck_version"
+if [[ "x$cppcheck_version" != "x1.69" ]]; then
+  bail_out "Require cppcheck version 1.69. Not $cppcheck_version ."
+fi
+
+# clang-format is installed correctly
+$CLANG_FORMAT -style=$NEST_SRC/.clang-format $NEST_SRC/nest/main.cpp >/dev/null 2>&1 || usage 1 "Executable $CLANG_FORMAT for clang-format is not working!"
+clang_format_version=`$CLANG_FORMAT --version | sed -${EXTENDED_REGEX_PARAM} 's/^.*([0-9]\.[0-9])\..*/\1/'`
+echo "clang-format version: $clang_format_version"
+if [[ "x$clang_format_version" != "x3.6" ]]; then
+  bail_out "Require clang-format version 3.6. Not $clang_format_version ."
+fi
+
+# Extracting changed files between two commits
+if [[ "x$ONLY_FILE" != "x" && -f $ONLY_FILE ]]; then
+  file_names=$ONLY_FILE
+else
+  file_names=`git diff --name-only $START_SHA..$END_SHA`
+fi
+format_error_files=""
+
+echo
+echo "Performing static analysis on:"
+for f in $file_names; do
+  echo "  $f"
+done
+if $INCREMENTAL; then
+  echo "Press enter to continue."
+  read
+else
+  echo
+fi
+
+for f in $file_names; do
+  if [ ! -f "$NEST_SRC/$f" ]; then
+    echo "$f : Is not a file or does not exist anymore."
+    continue
+  fi
+  # filter files
+  case $f in
+    *.h | *.c | *.cc | *.hpp | *.cpp )
+      echo
+      echo "Static analysis on file $f:"
+      if $INCREMENTAL; then
+        echo "Press enter to continue."
+        read
+      else
+        echo
+      fi
+
+      echo " - clang-format for $f: (critical: if there are diffs, perform $CLANG_FORMAT -i $f )"
+      # clang format creates tempory formatted file
+      $CLANG_FORMAT $NEST_SRC/$f > $NEST_SRC/${f}_formatted.txt
+      # compare the committed file and formatted file and 
+      # writes the differences to a temp file
+      diff $f $NEST_SRC/${f}_formatted.txt | tee $NEST_SRC/${f}_clang_format.txt
+
+      if [ -s $NEST_SRC/${f}_clang_format.txt ]; then 
+        # file exists and has size greater than zero
+        format_error_files="$format_error_files $f"
+      fi
+
+      # remove temporary files
+      rm $NEST_SRC/${f}_formatted.txt
+      rm $NEST_SRC/${f}_clang_format.txt
+
+      # Vera++ checks the specified list of rules given in the profile 
+      # nest which is placed in the <vera++ root>/lib/vera++/profile
+      echo " - vera++ for $f: (please consider fixing all warnings emitted here.)"
+      $VERA --profile nest $NEST_SRC/$f
+
+      # perform other static analysis
+      echo " - cppcheck for $f: (suggestions for improvements)"
+      $CPPCHECK --enable=all --inconclusive --std=c++03 $NEST_SRC/$f
+
+      ;;
+    *)
+      echo "$f : not a C/CPP file. Do not do static analysis / formatting checking."
+  esac
+done
+
+if [ "$format_error_files" != "" ]; then
+  echo
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "There are files with a formatting error:"
+  for f in $format_error_files; do
+    echo "  $f"
+  done
+  echo
+  echo "Perform '$CLANG_FORMAT -i <filename>' on them, otherwise TravisCI will report failure!"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  exit 42
+fi

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -24,21 +24,28 @@ usage ()
     cat <<EOF
 Usage: ./extras/check_code_style.sh [options ...]"
 
+This script checks our coding style guidelines. The checks are
+performed in the same way as in our TravisCI setup. First it looks
+for changed files in the repository in the commit range <git-start>..<git-end>
+(by default this is master..HEAD). Only the changed files are checked.
+You can specify a different commit range or define the file, which
+should be checked, as an argument.
+
 The script expects to be run from the base directory of the
 NEST sources, i.e. all executions should start like:
     ./extras/check_code_style.sh ...
 
-Setup of Tooling is explained here: 
+Setup of the tooling is explained here: 
     https://nest.github.io/nest-simulator/coding_guidelines_c++
 
 Options:
 
-    --help               Print program options and exit
+    --help               Print program options and exit.
     --incremental        Do analysis one file after another.
     --file=/path/to/file Perform the static analysis on this file only.
-    --git-start=SHA      Enter the default SHA for git to start the diff
+    --git-start=SHA      Enter the SHA from which git starts the diff.
                          (default=master)
-    --git-end=SHA        Enter the default SHA for git to end the diff
+    --git-end=SHA        Enter the SHA from which git ends the diff.
                          (default=HEAD)
     --cppcheck=exe       Enter the executable that is used for cppcheck. Due to
                          a bug in previous versions we require at least version
@@ -47,7 +54,7 @@ Options:
     --clang-format=exe   Enter the executable that is used for clang-format.
                          Due to formatting differences in version 3.6 and 3.7
                          we require version 3.6, which is also used in our
-                         TravisCI setup. (default=clang-format)
+                         TravisCI setup. (default=clang-format-3.6)
     --vera++=exe         Enter the executable that is used for vera++.
                          (default=vera++)
 EOF

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -148,6 +148,12 @@ else
 fi
 format_error_files=""
 
+if [ -z "$file_names" ]; then
+  echo
+  echo "Nothing to check."
+  exit 0
+fi
+
 echo
 echo "Performing static analysis on:"
 for f in $file_names; do

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -28,8 +28,8 @@ This script checks our coding style guidelines. The checks are
 performed in the same way as in our TravisCI setup. First it looks
 for changed files in the repository in the commit range <git-start>..<git-end>
 (by default this is master..HEAD). Only the changed files are checked.
-You can specify a different commit range or define the file, which
-should be checked, as an argument.
+You can specify a different commit range, or define the file to be checked,
+as an argument.
 
 The script expects to be run from the base directory of the
 NEST sources, i.e. all executions should start like:
@@ -41,7 +41,7 @@ Setup of the tooling is explained here:
 Options:
 
     --help               Print program options and exit.
-    --incremental        Do analysis one file after another.
+    --incremental        Do analysis on one file after another.
     --file=/path/to/file Perform the static analysis on this file only.
     --git-start=SHA      Enter the SHA from which git starts the diff.
                          (default=master)
@@ -125,6 +125,7 @@ $VERA --profile nest ./nest/main.cpp >/dev/null 2>&1 ||  bail_out "No profile ca
 echo "vera++ version: `vera++ --version`"
 
 # check cppcheck 1.69 is installed correctly
+# Previous versions of cppcheck halted on sli/tokenutils.cc (see https://github.com/nest/nest-simulator/pull/79)
 $CPPCHECK --enable=all --inconclusive --std=c++03 ./nest/main.cpp >/dev/null 2>&1 || usage 1 "Executable $CPPCHECK for cppcheck is not working!"
 cppcheck_version=`$CPPCHECK --version | sed 's/^Cppcheck //'`
 echo "cppcheck version: $cppcheck_version"
@@ -133,6 +134,9 @@ if [[ "x$cppcheck_version" != "x1.69" ]]; then
 fi
 
 # clang-format is installed correctly
+# clang-format version 3.5 and before do not understand all configuration
+# options we use. Version 3.7 has a different formatting behaviour. Since the
+# sources are formatted with 3.6, we require clang-format 3.6 for the checking.
 $CLANG_FORMAT -style=./.clang-format ./nest/main.cpp >/dev/null 2>&1 || usage 1 "Executable $CLANG_FORMAT for clang-format is not working!"
 clang_format_version=`$CLANG_FORMAT --version | sed -${EXTENDED_REGEX_PARAM} 's/^.*([0-9]\.[0-9])\..*/\1/'`
 echo "clang-format version: $clang_format_version"
@@ -210,7 +214,7 @@ for f in $file_names; do
 
       ;;
     *)
-      echo "$f : not a C/CPP file. Do not do static analysis / formatting checking."
+      echo "$f : not a C/CPP file. Skipping ..."
   esac
 done
 

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -7,7 +7,7 @@ END_SHA=HEAD
 CPPCHECK=cppcheck
 VERA=vera++
 
-CLANG_FORMAT=clang-format
+CLANG_FORMAT=clang-format-3.6
 INCREMENTAL=false
 
 ONLY_FILE=


### PR DESCRIPTION
This solves #38.

It checks, if the selected executables are working and have the correct version. Then it performs the static code analysis from the TravisCI and gives further information to the user.
It has an incremental mode, which allows to check one file at a time or the user can specify the file he wants to be checked. The CLI arguments follow the implementation from `testsuite/do_tests.sh`.

The documentation can be found in #96 .