### PR TITLE
TravisCI Python Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,13 @@ cache:
   apt: true 
   ccache: true
   pip: true
-#virtualenv:
- # system_site_packages: true
 
 before_install:
-  - echo $LANG
-  - echo $LC_ALL
+  # see https://github.com/travis-ci/travis-ci/issues/4948
+  # make sure, that the system provided Python version will be used and not some
+  # external TravisCI Python version.
+  #- echo $PATH
+  - export PATH="/home/travis/bin:/home/travis/.local/bin:/home/travis/.gimme/versions/go1.5.1.linux.amd64/bin:/home/travis/.local/bin:/usr/local/rvm/gems/ruby-2.2.3/bin:/usr/local/rvm/gems/ruby-2.2.3@global/bin:/usr/local/rvm/rubies/ruby-2.2.3/bin:/home/travis/.phpenv/shims:/usr/local/phantomjs/bin:/usr/local/phantomjs:/home/travis/perl5/perlbrew/bin:/home/travis/.nvm/versions/node/v4.1.2/bin:./node_modules/.bin:/usr/local/maven-3.1.1/bin:/usr/local/gradle/bin:/usr/local/clang-3.5.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/travis/.phpenv/bin:/usr/local/rvm/bin"
 
   # get repository for clang-3.6 stuff (including clang-format-3.6)
   - sudo sh -c 'echo -n "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" >> /etc/apt/sources.list'
@@ -48,8 +49,8 @@ before_install:
   # Install pip and cython
   - wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
   - sudo python get-pip.py
-  - pip install --user cython==0.21.1
   - sudo pip install -U setuptools
+  - pip install --user cython==0.23.4
 
   # MPI
   - sudo apt-get install -y openmpi-bin libopenmpi-dev
@@ -67,8 +68,11 @@ before_install:
   - sudo apt-get install -y jq
 
 install: 
+  - which cython
   - cython --version
+  - which python
   - python --version
+  - which pip
 
 before_script:
   - chmod +x build.sh 
@@ -82,7 +86,7 @@ before_deploy:
   - mkdir -p $TRAVIS_BUILD_DIR/build/artefacts_upload
   - mv logfiles.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
   - mv reports.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
-  
+
 #S3 deployment    
 
 deploy:

--- a/build.sh
+++ b/build.sh
@@ -11,11 +11,6 @@ EOF
 
 if [ "$xMPI" = "1" ] ; then
 
-   #openmpi
-   export LD_LIBRARY_PATH="/usr/lib/openmpi/lib:$LD_LIBRARY_PATH"
-   export CPATH="/usr/lib/openmpi/include:$CPATH"
-   export PATH="/usr/include/mpi:$PATH"
-   
 cat > $HOME/.nestrc <<EOF
     % ZYV: NEST MPI configuration
     /mpirun
@@ -63,9 +58,6 @@ cd "$NEST_VPATH"
     $CONFIGURE_PYTHON \
     $CONFIGURE_GSL \
 
-export PYTHONPATH=$NEST_RESULT/lib/python2.7/site-packages:$PYTHONPATH
-export PYTHONPATH=/usr/local/bin:$NEST_RESULT/lib64/python2.7/site-packages:$PYTHONPATH
-export PATH=~/.local/bin:/usr/local/bin:$NEST_RESULT/bin:$PATH
 make
 make install
 make installcheck


### PR DESCRIPTION
    Phase 6: Running PyNEST tests.
    ------------------------------
      Failure: ImportError (/home/travis/build/nest/nest-simulator/result/lib/python2.7/site-packages/nest/pynestkernel.so: undefined symbol: PyUnicodeUCS2_DecodeASCII) ... ERROR
      ERROR: Failure: ImportError (/home/travis/build/nest/nest-simulator/result/lib/python2.7/site-packages/nest/pynestkernel.so: undefined symbol: PyUnicodeUCS2_DecodeASCII)
      ImportError: /home/travis/build/nest/nest-simulator/result/lib/python2.7/site-packages/nest/pynestkernel.so: undefined symbol: PyUnicodeUCS2_DecodeASCII


After 14. Oct. TravisCI changed their Ubuntu Trusty image that performs our testsuite. Apparently, they installed multiple Python versions and put them first in the `PATH` (at least before the system provided Python). The system Python and the TravisCI Python are compiled using different size for [unicode characters](http://effbot.org/pyfaq/when-importing-module-x-why-do-i-get-undefined-symbol-pyunicodeucs2.htm). When we compiled PyNEST with the headers from the system provided `python-dev`, it was compiled with UCS2, but when the TravisCI Python tried to import PyNEST it crashed, as it is compiled for UCS4. And we are not alone with this: travis-ci/travis-ci#4948 .

This PR gives a 'brute-force hot-fix' for this issue: In the `.travis.yml` I hardcode the `PATH`, s.t. no other Python implementation is present and we only rely on the system provided Python.

Further, I removed some unnecessary instructions in `.travis.yml` and `build.sh`.