### PR TITLE
Add stdp_triplet_synapse from Pfister & Gerstner (2006)

### DIFF
--- a/models/Makefile.am
+++ b/models/Makefile.am
@@ -80,6 +80,7 @@ libmodelsmodule_la_SOURCES= \
 		stdp_dopa_connection.h stdp_dopa_connection.cpp\
 		stdp_connection_facetshw_hom.h stdp_connection_facetshw_hom_impl.h\
 		stdp_pl_connection_hom.h stdp_pl_connection_hom.cpp\
+		stdp_triplet_connection.h\
 		step_current_generator.h step_current_generator.cpp\
 		tsodyks2_connection.h\
 		tsodyks_connection.h\

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -117,6 +117,7 @@
 #include "stdp_connection_facetshw_hom.h"
 #include "stdp_connection_facetshw_hom_impl.h"
 #include "stdp_pl_connection_hom.h"
+#include "stdp_triplet_connection.h"
 #include "stdp_dopa_connection.h"
 #include "gap_junction.h"
 #include "ht_connection.h"
@@ -354,6 +355,16 @@ ModelsModule::init( SLIInterpreter* )
     net_, "stdp_pl_synapse_hom" );
   register_connection_model< STDPPLConnectionHom< TargetIdentifierIndex > >(
     net_, "stdp_pl_synapse_hom_hpc" );
+
+
+  /* BeginDocumentation
+     Name: stdp_triplet_synapse_hpc - Variant of stdp_triplet_synapse with low memory consumption.
+     SeeAlso: synapsedict, stdp_synapse, static_synapse_hpc
+  */
+  register_connection_model< STDPTripletConnection< TargetIdentifierPtrRport > >(
+    net_, "stdp_triplet_synapse" );
+  register_connection_model< STDPTripletConnection< TargetIdentifierIndex > >( 
+    net_, "stdp_triplet_synapse_hpc" );
 
 
   /* BeginDocumentation

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -363,7 +363,7 @@ ModelsModule::init( SLIInterpreter* )
   */
   register_connection_model< STDPTripletConnection< TargetIdentifierPtrRport > >(
     net_, "stdp_triplet_synapse" );
-  register_connection_model< STDPTripletConnection< TargetIdentifierIndex > >( 
+  register_connection_model< STDPTripletConnection< TargetIdentifierIndex > >(
     net_, "stdp_triplet_synapse_hpc" );
 
 

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -1,0 +1,333 @@
+/*
+ *  stdp_triplet_connection.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#ifndef STDP_TRIPLET_CONNECTION_H
+#define STDP_TRIPLET_CONNECTION_H
+
+/* BeginDocumentation
+  Name: stdp_triplet_synapse - Synapse type for spike-timing dependent 
+  plasticity accounting for spike triplets as described in [1].
+
+  Description:
+   stdp_triplet_synapse is a connector to create synapses with spike time 
+   dependent plasticity accounting for spike triplets (as defined in [1]). 
+   
+   Here, a multiplicative weight dependence is added (in contrast to [1]) 
+   to depression resulting in a stable weight distribution.
+  
+  Parameters:
+
+   tau_plus     time constant of STDP window, potentiation 
+                (tau_minus defined in post-synaptic neuron)
+   tau_x        time constant of triplet potentiation
+   tau_y        time constant of triplet depression
+   A_2p         weight of pair potentiation rule
+   A_2m         weight of pair depression rule
+   A_3p         weight of triplet potentiation rule
+   A_3m         weight of triplet depression rule
+
+
+  References:
+
+   [1] J.-P. Pfister & W. Gerstner (2006) Triplets of Spikes in a Model 
+   of Spike Timing-Dependent Plasticity.  The Journal of Neuroscience 
+   26(38):9673-9682; doi:10.1523/JNEUROSCI.1425-06.2006
+
+   Transmits: SpikeEvent
+
+  FirstVersion: Nov 2007
+  Author: Moritz Helias, Abigail Morrison, Eilif Muller
+  SeeAlso: synapsedict, stdp_synapse, tsodyks_synapse, static_synapse
+*/
+
+#include <cmath>
+#include "connection.h"
+
+namespace nest
+{
+// connections are templates of target identifier type 
+// (used for pointer / target index addressing)
+// derived from generic connection template
+template < typename targetidentifierT >
+class STDPTripletConnection : public Connection< targetidentifierT >
+{ 
+
+public:
+  typedef CommonSynapseProperties CommonPropertiesType;
+  typedef Connection< targetidentifierT > ConnectionBase;
+
+  /**
+   * Default Constructor.
+   * Sets default values for all parameters. Needed by GenericConnectorModel.
+   */
+  STDPTripletConnection();
+
+  
+  /**
+   * Copy constructor.
+   * Needs to be defined properly in order for GenericConnector to work.
+   */
+  STDPTripletConnection(const STDPTripletConnection &);
+
+
+  /**
+   * Default Destructor.
+   */
+  ~STDPTripletConnection() {}
+
+
+  // Explicitly declare all methods inherited from the dependent base 
+  // ConnectionBase. This avoids explicit name prefixes in all places 
+  // these functions are used. Since ConnectionBase depends on the template 
+  // parameter, they are not automatically found in the base class.
+  using ConnectionBase::get_delay_steps;
+  using ConnectionBase::get_delay;
+  using ConnectionBase::get_rport;
+  using ConnectionBase::get_target;
+
+  /**
+   * Get all properties of this connection and put them into a dictionary.
+   */
+  void get_status( DictionaryDatum& d ) const;
+
+  /**
+   * Set properties of this connection from the values given in dictionary.
+   */
+  void set_status( const DictionaryDatum& d, ConnectorModel& cm );
+
+  /**
+   * Send an event to the receiver of this connection.
+   * \param e The event to send
+   * \param t_lastspike Point in time of last spike sent.
+   * \param cp common properties of all synapses (empty).
+   */
+  void send( Event& e, thread t, double_t t_lastspike, const CommonSynapseProperties& cp );
+
+
+  class ConnTestDummyNode : public ConnTestDummyNodeBase
+  {
+  public:
+    // Ensure proper overriding of overloaded virtual functions.
+    // Return values from functions are ignored.
+    using ConnTestDummyNodeBase::handles_test_event;
+    port
+    handles_test_event( SpikeEvent&, rport )
+    {
+      return invalid_port_;
+    }
+  };
+  
+  /*
+   * This function calls check_connection on the sender and checks if the receiver
+   * accepts the event type and receptor type requested by the sender.
+   * Node::check_connection() will either confirm the receiver port by returning
+   * true or false if the connection should be ignored.
+   * We have to override the base class' implementation, since for STDP
+   * connections we have to call register_stdp_connection on the target neuron
+   * to inform the Archiver to collect spikes for this connection.
+   *
+   * \param s The source node
+   * \param r The target node
+   * \param receptor_type The ID of the requested receptor type
+   * \param t_lastspike last spike emitted by presynaptic neuron
+   */
+  void
+  check_connection( Node& s,
+    Node& t,
+    rport receptor_type,
+    double_t t_lastspike,
+    const CommonPropertiesType& )
+  {
+    ConnTestDummyNode dummy_target;
+
+    ConnectionBase::check_connection_( dummy_target, s, t, receptor_type );
+
+    t.register_stdp_connection( t_lastspike - get_delay() );
+  }
+
+  void
+  set_weight( double_t w )
+  {
+    weight_ = w;
+  } 
+
+ private:
+  double_t 
+  facilitate_(double_t w, double_t kplus, double_t ky)
+  {
+    return w+(A_2p_+A_3p_*ky)*kplus;
+  }
+
+  double_t 
+  depress_(double_t w, double_t kminus, double_t kx)
+  {
+    double new_w = w - kminus*(A_2m_ + A_3m_*kx); 
+    return new_w > 0.0 ? new_w : 0.0;
+  }
+
+  // data members of each connection
+  double_t weight_;
+  double_t tau_plus_;
+  double_t tau_x_;
+  double_t A_2p_;
+  double_t A_2m_;
+  double_t A_3p_;
+  double_t A_3m_;
+  double_t Kplus_;
+  double_t Kx_;
+  };
+
+
+/**
+ * Send an event to the receiver of this connection.
+ * \param e The event to send
+ * \param t The thread on which this connection is stored.
+ * \param t_lastspike Time point of last spike emitted
+ * \param cp Common properties object, containing the stdp parameters.
+ */
+template < typename targetidentifierT >
+inline void
+STDPTripletConnection< targetidentifierT >::send( Event& e,
+  thread t,
+  double_t t_lastspike,
+  const CommonSynapseProperties& )
+{
+  // synapse STDP depressing/facilitation dynamics
+  
+  double_t t_spike = e.get_stamp().get_ms();
+  // t_lastspike_ = 0 initially
+
+  // use accessor functions (inherited from Connection< >) to obtain delay and target
+  Node* target = get_target( t );
+  double_t dendritic_delay = get_delay(); 
+    
+  //get spike history in relevant range (t1, t2] from post-synaptic neuron
+  std::deque<histentry>::iterator start;
+  std::deque<histentry>::iterator finish;    
+  target->get_history(t_lastspike - dendritic_delay, t_spike - dendritic_delay, 
+			       &start, &finish);
+  //facilitation due to post-synaptic spikes since last pre-synaptic spike
+  double_t minus_dt;
+  double_t ky;
+  while (start != finish)
+  {      
+    // post-synaptic spike is delayed by dendritic_delay so that
+    // it is effectively late by that much at the synapse.
+    minus_dt = t_lastspike - (start->t_ + dendritic_delay);
+    // subtract 1.0 yields the triplet_Kminus value just prior to
+    // the post synaptic spike, implementing the t-epsilon in 
+    // Pfister et al, 2006
+    ky = start->triplet_Kminus_-1.0;
+    start++;
+    if (minus_dt == 0)
+      continue;
+    weight_ = facilitate_(weight_, Kplus_ * std::exp(minus_dt / tau_plus_),ky);
+  }
+
+  //depression due to new pre-synaptic spike
+  Kx_ *= std::exp((t_lastspike - t_spike) / tau_x_);
+
+  // dendritic delay means we must look back in time by that amount
+  // for determining the K value, because the K value must propagate
+  // out to the synapse
+  weight_ = depress_(weight_, target->get_K_value(t_spike - dendritic_delay),Kx_);
+
+  Kx_ += 1.0;
+
+  e.set_receiver( *target );
+  e.set_weight( weight_ );
+  // use accessor functions (inherited from Connection< >) to obtain delay in steps and rport
+  e.set_delay( get_delay_steps() );
+  e.set_rport( get_rport() );
+  e();
+
+  Kplus_ = Kplus_ * std::exp((t_lastspike - t_spike) / tau_plus_) + 1.0;
+
+}
+
+template < typename targetidentifierT >
+STDPTripletConnection< targetidentifierT >::STDPTripletConnection()
+  : ConnectionBase()
+  , weight_( 1.0 )
+  , tau_plus_( 20.0 )
+  , tau_x_( 700.0 )
+  , A_2p_( 0.01 )
+  , A_2m_( 0.01 )
+  , A_3p_( 0.01 )
+  , A_3m_( 0.0 )
+  , Kplus_( 0.0 )
+  , Kx_( 0.0 )
+{
+}
+
+template < typename targetidentifierT >
+STDPTripletConnection< targetidentifierT >::STDPTripletConnection(
+  const STDPTripletConnection< targetidentifierT >& rhs )
+  : ConnectionBase(rhs)
+  , weight_( rhs.weight_ )
+  , tau_plus_( rhs.tau_plus_ )
+  , tau_x_( rhs.tau_x_ )
+  , A_2p_( rhs.A_2p_ )
+  , A_2m_( rhs.A_2m_ )
+  , A_3p_( rhs.A_3p_ )
+  , A_3m_( rhs.A_3m_)
+  , Kplus_( rhs.Kplus_ )
+  , Kx_( rhs.Kx_ )
+{
+}
+
+template < typename targetidentifierT >
+void
+STDPTripletConnection< targetidentifierT >::get_status( DictionaryDatum& d ) const
+{
+  ConnectionBase::get_status( d );
+  def< double_t >( d, names::weight, weight_ );
+  def< double_t >( d, "tau_plus", tau_plus_ );
+  def< double_t >( d, "tau_x", tau_x_ );
+  def< double_t >( d, "A_2p", A_2p_ );
+  def< double_t >( d, "A_2m", A_2m_ );
+  def< double_t >( d, "A_3p", A_3p_ );
+  def< double_t >( d, "A_3m", A_3m_ );
+  def< double_t >( d, "Kplus", Kplus_ );
+  def<double_t>( d, "Kx", Kx_ );
+}
+
+template < typename targetidentifierT >
+void
+STDPTripletConnection< targetidentifierT >::set_status( const DictionaryDatum& d, ConnectorModel& cm )
+{
+  ConnectionBase::set_status( d, cm );
+  updateValue< double_t >( d, names::weight, weight_ );
+  updateValue< double_t >( d, "tau_plus", tau_plus_ );
+  updateValue< double_t >( d, "tau_x", tau_x_ );
+  updateValue< double_t >( d, "A_2p", A_2p_ );
+  updateValue< double_t >( d, "A_2m", A_2m_ );
+  updateValue< double_t >( d, "A_3p", A_3p_ );
+  updateValue< double_t >( d, "A_3m", A_3m_ );
+  updateValue< double_t >( d, "Kplus", Kplus_ );
+  updateValue<double_t>( d, "Kx", Kx_ );
+}
+
+} // of namespace nest
+
+#endif // of #ifndef STDP_TRIPLET_CONNECTION_H

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -24,42 +24,51 @@
 #define STDP_TRIPLET_CONNECTION_H
 
 /* BeginDocumentation
-  Name: stdp_triplet_synapse - Synapse type for spike-timing dependent
+  Name: stdp_triplet_synapse - Synapse type with spike-timing dependent
   plasticity accounting for spike triplets as described in [1].
 
   Description:
-   stdp_triplet_synapse is a connector to create synapses with spike time
-   dependent plasticity accounting for spike triplets (as defined in [1]).
+    stdp_triplet_synapse is a connection with spike time dependent
+    plasticity accounting for spike triplet effects (as defined in [1]).
 
-   Here, a multiplicative weight dependence is added (in contrast to [1])
-   to depression resulting in a stable weight distribution.
+    Here, a multiplicative weight dependence is added (in contrast to [1])
+    to depression resulting in a stable weight distribution.
 
   STDP examples:
-   pair-based   Aplus_triplet_ = Aminus_triplet = 0.0
-   triplet      Aplus_triplet_ = Aminus_triplet = 1.0
+    pair-based   Aplus_triplet = Aminus_triplet = 0.0
+    triplet      Aplus_triplet = Aminus_triplet = 1.0
 
   Parameters:
-   tau_plus          double: time constant of STDP window, potentiation
-                     (tau_minus defined in post-synaptic neuron)
-   tau_x             double: time constant of triplet potentiation
-   tau_y             double: time constant of triplet depression
-   Aplus             double: weight of pair potentiation rule
-   Aminus            double: weight of pair depression rule
-   Aplus_triplet_    double: weight of triplet potentiation rule
-   Aminus_triplet    double: weight of triplet depression rule
-   Kplus             double: pre-synaptic variable (e.g. amount of glutamate bound...)
-   Kplus_triplet     double: triplet pre-synaptic variable (e.g. number of NMDA receptors...)
+    tau_plus           double: time constant of short presynaptic trace (tau_plus of [1])
+    tau_plus_triplet   double: time constant of long presynaptic trace (tau_x of [1])
+    Aplus              double: weight of pair potentiation rule (A_plus_2 of [1])
+    Aplus_triplet      double: weight of triplet potentiation rule (A_plus_3 of [1])
+    Aminus             double: weight of pair depression rule (A_minus_2 of [1])
+    Aminus_triplet     double: weight of triplet depression rule (A_minus_3 of [1])
+
+  States:
+    Kplus              double: pre-synaptic trace (r_1 of [1])
+    Kplus_triplet      double: triplet pre-synaptic trace (r_2 of [1])
 
   Transmits: SpikeEvent
 
   References:
-   [1] J.-P. Pfister & W. Gerstner (2006) Triplets of Spikes in a Model
-   of Spike Timing-Dependent Plasticity.  The Journal of Neuroscience
-   26(38):9673-9682; doi:10.1523/JNEUROSCI.1425-06.2006
+    [1] J.-P. Pfister & W. Gerstner (2006) Triplets of Spikes in a Model
+        of Spike Timing-Dependent Plasticity.  The Journal of Neuroscience
+        26(38):9673-9682; doi:10.1523/JNEUROSCI.1425-06.2006
+
+  Notes:
+    - Presynaptic traces r_1 and r_2 of [1] are stored in the connection as
+      Kplus and Kplus_triplet and decay with time-constants tau_plus and
+      tau_plus_triplet, respectively.
+    - Postsynaptic traces o_1 and o_2 of [1] are acquired from the post-synaptic
+      neuron states Kminus_ and triplet_Kminus_ which decay on time-constants
+      tau_minus and tau_minus_triplet, respectively. These two time-constants can
+      can be set as properties of the postsynaptic neuron.
 
   FirstVersion: Nov 2007
-  Author: Moritz Helias, Abigail Morrison, Eilif Muller, Alex Seeholzer, Teo Stocco
-  SeeAlso: synapsedict, stdp_synapse, tsodyks_synapse, static_synapse
+  Author: Moritz Helias, Abigail Morrison, Eilif Muller, Alexander Seeholzer, Teo Stocco
+  SeeAlso: synapsedict, stdp_synapse, static_synapse
 */
 
 #include <cmath>
@@ -232,7 +241,6 @@ STDPTripletConnection< targetidentifierT >::send( Event& e,
     // the post synaptic spike, implementing the t-epsilon in
     // Pfister et al, 2006
     double_t ky = start->triplet_Kminus_ - 1.0;
-
     ++start;
     if ( minus_dt == 0 )
     {
@@ -327,18 +335,18 @@ STDPTripletConnection< targetidentifierT >::set_status( const DictionaryDatum& d
   if ( not( tau_plus_triplet_ > tau_plus_ ) )
   {
     throw BadProperty(
-      "Potentiation time-constant for triplet (tau_plus_triplet) must be bigger than pair-based "
-      "one (tau_plus)." );
+      "Parameter tau_plus_triplet (time-constant of long trace) must be larger than tau_plus "
+      "(time-constant of short trace)." );
   }
 
   if ( not( Kplus_ >= 0 ) )
   {
-    throw BadProperty( "Variable Kplus must be positive." );
+    throw BadProperty( "State Kplus must be positive." );
   }
 
   if ( not( Kplus_triplet_ >= 0 ) )
   {
-    throw BadProperty( "Variable Kplus_triplet must be positive." );
+    throw BadProperty( "State Kplus_triplet must be positive." );
   }
 }
 

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -182,7 +182,7 @@ public:
 
 private:
   inline double_t
-    facilitate_( double_t w, double_t kplus, double_t ky )
+  facilitate_( double_t w, double_t kplus, double_t ky )
   {
     return w + kplus * ( Aplus_ + Aplus_triplet_ * ky );
   }

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -181,7 +181,7 @@ public:
   }
 
 private:
-  inline double_t // TBD
+  inline double_t
     facilitate_( double_t w, double_t kplus, double_t ky )
   {
     return w + kplus * ( Aplus_ + Aplus_triplet_ * ky );
@@ -192,7 +192,7 @@ private:
   {
     double new_w = w - kminus * ( Aminus_ + Aminus_triplet_ * Kplus_triplet_ );
     return new_w > 0.0 ? new_w : 0.0;
-  } // TBD max weight
+  }
 
   // data members of each connection
   double_t weight_;
@@ -314,7 +314,7 @@ STDPTripletConnection< targetidentifierT >::get_status( DictionaryDatum& d ) con
   def< double_t >( d, "Aminus_triplet", Aminus_triplet_ );
   def< double_t >( d, "Kplus", Kplus_ );
   def< double_t >( d, "Kplus_triplet", Kplus_triplet_ );
-} // TBD names
+}
 
 template < typename targetidentifierT >
 void

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -68,7 +68,7 @@
 
   FirstVersion: Nov 2007
   Author: Moritz Helias, Abigail Morrison, Eilif Muller, Alexander Seeholzer, Teo Stocco
-  SeeAlso: synapsedict, stdp_synapse, static_synapse
+  SeeAlso: stdp_triplet_synapse_hpc, synapsedict, stdp_synapse, static_synapse
 */
 
 #include <cmath>

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -31,9 +31,6 @@
     stdp_triplet_synapse is a connection with spike time dependent
     plasticity accounting for spike triplet effects (as defined in [1]).
 
-    Here, a multiplicative weight dependence is added (in contrast to [1])
-    to depression resulting in a stable weight distribution.
-
   STDP examples:
     pair-based   Aplus_triplet = Aminus_triplet = 0.0
     triplet      Aplus_triplet = Aminus_triplet = 1.0
@@ -65,6 +62,9 @@
       neuron states Kminus_ and triplet_Kminus_ which decay on time-constants
       tau_minus and tau_minus_triplet, respectively. These two time-constants can
       can be set as properties of the postsynaptic neuron.
+    - This version implements the 'all-to-all' spike interaction of [1]. The 'nearest-spike'
+      interaction of [1] can currently not be implemented without changing the postsynaptic
+      archiving-node (clip the traces to a maximum of 1).
 
   FirstVersion: Nov 2007
   Author: Moritz Helias, Abigail Morrison, Eilif Muller, Alexander Seeholzer, Teo Stocco

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -186,7 +186,7 @@ public:
   // data members of each connection
   double_t weight_;
   double_t tau_plus_;
-  double_t tau_plus_triplet;
+  double_t tau_plus_triplet_;
   double_t Aplus_;
   double_t Aminus_;
   double_t Aplus_triplet_;
@@ -241,7 +241,7 @@ STDPTripletConnection< targetidentifierT >::send( Event& e,
   }
 
   // depression due to new pre-synaptic spike
-  Kplus_triplet_ *= std::exp( ( t_lastspike - t_spike ) / tau_plus_triplet );
+  Kplus_triplet_ *= std::exp( ( t_lastspike - t_spike ) / tau_plus_triplet_);
 
   // dendritic delay means we must look back in time by that amount
   // for determining the K value, because the K value must propagate
@@ -264,7 +264,7 @@ STDPTripletConnection< targetidentifierT >::STDPTripletConnection()
   : ConnectionBase()
   , weight_( 1.0 )
   , tau_plus_( 16.8 )
-  , tau_plus_triplet( 101.0 )
+  , tau_plus_triplet_( 101.0 )
   , Aplus_( 5e-10 )
   , Aminus_( 7e-3 )
   , Aplus_triplet_( 6.2e-3 )
@@ -280,7 +280,7 @@ STDPTripletConnection< targetidentifierT >::STDPTripletConnection(
   : ConnectionBase(rhs)
   , weight_( rhs.weight_ )
   , tau_plus_( rhs.tau_plus_ )
-  , tau_plus_triplet( rhs.tau_plus_triplet )
+  , tau_plus_triplet_( rhs.tau_plus_triplet_)
   , Aplus_( rhs.Aplus_ )
   , Aminus_( rhs.Aminus_ )
   , Aplus_triplet_( rhs.Aplus_triplet_ )
@@ -297,13 +297,13 @@ STDPTripletConnection< targetidentifierT >::get_status( DictionaryDatum& d ) con
   ConnectionBase::get_status( d );
   def< double_t >( d, names::weight, weight_ );
   def< double_t >( d, "tau_plus", tau_plus_ );
-  def< double_t >( d, "tau_x", tau_plus_triplet );
+  def< double_t >( d, "tau_plus_triplet", tau_plus_triplet_);
   def< double_t >( d, "Aplus", Aplus_ );
   def< double_t >( d, "Aminus", Aminus_ );
-  def< double_t >( d, "Aplus_triplet_", Aplus_triplet_ );
+  def< double_t >( d, "Aplus_triplet", Aplus_triplet_ );
   def< double_t >( d, "Aminus_triplet", Aminus_triplet_ );
   def< double_t >( d, "Kplus", Kplus_ );
-  def<double_t>( d, "Kplus_triplet_", Kplus_triplet_ );
+  def<double_t>( d, "Kplus_triplet", Kplus_triplet_ );
 } // TBD names
 
 template < typename targetidentifierT >
@@ -313,13 +313,25 @@ STDPTripletConnection< targetidentifierT >::set_status( const DictionaryDatum& d
   ConnectionBase::set_status( d, cm );
   updateValue< double_t >( d, names::weight, weight_ );
   updateValue< double_t >( d, "tau_plus", tau_plus_ );
-  updateValue< double_t >( d, "tau_x", tau_plus_triplet );
+  updateValue< double_t >( d, "tau_plus_triplet", tau_plus_triplet_);
   updateValue< double_t >( d, "Aplus", Aplus_ );
   updateValue< double_t >( d, "Aminus", Aminus_ );
-  updateValue< double_t >( d, "Aplus_triplet_", Aplus_triplet_ );
+  updateValue< double_t >( d, "Aplus_triplet", Aplus_triplet_ );
   updateValue< double_t >( d, "Aminus_triplet", Aminus_triplet_ );
   updateValue< double_t >( d, "Kplus", Kplus_ );
-  updateValue<double_t>( d, "Kplus_triplet_", Kplus_triplet_ );
+  updateValue<double_t>( d, "Kplus_triplet", Kplus_triplet_ );
+	
+  if ( ! ( tau_plus_triplet_ > tau_plus_ ) ) {
+    throw BadProperty( "Potentiation time-constant for triplet (tau_plus_triplet) must be bigger than pair-based one (tau_plus)." );
+  }
+	
+  if ( ! ( Kplus_ >= 0 ) ) {
+	throw BadProperty( "Variable Kplus must be positive." );
+  }
+
+  if ( ! ( Kplus_triplet_ >= 0 ) ) {
+    throw BadProperty( "Variable Kplus_triplet must be positive." );
+  }
 }
 
 } // of namespace nest

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -41,6 +41,7 @@
     Aplus_triplet      double: weight of triplet potentiation rule (A_plus_3 of [1])
     Aminus             double: weight of pair depression rule (A_minus_2 of [1])
     Aminus_triplet     double: weight of triplet depression rule (A_minus_3 of [1])
+    Wmax               double: maximum allowed weight
 
   States:
     Kplus              double: pre-synaptic trace (r_1 of [1])
@@ -183,13 +184,14 @@ private:
   inline double_t
   facilitate_( double_t w, double_t kplus, double_t ky )
   {
-    return w + kplus * ( Aplus_ + Aplus_triplet_ * ky );
+    double_t new_w = w + kplus * ( Aplus_ + Aplus_triplet_ * ky );
+    return new_w < Wmax_ ? new_w : Wmax_;
   }
 
   inline double_t
   depress_( double_t w, double_t kminus, double_t Kplus_triplet_ )
   {
-    double new_w = w - kminus * ( Aminus_ + Aminus_triplet_ * Kplus_triplet_ );
+    double_t new_w = w - kminus * ( Aminus_ + Aminus_triplet_ * Kplus_triplet_ );
     return new_w > 0.0 ? new_w : 0.0;
   }
 
@@ -203,6 +205,7 @@ private:
   double_t Aminus_triplet_;
   double_t Kplus_;
   double_t Kplus_triplet_;
+  double_t Wmax_;
 };
 
 /**
@@ -280,6 +283,7 @@ STDPTripletConnection< targetidentifierT >::STDPTripletConnection()
   , Aminus_triplet_( 2.3e-4 )
   , Kplus_( 0.0 )
   , Kplus_triplet_( 0.0 )
+  , Wmax_( 100.0 )
 {
 }
 
@@ -296,6 +300,7 @@ STDPTripletConnection< targetidentifierT >::STDPTripletConnection(
   , Aminus_triplet_( rhs.Aminus_triplet_ )
   , Kplus_( rhs.Kplus_ )
   , Kplus_triplet_( rhs.Kplus_triplet_ )
+  , Wmax_( rhs.Wmax_ )
 {
 }
 
@@ -313,6 +318,7 @@ STDPTripletConnection< targetidentifierT >::get_status( DictionaryDatum& d ) con
   def< double_t >( d, "Aminus_triplet", Aminus_triplet_ );
   def< double_t >( d, "Kplus", Kplus_ );
   def< double_t >( d, "Kplus_triplet", Kplus_triplet_ );
+  def< double_t >( d, "Wmax", Wmax_ );
 }
 
 template < typename targetidentifierT >
@@ -330,6 +336,7 @@ STDPTripletConnection< targetidentifierT >::set_status( const DictionaryDatum& d
   updateValue< double_t >( d, "Aminus_triplet", Aminus_triplet_ );
   updateValue< double_t >( d, "Kplus", Kplus_ );
   updateValue< double_t >( d, "Kplus_triplet", Kplus_triplet_ );
+  updateValue< double_t >( d, "Wmax", Wmax_ );
 
   if ( not( Kplus_ >= 0 ) )
   {

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -24,8 +24,7 @@
 #define STDP_TRIPLET_CONNECTION_H
 
 /* BeginDocumentation
-  Name: stdp_triplet_synapse - Synapse type with spike-timing dependent
-  plasticity accounting for spike triplets as described in [1].
+  Name: stdp_triplet_synapse - Synapse type with spike-timing dependent plasticity (triplets).
 
   Description:
     stdp_triplet_synapse is a connection with spike time dependent

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -332,13 +332,6 @@ STDPTripletConnection< targetidentifierT >::set_status( const DictionaryDatum& d
   updateValue< double_t >( d, "Kplus", Kplus_ );
   updateValue< double_t >( d, "Kplus_triplet", Kplus_triplet_ );
 
-  if ( not( tau_plus_triplet_ > tau_plus_ ) )
-  {
-    throw BadProperty(
-      "Parameter tau_plus_triplet (time-constant of long trace) must be larger than tau_plus "
-      "(time-constant of short trace)." );
-  }
-
   if ( not( Kplus_ >= 0 ) )
   {
     throw BadProperty( "State Kplus must be positive." );

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -66,7 +66,7 @@
       archiving-node (clip the traces to a maximum of 1).
 
   FirstVersion: Nov 2007
-  Author: Moritz Helias, Abigail Morrison, Eilif Muller, Alexander Seeholzer, Teo Stocco
+  Author: Abigail Morrison, Eilif Muller, Alexander Seeholzer, Teo Stocco
   SeeAlso: stdp_triplet_synapse_hpc, synapsedict, stdp_synapse, static_synapse
 */
 

--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -46,6 +46,7 @@ from . import test_csa
 from . import test_quantal_stp_synapse
 from . import test_msp
 from . import test_parrot_neuron
+from . import test_stdp_triplet_synapse
 
 
 def suite():
@@ -74,6 +75,7 @@ def suite():
     suite.addTest(test_quantal_stp_synapse.suite())
     suite.addTest(test_msp.suite())
     suite.addTest(test_parrot_neuron.suite())
+    suite.addTest(test_stdp_triplet_synapse.suite())    
 
     return suite
 

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -64,8 +64,9 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
     def generateSpikes(self, neuron, times):
         """Trigger spike to given neuron at specified times."""
-        gen = nest.Create("spike_generator", 1, {"spike_times": times})
-        nest.Connect(gen, neuron)
+        delay = 1.
+        gen = nest.Create("spike_generator", 1, {"spike_times": [t-delay for t in times]})
+        nest.Connect(gen, neuron, syn_spec={"delay": delay})
 
     def status(self, which):
         """Get synapse parameter status."""

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -2,6 +2,7 @@ import nest
 import unittest
 from math import exp
 
+
 @nest.check_stack
 class STDPTripletConnectionTestCase(unittest.TestCase):
     """Check stdp_triplet_connection model properties."""
@@ -17,7 +18,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         self.syn_spec = {
             "model": self.synapse_model,
             "delay": self.dendritic_delay,
-            "receptor_type": 1, # set receptor 1 post-synaptically, to not generate extra spikes
+            "receptor_type": 1,  # set receptor 1 post-synaptically, to not generate extra spikes
             "weight": 5.0,
             "tau_plus": 16.8,
             "tau_plus_triplet": 101.0,
@@ -32,20 +33,20 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
             "tau_minus": 33.7,
             "tau_minus_triplet": 125.0,
         }
-        
+
         # setup basic circuit
         self.pre_neuron = nest.Create("parrot_neuron")
-        self.post_neuron = nest.Create("parrot_neuron", 1, params = self.post_neuron_params)
-        nest.Connect(self.pre_neuron, self.post_neuron, syn_spec = self.syn_spec)
+        self.post_neuron = nest.Create("parrot_neuron", 1, params=self.post_neuron_params)
+        nest.Connect(self.pre_neuron, self.post_neuron, syn_spec=self.syn_spec)
 
     def generateSpikes(self, neuron, times):
         """Trigger spike to given neuron at specified times."""
-        gen = nest.Create("spike_generator", 1, { "spike_times": times })
+        gen = nest.Create("spike_generator", 1, {"spike_times": times})
         nest.Connect(gen, neuron)
 
     def status(self, which):
         """Get synapse parameter status."""
-        stats = nest.GetConnections(self.pre_neuron, synapse_model = self.synapse_model)
+        stats = nest.GetConnections(self.pre_neuron, synapse_model=self.synapse_model)
         return nest.GetStatus(stats, [which])[0][0]
 
     def decay(self, time, Kplus, Kplus_triplet, Kminus, Kminus_triplet):
@@ -67,27 +68,30 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
     def assertAlmostEqualDetailed(self, expected, given, message):
         """Improve assetAlmostEqual with detailed message."""
         messageWithValues = "%s (expected: `%s` was: `%s`" % (message, str(expected), str(given))
-        self.assertAlmostEqual(given, expected, msg = messageWithValues)
-
+        self.assertAlmostEqual(given, expected, msg=messageWithValues)
 
     def test_badPropertiesSetupsThrowExceptions(self):
         """Check that exceptions are thrown when setting bad parameters."""
         def setupProperty(property):
             bad_syn_spec = self.syn_spec.copy()
             bad_syn_spec.update(property)
-            nest.Connect(self.pre_neuron, self.post_neuron, syn_spec = bad_syn_spec)
+            nest.Connect(self.pre_neuron, self.post_neuron, syn_spec=bad_syn_spec)
 
         def badPropertyWith(content, parameters):
             self.assertRaisesRegexp(nest.NESTError, "BadProperty(.+)" + content, setupProperty, parameters)
 
-        badPropertyWith("Kplus", { "Kplus": -1.0 })
-        badPropertyWith("Kplus_triplet", { "Kplus_triplet": -1.0 })
-        badPropertyWith("tau_plus_triplet(.+)tau_plus", { "tau_plus": 1.0, "tau_plus_triplet": 1.0 })
+        badPropertyWith("Kplus", {"Kplus": -1.0})
+        badPropertyWith("Kplus_triplet", {"Kplus_triplet": -1.0})
+        badPropertyWith("tau_plus_triplet(.+)tau_plus", {"tau_plus": 1.0, "tau_plus_triplet": 1.0})
 
     def test_varsZeroAtStart(self):
         """Check that pre and post-synaptic variables are zero at start."""
         self.assertAlmostEqualDetailed(0.0, self.status("Kplus"), "Kplus should be zero")
         self.assertAlmostEqualDetailed(0.0, self.status("Kplus_triplet"), "Kplus_triplet should be zero")
+
+        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
+        # The lines below will be uncommented in a future PR, after archiving_node has been adapted.
+
         # self.assertAlmostEqualDetailed(0.0, self.status("Kminus"), "Kminus should be zero")
         # self.assertAlmostEqualDetailed(0.0, self.status("Kminus_triplet"), "Kminus_triplet should be zero")
 
@@ -107,6 +111,9 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
     def test_postVarsIncreaseWithPostSpike(self):
         """Check that post-synaptic variables (Kminus, Kminus_triplet) increase after each post-synaptic spike."""
 
+        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
+        # This test will be uncommented in a future PR, after archiving_node has been adapted.
+
         # self.generateSpikes(self.post_neuron, [2.0])
         # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay]) # trigger computation
         #
@@ -122,7 +129,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         """Check that pre-synaptic variables (Kplus, Kplus_triplet) decay after each pre-synaptic spike."""
 
         self.generateSpikes(self.pre_neuron, [2.0])
-        self.generateSpikes(self.pre_neuron, [2.0 + self.decay_duration]) # trigger computation
+        self.generateSpikes(self.pre_neuron, [2.0 + self.decay_duration])  # trigger computation
 
         (Kplus, Kplus_triplet, _, _) = self.decay(self.decay_duration, 1.0, 1.0, 0.0, 0.0)
         Kplus += 1.0
@@ -137,7 +144,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
         self.generateSpikes(self.pre_neuron, [2.0])
         self.generateSpikes(self.post_neuron, [3.0, 4.0])
-        self.generateSpikes(self.pre_neuron, [2.0 + self.decay_duration]) # trigger computation
+        self.generateSpikes(self.pre_neuron, [2.0 + self.decay_duration])  # trigger computation
 
         (Kplus, Kplus_triplet, _, _) = self.decay(self.decay_duration, 1.0, 1.0, 0.0, 0.0)
         Kplus += 1.0
@@ -149,6 +156,9 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
     def test_postVarsDecayAfterPreSpike(self):
         """Check that post-synaptic variables (Kminus, Kminus_triplet) decay after each pre-synaptic spike."""
+
+        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
+        # This test will be uncommented in a future PR, after archiving_node has been adapted.
 
         # self.generateSpikes(self.post_neuron, [2.0])
         # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay + self.decay_duration]) # trigger computation
@@ -162,6 +172,9 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
     def test_postVarsDecayAfterPostSpike(self):
         """Check that post-synaptic variables (Kminus, Kminus_triplet) decay after each post-synaptic spike."""
+
+        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
+        # This test will be uncommented in a future PR, after archiving_node has been adapted.
 
         # self.generateSpikes(self.post_neuron, [2.0, 3.0, 4.0])
         # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay + self.decay_duration]) # trigger computation
@@ -186,12 +199,12 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
         self.generateSpikes(self.pre_neuron, [2.0])
         self.generateSpikes(self.post_neuron, [4.0])
-        self.generateSpikes(self.pre_neuron, [6.0]) # trigger computation
+        self.generateSpikes(self.pre_neuron, [6.0])  # trigger computation
 
         Kplus = self.status("Kplus")
         Kplus_triplet = self.status("Kplus_triplet")
-        Kminus = 0.0 # self.status("Kminus")
-        Kminus_triplet = 0.0 # self.status("Kminus_triplet")
+        Kminus = 0.0  # self.status("Kminus")
+        Kminus_triplet = 0.0  # self.status("Kminus_triplet")
         weight = self.status("weight")
 
         (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)
@@ -199,13 +212,13 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         Kplus += 1.0
         Kplus_triplet += 1.0
 
-        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 + self.dendritic_delay, Kplus, Kplus_triplet, 
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 + self.dendritic_delay, Kplus, Kplus_triplet,
                                                                     Kminus, Kminus_triplet)
         weight = self.facilitate(weight, Kplus, Kminus_triplet)
         Kminus += 1.0
         Kminus_triplet += 1.0
 
-        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 - self.dendritic_delay, Kplus, Kplus_triplet, 
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 - self.dendritic_delay, Kplus, Kplus_triplet,
                                                                     Kminus, Kminus_triplet)
         weight = self.depress(weight, Kminus, Kplus_triplet)
 
@@ -217,12 +230,12 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
         self.generateSpikes(self.pre_neuron, [2.0, 6.0])
         self.generateSpikes(self.post_neuron, [4.0])
-        self.generateSpikes(self.pre_neuron, [8.0]) # trigger computation
+        self.generateSpikes(self.pre_neuron, [8.0])  # trigger computation
 
         Kplus = self.status("Kplus")
         Kplus_triplet = self.status("Kplus_triplet")
-        Kminus = 0.0 # self.status("Kminus")
-        Kminus_triplet = 0.0 # self.status("Kminus_triplet")
+        Kminus = 0.0  # self.status("Kminus")
+        Kminus_triplet = 0.0  # self.status("Kminus_triplet")
         weight = self.status("weight")
 
         (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)
@@ -230,7 +243,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         Kplus += 1.0
         Kplus_triplet += 1.0
 
-        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 + self.dendritic_delay, Kplus, Kplus_triplet, 
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 + self.dendritic_delay, Kplus, Kplus_triplet,
                                                                     Kminus, Kminus_triplet)
         weight = self.facilitate(weight, Kplus, Kminus_triplet)
         Kminus += 1.0
@@ -248,11 +261,13 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         nest.Simulate(20.0)
         self.assertAlmostEqualDetailed(weight, self.status("weight"), "weight should have decreased")
 
+
 def suite():
     return unittest.makeSuite(STDPTripletConnectionTestCase, "test")
 
+
 def run():
-    runner = unittest.TextTestRunner(verbosity = 2)
+    runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite())
 
 if __name__ == "__main__":

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# test_stdp_triplet_synapse.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+# This script tests the stdp_triplet_synapse in NEST.
+
 import nest
 import unittest
 from math import exp

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -1,0 +1,259 @@
+import nest
+import unittest
+from math import exp
+
+@nest.check_stack
+class STDPTripletConnectionTestCase(unittest.TestCase):
+    """Check stdp_triplet_connection model properties."""
+
+    def setUp(self):
+        nest.set_verbosity('M_WARNING')
+        nest.ResetKernel()
+
+        # settings
+        self.dendritic_delay = 1.0
+        self.decay_duration = 5.0
+        self.synapse_model = "stdp_triplet_synapse"
+        self.syn_spec = {
+            "model": self.synapse_model,
+            "delay": self.dendritic_delay,
+            "receptor_type": 1, # set receptor 1 post-synaptically, to not generate extra spikes
+            "weight": 5.0,
+            "tau_plus": 16.8,
+            "tau_plus_triplet": 101.0,
+            "Aplus": 0.1,
+            "Aminus": 0.1,
+            "Aplus_triplet": 0.1,
+            "Aminus_triplet": 0.1,
+            "Kplus": 0.0,
+            "Kplus_triplet": 0.0,
+        }
+        self.post_neuron_params = {
+            "tau_minus": 33.7,
+            "tau_minus_triplet": 125.0,
+        }
+        
+        # setup basic circuit
+        self.pre_neuron = nest.Create("parrot_neuron")
+        self.post_neuron = nest.Create("parrot_neuron", 1, params = self.post_neuron_params)
+        nest.Connect(self.pre_neuron, self.post_neuron, syn_spec = self.syn_spec)
+
+    def generateSpikes(self, neuron, times):
+        """Trigger spike to given neuron at specified times."""
+        gen = nest.Create("spike_generator", 1, { "spike_times": times })
+        nest.Connect(gen, neuron)
+
+    def status(self, which):
+        """Get synapse parameter status."""
+        stats = nest.GetConnections(self.pre_neuron, synapse_model = self.synapse_model)
+        return nest.GetStatus(stats, [which])[0][0]
+
+    def decay(self, time, Kplus, Kplus_triplet, Kminus, Kminus_triplet):
+        """Decay variables."""
+        Kplus *= exp(- time / self.syn_spec["tau_plus"])
+        Kplus_triplet *= exp(- time / self.syn_spec["tau_plus_triplet"])
+        Kminus *= exp(- time / self.post_neuron_params["tau_minus"])
+        Kminus_triplet *= exp(- time / self.post_neuron_params["tau_minus_triplet"])
+        return (Kplus, Kplus_triplet, Kminus, Kminus_triplet)
+
+    def facilitate(self, w, Kplus, Kminus_triplet):
+        """Facilitate weight."""
+        return w + Kplus * (self.syn_spec["Aplus"] + self.syn_spec["Aplus_triplet"] * Kminus_triplet)
+
+    def depress(self, w, Kminus, Kplus_triplet):
+        """Depress weight."""
+        return w - Kminus * (self.syn_spec["Aminus"] + self.syn_spec["Aminus_triplet"] * Kplus_triplet)
+
+    def assertAlmostEqualDetailed(self, expected, given, message):
+        """Improve assetAlmostEqual with detailed message."""
+        messageWithValues = "%s (expected: `%s` was: `%s`" % (message, str(expected), str(given))
+        self.assertAlmostEqual(given, expected, msg = messageWithValues)
+
+
+    def test_badPropertiesSetupsThrowExceptions(self):
+        """Check that exceptions are thrown when setting bad parameters."""
+        def setupProperty(property):
+            bad_syn_spec = self.syn_spec.copy()
+            bad_syn_spec.update(property)
+            nest.Connect(self.pre_neuron, self.post_neuron, syn_spec = bad_syn_spec)
+
+        def badPropertyWith(content, parameters):
+            self.assertRaisesRegexp(nest.NESTError, "BadProperty(.+)" + content, setupProperty, parameters)
+
+        badPropertyWith("Kplus", { "Kplus": -1.0 })
+        badPropertyWith("Kplus_triplet", { "Kplus_triplet": -1.0 })
+        badPropertyWith("tau_plus_triplet(.+)tau_plus", { "tau_plus": 1.0, "tau_plus_triplet": 1.0 })
+
+    def test_varsZeroAtStart(self):
+        """Check that pre and post-synaptic variables are zero at start."""
+        self.assertAlmostEqualDetailed(0.0, self.status("Kplus"), "Kplus should be zero")
+        self.assertAlmostEqualDetailed(0.0, self.status("Kplus_triplet"), "Kplus_triplet should be zero")
+        # self.assertAlmostEqualDetailed(0.0, self.status("Kminus"), "Kminus should be zero")
+        # self.assertAlmostEqualDetailed(0.0, self.status("Kminus_triplet"), "Kminus_triplet should be zero")
+
+    def test_preVarsIncreaseWithPreSpike(self):
+        """Check that pre-synaptic variables (Kplus, Kplus_triplet) increase after each pre-synaptic spike."""
+
+        self.generateSpikes(self.pre_neuron, [2.0])
+
+        Kplus = self.status("Kplus")
+        Kplus_triplet = self.status("Kplus_triplet")
+
+        nest.Simulate(20.0)
+        self.assertAlmostEqualDetailed(Kplus + 1.0, self.status("Kplus"), "Kplus should have increased by 1")
+        self.assertAlmostEqualDetailed(Kplus_triplet + 1.0, self.status("Kplus_triplet"),
+                                       "Kplus_triplet should have increased by 1")
+
+    def test_postVarsIncreaseWithPostSpike(self):
+        """Check that post-synaptic variables (Kminus, Kminus_triplet) increase after each post-synaptic spike."""
+
+        # self.generateSpikes(self.post_neuron, [2.0])
+        # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay]) # trigger computation
+        #
+        # Kminus = self.status("Kminus")
+        # Kminus_triplet = self.status("Kminus_triplet")
+        #
+        # nest.Simulate(20.0)
+        # self.assertAlmostEqualDetailed(Kminus + 1.0, self.status("Kminus"), "Kminus should have increased by 1")
+        # self.assertAlmostEqualDetailed(Kminus_triplet + 1.0, self.status("Kminus_triplet"),
+        #                                "Kminus_triplet should have increased by 1")
+
+    def test_preVarsDecayAfterPreSpike(self):
+        """Check that pre-synaptic variables (Kplus, Kplus_triplet) decay after each pre-synaptic spike."""
+
+        self.generateSpikes(self.pre_neuron, [2.0])
+        self.generateSpikes(self.pre_neuron, [2.0 + self.decay_duration]) # trigger computation
+
+        (Kplus, Kplus_triplet, _, _) = self.decay(self.decay_duration, 1.0, 1.0, 0.0, 0.0)
+        Kplus += 1.0
+        Kplus_triplet += 1.0
+
+        nest.Simulate(20.0)
+        self.assertAlmostEqualDetailed(Kplus, self.status("Kplus"), "Kplus should have decay")
+        self.assertAlmostEqualDetailed(Kplus_triplet, self.status("Kplus_triplet"), "Kplus_triplet should have decay")
+
+    def test_preVarsDecayAfterPostSpike(self):
+        """Check that pre-synaptic variables (Kplus, Kplus_triplet) decay after each post-synaptic spike."""
+
+        self.generateSpikes(self.pre_neuron, [2.0])
+        self.generateSpikes(self.post_neuron, [3.0, 4.0])
+        self.generateSpikes(self.pre_neuron, [2.0 + self.decay_duration]) # trigger computation
+
+        (Kplus, Kplus_triplet, _, _) = self.decay(self.decay_duration, 1.0, 1.0, 0.0, 0.0)
+        Kplus += 1.0
+        Kplus_triplet += 1.0
+
+        nest.Simulate(20.0)
+        self.assertAlmostEqualDetailed(Kplus, self.status("Kplus"), "Kplus should have decay")
+        self.assertAlmostEqualDetailed(Kplus_triplet, self.status("Kplus_triplet"), "Kplus_triplet should have decay")
+
+    def test_postVarsDecayAfterPreSpike(self):
+        """Check that post-synaptic variables (Kminus, Kminus_triplet) decay after each pre-synaptic spike."""
+
+        # self.generateSpikes(self.post_neuron, [2.0])
+        # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay + self.decay_duration]) # trigger computation
+        #
+        # (_, _, Kminus, Kminus_triplet) = self.decay(self.decay_duration, 0.0, 0.0, 1.0, 1.0)
+        #
+        # nest.Simulate(20.0)
+        # self.assertAlmostEqualDetailed(Kminus, self.status("Kminus"), "Kminus should have decay")
+        # self.assertAlmostEqualDetailed(Kminus_triplet, self.status("Kminus_triplet"),
+        #                                "Kminus_triplet should have decay")
+
+    def test_postVarsDecayAfterPostSpike(self):
+        """Check that post-synaptic variables (Kminus, Kminus_triplet) decay after each post-synaptic spike."""
+
+        # self.generateSpikes(self.post_neuron, [2.0, 3.0, 4.0])
+        # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay + self.decay_duration]) # trigger computation
+        #
+        # (_, _, Kminus, Kminus_triplet) = self.decay(1.0, 0.0, 0.0, 1.0, 1.0)
+        # Kminus += 1.0
+        # Kminus_triplet += 1.0
+        #
+        # (_, _, Kminus, Kminus_triplet) = self.decay(1.0, 0.0, 0.0, Kminus, Kminus_triplet)
+        # Kminus += 1.0
+        # Kminus_triplet += 1.0
+        #
+        # (_, _, Kminus, Kminus_triplet) = self.decay(self.decay_duration - 2.0, 0.0, 0.0, Kminus, Kminus_triplet)
+        #
+        # nest.Simulate(20.0)
+        # self.assertAlmostEqualDetailed(Kminus, self.status("Kminus"), "Kminus should have decay")
+        # self.assertAlmostEqualDetailed(Kminus_triplet, self.status("Kminus_triplet"),
+        #                                "Kminus_triplet should have decay")
+
+    def test_weightChangeWhenPrePostSpikes(self):
+        """Check that weight changes whenever a pre-post spike pair happen."""
+
+        self.generateSpikes(self.pre_neuron, [2.0])
+        self.generateSpikes(self.post_neuron, [4.0])
+        self.generateSpikes(self.pre_neuron, [6.0]) # trigger computation
+
+        Kplus = self.status("Kplus")
+        Kplus_triplet = self.status("Kplus_triplet")
+        Kminus = 0.0 # self.status("Kminus")
+        Kminus_triplet = 0.0 # self.status("Kminus_triplet")
+        weight = self.status("weight")
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)
+        weight = self.depress(weight, Kminus, Kplus_triplet)
+        Kplus += 1.0
+        Kplus_triplet += 1.0
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 + self.dendritic_delay, Kplus, Kplus_triplet, 
+                                                                    Kminus, Kminus_triplet)
+        weight = self.facilitate(weight, Kplus, Kminus_triplet)
+        Kminus += 1.0
+        Kminus_triplet += 1.0
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 - self.dendritic_delay, Kplus, Kplus_triplet, 
+                                                                    Kminus, Kminus_triplet)
+        weight = self.depress(weight, Kminus, Kplus_triplet)
+
+        nest.Simulate(20.0)
+        self.assertAlmostEqualDetailed(weight, self.status("weight"), "weight should have decreased")
+
+    def test_weightChangeWhenPrePostPreSpikes(self):
+        """Check that weight changes whenever a pre-post-pre spike triplet happen."""
+
+        self.generateSpikes(self.pre_neuron, [2.0, 6.0])
+        self.generateSpikes(self.post_neuron, [4.0])
+        self.generateSpikes(self.pre_neuron, [8.0]) # trigger computation
+
+        Kplus = self.status("Kplus")
+        Kplus_triplet = self.status("Kplus_triplet")
+        Kminus = 0.0 # self.status("Kminus")
+        Kminus_triplet = 0.0 # self.status("Kminus_triplet")
+        weight = self.status("weight")
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)
+        weight = self.depress(weight, Kminus, Kplus_triplet)
+        Kplus += 1.0
+        Kplus_triplet += 1.0
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 + self.dendritic_delay, Kplus, Kplus_triplet, 
+                                                                    Kminus, Kminus_triplet)
+        weight = self.facilitate(weight, Kplus, Kminus_triplet)
+        Kminus += 1.0
+        Kminus_triplet += 1.0
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0 - self.dendritic_delay, Kplus, Kplus_triplet,
+                                                                    Kminus, Kminus_triplet)
+        weight = self.depress(weight, Kminus, Kplus_triplet)
+        Kplus += 1.0
+        Kplus_triplet += 1.0
+
+        (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)
+        weight = self.depress(weight, Kminus, Kplus_triplet)
+
+        nest.Simulate(20.0)
+        self.assertAlmostEqualDetailed(weight, self.status("weight"), "weight should have decreased")
+
+def suite():
+    return unittest.makeSuite(STDPTripletConnectionTestCase, "test")
+
+def run():
+    runner = unittest.TextTestRunner(verbosity = 2)
+    runner.run(suite())
+
+if __name__ == "__main__":
+    run()

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -51,7 +51,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
             "Aminus_triplet": 0.1,
             "Kplus": 0.0,
             "Kplus_triplet": 0.0,
-			"Wmax": 100.0,
+            "Wmax": 100.0,
         }
         self.post_neuron_params = {
             "tau_minus": 33.7,

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -112,12 +112,6 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         self.assertAlmostEqualDetailed(0.0, self.status("Kplus"), "Kplus should be zero")
         self.assertAlmostEqualDetailed(0.0, self.status("Kplus_triplet"), "Kplus_triplet should be zero")
 
-        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
-        # The lines below will be uncommented in a future PR, after archiving_node has been adapted.
-
-        # self.assertAlmostEqualDetailed(0.0, self.status("Kminus"), "Kminus should be zero")
-        # self.assertAlmostEqualDetailed(0.0, self.status("Kminus_triplet"), "Kminus_triplet should be zero")
-
     def test_preVarsIncreaseWithPreSpike(self):
         """Check that pre-synaptic variables (Kplus, Kplus_triplet) increase after each pre-synaptic spike."""
 
@@ -130,23 +124,6 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         self.assertAlmostEqualDetailed(Kplus + 1.0, self.status("Kplus"), "Kplus should have increased by 1")
         self.assertAlmostEqualDetailed(Kplus_triplet + 1.0, self.status("Kplus_triplet"),
                                        "Kplus_triplet should have increased by 1")
-
-    def test_postVarsIncreaseWithPostSpike(self):
-        """Check that post-synaptic variables (Kminus, Kminus_triplet) increase after each post-synaptic spike."""
-
-        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
-        # This test will be uncommented in a future PR, after archiving_node has been adapted.
-
-        # self.generateSpikes(self.post_neuron, [2.0])
-        # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay]) # trigger computation
-        #
-        # Kminus = self.status("Kminus")
-        # Kminus_triplet = self.status("Kminus_triplet")
-        #
-        # nest.Simulate(20.0)
-        # self.assertAlmostEqualDetailed(Kminus + 1.0, self.status("Kminus"), "Kminus should have increased by 1")
-        # self.assertAlmostEqualDetailed(Kminus_triplet + 1.0, self.status("Kminus_triplet"),
-        #                                "Kminus_triplet should have increased by 1")
 
     def test_preVarsDecayAfterPreSpike(self):
         """Check that pre-synaptic variables (Kplus, Kplus_triplet) decay after each pre-synaptic spike."""
@@ -177,46 +154,6 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         self.assertAlmostEqualDetailed(Kplus, self.status("Kplus"), "Kplus should have decay")
         self.assertAlmostEqualDetailed(Kplus_triplet, self.status("Kplus_triplet"), "Kplus_triplet should have decay")
 
-    def test_postVarsDecayAfterPreSpike(self):
-        """Check that post-synaptic variables (Kminus, Kminus_triplet) decay after each pre-synaptic spike."""
-
-        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
-        # This test will be uncommented in a future PR, after archiving_node has been adapted.
-
-        # self.generateSpikes(self.post_neuron, [2.0])
-        # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay + self.decay_duration]) # trigger computation
-        #
-        # (_, _, Kminus, Kminus_triplet) = self.decay(self.decay_duration, 0.0, 0.0, 1.0, 1.0)
-        #
-        # nest.Simulate(20.0)
-        # self.assertAlmostEqualDetailed(Kminus, self.status("Kminus"), "Kminus should have decay")
-        # self.assertAlmostEqualDetailed(Kminus_triplet, self.status("Kminus_triplet"),
-        #                                "Kminus_triplet should have decay")
-
-    def test_postVarsDecayAfterPostSpike(self):
-        """Check that post-synaptic variables (Kminus, Kminus_triplet) decay after each post-synaptic spike."""
-
-        # Currently there is no way to access the postsynaptic Kminus, Kminus_triplet from pynest.
-        # This test will be uncommented in a future PR, after archiving_node has been adapted.
-
-        # self.generateSpikes(self.post_neuron, [2.0, 3.0, 4.0])
-        # self.generateSpikes(self.pre_neuron, [2.0 + self.dendritic_delay + self.decay_duration]) # trigger computation
-        #
-        # (_, _, Kminus, Kminus_triplet) = self.decay(1.0, 0.0, 0.0, 1.0, 1.0)
-        # Kminus += 1.0
-        # Kminus_triplet += 1.0
-        #
-        # (_, _, Kminus, Kminus_triplet) = self.decay(1.0, 0.0, 0.0, Kminus, Kminus_triplet)
-        # Kminus += 1.0
-        # Kminus_triplet += 1.0
-        #
-        # (_, _, Kminus, Kminus_triplet) = self.decay(self.decay_duration - 2.0, 0.0, 0.0, Kminus, Kminus_triplet)
-        #
-        # nest.Simulate(20.0)
-        # self.assertAlmostEqualDetailed(Kminus, self.status("Kminus"), "Kminus should have decay")
-        # self.assertAlmostEqualDetailed(Kminus_triplet, self.status("Kminus_triplet"),
-        #                                "Kminus_triplet should have decay")
-
     def test_weightChangeWhenPrePostSpikes(self):
         """Check that weight changes whenever a pre-post spike pair happen."""
 
@@ -226,8 +163,8 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
         Kplus = self.status("Kplus")
         Kplus_triplet = self.status("Kplus_triplet")
-        Kminus = 0.0  # self.status("Kminus")
-        Kminus_triplet = 0.0  # self.status("Kminus_triplet")
+        Kminus = 0.0
+        Kminus_triplet = 0.0
         weight = self.status("weight")
 
         (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)
@@ -257,8 +194,8 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
         Kplus = self.status("Kplus")
         Kplus_triplet = self.status("Kplus_triplet")
-        Kminus = 0.0  # self.status("Kminus")
-        Kminus_triplet = 0.0  # self.status("Kminus_triplet")
+        Kminus = 0.0
+        Kminus_triplet = 0.0
         weight = self.status("weight")
 
         (Kplus, Kplus_triplet, Kminus, Kminus_triplet) = self.decay(2.0, Kplus, Kplus_triplet, Kminus, Kminus_triplet)

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -106,7 +106,6 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 
         badPropertyWith("Kplus", {"Kplus": -1.0})
         badPropertyWith("Kplus_triplet", {"Kplus_triplet": -1.0})
-        badPropertyWith("tau_plus_triplet(.+)tau_plus", {"tau_plus": 1.0, "tau_plus_triplet": 1.0})
 
     def test_varsZeroAtStart(self):
         """Check that pre and post-synaptic variables are zero at start."""

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -51,6 +51,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
             "Aminus_triplet": 0.1,
             "Kplus": 0.0,
             "Kplus_triplet": 0.0,
+			"Wmax": 100.0,
         }
         self.post_neuron_params = {
             "tau_minus": 33.7,
@@ -221,6 +222,19 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
         nest.Simulate(20.0)
         self.assertAlmostEqualDetailed(weight, self.status("weight"), "weight should have decreased")
 
+    def test_maxWeightStaturatesWeight(self):
+        """Check that setting maximum weight property keep weight limited."""
+
+        limited_weight = self.status("weight") + 1e-10
+        limited_syn_spec = self.syn_spec.copy()
+        limited_syn_spec.update({"Wmax": limited_weight })
+        nest.Connect(self.pre_neuron, self.post_neuron, syn_spec=limited_syn_spec)
+
+        self.generateSpikes(self.pre_neuron, [2.0])
+        self.generateSpikes(self.pre_neuron, [3.0])  # trigger computation
+
+        nest.Simulate(20.0)
+        self.assertAlmostEqualDetailed(limited_weight, self.status("weight"), "weight should have been limited")
 
 def suite():
     return unittest.makeSuite(STDPTripletConnectionTestCase, "test")


### PR DESCRIPTION
This PR add the connection described in Pfister & Gerstner (2006) with some tests.
The work is based on the file @abigailm gave us and was supervised by @flinz.

**Points to be discussed**

*Nearest-spike pairing*
This would require a capping of the postsynaptic trace to a maximum of 1. This is not possible without changing the way that archiving_node updates `Kminus` and `triplet_Kminus`.

*Tests involving the postsynaptic decay*
This would require access to the postsynaptic traces (states `Kminus` and `triplet_Kminus` of the archiving_node). This could be added. However, the correct decay of these states should be tested in the archiving_node itself.

*Naming conventions*
We chose to stick to similar names across all variables, i.e. Kplus, Kminus, etc..
In addition `Kminus` might be named `K_minus` according the [naming conventions](https://nest.github.io/nest-simulator/variables_parameters_naming) but the name in archiving node is `Kminus` without the underscore. To keep coherence we used the same rule in the connection. However `triplet_var` is used as a prefix in archiving node whereas it might make more sense to use it as a suffix, i.e. `var_triplet`.

*Inlining facilitate and depress*
Should the `facilitate_` and `depress_` be inlined or not? Pros/cons?

*Max weight parameters*
One could add additionally options to update the weights with either a hard maximal weight bound or multiplicative updating of weights. 

*Negative weight*
Currently the weights are set to a minimum of 0, so no negative weights are technically possible.

*Parameters names*
Should they be defined in `nest_names.h` or only the ones that are regularly re-used?