### PR TITLE
Python issues on  the new Travis trusty beta.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: generic
 compiler:
   - gcc
 
@@ -28,7 +28,7 @@ before_install:
   # make sure, that the system provided Python version will be used and not some
   # external TravisCI Python version.
   #- echo $PATH
-  - export PATH="/home/travis/bin:/home/travis/.local/bin:/home/travis/.gimme/versions/go1.5.1.linux.amd64/bin:/home/travis/.local/bin:/usr/local/rvm/gems/ruby-2.2.3/bin:/usr/local/rvm/gems/ruby-2.2.3@global/bin:/usr/local/rvm/rubies/ruby-2.2.3/bin:/home/travis/.phpenv/shims:/usr/local/phantomjs/bin:/usr/local/phantomjs:/home/travis/perl5/perlbrew/bin:/home/travis/.nvm/versions/node/v4.1.2/bin:./node_modules/.bin:/usr/local/maven-3.1.1/bin:/usr/local/gradle/bin:/usr/local/clang-3.5.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/travis/.phpenv/bin:/usr/local/rvm/bin"
+  #- export PATH="/home/travis/bin:/home/travis/.local/bin:/home/travis/.gimme/versions/go1.5.1.linux.amd64/bin:/home/travis/.local/bin:/usr/local/rvm/gems/ruby-2.2.3/bin:/usr/local/rvm/gems/ruby-2.2.3@global/bin:/usr/local/rvm/rubies/ruby-2.2.3/bin:/home/travis/.phpenv/shims:/usr/local/phantomjs/bin:/usr/local/phantomjs:/home/travis/perl5/perlbrew/bin:/home/travis/.nvm/versions/node/v4.1.2/bin:./node_modules/.bin:/usr/local/maven-3.1.1/bin:/usr/local/gradle/bin:/usr/local/clang-3.5.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/travis/.phpenv/bin:/usr/local/rvm/bin"
 
   # get repository for clang-3.6 stuff (including clang-format-3.6)
   - sudo sh -c 'echo -n "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" >> /etc/apt/sources.list'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# Force travis to use its minimal image with default Python settings.If we use the minimal image, it uses only the system provided python and not some extrenal Python versions
 language: generic
 compiler:
   - gcc
@@ -24,11 +25,6 @@ cache:
   pip: true
 
 before_install:
-  # see https://github.com/travis-ci/travis-ci/issues/4948
-  # make sure, that the system provided Python version will be used and not some
-  # external TravisCI Python version.
-  #- echo $PATH
-  #- export PATH="/home/travis/bin:/home/travis/.local/bin:/home/travis/.gimme/versions/go1.5.1.linux.amd64/bin:/home/travis/.local/bin:/usr/local/rvm/gems/ruby-2.2.3/bin:/usr/local/rvm/gems/ruby-2.2.3@global/bin:/usr/local/rvm/rubies/ruby-2.2.3/bin:/home/travis/.phpenv/shims:/usr/local/phantomjs/bin:/usr/local/phantomjs:/home/travis/perl5/perlbrew/bin:/home/travis/.nvm/versions/node/v4.1.2/bin:./node_modules/.bin:/usr/local/maven-3.1.1/bin:/usr/local/gradle/bin:/usr/local/clang-3.5.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/travis/.phpenv/bin:/usr/local/rvm/bin"
 
   # get repository for clang-3.6 stuff (including clang-format-3.6)
   - sudo sh -c 'echo -n "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" >> /etc/apt/sources.list'


### PR DESCRIPTION
Easy way is to use the minimal image which forces the program to use the system python instead of any non-system python.
Modified file:   .travis.yml