### PR TITLE
Labeled Synapses

### DIFF
--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -482,7 +482,8 @@ def
    Synopsis:
    << /source [sgid1 sgid2 ...] 
       /target [tgid1 tgid2 ...]
-      /synapse_model /smodel    >> GetConnections -> [ conn1 conn2 ... ]
+      /synapse_model /smodel    
+      /synapse_label label      >> GetConnections -> [ conn1 conn2 ... ]
 
    Parameters:
    A dictionary that may contain the following fields (all are optional):
@@ -491,7 +492,9 @@ def
    /target  - array with GIDs of post-synaptic nodes whose connections are sought.
               If not given, all neurons are searched as targets.
    /synapse_model - literal specifying synapse model
-                    If not given, connections of all synapse models are returned. 
+                    If not given, connections of all synapse models are returned.
+   /synapse_label - integer specifying synapse label
+                    If not given, connections of all synapse labels are returned.
 
    Description:
    1. If called with an empty dictionary, GetConnections returns all connections of the 
@@ -501,16 +504,19 @@ def
    3. The optional dictionary elements /source and /target can be used to filter 
       for specific pre- and post-synaptic neurons, respectively.
    4. The optional parameter /synapse_model can be used to filter for a specific synapse model.
-   5. In a parallel simulation, GetConnections only returns connections with *targets*
+   5. The optional parameter /synapse_label can be used to filter for a specific synapse label.
+   6. In a parallel simulation, GetConnections only returns connections with *targets*
       on the MPI process executing the function. 
 
    Remarks:
    1. See synapsedict for the synapse-model-id's for all synapse models.
-   2. The "port" enumerates connections per source, thread and synapse model. It is
+   2. The /synapse_label property can only be assigned to synapse models with its name ending
+      with '_lbl'. All other synapses have the default synapse_label UNLABELED_CONNECTION (-1).
+   3. The "port" enumerates connections per source, thread and synapse model. It is
       mainly important for NEST internally.
-   3. In OpenMP mode, GetConnections works thread-parallel for better performance.
-   4. Connection objects can be converted to SLI lists with cva.
-   5. Connection objects can be passed to SetSynapseStatus, GetSynapseStatus, and DataConnect
+   4. In OpenMP mode, GetConnections works thread-parallel for better performance.
+   5. Connection objects can be converted to SLI lists with cva.
+   6. Connection objects can be passed to SetSynapseStatus, GetSynapseStatus, and DataConnect
 
    SeeAlso: DataConnect, SetSynapseStatus, GetSynapseStatus, synapsedict
 */

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -510,7 +510,7 @@ def
 
    Remarks:
    1. See synapsedict for the synapse-model-id's for all synapse models.
-   2. The /synapse_label property can only be assigned to synapse models with its name ending
+   2. The /synapse_label property can only be assigned to synapse models with names ending
       with '_lbl'. All other synapses have the default synapse_label UNLABELED_CONNECTION (-1).
    3. The "port" enumerates connections per source, thread and synapse model. It is
       mainly important for NEST internally.

--- a/libnestutil/Makefile.am
+++ b/libnestutil/Makefile.am
@@ -25,7 +25,8 @@ libnestutil_la_SOURCES= \
 		libc_allocator_with_realloc.h \
 		hashtable-common.h \
 		sparsetable.h \
-		compose.hpp
+		compose.hpp \
+		string_utils.h
 
 
 common_cppflags= -I$(top_srcdir)/librandom \

--- a/libnestutil/string_utils.h
+++ b/libnestutil/string_utils.h
@@ -1,0 +1,44 @@
+/*
+ *  string_utils.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef STRING_UTILS_H
+#define STRING_UTILS_H
+
+#include <algorithm>
+#include <string>
+
+/**
+ * This header is supposed to group string related utility functions.
+ */
+
+/**
+ * Returns true, if the string `value` ends with the string `ending`.
+ */
+inline bool
+ends_with( std::string const& value, std::string const& ending )
+{
+  if ( ending.size() > value.size() )
+    return false;
+  return std::equal( ending.rbegin(), ending.rend(), value.rbegin() );
+}
+
+#endif /* STRING_UTILS_H */

--- a/nestkernel/Makefile.am
+++ b/nestkernel/Makefile.am
@@ -37,7 +37,8 @@ libnest_la_SOURCES=\
 		communicator.h communicator_impl.h communicator.cpp\
 		sibling_container.h sibling_container.cpp\
 		subnet.h subnet.cpp\
-		connection.h connection_label.h\
+		connection.h\
+		connection_label.h\
 		common_properties_hom_w.h\
 		syn_id_delay.h\
 		connector_base.h connector_base.cpp\

--- a/nestkernel/Makefile.am
+++ b/nestkernel/Makefile.am
@@ -37,7 +37,7 @@ libnest_la_SOURCES=\
 		communicator.h communicator_impl.h communicator.cpp\
 		sibling_container.h sibling_container.cpp\
 		subnet.h subnet.cpp\
-		connection.h\
+		connection.h connection_label.h\
 		common_properties_hom_w.h\
 		syn_id_delay.h\
 		connector_base.h connector_base.cpp\

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -159,9 +159,8 @@ nest::ConnBuilder::ConnBuilder( Network& net,
             it != synapse_params_.end();
             ++it )
       {
-        if ( it->first == names::receptor_type 
-            || it->first == names::music_channel
-            || it->first == names::synapse_label)
+        if ( it->first == names::receptor_type || it->first == names::music_channel
+          || it->first == names::synapse_label )
           ( *param_dicts_[ t ] )[ it->first ] = Token( new IntegerDatum( 0 ) );
         else
           ( *param_dicts_[ t ] )[ it->first ] = Token( new DoubleDatum( 0.0 ) );
@@ -307,7 +306,8 @@ nest::ConnBuilder::single_connect_( index sgid,
           it != synapse_params_.end();
           ++it )
     {
-      if ( it->first == names::receptor_type || it->first == names::music_channel || it->first == names::synapse_label )
+      if ( it->first == names::receptor_type || it->first == names::music_channel
+        || it->first == names::synapse_label )
       {
         try
         {

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -159,7 +159,9 @@ nest::ConnBuilder::ConnBuilder( Network& net,
             it != synapse_params_.end();
             ++it )
       {
-        if ( it->first == names::receptor_type || it->first == names::music_channel )
+        if ( it->first == names::receptor_type 
+            || it->first == names::music_channel
+            || it->first == names::synapse_label)
           ( *param_dicts_[ t ] )[ it->first ] = Token( new IntegerDatum( 0 ) );
         else
           ( *param_dicts_[ t ] )[ it->first ] = Token( new DoubleDatum( 0.0 ) );
@@ -305,7 +307,7 @@ nest::ConnBuilder::single_connect_( index sgid,
           it != synapse_params_.end();
           ++it )
     {
-      if ( it->first == names::receptor_type || it->first == names::music_channel )
+      if ( it->first == names::receptor_type || it->first == names::music_channel || it->first == names::synapse_label )
       {
         try
         {

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -318,7 +318,19 @@ nest::ConnBuilder::single_connect_( index sgid,
         }
         catch ( KernelException& e )
         {
-          throw BadProperty( "Receptor type must be of type integer." );
+          if( it->first == names::receptor_type )
+          {
+            throw BadProperty( "Receptor type must be of type integer." );
+          }
+          else if ( it->first == names::music_channel )
+          {
+            throw BadProperty( "Music channel type must be of type integer." );
+          }
+          else if ( it->first == names::synapse_label )
+          {
+            throw BadProperty( "Synapse label must be of type integer." );
+          }
+          
         }
       }
       else

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -318,7 +318,7 @@ nest::ConnBuilder::single_connect_( index sgid,
         }
         catch ( KernelException& e )
         {
-          if( it->first == names::receptor_type )
+          if ( it->first == names::receptor_type )
           {
             throw BadProperty( "Receptor type must be of type integer." );
           }
@@ -330,7 +330,6 @@ nest::ConnBuilder::single_connect_( index sgid,
           {
             throw BadProperty( "Synapse label must be of type integer." );
           }
-          
         }
       }
       else

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -33,6 +33,7 @@
 #include "arraydatum.h"
 #include "doubledatum.h"
 #include "common_synapse_properties.h"
+#include "connection_label.h"
 #include "nest_names.h"
 #include "spikecounter.h"
 #include "syn_id_delay.h"

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -201,7 +201,7 @@ public:
     return syn_id_delay_.syn_id;
   }
 
-  long
+  long_t
   get_label() const
   {
     return UNLABELED_CONNECTION;

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -201,6 +201,11 @@ public:
     return syn_id_delay_.syn_id;
   }
 
+  long
+  get_label() const
+  {
+    return UNLABELED_CONNECTION;
+  }
 
   /**
    * triggers an update of a synaptic weight

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -48,10 +48,10 @@ public:
    */
   void set_status( const DictionaryDatum& d, ConnectorModel& cm );
 
-  long get_label() const;
+  long_t get_label() const;
 
 private:
-  long label_;
+  long_t label_;
 };
 
 template < typename Connection_t >
@@ -68,7 +68,7 @@ template < typename Connection_t >
 void
 ConnectionLabel< Connection_t >::set_status( const DictionaryDatum& d, ConnectorModel& cm )
 {
-  long lbl;
+  long_t lbl;
   if ( updateValue< long >( d, names::synapse_label, lbl ) )
   {
     if ( lbl >= 0 )
@@ -84,7 +84,7 @@ ConnectionLabel< Connection_t >::set_status( const DictionaryDatum& d, Connector
 }
 
 template < typename Connection_t >
-inline long
+inline long_t
 ConnectionLabel< Connection_t >::get_label() const
 {
   return label_;

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -32,25 +32,24 @@ namespace nest
 {
 class ConnectorModel;
 
-template <class Connection_t>
-class ConnectionLabel: public Connection_t
+template < class Connection_t >
+class ConnectionLabel : public Connection_t
 {
 public:
-  
   /**
    * Get all properties of this connection and put them into a dictionary.
    */
   void get_status( DictionaryDatum& d ) const;
-  
+
   /**
    * Set properties of this connection from the values given in dictionary.
    *
    * @note Target and Rport cannot be changed after a connection has been created.
    */
   void set_status( const DictionaryDatum& d, ConnectorModel& cm );
-  
+
   long get_label() const;
-  
+
 private:
   long label_;
 };

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -45,7 +45,7 @@ const long_t UNLABELED_CONNECTION = -1;
  * dictionary of `Set/GetStatus` or `Connect`.
  * Using the `GetConnections` function, synapses with the same label can be specified.
  *
- * The name of synapse models, which can be labels, end with '_lbl'.
+ * The name of synapse models, which can be labeled, end with '_lbl'.
  * @see nest::ConnectionManager::get_connections
  */
 template < class Connection_t >

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -58,8 +58,10 @@ template < typename Connection_t >
 void
 ConnectionLabel< Connection_t >::get_status( DictionaryDatum& d ) const
 {
-  def< long >( d, names::synapse_label, label_ );
   Connection_t::get_status( d );
+  def< long_t >( d, names::synapse_label, label_ );
+  // override, as the size changes here
+  def< long_t >( d, names::size_of, sizeof( *this ) );
 }
 
 template < typename Connection_t >

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -32,6 +32,8 @@ namespace nest
 {
 class ConnectorModel;
 
+const long_t UNLABELED_CONNECTION = -1;
+
 template < class Connection_t >
 class ConnectionLabel : public Connection_t
 {

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -1,0 +1,96 @@
+/*
+ *  connection_label.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CONNECTION_LABEL_H
+#define CONNECTION_LABEL_H
+
+#include "nest.h"
+#include "nest_names.h"
+#include "dictdatum.h"
+#include "dictutils.h"
+
+namespace nest
+{
+class ConnectorModel;
+
+template <class Connection_t>
+class ConnectionLabel: public Connection_t
+{
+public:
+  
+  /**
+   * Get all properties of this connection and put them into a dictionary.
+   */
+  void get_status( DictionaryDatum& d ) const;
+  
+  /**
+   * Set properties of this connection from the values given in dictionary.
+   *
+   * @note Target and Rport cannot be changed after a connection has been created.
+   */
+  void set_status( const DictionaryDatum& d, ConnectorModel& cm );
+  
+  long get_label() const;
+  
+private:
+  long label_;
+};
+
+template < typename Connection_t >
+void
+ConnectionLabel< Connection_t >::get_status( DictionaryDatum& d ) const
+{
+  def< long >( d, names::synapse_label, label_ );
+  Connection_t::get_status( d );
+}
+
+template < typename Connection_t >
+void
+ConnectionLabel< Connection_t >::set_status( const DictionaryDatum& d, ConnectorModel& cm )
+{
+  long lbl;
+  if ( updateValue< long >( d, names::synapse_label, lbl ) )
+  {
+    if ( lbl >= 0 )
+    {
+      label_ = lbl;
+    }
+    else
+    {
+      throw BadProperty( "Connection label must be positive." );
+    }
+  }
+  Connection_t::set_status( d, cm );
+}
+
+template < typename Connection_t >
+inline long
+ConnectionLabel< Connection_t >::get_label() const
+{
+  return label_;
+}
+
+
+} // namespace nest
+
+
+#endif /* CONNECTION_LABEL_H */

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -32,8 +32,22 @@ namespace nest
 {
 class ConnectorModel;
 
+/**
+ * Connections are unlabeled by default. Unlabeled connections cannot be specified
+ * as a search criterion in the `GetConnections` function.
+ * @see ConnectionLabel
+ */
 const long_t UNLABELED_CONNECTION = -1;
 
+/**
+ * The class ConnectionLabel enables synapse model to be labeled by a positive integer. The
+ * label can be set / retrieved with the `names::synapse_label` property in the parameter
+ * dictionary of `Set/GetStatus` or `Connect`.
+ * Using the `GetConnections` function, synapses with the same label can be specified.
+ *
+ * The name of synapse models, which can be labels, end with '_lbl'.
+ * @see nest::ConnectionManager::get_connections
+ */
 template < class Connection_t >
 class ConnectionLabel : public Connection_t
 {

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -37,7 +37,7 @@ class ConnectorModel;
  * as a search criterion in the `GetConnections` function.
  * @see ConnectionLabel
  */
-const long_t UNLABELED_CONNECTION = -1;
+const static long_t UNLABELED_CONNECTION = -1;
 
 /**
  * The class ConnectionLabel enables synapse model to be labeled by a positive integer. The
@@ -48,10 +48,12 @@ const long_t UNLABELED_CONNECTION = -1;
  * The name of synapse models, which can be labeled, end with '_lbl'.
  * @see nest::ConnectionManager::get_connections
  */
-template < class Connection_t >
-class ConnectionLabel : public Connection_t
+template < typename ConnectionT >
+class ConnectionLabel : public ConnectionT
 {
 public:
+  ConnectionLabel();
+  
   /**
    * Get all properties of this connection and put them into a dictionary.
    */
@@ -69,20 +71,29 @@ public:
 private:
   long_t label_;
 };
-
-template < typename Connection_t >
-void
-ConnectionLabel< Connection_t >::get_status( DictionaryDatum& d ) const
+  
+template < typename ConnectionT >
+ConnectionLabel< ConnectionT >::ConnectionLabel()
+  : ConnectionT()
+  , label_(UNLABELED_CONNECTION)
 {
-  Connection_t::get_status( d );
+}
+
+template < typename ConnectionT >
+void
+ConnectionLabel< ConnectionT >::get_status( DictionaryDatum& d ) const
+{
+  ConnectionT::get_status( d );
   def< long_t >( d, names::synapse_label, label_ );
-  // override, as the size changes here
+  // override names::size_of from ConnectionT,
+  // as the size from ConnectionLabel< ConnectionT > is 
+  // one long_t larger
   def< long_t >( d, names::size_of, sizeof( *this ) );
 }
 
-template < typename Connection_t >
+template < typename ConnectionT >
 void
-ConnectionLabel< Connection_t >::set_status( const DictionaryDatum& d, ConnectorModel& cm )
+ConnectionLabel< ConnectionT >::set_status( const DictionaryDatum& d, ConnectorModel& cm )
 {
   long_t lbl;
   if ( updateValue< long >( d, names::synapse_label, lbl ) )
@@ -96,12 +107,12 @@ ConnectionLabel< Connection_t >::set_status( const DictionaryDatum& d, Connector
       throw BadProperty( "Connection label must not be negative." );
     }
   }
-  Connection_t::set_status( d, cm );
+  ConnectionT::set_status( d, cm );
 }
 
-template < typename Connection_t >
+template < typename ConnectionT >
 inline long_t
-ConnectionLabel< Connection_t >::get_label() const
+ConnectionLabel< ConnectionT >::get_label() const
 {
   return label_;
 }

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -93,7 +93,7 @@ ConnectionLabel< Connection_t >::set_status( const DictionaryDatum& d, Connector
     }
     else
     {
-      throw BadProperty( "Connection label must be positive." );
+      throw BadProperty( "Connection label must not be negative." );
     }
   }
   Connection_t::set_status( d, cm );

--- a/nestkernel/connection_label.h
+++ b/nestkernel/connection_label.h
@@ -53,7 +53,7 @@ class ConnectionLabel : public ConnectionT
 {
 public:
   ConnectionLabel();
-  
+
   /**
    * Get all properties of this connection and put them into a dictionary.
    */
@@ -71,11 +71,11 @@ public:
 private:
   long_t label_;
 };
-  
+
 template < typename ConnectionT >
 ConnectionLabel< ConnectionT >::ConnectionLabel()
   : ConnectionT()
-  , label_(UNLABELED_CONNECTION)
+  , label_( UNLABELED_CONNECTION )
 {
 }
 
@@ -86,7 +86,7 @@ ConnectionLabel< ConnectionT >::get_status( DictionaryDatum& d ) const
   ConnectionT::get_status( d );
   def< long_t >( d, names::synapse_label, label_ );
   // override names::size_of from ConnectionT,
-  // as the size from ConnectionLabel< ConnectionT > is 
+  // as the size from ConnectionLabel< ConnectionT > is
   // one long_t larger
   def< long_t >( d, names::size_of, sizeof( *this ) );
 }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "connection_manager.h"
 #include "connector_base.h"
+#include "connection_label.h"
 #include "network.h"
 #include "nest_time.h"
 #include "nest_datums.h"
@@ -337,20 +338,15 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
   const Token& source_t = params->lookup( names::source );
   const Token& target_t = params->lookup( names::target );
   const Token& syn_model_t = params->lookup( names::synapse_model );
-  const Token& label_token = params->lookup( names::synapse_label );
   const TokenArray* source_a = 0;
   const TokenArray* target_a = 0;
   long_t label = UNLABELED_CONNECTION;
+  updateValue< long_t >( params, names::synapse_label, label );
 
   if ( not source_t.empty() )
     source_a = dynamic_cast< TokenArray const* >( source_t.datum() );
   if ( not target_t.empty() )
     target_a = dynamic_cast< TokenArray const* >( target_t.datum() );
-
-  if ( not label_token.empty() )
-  {
-    label = getValue< long_t >( label_token );
-  }
 
   size_t syn_id = 0;
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -523,7 +523,8 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
             {
               size_t target_id = target->get( t_id );
               validate_pointer( connections_[ t ].get( source_id ) )
-                ->get_connections( source_id, target_id, t, syn_id, synapse_label, conns_in_thread );
+                ->get_connections(
+                  source_id, target_id, t, syn_id, synapse_label, conns_in_thread );
             }
           }
         }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -346,8 +346,8 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
     source_a = dynamic_cast< TokenArray const* >( source_t.datum() );
   if ( not target_t.empty() )
     target_a = dynamic_cast< TokenArray const* >( target_t.datum() );
-  
-  if (not label_token.empty() )
+
+  if ( not label_token.empty() )
   {
     label = getValue< long >( label_token );
   }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -337,13 +337,20 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
   const Token& source_t = params->lookup( names::source );
   const Token& target_t = params->lookup( names::target );
   const Token& syn_model_t = params->lookup( names::synapse_model );
+  const Token& label_token = params->lookup( names::synapse_label );
   const TokenArray* source_a = 0;
   const TokenArray* target_a = 0;
+  long label = UNLABELED_CONNECTION;
 
   if ( not source_t.empty() )
     source_a = dynamic_cast< TokenArray const* >( source_t.datum() );
   if ( not target_t.empty() )
     target_a = dynamic_cast< TokenArray const* >( target_t.datum() );
+  
+  if (not label_token.empty() )
+  {
+    label = getValue< long >( label_token );
+  }
 
   size_t syn_id = 0;
 
@@ -364,14 +371,14 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
       syn_id = static_cast< size_t >( synmodel );
     else
       throw UnknownModelName( synmodel_name.toString() );
-    get_connections( connectome, source_a, target_a, syn_id );
+    get_connections( connectome, source_a, target_a, syn_id, label );
   }
   else
   {
     for ( syn_id = 0; syn_id < prototypes_[ 0 ].size(); ++syn_id )
     {
       ArrayDatum conn;
-      get_connections( conn, source_a, target_a, syn_id );
+      get_connections( conn, source_a, target_a, syn_id, label );
       if ( conn.size() > 0 )
         connectome.push_back( new ArrayDatum( conn ) );
     }
@@ -384,7 +391,8 @@ void
 ConnectionManager::get_connections( ArrayDatum& connectome,
   TokenArray const* source,
   TokenArray const* target,
-  size_t syn_id ) const
+  size_t syn_id,
+  long label ) const
 {
   size_t num_connections = 0;
 
@@ -421,7 +429,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
       {
         if ( connections_[ t ].get( source_id ) != 0 )
           validate_pointer( connections_[ t ].get( source_id ) )
-            ->get_connections( source_id, t, syn_id, conns_in_thread );
+            ->get_connections( source_id, t, syn_id, label, conns_in_thread );
       }
       if ( conns_in_thread.size() > 0 )
       {
@@ -465,7 +473,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
           {
             size_t target_id = target->get( t_id );
             validate_pointer( connections_[ t ].get( source_id ) )
-              ->get_connections( source_id, target_id, t, syn_id, conns_in_thread );
+              ->get_connections( source_id, target_id, t, syn_id, label, conns_in_thread );
           }
         }
       }
@@ -511,7 +519,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
           if ( target == 0 )
           {
             validate_pointer( connections_[ t ].get( source_id ) )
-              ->get_connections( source_id, t, syn_id, conns_in_thread );
+              ->get_connections( source_id, t, syn_id, label, conns_in_thread );
           }
           else
           {
@@ -519,7 +527,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
             {
               size_t target_id = target->get( t_id );
               validate_pointer( connections_[ t ].get( source_id ) )
-                ->get_connections( source_id, target_id, t, syn_id, conns_in_thread );
+                ->get_connections( source_id, target_id, t, syn_id, label, conns_in_thread );
             }
           }
         }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -340,8 +340,8 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
   const Token& syn_model_t = params->lookup( names::synapse_model );
   const TokenArray* source_a = 0;
   const TokenArray* target_a = 0;
-  long_t label = UNLABELED_CONNECTION;
-  updateValue< long_t >( params, names::synapse_label, label );
+  long_t synapse_label = UNLABELED_CONNECTION;
+  updateValue< long_t >( params, names::synapse_label, synapse_label );
 
   if ( not source_t.empty() )
     source_a = dynamic_cast< TokenArray const* >( source_t.datum() );
@@ -367,14 +367,14 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
       syn_id = static_cast< size_t >( synmodel );
     else
       throw UnknownModelName( synmodel_name.toString() );
-    get_connections( connectome, source_a, target_a, syn_id, label );
+    get_connections( connectome, source_a, target_a, syn_id, synapse_label );
   }
   else
   {
     for ( syn_id = 0; syn_id < prototypes_[ 0 ].size(); ++syn_id )
     {
       ArrayDatum conn;
-      get_connections( conn, source_a, target_a, syn_id, label );
+      get_connections( conn, source_a, target_a, syn_id, synapse_label );
       if ( conn.size() > 0 )
         connectome.push_back( new ArrayDatum( conn ) );
     }
@@ -388,7 +388,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
   TokenArray const* source,
   TokenArray const* target,
   size_t syn_id,
-  long_t label ) const
+  long_t synapse_label ) const
 {
   size_t num_connections = 0;
 
@@ -425,7 +425,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
       {
         if ( connections_[ t ].get( source_id ) != 0 )
           validate_pointer( connections_[ t ].get( source_id ) )
-            ->get_connections( source_id, t, syn_id, label, conns_in_thread );
+            ->get_connections( source_id, t, syn_id, synapse_label, conns_in_thread );
       }
       if ( conns_in_thread.size() > 0 )
       {
@@ -469,7 +469,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
           {
             size_t target_id = target->get( t_id );
             validate_pointer( connections_[ t ].get( source_id ) )
-              ->get_connections( source_id, target_id, t, syn_id, label, conns_in_thread );
+              ->get_connections( source_id, target_id, t, syn_id, synapse_label, conns_in_thread );
           }
         }
       }
@@ -515,7 +515,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
           if ( target == 0 )
           {
             validate_pointer( connections_[ t ].get( source_id ) )
-              ->get_connections( source_id, t, syn_id, label, conns_in_thread );
+              ->get_connections( source_id, t, syn_id, synapse_label, conns_in_thread );
           }
           else
           {
@@ -523,7 +523,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
             {
               size_t target_id = target->get( t_id );
               validate_pointer( connections_[ t ].get( source_id ) )
-                ->get_connections( source_id, target_id, t, syn_id, label, conns_in_thread );
+                ->get_connections( source_id, target_id, t, syn_id, synapse_label, conns_in_thread );
             }
           }
         }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -340,7 +340,7 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
   const Token& label_token = params->lookup( names::synapse_label );
   const TokenArray* source_a = 0;
   const TokenArray* target_a = 0;
-  long label = UNLABELED_CONNECTION;
+  long_t label = UNLABELED_CONNECTION;
 
   if ( not source_t.empty() )
     source_a = dynamic_cast< TokenArray const* >( source_t.datum() );
@@ -349,7 +349,7 @@ ConnectionManager::get_connections( DictionaryDatum params ) const
 
   if ( not label_token.empty() )
   {
-    label = getValue< long >( label_token );
+    label = getValue< long_t >( label_token );
   }
 
   size_t syn_id = 0;
@@ -392,7 +392,7 @@ ConnectionManager::get_connections( ArrayDatum& connectome,
   TokenArray const* source,
   TokenArray const* target,
   size_t syn_id,
-  long label ) const
+  long_t label ) const
 {
   size_t num_connections = 0;
 

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -94,6 +94,7 @@ public:
    * 'target' a token array with GIDs of target neuron.
    * If either of these does not exist, all neuron are used for the respective entry.
    * 'synapse_model' name of the synapse model, or all synapse models are searched.
+   * 'synapse_label' label (int) of the synapse, or all synapses are searched.
    * The function then iterates all entries in source and collects the connection IDs to all neurons
    * in target.
    */
@@ -102,7 +103,8 @@ public:
   void get_connections( ArrayDatum& connectome,
     TokenArray const* source,
     TokenArray const* target,
-    size_t syn_id ) const;
+    size_t syn_id,
+    long label ) const;
 
   // aka CopyModel for synapse models
   synindex copy_synapse_prototype( synindex old_id, std::string new_name );

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -104,7 +104,7 @@ public:
     TokenArray const* source,
     TokenArray const* target,
     size_t syn_id,
-    long label ) const;
+    long_t label ) const;
 
   // aka CopyModel for synapse models
   synindex copy_synapse_prototype( synindex old_id, std::string new_name );

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -104,7 +104,7 @@ public:
     TokenArray const* source,
     TokenArray const* target,
     size_t syn_id,
-    long_t label ) const;
+    long_t synapse_label ) const;
 
   // aka CopyModel for synapse models
   synindex copy_synapse_prototype( synindex old_id, std::string new_name );

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -94,7 +94,7 @@ public:
    * 'target' a token array with GIDs of target neuron.
    * If either of these does not exist, all neuron are used for the respective entry.
    * 'synapse_model' name of the synapse model, or all synapse models are searched.
-   * 'synapse_label' label (int) of the synapse, or all synapses are searched.
+   * 'synapse_label' label (long_t) of the synapse, or all synapses are searched.
    * The function then iterates all entries in source and collects the connection IDs to all neurons
    * in target.
    */

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -133,14 +133,14 @@ public:
   virtual void get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const = 0;
 
   virtual void get_connections( size_t source_gid,
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const = 0;
 
   virtual void
@@ -354,12 +354,12 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
-        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+        if ( synapse_label == UNLABELED_CONNECTION || C_[ i ].get_label() == synapse_label )
           conns.push_back( ConnectionDatum( ConnectionID(
             source_gid, C_[ i ].get_target( thrd )->get_gid(), thrd, synapse_id, i ) ) );
   }
@@ -369,12 +369,12 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
-        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+        if ( synapse_label == UNLABELED_CONNECTION || C_[ i ].get_label() == synapse_label )
           if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
             conns.push_back(
               ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
@@ -575,12 +575,12 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
-      if ( label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == label )
+      if ( synapse_label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == synapse_label )
       {
         conns.push_back( ConnectionDatum( ConnectionID(
           source_gid, C_[ 0 ].get_target( thrd )->get_gid(), thrd, synapse_id, 0 ) ) );
@@ -593,12 +593,12 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
-      if ( label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == label )
+      if ( synapse_label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == synapse_label )
       {
         if ( C_[ 0 ].get_target( thrd )->get_gid() == target_gid )
           conns.push_back(
@@ -800,12 +800,12 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < C_.size(); i++ )
       if ( get_syn_id() == synapse_id )
-        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+        if ( synapse_label == UNLABELED_CONNECTION || C_[ i ].get_label() == synapse_label )
           conns.push_back( ConnectionDatum( ConnectionID(
             source_gid, C_[ i ].get_target( thrd )->get_gid(), thrd, synapse_id, i ) ) );
   }
@@ -815,12 +815,12 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
       for ( size_t i = 0; i < C_.size(); i++ )
-        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+        if ( synapse_label == UNLABELED_CONNECTION || C_[ i ].get_label() == synapse_label )
           if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
             conns.push_back(
               ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
@@ -969,11 +969,11 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
-      at( i )->get_connections( source_gid, thrd, synapse_id, label, conns );
+      at( i )->get_connections( source_gid, thrd, synapse_id, synapse_label, conns );
   }
 
   void
@@ -981,11 +981,11 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long_t label,
+    long_t synapse_label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
-      at( i )->get_connections( source_gid, target_gid, thrd, synapse_id, label, conns );
+      at( i )->get_connections( source_gid, target_gid, thrd, synapse_id, synapse_label, conns );
   }
 
   void

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -32,6 +32,7 @@
 #include "spikecounter.h"
 #include "nest_names.h"
 #include "connector_model.h"
+#include "connection_label.h"
 #include "nest_datums.h"
 #ifdef _OPENMP
 #include <omp.h>

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -132,14 +132,14 @@ public:
   virtual void get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const = 0;
 
   virtual void get_connections( size_t source_gid,
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const = 0;
 
   virtual void
@@ -353,7 +353,7 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
@@ -368,7 +368,7 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
@@ -574,7 +574,7 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
@@ -592,7 +592,7 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
@@ -799,7 +799,7 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < C_.size(); i++ )
@@ -814,7 +814,7 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
@@ -968,7 +968,7 @@ public:
   get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
@@ -980,7 +980,7 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
-    long label,
+    long_t label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -132,12 +132,14 @@ public:
   virtual void get_connections( size_t source_gid,
     size_t thrd,
     synindex synapse_id,
+    long label,
     ArrayDatum& conns ) const = 0;
 
   virtual void get_connections( size_t source_gid,
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
+    long label,
     ArrayDatum& conns ) const = 0;
 
   virtual void
@@ -348,12 +350,13 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, ArrayDatum& conns ) const
+  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
-        conns.push_back( ConnectionDatum( ConnectionID(
-          source_gid, C_[ i ].get_target( thrd )->get_gid(), thrd, synapse_id, i ) ) );
+        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+          conns.push_back( ConnectionDatum( ConnectionID(
+            source_gid, C_[ i ].get_target( thrd )->get_gid(), thrd, synapse_id, i ) ) );
   }
 
   void
@@ -361,13 +364,15 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
+    long label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
-        if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
-          conns.push_back(
-            ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
+        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+          if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
+            conns.push_back(
+              ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
   }
 
   /**
@@ -562,12 +567,15 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, ArrayDatum& conns ) const
+  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
-      conns.push_back( ConnectionDatum(
-        ConnectionID( source_gid, C_[ 0 ].get_target( thrd )->get_gid(), thrd, synapse_id, 0 ) ) );
+      if ( label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == label )
+      {
+        conns.push_back( ConnectionDatum(
+          ConnectionID( source_gid, C_[ 0 ].get_target( thrd )->get_gid(), thrd, synapse_id, 0 ) ) );
+      }
     }
   }
 
@@ -576,13 +584,17 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
+    long label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
-      if ( C_[ 0 ].get_target( thrd )->get_gid() == target_gid )
-        conns.push_back(
-          ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, 0 ) ) );
+      if ( label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == label )
+      {
+        if ( C_[ 0 ].get_target( thrd )->get_gid() == target_gid )
+          conns.push_back(
+            ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, 0 ) ) );
+      }
     }
   }
 
@@ -776,12 +788,13 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, ArrayDatum& conns ) const
+  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < C_.size(); i++ )
       if ( get_syn_id() == synapse_id )
-        conns.push_back( ConnectionDatum( ConnectionID(
-          source_gid, C_[ i ].get_target( thrd )->get_gid(), thrd, synapse_id, i ) ) );
+        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+          conns.push_back( ConnectionDatum( ConnectionID(
+            source_gid, C_[ i ].get_target( thrd )->get_gid(), thrd, synapse_id, i ) ) );
   }
 
   void
@@ -789,13 +802,15 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
+    long label,
     ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
       for ( size_t i = 0; i < C_.size(); i++ )
-        if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
-          conns.push_back(
-            ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
+        if ( label == UNLABELED_CONNECTION || C_[ i ].get_label() == label )
+          if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
+            conns.push_back(
+              ConnectionDatum( ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
   }
 
   void
@@ -938,10 +953,10 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, ArrayDatum& conns ) const
+  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
-      at( i )->get_connections( source_gid, thrd, synapse_id, conns );
+      at( i )->get_connections( source_gid, thrd, synapse_id, label, conns );
   }
 
   void
@@ -949,10 +964,11 @@ public:
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
+    long label,
     ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
-      at( i )->get_connections( source_gid, target_gid, thrd, synapse_id, conns );
+      at( i )->get_connections( source_gid, target_gid, thrd, synapse_id, label, conns );
   }
 
   void

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -350,7 +350,11 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
+  get_connections( size_t source_gid,
+    size_t thrd,
+    synindex synapse_id,
+    long label,
+    ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
@@ -567,14 +571,18 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
+  get_connections( size_t source_gid,
+    size_t thrd,
+    synindex synapse_id,
+    long label,
+    ArrayDatum& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
       if ( label == UNLABELED_CONNECTION || C_[ 0 ].get_label() == label )
       {
-        conns.push_back( ConnectionDatum(
-          ConnectionID( source_gid, C_[ 0 ].get_target( thrd )->get_gid(), thrd, synapse_id, 0 ) ) );
+        conns.push_back( ConnectionDatum( ConnectionID(
+          source_gid, C_[ 0 ].get_target( thrd )->get_gid(), thrd, synapse_id, 0 ) ) );
       }
     }
   }
@@ -788,7 +796,11 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
+  get_connections( size_t source_gid,
+    size_t thrd,
+    synindex synapse_id,
+    long label,
+    ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < C_.size(); i++ )
       if ( get_syn_id() == synapse_id )
@@ -953,7 +965,11 @@ public:
   }
 
   void
-  get_connections( size_t source_gid, size_t thrd, synindex synapse_id, long label, ArrayDatum& conns ) const
+  get_connections( size_t source_gid,
+    size_t thrd,
+    synindex synapse_id,
+    long label,
+    ArrayDatum& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
       at( i )->get_connections( source_gid, thrd, synapse_id, label, conns );

--- a/nestkernel/connector_model.h
+++ b/nestkernel/connector_model.h
@@ -277,7 +277,7 @@ public:
   }
 
   virtual std::vector< SecondaryEvent* >
-  create_event( size_t n ) const
+  create_event( size_t ) const
   {
     // Should not be called for a ConnectorModel belonging to a primary
     // connection. Only required for secondary connection types.

--- a/nestkernel/connector_model.h
+++ b/nestkernel/connector_model.h
@@ -276,8 +276,7 @@ public:
     return default_connection_;
   }
 
-  virtual std::vector< SecondaryEvent* >
-  create_event( size_t ) const
+  virtual std::vector< SecondaryEvent* > create_event( size_t ) const
   {
     // Should not be called for a ConnectorModel belonging to a primary
     // connection. Only required for secondary connection types.

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -587,16 +587,22 @@ register_connection_model( Network& net, const std::string& name )
  * Register a synape with default Connector and without any common properties.
  */
 template < class ConnectionT >
-synindex
+void
 register_secondary_connection_model( Network& net, const std::string& name, bool has_delay = true )
 {
-  ConnectorModel& cm =
-    *( new GenericSecondaryConnectorModel< ConnectionT >( net, name, has_delay ) );
+  ConnectorModel* cm = new GenericSecondaryConnectorModel< ConnectionT >( net, name, has_delay );
 
-  synindex synid = net.register_secondary_synapse_prototype( &cm );
+  synindex synid = net.register_secondary_synapse_prototype( cm );
 
   ConnectionT::EventType::set_syn_id( synid );
-  return synid;
+
+  // create labeled secondary event connection model
+  cm = new GenericSecondaryConnectorModel< ConnectionLabel< ConnectionT > >(
+    net, name + "_lbl", has_delay );
+
+  synid = net.register_secondary_synapse_prototype( cm );
+
+  ConnectionT::EventType::set_syn_id( synid );
 }
 
 } // namespace nest

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -29,6 +29,7 @@
 #include "network.h"
 #include "connector_model.h"
 #include "connector_base.h"
+#include "connection_label.h"
 
 
 template < typename T, typename C >
@@ -562,28 +563,34 @@ GenericConnectorModel< ConnectionT >::delete_connection( Node& tgt,
  * Register a synape with default Connector and without any common properties.
  */
 template < class ConnectionT >
-synindex
+void
 register_connection_model( Network& net, const std::string& name )
 {
-  return net.register_synapse_prototype( new GenericConnectorModel< ConnectionT >(
+  net.register_synapse_prototype( new GenericConnectorModel< ConnectionT >(
     net, name, /*is_primary=*/true, /*has_delay=*/true ) );
+  net.register_synapse_prototype( new GenericConnectorModel< ConnectionLabel< ConnectionT > >(
+    net, name + "_lbl", /*is_primary=*/true, /*has_delay=*/true ) );
 }
 
 /**
  * Register a synape with default Connector and without any common properties.
  */
 template < class ConnectionT >
-synindex
+void
 register_secondary_connection_model( Network& net, const std::string& name, bool has_delay = true )
 {
-  ConnectorModel& cm =
-    *( new GenericSecondaryConnectorModel< ConnectionT >( net, name, has_delay ) );
+  ConnectorModel* cm = new GenericSecondaryConnectorModel< ConnectionT >( net, name, has_delay );
 
-  synindex synid = net.register_secondary_synapse_prototype( &cm );
+  synindex synid = net.register_secondary_synapse_prototype( cm );
 
   ConnectionT::EventType::set_syn_id( synid );
 
-  return synid;
+  cm = new GenericSecondaryConnectorModel< ConnectionLabel< ConnectionT > >(
+    net, name + "_lbl", has_delay );
+
+  synid = net.register_secondary_synapse_prototype( cm );
+
+  ConnectionLabel< ConnectionT >::EventType::set_syn_id( synid );
 }
 
 } // namespace nest

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -30,6 +30,7 @@
 #include "connector_model.h"
 #include "connector_base.h"
 #include "connection_label.h"
+#include "string_utils.h"
 
 
 template < typename T, typename C >
@@ -558,14 +559,6 @@ GenericConnectorModel< ConnectionT >::delete_connection( Node& tgt,
 // Convenient versions of template functions for registering new synapse types //
 // by modules                                                                  //
 /////////////////////////////////////////////////////////////////////////////////
-
-inline bool
-ends_with( std::string const& value, std::string const& ending )
-{
-  if ( ending.size() > value.size() )
-    return false;
-  return std::equal( ending.rbegin(), ending.rend(), value.rbegin() );
-}
 
 /**
  * Register a synape with default Connector and without any common properties.

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -560,11 +560,11 @@ GenericConnectorModel< ConnectionT >::delete_connection( Node& tgt,
 /////////////////////////////////////////////////////////////////////////////////
 
 inline bool
-ends_with(std::string const & value, std::string const & ending)
+ends_with( std::string const& value, std::string const& ending )
 {
-  if (ending.size() > value.size()) 
+  if ( ending.size() > value.size() )
     return false;
-  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+  return std::equal( ending.rbegin(), ending.rend(), value.rbegin() );
 }
 
 /**

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -121,6 +121,8 @@ const index invalid_index = std::numeric_limits< index >::max();
 typedef unsigned char synindex;
 const synindex invalid_synindex = std::numeric_limits< synindex >::max();
 
+#define UNLABELED_CONNECTION -1
+
 /**
  * Unsigned short type for compact target representation.
  *

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -121,8 +121,6 @@ const index invalid_index = std::numeric_limits< index >::max();
 typedef unsigned char synindex;
 const synindex invalid_synindex = std::numeric_limits< synindex >::max();
 
-#define UNLABELED_CONNECTION -1
-
 /**
  * Unsigned short type for compact target representation.
  *

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -267,6 +267,7 @@ const Name stop( "stop" );
 const Name structure( "structure" );
 const Name success( "success" );
 const Name synapse( "synapse" );
+const Name synapse_label( "synapse_label" );
 const Name synapse_model( "synapse_model" );
 const Name synapse_modelid( "synapse_modelid" );
 const Name synaptic_elements( "synaptic_elements" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -292,6 +292,7 @@ extern const Name stop;        //!< Device parameters
 extern const Name structure;   //!< Node type
 extern const Name success;
 extern const Name synapse;           //!< Node type
+extern const Name synapse_label;     //!< Label id of synapses with labels
 extern const Name synapse_model;     //!< Connection parameters
 extern const Name synapse_modelid;   //!< Connection parameters
 extern const Name synaptic_elements; //!< Synaptic elements used in structural plasticity

--- a/nestkernel/network.h
+++ b/nestkernel/network.h
@@ -938,10 +938,10 @@ private:
      Name: synapsedict - Dictionary containing all synapse models.
      Description:
      'synapsedict info' shows the contents of the dictionary
-     Synapse model names ending with '_hpc' provide minimal memory requirments by using
+     Synapse model names ending with '_hpc' provide minimal memory requirements by using
      thread-local target neuron IDs and fixing the `rport` to 0.
      Synapse model names ending with '_lbl' allow to assign an individual integer label
-     (`synapse_label`) to created synapses at the cost of increased memory requirments.
+     (`synapse_label`) to created synapses at the cost of increased memory requirements.
      FirstVersion: October 2005
      Author: Jochen Martin Eppler
      SeeAlso: info

--- a/nestkernel/network.h
+++ b/nestkernel/network.h
@@ -938,6 +938,10 @@ private:
      Name: synapsedict - Dictionary containing all synapse models.
      Description:
      'synapsedict info' shows the contents of the dictionary
+     Synapse model names ending with '_hpc' provide minimal memory requirments by using
+     thread-local target neuron IDs and fixing the `rport` to 0.
+     Synapse model names ending with '_lbl' allow to assign an individual integer label
+     (`synapse_label`) to created synapses at the cost of increased memory requirments.
      FirstVersion: October 2005
      Author: Jochen Martin Eppler
      SeeAlso: info

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -82,7 +82,7 @@ def FindConnections(source, target=None, synapse_model=None, synapse_type=None):
 
 
 @check_stack
-def GetConnections(source=None, target=None, synapse_model=None):
+def GetConnections(source=None, target=None, synapse_model=None, synapse_label=None):
     """
     Return an array of connection identifiers.
     
@@ -90,6 +90,7 @@ def GetConnections(source=None, target=None, synapse_model=None):
     source - list of source GIDs
     target - list of target GIDs
     synapse_model - string with the synapse model
+    synapse_label - non negative integer with synapse label
     
     If GetConnections is called without parameters, all connections
     in the network are returned.
@@ -102,9 +103,12 @@ def GetConnections(source=None, target=None, synapse_model=None):
 
     If a synapse model is given, only connections with this synapse
     type are returned.
+    
+    If a synapse label is given, only connections with this synapse
+    label are returned.
 
-    Any combination of source, target and synapse_model parameters
-    is permitted.
+    Any combination of source, target, synapse_model and synapse_label
+    parameters is permitted.
 
     Each connection id is a 5-tuple or, if available, a NumPy
     array with the following five entries:
@@ -128,6 +132,9 @@ def GetConnections(source=None, target=None, synapse_model=None):
 
     if synapse_model is not None:
         params['synapse_model'] = kernel.SLILiteral(synapse_model)
+
+    if synapse_label is not None:
+        params['synapse_label'] = synapse_label
 
     sps(params)
     sr("GetConnections")

--- a/pynest/nest/lib/hl_api_models.py
+++ b/pynest/nest/lib/hl_api_models.py
@@ -33,6 +33,13 @@ def Models(mtype="all", sel=None):
     mtype='synapses' to only see synapse models. sel can be a string,
     used to filter the result list and only return models containing
     it.
+
+    Synapse model names ending with '_hpc' provide minimal memory
+    requirments by using thread-local target neuron IDs and fixing
+    the `rport` to 0.
+    Synapse model names ending with '_lbl' allow to assign an individual
+    integer label (`synapse_label`) to created synapses at the cost
+    of increased memory requirments.
     """
 
     if mtype not in ("all", "nodes", "synapses"):

--- a/pynest/nest/lib/hl_api_models.py
+++ b/pynest/nest/lib/hl_api_models.py
@@ -35,11 +35,11 @@ def Models(mtype="all", sel=None):
     it.
 
     Synapse model names ending with '_hpc' provide minimal memory
-    requirments by using thread-local target neuron IDs and fixing
+    requirements by using thread-local target neuron IDs and fixing
     the `rport` to 0.
     Synapse model names ending with '_lbl' allow to assign an individual
     integer label (`synapse_label`) to created synapses at the cost
-    of increased memory requirments.
+    of increased memory requirements.
     """
 
     if mtype not in ("all", "nodes", "synapses"):

--- a/pynest/nest/tests/test_labeled_synapses.py
+++ b/pynest/nest/tests/test_labeled_synapses.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+#
+# test_labeled_synapses.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test setting and getting labels on synapses.
+"""
+
+import unittest
+import nest
+
+@nest.check_stack
+class LabeledSynapsesTestCase(unittest.TestCase):
+    """Test labeled synapses"""
+
+    def default_network(self):
+        nest.ResetKernel()
+        # set volume transmitter for stdp_dopamine_synapse_lbl
+        vol = nest.Create('volume_transmitter', 3)
+        nest.SetDefaults('stdp_dopamine_synapse',{'vt':vol[0]})
+        nest.SetDefaults('stdp_dopamine_synapse_lbl',{'vt':vol[1]})
+        nest.SetDefaults('stdp_dopamine_synapse_hpc',{'vt':vol[2]})
+
+        # create a neuron that accepts all synapse connections...
+        return nest.Create("hh_psc_alpha_gap", 5)
+
+    def test_SetLabelToSynapseOnConnect(self):
+        """Set a label to a labeled synapse on connect."""
+
+        labeled_synapse_models = [s for s in nest.Models(mtype='synapses') if s.endswith("_lbl")]
+        for syn in labeled_synapse_models:
+            a = self.default_network()
+
+            # set a label during connection
+            nest.Connect(a, a, {"rule": "one_to_one"}, {"model": syn, "synapse_label": 123})
+            c = nest.GetConnections(a, a)
+            self.assertTrue(all([status['synapse_label']==123 for status in nest.GetStatus(c)]))
+
+    def test_SetLabelToSynapseSetStatus(self):
+        """Set a label to a labeled synapse on SetStatus."""
+
+        labeled_synapse_models = [s for s in nest.Models(mtype='synapses') if s.endswith("_lbl")]
+        for syn in labeled_synapse_models:
+            a = self.default_network()
+
+            # set no label during connection
+            nest.Connect(a, a, {"rule": "one_to_one"}, {"model": syn})
+            c = nest.GetConnections(a, a)
+            # still unlabeled
+            self.assertTrue(all([status['synapse_label']==-1 for status in nest.GetStatus(c)]))
+
+            # set a label
+            nest.SetStatus(c, {'synapse_label': 123})
+            self.assertTrue(all([status['synapse_label']==123 for status in nest.GetStatus(c)]))
+
+    def test_SetLabelToSynapseSetDefaults(self):
+        """Set a label to a labeled synapse on SetDefaults."""
+
+        labeled_synapse_models = [s for s in nest.Models(mtype='synapses') if s.endswith("_lbl")]
+        for syn in labeled_synapse_models:
+            a = self.default_network()
+
+            # set a label during SetDefaults
+            nest.SetDefaults(syn, {'synapse_label': 123})
+            nest.Connect(a, a, {"rule": "one_to_one"}, {"model": syn})
+            c = nest.GetConnections(a, a)
+            self.assertTrue(all([status['synapse_label']==123 for status in nest.GetStatus(c)]))
+
+    def test_GetLabeledSynapses(self):
+        """Get labeled synapses with GetConnections."""
+
+        labeled_synapse_models = [s for s in nest.Models(mtype='synapses') if s.endswith("_lbl")]
+        for syn in labeled_synapse_models:
+            a = self.default_network()
+
+            # some more connections
+            nest.Connect(a, a, {"rule": "one_to_one"}, {"model": "static_synapse"})
+            # set a label during connection
+            nest.Connect(a, a, {"rule": "one_to_one"}, {"model": syn, "synapse_label": 123})
+            c = nest.GetConnections(a, a, synapse_label=123)
+            self.assertTrue(all([status['synapse_label']==123 for status in nest.GetStatus(c)]))
+
+    def test_SetLabelToNotLabeledSynapse(self):
+        """Try set a label to an 'un-label-able' synapse."""
+        labeled_synapse_models = [s for s in nest.Models(mtype='synapses') if not s.endswith("_lbl")]
+        for syn in labeled_synapse_models:
+            a = self.default_network()
+
+            # try set a label during SetDefaults
+            with self.assertRaises(nest.NESTError):
+                nest.SetDefaults(syn, {'synapse_label': 123})
+
+            # try set on connect
+            with self.assertRaises(nest.NESTError):
+                nest.Connect(a, a, {"rule": "one_to_one"}, {"model": syn, "synapse_label":123})
+
+            # plain connection
+            nest.Connect(a, a, {"rule": "one_to_one"}, {"model": syn})
+            # try set on SetStatus
+            c = nest.GetConnections(a, a)
+            with self.assertRaises(nest.NESTError):
+                nest.SetStatus(c, {'synapse_label': 123})
+
+def suite():
+    suite = unittest.makeSuite(LabeledSynapsesTestCase,'test')
+    return suite
+
+def run():
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    run()

--- a/pynest/nest/tests/test_labeled_synapses.py
+++ b/pynest/nest/tests/test_labeled_synapses.py
@@ -26,7 +26,10 @@ Test setting and getting labels on synapses.
 import unittest
 import nest
 
+HAVE_GSL = nest.sli_func("statusdict/have_gsl ::")
+
 @nest.check_stack
+@unittest.skipIf(not HAVE_GSL, 'GSL is not available')
 class LabeledSynapsesTestCase(unittest.TestCase):
     """Test labeled synapses"""
 
@@ -38,7 +41,8 @@ class LabeledSynapsesTestCase(unittest.TestCase):
         nest.SetDefaults('stdp_dopamine_synapse_lbl',{'vt':vol[1]})
         nest.SetDefaults('stdp_dopamine_synapse_hpc',{'vt':vol[2]})
 
-        # create a neuron that accepts all synapse connections...
+        # create neurons that accept all synapse connections (especially gap junctions)...
+        # hh_psc_alpha_gap is only available with GSL, hence the skipIf above
         return nest.Create("hh_psc_alpha_gap", 5)
 
     def test_SetLabelToSynapseOnConnect(self):

--- a/testsuite/regressiontests/ticket-478.sli
+++ b/testsuite/regressiontests/ticket-478.sli
@@ -48,22 +48,27 @@ M_ERROR setverbosity
 /excluded_synapses [ /gap_junction ] def
 
 % find all static and plastic synapses
-% we identifiy as static all synapses that have the same default parameter names
-% as static_synapse
+% we identify as static all synapses that have the same default parameter names
+% as static_synapse or static_synapse_lbl
 /static_defaults
   /static_synapse GetDefaults keys { cvs } Map Sort
+def
+/static_lbl_defaults
+  /static_synapse_lbl GetDefaults keys { cvs } Map Sort
 def
 
 /static_syn_models
   synapsedict keys
   { excluded_synapses exch MemberQ not } Select
   { GetDefaults keys { cvs } Map Sort static_defaults eq } Select
+  { GetDefaults keys { cvs } Map Sort static_lbl_defaults eq } Select
 def
 
 /plastic_syn_models
   synapsedict keys
   { excluded_synapses exch MemberQ not } Select
   { GetDefaults keys { cvs } Map Sort static_defaults neq } Select
+  { GetDefaults keys { cvs } Map Sort static_lbl_defaults neq } Select
 def
 
 % We perform the tests first for all relevant generators


### PR DESCRIPTION
In response to #121.

This PR introduces a decorator for connections that adds an integer label to the decorated synapse. 
* See the template class `ConnectionLabel`: the template argument can be any synapse model. The `ConnectionLabel` then subclasses this model and overrides the `get_status`, `set_status` and `get_label` methods. The `get_label` method is added to `Connection` as well, returns `UNLABELED_CONNECTION` (-1) and ensures valid return values for all synapse models.
* See `connector_model_impl.h`: all synapse models that are registered via `register_connection_model` (i.e. no `gap_junction` model) and which are not postfixed with `_hpc`, will also register a decorated version of this synapse type. The model name is postfixed with `_lbl`.

        SLI ] /iaf_neuron 2 Create ;
        SLI ] [1 2] [2 1] << /rule /one_to_one >> << /model /static_synapse_lbl /synapse_label 5 >> Connect
* The function `GetConnections` allows to search for synapses with a certain label:

        SLI ] << /synapse_label 5 >> GetConnections /proj_syn Set
        SLI ] proj_syn ==
        [<1,2,0,1,0> <2,1,0,1,0>]
        SLI ] proj_syn 0 get GetStatus info
        --------------------------------------------------
        Name                     Type                Value
        --------------------------------------------------
        delay                    doubletype          1
        receptor                 integertype         0
        sizeof                   integertype         40
        source                   integertype         1
        synapse_label            integertype         5
        synapse_model            literaltype         static_synapse_lbl
        target                   integertype         2
        weight                   doubletype          1
        --------------------------------------------------
        Total number of entries: 8
This allows to assign a label / projection id to a projection between neuron populations, retrieve all synapses of this projection and, get and set properties of these synapses.
* As a consequence, all synapse models with label use more memory (one `long_t` more).