### PR TITLE
Fix issue #82: parrot neuron now emits multiple spikes via spike multiplicity instead of a loop

### DIFF
--- a/models/parrot_neuron.cpp
+++ b/models/parrot_neuron.cpp
@@ -56,12 +56,16 @@ parrot_neuron::update( Time const& origin, const long_t from, const long_t to )
     const ulong_t current_spikes_n = static_cast< ulong_t >( B_.n_spikes_.get_value( lag ) );
     if ( current_spikes_n > 0 )
     {
-      // create a new SpikeEvent and set its multiplicity
+      // create a new SpikeEvent, set its multiplicity and send it
       SpikeEvent se;
       se.set_multiplicity( current_spikes_n );
-
       network()->send( *this, se, lag );
-      set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
+
+      // set the spike times, respecting the multiplicity
+      for ( ulong_t i = 0; i < current_spikes_n; i++ )
+      {
+        set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
+      }
     }
   }
 }

--- a/models/parrot_neuron.cpp
+++ b/models/parrot_neuron.cpp
@@ -51,18 +51,16 @@ parrot_neuron::update( Time const& origin, const long_t from, const long_t to )
   assert( to >= 0 && ( delay ) from < Scheduler::get_min_delay() );
   assert( from < to );
 
-  SpikeEvent se;
-
   for ( long_t lag = from; lag < to; ++lag )
   {
     const ulong_t current_spikes_n = static_cast< ulong_t >( B_.n_spikes_.get_value( lag ) );
-
     if ( current_spikes_n > 0 )
     {
-      for ( ulong_t i_spike = 0; i_spike < current_spikes_n; i_spike++ )
-      {
-        network()->send( *this, se, lag );
-      }
+      // create a new SpikeEvent and set its multiplicity
+      SpikeEvent se;
+      se.set_multiplicity( current_spikes_n );
+
+      network()->send( *this, se, lag );
       set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
     }
   }

--- a/models/parrot_neuron.h
+++ b/models/parrot_neuron.h
@@ -54,7 +54,8 @@ Sends: SpikeEvent
 Parameters:
 No parameters to be set in the status dictionary.
 
-Author:  May 2006, Reichert, Morrison
+Author: David Reichert, Abigail Morrison, Alexander Seeholzer, Hans Ekkehard Plesser
+FirstVersion: May 2006
 */
 
 
@@ -64,9 +65,6 @@ Author:  May 2006, Reichert, Morrison
  * time step.
  * Instead of the accumulated weigths of the incoming spikes, the
  * number of the spikes is stored within a ring buffer.
- *
- * \author David Reichert
- * \date may 2006
  */
 
 #ifndef PARROT_NEURON_H

--- a/pynest/nest/tests/test_parrot_neuron.py
+++ b/pynest/nest/tests/test_parrot_neuron.py
@@ -71,6 +71,20 @@ class ParrotNeuronTestCase(unittest.TestCase):
         post_time = events['times'][events['senders'] == self.parrot[0]]
         assert len(post_time) == 0, "Parrot neuron failed to ignore spike arriving on port 1"
 
+    def test_ParrotNeuronMultiplicity(self):
+        """Check parrot_neuron correctly repeats spikes with multiplicity"""
+
+        # connect twice
+        nest.Connect(self.source, self.parrot, syn_spec={"delay": self.delay})
+        nest.Connect(self.source, self.parrot, syn_spec={"delay": self.delay})
+        nest.Simulate(self.spike_time + 2. * self.delay)
+
+        # get spikes from parrot neuron, assert two were transmitted
+        events = nest.GetStatus(self.spikes)[0]["events"]
+        post_times = events['times'][events['senders'] == self.parrot[0]]
+        assert len(post_times) == 2 and post_times[0] == post_times[1], \
+            "Parrot neuron failed to correctly repeat spikes with multiplicity."
+
 
 @nest.check_stack
 class ParrotNeuronSTDPTestCase(unittest.TestCase):


### PR DESCRIPTION
Addresses issue https://github.com/nest/nest-simulator/issues/82.
Added test for parrot neuron that checks for correct spike repetition with multiplicity.