### PR TITLE
Updated online documentation on kernel parameters

### DIFF
--- a/nestkernel/network.h
+++ b/nestkernel/network.h
@@ -103,42 +103,61 @@ class GIDCollection;
 Name: kernel - Global properties of the simulation kernel.
 
 Description:
-(start here.)
+Global properties of the simulation kernel.
 
 Parameters:
-  The following parameters can be set in the status dictionary.
+  The following parameters are available in the kernel status dictionary.
 
-  data_path                stringtype  - A path, where all data is written to (default is the
-current directory)
-  data_prefix              stringtype  - A common prefix for all data files
-  dict_miss_is_error       booltype    - Whether missed dictionary entries are treated as errors
-  local_num_threads        integertype - The local number of threads (cf. global_num_virt_procs)
+  Time and resolution
+  resolution               doubletype  - The resolution of the simulation (in ms)
+  time                     doubletype  - The current simulation time
+  to_do                    integertype - The number of steps yet to be simulated (read only)
   max_delay                doubletype  - The maximum delay in the network
   min_delay                doubletype  - The minimum delay in the network
-  ms_per_tic               doubletype  - The number of miliseconds per tic (cf. tics_per_ms,
-tics_per_step)
-  network_size             integertype - The number of nodes in the network
-  num_connections          integertype - The number of connections in the network
-  num_processes            integertype - The number of MPI processes
+  ms_per_tic               doubletype  - The number of milliseconds per tic
+  tics_per_ms              doubletype  - The number of tics per millisecond
+  tics_per_step            integertype - The number of tics per simulation time step
+  T_max                    doubletype  - The largest representable time value (read only)
+  T_min                    doubletype  - The smallest representable time value (read only)
+
+  Parallel processing
+  total_num_virtual_procs  integertype - The total number of virtual processes
+  local_num_threads        integertype - The local number of threads
+  num_processes            integertype - The number of MPI processes (read only)
   num_rec_processes        integertype - The number of MPI processes reserved for recording spikes
   num_sim_processes        integertype - The number of MPI processes reserved for simulating neurons
-  off_grid_spiking         booltype    - Whether to transmit precise spike times in MPI communicatio
+  off_grid_spiking         booltype    - Whether to transmit precise spike times in MPI
+                                         communication (read only)
+
+  Random number generators
+  grng_seed                integertype - Seed for global random number generator used
+                                         synchronously by all virtual processes to
+                                         create, e.g., fixed fan-out connections
+                                         (write only).
+  rng_seeds                arraytype   - Seeds for the per-virtual-process random
+                                         number generators used for most purposes.
+                                         Array with one integer per virtual process,
+                                         all must be unique and differ from
+                                         grng_seed (write only).
+
+  Output
+  data_path                stringtype  - A path, where all data is written to
+                                         (default is the current directory)
+  data_prefix              stringtype  - A common prefix for all data files
   overwrite_files          booltype    - Whether to overwrite existing data files
   print_time               booltype    - Whether to print progress information during the simulation
-  resolution               doubletype  - The resolution of the simulation (in ms)
-  tics_per_ms              doubletype  - The number of tics per milisecond (cf. ms_per_tic,
-tics_per_step)
-  tics_per_step            integertype - The number of tics per simulation time step (cf.
-ms_per_tic, tics_per_ms)
-  time                     doubletype  - The current simulation time
-  total_num_virtual_procs  integertype - The total number of virtual processes (cf.
-local_num_threads)
-  to_do                    integertype - The number of steps yet to be simulated
-  T_max                    doubletype  - The largest representable time value
-  T_min                    doubletype  - The smallest representable time value
+
+  Network information
+  network_size             integertype - The number of nodes in the network (read only)
+  num_connections          integertype - The number of connections in the network
+                                         (read only, local only)
+
+  Miscellaneous
+  dict_miss_is_error       booltype    - Whether missed dictionary entries are treated as errors
   prelim_tol		   doubletype  - Tolerance of prelim iterations
   prelim_interpolation_order integertype - Interpolation order of polynomial used in prelim
-iterations
+                                           iterations
+
 SeeAlso: Simulate, Node
 */
 


### PR DESCRIPTION
This should fix #161.

In addition to adding information on the rng seeds, I also grouped the parameters by topic and marked parameters as read/write only.

Suggested reviewers @jougs @SepehrMN