### PR TITLE
Allow newer versions of cppcheck.

### DIFF
--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -131,10 +131,9 @@ cppcheck_version=`$CPPCHECK --version | sed 's/^Cppcheck //'`
 echo "cppcheck version: $cppcheck_version"
 IFS=\. read -a cppcheck_version_a <<< "$cppcheck_version"
 if [[ ${cppcheck_version_a[0]} -lt 1 ]]; then
-  bail_out "Require cppcheck version 1.69. Not $cppcheck_version ."
-fi
-if [[ ${cppcheck_version_a[1]} -lt 69 ]]; then
-  bail_out "Require cppcheck version 1.69. Not $cppcheck_version ."
+  bail_out "Require cppcheck version 1.69 or later. Not $cppcheck_version ."
+elif [[ ${cppcheck_version_a[0]} -eq 1 && ${cppcheck_version_a[1]} -lt 69 ]]; then
+  bail_out "Require cppcheck version 1.69 or later. Not $cppcheck_version ."
 fi
 
 # clang-format is installed correctly

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -129,7 +129,11 @@ echo "vera++ version: `vera++ --version`"
 $CPPCHECK --enable=all --inconclusive --std=c++03 ./nest/main.cpp >/dev/null 2>&1 || usage 1 "Executable $CPPCHECK for cppcheck is not working!"
 cppcheck_version=`$CPPCHECK --version | sed 's/^Cppcheck //'`
 echo "cppcheck version: $cppcheck_version"
-if [[ "x$cppcheck_version" != "x1.69" ]]; then
+IFS=\. read -a cppcheck_version_a <<< "$cppcheck_version"
+if [[ ${cppcheck_version_a[0]} -lt 1 ]]; then
+  bail_out "Require cppcheck version 1.69. Not $cppcheck_version ."
+fi
+if [[ ${cppcheck_version_a[1]} -lt 69 ]]; then
   bail_out "Require cppcheck version 1.69. Not $cppcheck_version ."
 fi
 


### PR DESCRIPTION
With TravisCI we perform the `cppcheck` with v1.69, since a previous version had a bug (see #79). With the script from #95, we can check the code style locally and there is no reason, why we should not use a newer `cppcheck`. With this PR we allow newer version of `cppcheck` in that script.