### PR TITLE
Fix process_static_analysis.sh

### DIFF
--- a/extras/parse_travis_log.py
+++ b/extras/parse_travis_log.py
@@ -165,7 +165,7 @@ def process_static_analysis(f, line):
         if line.startswith('+echo Static analysis on file '):
             return res
 
-        if line.startswith('+format_error_files='):
+        if line.startswith('+rm -rf ./cppcheck'):
             return res
 
         if line.startswith(' - vera++ for '):


### PR DESCRIPTION
If all formats are ok, the static analysis section does not end with `+format_error_files=`. Also with #119 the static code analysis is moved before building NEST. This means, if static analysis parsing reads in all of the rest, the script will error. This PR sets a proper stop position for static code analysis.