### PR TITLE
Wrong comparison operator for connections using parameter arrays

### DIFF
--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -1137,13 +1137,13 @@ def Connect(pre, post, conn_spec=None, syn_spec=None, model=None):
                 if isinstance(value, (np.ndarray, np.generic)):
                     if len(value.shape) == 1:
                         if rule == 'one_to_one':
-                            if value.shape[0] is not len(pre):
+                            if value.shape[0] != len(pre):
                                 raise NESTError("'" + key + "' has to be an array of dimension " + str(len(pre)) + ", a scalar or a dictionary.")
                         else:
                             raise NESTError("'" + key + "' has the wrong type. One-dimensional parameter arrays can only be used in conjunction with rule 'one_to_one'.")
                     elif len(value.shape) == 2:
                         if rule == 'all_to_all':
-                            if value.shape[0] is not len(post) or value.shape[1] is not len(pre):
+                            if value.shape[0] != len(post) or value.shape[1] != len(pre):
                                 raise NESTError("'" + key + "' has to be an array of dimension " + str(len(post)) + "x" + str(len(pre)) + " (n_target x n_sources), a scalar or a dictionary.")
                             else:
                                 syn_spec[key] = value.flatten()

--- a/pynest/nest/tests/test_connect_all_to_all.py
+++ b/pynest/nest/tests/test_connect_all_to_all.py
@@ -35,6 +35,8 @@ class TestAllToAll(TestParams):
     # sizes of populations
     N1 = 6
     N2 = 7
+    N1_array = 500
+    N2_array = 10
             
     #def testErrorMessages(self):
       
@@ -53,11 +55,11 @@ class TestAllToAll(TestParams):
         for label in ['weight', 'delay']:
             syn_params = {}
             if label == 'weight':
-                self.param_array = np.arange(self.N1*self.N2, dtype=float).reshape(self.N2,self.N1)
+                self.param_array = np.arange(self.N1_array*self.N2_array, dtype=float).reshape(self.N2_array,self.N1_array)
             elif label == 'delay':
-                self.param_array = np.arange(1,self.N1*self.N2+1).reshape(self.N2,self.N1)*0.1
+                self.param_array = np.arange(1,self.N1_array*self.N2_array+1).reshape(self.N2_array,self.N1_array)*0.1
             syn_params[label] = self.param_array
-            self.setUpNetwork(self.conn_dict, syn_params)
+            self.setUpNetwork(self.conn_dict, syn_params, N1=self.N1_array, N2=self.N2_array)
             M_nest = hf.get_weighted_connectivity_matrix(self.pop1,self.pop2,label)
             hf.mpi_assert(M_nest, self.param_array, self)
     

--- a/pynest/nest/tests/test_connect_one_to_one.py
+++ b/pynest/nest/tests/test_connect_one_to_one.py
@@ -33,6 +33,7 @@ class TestOneToOne(TestParams):
     N = 6
     N1 = N
     N2 = N
+    N_array = 1000
     
     #def testErrorMessages(self):
         
@@ -49,11 +50,11 @@ class TestOneToOne(TestParams):
         syn_params = {}
         for label in ['weight', 'delay']:
             if label == 'weight':
-                self.param_array = np.arange(self.N1, dtype=float)
+                self.param_array = np.arange(self.N_array, dtype=float)
             elif label == 'delay':
-                self.param_array = np.arange(1,self.N1+1)*0.1
+                self.param_array = np.arange(1,self.N_array+1)*0.1
             syn_params[label] = self.param_array
-            self.setUpNetwork(self.conn_dict, syn_params)
+            self.setUpNetwork(self.conn_dict, syn_params, N1=self.N_array, N2=self.N_array)
             M_nest = hf.get_weighted_connectivity_matrix(self.pop1,self.pop2,label)
             hf.mpi_assert(M_nest, np.diag(self.param_array), self)
 


### PR DESCRIPTION
Changed the comparison operator checking the dimensionality of parameter arrays from 'is not' to !=. This caused problems for larger arrays since 'is not' compares the identity of objects (which appears to be fixed in Python for integers ranging from -5 to 256) rather than their value. @heplesser @jougs 