### PR TITLE
Hot-fix for gap junction framework.

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -235,6 +235,7 @@ ConnectionManager::copy_synapse_prototype( synindex old_id, std::string new_name
   }
   assert( new_id != invalid_synindex );
 
+  // This is a hot-fix for issue #172: CopyModel on gap_junction does not work.
   if ( get_synapse_prototype( old_id ).is_primary() == false )
   {
     net_.message( SLIInterpreter::M_ERROR,

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -235,6 +235,15 @@ ConnectionManager::copy_synapse_prototype( synindex old_id, std::string new_name
   }
   assert( new_id != invalid_synindex );
 
+  if ( get_synapse_prototype( old_id ).is_primary() == false )
+  {
+    net_.message( SLIInterpreter::M_ERROR,
+      "ConnectionManager::copy_synapse_prototype",
+      "Cannot copy secondary connector model. Please use the "
+      "`syn_spec` to change parameters during `Connect`." );
+    throw KernelException( "Secondary connector models cannot be copied" );
+  }
+
   for ( thread t = 0; t < net_.get_num_threads(); ++t )
   {
     prototypes_[ t ].push_back( get_synapse_prototype( old_id ).clone( new_name ) );

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -597,7 +597,7 @@ NestModule::ResumeSimulationFunction::execute( SLIInterpreter* i ) const
    A copy of model is created and registered in modeldict or synapsedict
    under the name new_model. If a parameter dictionary is given, the parameters
    are set in new_model.
-   
+
    Note: Copying the `gap_junction` model (or any other model using SecondaryEvents)
          is not possible at this time. Please see issue #172.
  */

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -609,17 +609,6 @@ NestModule::CopyModel_l_l_DFunction::execute( SLIInterpreter* i ) const
   const std::string newmodname = getValue< std::string >( i->OStack.pick( 1 ) );
   DictionaryDatum dict = getValue< DictionaryDatum >( i->OStack.pick( 0 ) );
 
-  if ( oldmodname.toString() == "gap_junction" )
-  {
-    get_network().message( SLIInterpreter::M_WARNING,
-      "CopyModel",
-      "Cannot copy the `gap_junction` model. Please use the "
-      "`syn_spec` to change parameters during `Connect`." );
-    i->OStack.pop( 3 );
-    i->EStack.pop();
-    return;
-  }
-
   const Dictionary& modeldict = get_network().get_modeldict();
   const Dictionary& synapsedict = get_network().get_synapsedict();
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -609,6 +609,17 @@ NestModule::CopyModel_l_l_DFunction::execute( SLIInterpreter* i ) const
   const std::string newmodname = getValue< std::string >( i->OStack.pick( 1 ) );
   DictionaryDatum dict = getValue< DictionaryDatum >( i->OStack.pick( 0 ) );
 
+  if ( oldmodname.toString() == "gap_junction" )
+  {
+    get_network().message( SLIInterpreter::M_WARNING,
+      "CopyModel",
+      "Cannot copy the `gap_junction` model. Please use the "
+      "`syn_spec` to change parameters during `Connect`." );
+    i->OStack.pop( 3 );
+    i->EStack.pop();
+    return;
+  }
+
   const Dictionary& modeldict = get_network().get_modeldict();
   const Dictionary& synapsedict = get_network().get_synapsedict();
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -597,7 +597,9 @@ NestModule::ResumeSimulationFunction::execute( SLIInterpreter* i ) const
    A copy of model is created and registered in modeldict or synapsedict
    under the name new_model. If a parameter dictionary is given, the parameters
    are set in new_model.
-   Warning: It is impossible to unload modules after use of CopyModel.
+   
+   Note: Copying the `gap_junction` model (or any other model using SecondaryEvents)
+         is not possible at this time. Please see issue #172.
  */
 void
 NestModule::CopyModel_l_l_DFunction::execute( SLIInterpreter* i ) const


### PR DESCRIPTION
In #158 we found, that copying `gap_junction` connections is not functional yet. This PR adds a warning, when trying to `CopyModel` the `gap_junction` model, and prohibits the copy.
See #172 for ongoing work for this issue.