### PR TITLE
add check for openmp, protect openmp call on K when building without

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -60,7 +60,7 @@ template < typename Tnew, typename Told, typename C >
 inline Tnew*
 suicide_and_resurrect( Told* connector, C connection )
 {
-#ifdef USE_PMA
+#if defined _OPENMP && defined USE_PMA
 #ifdef IS_K
   Tnew* p = new ( poormansallocpool[ omp_get_thread_num() ].alloc( sizeof( Tnew ) ) )
     Tnew( *connector, connection );

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -35,7 +35,7 @@ template < typename T, typename C >
 inline T*
 allocate( C c )
 {
-#ifdef USE_PMA
+#if defined _OPENMP && defined USE_PMA
 #ifdef IS_K
   T* p = new ( poormansallocpool[ omp_get_thread_num() ].alloc( sizeof( T ) ) ) T( c );
 #else
@@ -55,7 +55,7 @@ template < typename T >
 inline T*
 allocate()
 {
-#ifdef USE_PMA
+#if defined _OPENMP && defined USE_PMA
 #ifdef IS_K
   T* p = new ( poormansallocpool[ omp_get_thread_num() ].alloc( sizeof( T ) ) ) T();
 #else


### PR DESCRIPTION
When building nest without OpenMP on K, omp_get_thread_num() is undefined and the build will fail. Added checks to make sure we're using the right code path for this case.