### PR TITLE
Improve hpc_benchmark.sli

### DIFF
--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -50,7 +50,7 @@
 
 % -------------------------------------------------------------------------------------
 
-%%% DEFINE FUNCTION TO CONVERT SYNAPSE WEIGHT FROM mV to pA %%%%%%%%%%
+%%% Define function to convert synapse weight from  mV to pA %%%%%%%%%%
 
 /ConvertSynapseWeight
 {
@@ -86,7 +86,7 @@ def
 
   /model_params
    <<
-   % Set variables for iaf_psc_exp
+   % Set variables for iaf_neuron
     /E_L     0.0  mV  % Resting membrane potential [mV]
     /C_m   250.0  pF  % Capacity of the membrane [pF]
     /tau_m  10.0  ms  % Membrane time constant [ms]

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -81,7 +81,7 @@
 
   /mean_potential 5.7 mV
   /sigma_potential 7.2 mV
- 
+  /randomize_Vm true
 
   /delay  1.5 ms         % synaptic delay, all connections [ms] 
 
@@ -143,6 +143,28 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
   /I_from I_net 1 add def                    % gid of first child
   /I_to 0 GetStatus /network_size get 1 sub def % gid of last child
 
+  randomize_Vm
+  {
+      M_INFO (BuildNetwork)
+      (Randomzing membrane potentials.) message
+
+      0 GetStatus /rng_seeds get Last 1 add 0 /vp get add 
+      rngdict/MT19937 :: exch CreateRNG 
+      rdevdict/normal :: CreateRDV /normal Set
+
+      [E_from E_to] Range
+      { 
+	  << /V_m mean_potential sigma_potential normal Random mul add >> 
+	  SetStatus 
+      } forall
+
+      [I_from I_to] Range
+      { 
+	  << /V_m mean_potential sigma_potential normal Random mul add >> 
+	  SetStatus 
+      } forall
+  } if
+   
   /E_neurons E_from E_to cvgidcollection def % get memory efficient gid-collection
 
   /I_neurons I_from I_to cvgidcollection def % get memory efficient gid-collection

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -50,6 +50,30 @@
 
 % -------------------------------------------------------------------------------------
 
+%%% DEFINE FUNCTION TO CONVERT SYNAPSE WEIGHT FROM mV to pA %%%%%%%%%%
+
+/ConvertSynapseWeight
+{
+  /tauMem Set
+  /tauSyn Set
+  /CMem Set
+  % This function is specific to the used neuron model
+  % Leaky integrate-and-fire neuron with alpha-shaped
+  % postsynaptic currents
+  (
+  a = tauMem / tauSyn;
+  b = 1.0 / tauSyn - 1.0 / tauMem;
+  % time of maximum
+  t_max = 1.0/b * (-LambertWm1(-exp(-1.0/a)/a)-1.0/a);
+  % maximum of PSP for current of unit amplitude
+  exp(1.0)/(tauSyn*CMem*b) * ((exp(-t_max/tauMem) - exp(-t_max/tauSyn)) / b - t_max*exp(-t_max/tauSyn))
+  ) ExecMath
+  1 exch div
+}
+def
+
+% -------------------------------------------------------------------------------------
+
 /brunel_params
 <<
 
@@ -81,9 +105,9 @@
 
   /delay  1.5 ms         % synaptic delay, all connections [ms] 
 
-   % synaptic strengths
-  /JE 325.78288268410768 0.14 mul pA    %peak of EPSC
-
+   % synaptic weight
+  /JE 0.14 mV %peak of EPSP
+  
   /sigma_w 3.47 pA      %standard dev. of E->E synapses [pA]
   /g  -5.0 	
     
@@ -175,7 +199,12 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
   (Creating excitatory stimulus generator.) message
 
   model_params using
-  /nu_thresh V_th CE tau_m C_m div mul JE mul 1.0 exp mul tau_syn mul div def
+   
+  % Convert synapse weight from mV to pA
+  C_m tau_syn tau_m ConvertSynapseWeight /conversion_factor Set
+  /JE_pA conversion_factor JE mul def
+  
+  /nu_thresh V_th CE tau_m C_m div mul JE_pA mul 1.0 exp mul tau_syn mul div def
   /nu_ext nu_thresh eta mul def
   endusing
     
@@ -218,10 +247,10 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
   % our excitatory and inhibitory connections
   /static_synapse_hpc << /delay delay >> SetDefaults
   /static_synapse_hpc /syn_std  CopyModel
-  /static_synapse_hpc /syn_ex << /weight JE >> CopyModel
-  /static_synapse_hpc /syn_in << /weight JE g mul >> CopyModel
+  /static_synapse_hpc /syn_ex << /weight JE_pA >> CopyModel
+  /static_synapse_hpc /syn_in << /weight JE_pA g mul >> CopyModel
       	
-  stdp_params /weight JE put	
+  stdp_params /weight JE_pA put	
   /stdp_pl_synapse_hom_hpc stdp_params SetDefaults
 
   

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -91,7 +91,7 @@ def
   
 } def
 
-% Inverting this equation leads to tau_syn = 0.32582722403722841 ms, as specified in model_params below.
+% Inverting this equation numerically leads to tau_syn = 0.32582722403722841 ms, as specified in model_params below.
 
 % -------------------------------------------------------------------------------------
 

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -72,6 +72,27 @@
 }
 def
 
+%%% Rise time of synaptic currents
+
+% The synaptic rise time is chosen such that the rise time of the
+% evoked post-synaptic potential is 1.700759 ms.
+% For alpha-shaped postynaptic currents, the rise time of the post-synaptic
+% potential follows from the synaptic rise time as
+
+/PSP_rise_time
+{
+  /taumem set
+  /tausyn set
+  
+  (
+  a = taumem / tausyn;
+  b = 1.0 / tausyn - 1.0 / taumem;
+  ) execmath
+  
+} def
+
+% Inverting this equation leads to tau_syn = 0.32582722403722841 ms, as specified in model_params below.
+
 % -------------------------------------------------------------------------------------
 
 /brunel_params

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -41,7 +41,7 @@
 
 /nvp 1 def % total number of virtual processes
 /scale 0.2 def %  scaling factor of the network size, total network size = scale*11250 neurons
-/Tsim 100. def % total simulation time in ms
+/Tsim 1000. def % total simulation time in ms
 /record_spikes true def % switch to record spikes of excitatory neurons to file
 /path_name (.) def % path where all files will have to be written
 /log_file (log) def % naming scheme for the log files

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -120,9 +120,12 @@ def
     /V_m 5.7 mV % mean value of membrane potential
    >> 
 
-  /mean_potential 5.7 mV
-  /sigma_potential 7.2 mV
+  
+  
   /randomize_Vm true
+  /mean_potential 5.7 mV  % Note that Kunkel et al. (2014) report different values. The values
+  /sigma_potential 7.2 mV % in the paper were used for the benchmarks on K, the values given
+                          % here were used for the benchmark on JUQUEEN.
 
   /delay  1.5 ms         % synaptic delay, all connections [ms] 
 

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -41,7 +41,9 @@
 
 /nvp 1 def % total number of virtual processes
 /scale 0.2 def %  scaling factor of the network size, total network size = scale*11250 neurons
-/Tsim 1000. def % total simulation time in ms
+/simtime 1000. def % total simulation time in ms
+/presimtime 100. ms def % simulation time until reaching equilibrium
+/dt         0.1 ms def % simulation step
 /record_spikes true def % switch to record spikes of excitatory neurons to file
 /path_name (.) def % path where all files will have to be written
 /log_file (log) def % naming scheme for the log files
@@ -51,13 +53,7 @@
 /brunel_params
 <<
 
-  /virtual_processes nvp      % number of virtual processes to use
-  /simtime Tsim ms        % simulated time
-  /presimtime 100. ms     % simulation time until reaching equilibrium
-  /dt         0.1 ms        % simulation step
 
-  /scale scale def
-  
   /NE 9000 scale mul round cvi   % number of excitatory neurons
   /NI 2250 scale mul round cvi   % number of inhibitory neurons
 
@@ -125,7 +121,7 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
   % set global kernel parameters
   0
   <<
-     /total_num_virtual_procs virtual_processes
+     /total_num_virtual_procs nvp
      /resolution  dt
      /overwrite_files true
   >> SetStatus

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -131,10 +131,10 @@ def
 
    % synaptic weight
   /JE 0.14 mV %peak of EPSP
-  
+
   /sigma_w 3.47 pA      %standard dev. of E->E synapses [pA]
-  /g  -5.0 	
-    
+  /g  -5.0
+
   /stdp_params
   <<
     /delay 1.5 ms


### PR DESCRIPTION
@suku248 discovered that the hpc_benchmark.sli script, which is supposed to represent the benchmark script used in the recent NEST Technology papers, lacked the functionality of randomizing initial membrane potential, which we used and described in Kunkel et al. (2014).

Therefore, I implemented this option.

Furthermore, @suku248 and I discovered two inconsistencies:
- The simulation time in hpc_benchmark.sli was set to 100. ms but for the benchmarks in the publications, we always used 1000 ms. Perhaps this was done to make simulating the script on a local laptop more convenient, but it should be set to the original simulation time to avoid confusion, in our opinion.

- The pre-simulation time is fixed to 100. ms in hpc_benchmark.sli. However, for the publication we simulated 1 timestep + 10 min_delay periods = 15.1 ms (for the default settings). I did not apply any changes, should I change this or should we leave it at a fixed value of 100. ms. For simplicity, I would leave things as they are, because the pre-simulation time is just meant to skip the initial transient in the network.

@suku248 , @diesmann , please take a look at this pull-request.
