### PR TITLE
`NumericalInstability` exception incorrectly refered to GSL.

### DIFF
--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -366,7 +366,6 @@ nest::NumericalInstability::message()
 {
   std::ostringstream msg;
   msg << "NEST detected a numerical instability while "
-      << "updating " << model_ << ". Try to reduce "
-      << "gsl_error_tol for the model.";
+      << "updating " << model_ << ".";
   return msg.str();
 }

--- a/nestkernel/exceptions.h
+++ b/nestkernel/exceptions.h
@@ -836,7 +836,7 @@ public:
    * @param model name of model causing problem
    */
   NumericalInstability( const std::string& model )
-    : KernelException( "GSLSolverFailure" )
+    : KernelException( "NumericalInstability" )
     , model_( model )
   {
   }


### PR DESCRIPTION
Just a small fix. We have a dedicated `GSLSolverFailure` exception for cases in which GSL ODE solvers run into trouble. `NumericalInstability` is for cases which do not use GSL.