### PR TITLE
Fix issue #141: Error with non default tics_per_ms

### DIFF
--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -35,7 +35,7 @@
  * ---------------------------------------------------------------- */
 
 nest::correlospinmatrix_detector::Parameters_::Parameters_()
-  : delta_tau_( Time::ms( 0.1 ) )
+  : delta_tau_( Time::min() )
   , tau_max_( 10 * delta_tau_ )
   , Tstart_( Time::ms( 0.0 ) )
   , Tstop_( Time::pos_inf() )


### PR DESCRIPTION
When compiled with --with-tics-per-ms=4, on NEST import a NEST error occurs in constructor of node class "correlospinmatrix_detector".

"The default resolution of 0.25 ms (= 1 tics = 1 step) is not consistent with the value
0 ms (= 0 tics = 0 steps) of property 'delta_tau' in model UnknownNode."

The default value for delta_tau of 0.1 assumes tics_per_ms
to be a multiple of 10.