### PR TITLE
Two fixes for the K computer

### DIFF
--- a/librandom/clipped_randomdev.h
+++ b/librandom/clipped_randomdev.h
@@ -93,7 +93,7 @@ public:
   ClippedRedrawContinuousRandomDev( RngPtr );
   ClippedRedrawContinuousRandomDev(); // threaded
 
-#if not defined( HAVE_XLC_ICE_ON_USING )
+#if not defined( HAVE_XLC_ICE_ON_USING ) and not defined( IS_K )
   using RandomDev::operator();
 #endif
 
@@ -200,7 +200,7 @@ public:
 // to ensure that they forward to the clipped generator.
 // Null-pointer checking is done in the underlying generator.
 
-#if not defined( HAVE_XLC_ICE_ON_USING )
+#if not defined( HAVE_XLC_ICE_ON_USING ) and not defined( IS_K )
   using RandomDev::operator();
   using RandomDev::ldev;
 #endif
@@ -333,7 +333,7 @@ public:
   ClippedToBoundaryContinuousRandomDev( RngPtr );
   ClippedToBoundaryContinuousRandomDev(); // threaded
 
-#if not defined( HAVE_XLC_ICE_ON_USING )
+#if not defined( HAVE_XLC_ICE_ON_USING ) and not defined( IS_K )
   using RandomDev::operator();
 #endif
 
@@ -442,7 +442,7 @@ public:
 // to ensure that they forward to the clipped generator.
 // Null-pointer checking is done in the underlying generator.
 
-#if not defined( HAVE_XLC_ICE_ON_USING )
+#if not defined( HAVE_XLC_ICE_ON_USING ) and not defined( IS_K )
   using RandomDev::operator();
   using RandomDev::ldev;
 #endif

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -81,8 +81,13 @@ namespace nest
 
 #ifdef HAVE_LONG_LONG
 typedef long long tic_t;
+#ifdef IS_K
+const tic_t tic_t_max = LLONG_MAX;
+const tic_t tic_t_min = LLONG_MIN;
+#else
 const tic_t tic_t_max = LONG_LONG_MAX;
 const tic_t tic_t_min = LONG_LONG_MIN;
+#endif
 #else
 typedef long tic_t;
 const tic_t tic_t_max = LONG_MAX;


### PR DESCRIPTION
In response to trac#960 and #123.
 
* Added support for LLONG_MIN/MAX constants for long long limits on K
* Set "not defined( IS_K )" for "using RandomDev::" statements in clipped_randomdev.h, as they produced a compiler error on K