### PR TITLE
Added check for OpenMP to protect another OMP call

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -79,7 +79,7 @@ template < typename Tnew, typename Told >
 inline Tnew*
 suicide_and_resurrect( Told* connector, size_t i )
 {
-#ifdef USE_PMA
+#if defined _OPENMP && defined USE_PMA
 #ifdef IS_K
   Tnew* p =
     new ( poormansallocpool[ omp_get_thread_num() ].alloc( sizeof( Tnew ) ) ) Tnew( *connector, i );


### PR DESCRIPTION
One more unprotected OMP call snuck in with a recent commit. Added a check to see that we are building with OpenMP.