### PR TITLE
Get RCS information from git

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -12,7 +12,7 @@ doc:
 if DOXYGEN_AVAILABLE
 
 	$(eval RCSINFO:=`@PKGSRCDIR@/extras/create_rcsinfo.sh @PKGSRCDIR@ /tmp`) \
-	  $(SED) -i '' "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/normaldoc.conf
+	  $(SED) -i "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/normaldoc.conf
 	$(DOXYGEN) @PKGBUILDDIR@/doc/normaldoc.conf
 
 endif
@@ -22,7 +22,7 @@ if DOXYGEN_AVAILABLE
 if DOT_AVAILABLE
 
 	$(eval RCSINFO:=`@PKGSRCDIR@/extras/create_rcsinfo.sh @PKGSRCDIR@ /tmp`) \
-	  $(SED) -i '' "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/fulldoc.conf
+	  $(SED) -i "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/fulldoc.conf
 	$(DOXYGEN) @PKGBUILDDIR@/doc/fulldoc.conf
 
 ## is it possible to issue a message here if DOT is not available?
@@ -42,4 +42,3 @@ nobase_data_DATA=\
 	quickref.html\
 	doc_header.txt\
 	model_details/noise_generator.ipynb
-	

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -12,7 +12,7 @@ doc:
 if DOXYGEN_AVAILABLE
 
 	$(eval RCSINFO:=`@PKGSRCDIR@/extras/create_rcsinfo.sh @PKGSRCDIR@ /tmp`) \
-	  $(SED) -i "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/normaldoc.conf
+	  $(SED) -i'' -e "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/normaldoc.conf
 	$(DOXYGEN) @PKGBUILDDIR@/doc/normaldoc.conf
 
 endif
@@ -22,7 +22,7 @@ if DOXYGEN_AVAILABLE
 if DOT_AVAILABLE
 
 	$(eval RCSINFO:=`@PKGSRCDIR@/extras/create_rcsinfo.sh @PKGSRCDIR@ /tmp`) \
-	  $(SED) -i "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/fulldoc.conf
+	  $(SED) -i'' -e "/^PROJECT_NUMBER/ s/=.*/= @SLI_VERSION@, $(RCSINFO)/" @PKGBUILDDIR@/doc/fulldoc.conf
 	$(DOXYGEN) @PKGBUILDDIR@/doc/fulldoc.conf
 
 ## is it possible to issue a message here if DOT is not available?

--- a/extras/create_rcsinfo.sh
+++ b/extras/create_rcsinfo.sh
@@ -12,7 +12,7 @@ version=""
 # check if we can run the git command
 if command -v git >/dev/null 2>&1; then
   # check if sourcedir is a git repository
-    if cd $1 && git status >/dev/null 2>&1; then
+    if (cd $1 && git status) >/dev/null 2>&1; then
     # replace branch and version with correct values
     branch=`cd $1; git rev-parse --abbrev-ref HEAD`
     version='@'`cd $1; git rev-parse --short HEAD`

--- a/extras/create_rcsinfo.sh
+++ b/extras/create_rcsinfo.sh
@@ -4,18 +4,18 @@
 #   $1: sourcedir
 #   $2: builddir
 
-# default values, if svn is not installed or
+# default values, if git is not installed or
 # if the source directory is not revisioned
 branch="no_rcsinfo_available"
 version=""
 
-# check if we can run the svn command
-if command -v svn >/dev/null 2>&1; then
-  # check if sourcedir is a repository
-  if svn info $1 >/dev/null 2>&1; then
+# check if we can run the git command
+if command -v git >/dev/null 2>&1; then
+  # check if sourcedir is a git repository
+    if cd $1 && git status >/dev/null 2>&1; then
     # replace branch and version with correct values
-    branch=`svn info $1 | grep ^URL\: | rev | cut -d'/' -f1 | rev | uniq`
-    version='@'`svnversion $1`
+    branch=`cd $1; git rev-parse --abbrev-ref HEAD`
+    version='@'`cd $1; git rev-parse --short HEAD`
   fi
 fi
 

--- a/extras/create_rcsinfo.sh
+++ b/extras/create_rcsinfo.sh
@@ -4,9 +4,8 @@
 #   $1: sourcedir
 #   $2: builddir
 
-# default values, if git is not installed or
-# if the source directory is not revisioned
-branch="no_rcsinfo_available"
+# default value, if git is not installed or if the source directory is
+# not under version control
 version=""
 
 # check if we can run the git command
@@ -14,8 +13,13 @@ if command -v git >/dev/null 2>&1; then
   # check if sourcedir is a git repository
     if (cd $1 && git status) >/dev/null 2>&1; then
     # replace branch and version with correct values
-    branch=`cd $1; git rev-parse --abbrev-ref HEAD`
-    version='@'`cd $1; git rev-parse --short HEAD`
+    version=`cd $1; git rev-parse --abbrev-ref HEAD`
+    if [ $version = "HEAD" ] || [ $version = "master" ]; then
+      version=""
+    else
+      version=$version'@'
+    fi
+    version=$version`cd $1; git rev-parse --short HEAD`
   fi
 fi
 
@@ -24,7 +28,7 @@ sli_libdir="$2/lib/sli"
 mkdir -p $sli_libdir
 
 # create rcsinfo.sli
-echo "statusdict /rcsinfo ($branch$version) put" > $sli_libdir/rcsinfo.sli
-echo $branch$version
+echo "statusdict /rcsinfo ($version) put" > $sli_libdir/rcsinfo.sli
+echo $version
 
 exit 0

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,7 +11,6 @@ nobase_pkgdata_DATA=\
   sli/oosupport.sli\
   sli/processes.sli\
   sli/ps-lib.sli\
-  sli/rcsinfo.sli\
   sli/regexp.sli\
   sli/sli-init.sli\
   sli/typeinit.sli\

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -2364,4 +2364,11 @@ SeeAlso: statusdict
   statusdict/threading :: ToLowercase (openmp) searchif
 } def
 
-(rcsinfo) run
+% Check for rcsinfo SLI file and run it. If it does not
+% exist, put an empty string into statusdict/rcsinfo.
+mark
+  { (rcsinfo) (r) file } stopped not
+    { (rcsinfo) run }
+    { statusdict /rcsinfo () put }
+  ifelse
+] ;


### PR DESCRIPTION
This updates the script for retrieving RCS information to use git instead of svn. It also fixes a bug in the `doc` and `fulldoc` targets. This fixes #63.