### PR TITLE
Fix for issue #172: Added CopyModel compatibility for gap_junction model

### DIFF
--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -333,7 +333,7 @@ ModelsModule::init( SLIInterpreter* )
   /* BeginDocumentation
      Name: gap_junction - Connection model for gap junctions.
      SeeAlso: synapsedict
-  */  
+  */ 
   register_secondary_connection_model< GapJunction< TargetIdentifierPtrRport > >(
     net_, "gap_junction", false );
 

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -333,7 +333,7 @@ ModelsModule::init( SLIInterpreter* )
   /* BeginDocumentation
      Name: gap_junction - Connection model for gap junctions.
      SeeAlso: synapsedict
-  */ 
+  */
   register_secondary_connection_model< GapJunction< TargetIdentifierPtrRport > >(
     net_, "gap_junction", false );
 

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -329,6 +329,11 @@ ModelsModule::init( SLIInterpreter* )
     net_, "static_synapse_hom_w" );
   register_connection_model< StaticConnectionHomW< TargetIdentifierIndex > >(
     net_, "static_synapse_hom_w_hpc" );
+
+  /* BeginDocumentation
+     Name: gap_junction - Connection model for gap junctions.
+     SeeAlso: synapsedict
+  */  
   register_secondary_connection_model< GapJunction< TargetIdentifierPtrRport > >(
     net_, "gap_junction", false );
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -234,7 +234,14 @@ ConnectionManager::copy_synapse_prototype( synindex old_id, std::string new_name
     throw KernelException( "Synapse model count exceeded" );
   }
   assert( new_id != invalid_synindex );
-
+  
+  // if the copied synapse is a secondary connector model the synid of the copy has to
+  // be mapped to the corresponding secondary event type
+  if ( get_synapse_prototype( old_id ).is_primary() == false )
+  {
+    ( get_synapse_prototype( old_id ).get_event() )->add_syn_id( new_id );
+  }
+  
   for ( thread t = 0; t < net_.get_num_threads(); ++t )
   {
     prototypes_[ t ].push_back( get_synapse_prototype( old_id ).clone( new_name ) );
@@ -721,7 +728,7 @@ ConnectionManager::send_secondary( thread t, SecondaryEvent& e )
 
         if ( p->homogeneous_model() )
         {
-          if ( p->get_syn_id() == e.get_syn_id() )
+          if ( e.has_syn_id ( p->get_syn_id() ) )
             p->send( e, t, prototypes_[ t ] );
         }
         else

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -237,7 +237,7 @@ ConnectionManager::copy_synapse_prototype( synindex old_id, std::string new_name
 
   // if the copied synapse is a secondary connector model the synid of the copy has to
   // be mapped to the corresponding secondary event type
-  if ( get_synapse_prototype( old_id ).is_primary() == false )
+  if ( not get_synapse_prototype( old_id ).is_primary() )
   {
     ( get_synapse_prototype( old_id ).get_event() )->add_syn_id( new_id );
   }
@@ -728,7 +728,7 @@ ConnectionManager::send_secondary( thread t, SecondaryEvent& e )
 
         if ( p->homogeneous_model() )
         {
-          if ( e.has_syn_id( p->get_syn_id() ) )
+          if ( e.supports_syn_id( p->get_syn_id() ) )
             p->send( e, t, prototypes_[ t ] );
         }
         else

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -234,14 +234,14 @@ ConnectionManager::copy_synapse_prototype( synindex old_id, std::string new_name
     throw KernelException( "Synapse model count exceeded" );
   }
   assert( new_id != invalid_synindex );
-  
+
   // if the copied synapse is a secondary connector model the synid of the copy has to
   // be mapped to the corresponding secondary event type
   if ( get_synapse_prototype( old_id ).is_primary() == false )
   {
     ( get_synapse_prototype( old_id ).get_event() )->add_syn_id( new_id );
   }
-  
+
   for ( thread t = 0; t < net_.get_num_threads(); ++t )
   {
     prototypes_[ t ].push_back( get_synapse_prototype( old_id ).clone( new_name ) );
@@ -728,7 +728,7 @@ ConnectionManager::send_secondary( thread t, SecondaryEvent& e )
 
         if ( p->homogeneous_model() )
         {
-          if ( e.has_syn_id ( p->get_syn_id() ) )
+          if ( e.has_syn_id( p->get_syn_id() ) )
             p->send( e, t, prototypes_[ t ] );
         }
         else

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -991,7 +991,7 @@ public:
   {
     // for all secondary connections delegate send to the matching homogeneous connector only
     for ( size_t i = primary_end_; i < size(); i++ )
-      if ( e.has_syn_id( at( i )->get_syn_id() ) )
+      if ( e.supports_syn_id( at( i )->get_syn_id() ) )
       {
         at( i )->send( e, t, cm );
         break;

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -991,7 +991,7 @@ public:
   {
     // for all secondary connections delegate send to the matching homogeneous connector only
     for ( size_t i = primary_end_; i < size(); i++ )
-      if ( at( i )->get_syn_id() == e.get_syn_id() )
+      if ( e.has_syn_id ( at( i )->get_syn_id() ) )
       {
         at( i )->send( e, t, cm );
         break;

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -991,7 +991,7 @@ public:
   {
     // for all secondary connections delegate send to the matching homogeneous connector only
     for ( size_t i = primary_end_; i < size(); i++ )
-      if ( e.has_syn_id ( at( i )->get_syn_id() ) )
+      if ( e.has_syn_id( at( i )->get_syn_id() ) )
       {
         at( i )->send( e, t, cm );
         break;

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -121,7 +121,6 @@ void GapJEvent::operator()()
   receiver_->handle( *this );
 }
 
-synindex GapJEvent::synid_ = invalid_synindex;
 std::vector< synindex > GapJEvent::supported_syn_ids_;
 size_t GapJEvent::coeff_length_ = 0;
 }

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -122,5 +122,6 @@ void GapJEvent::operator()()
 }
 
 synindex GapJEvent::synid_ = invalid_synindex;
+std::vector< synindex > GapJEvent::synid_vector_;
 size_t GapJEvent::coeff_length_ = 0;
 }

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -122,6 +122,6 @@ void GapJEvent::operator()()
 }
 
 synindex GapJEvent::synid_ = invalid_synindex;
-std::vector< synindex > GapJEvent::synid_vector_;
+std::vector< synindex > GapJEvent::supported_syn_ids_;
 size_t GapJEvent::coeff_length_ = 0;
 }

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -736,6 +736,10 @@ public:
 
   virtual synindex get_syn_id() const = 0;
 
+  virtual void add_syn_id( const synindex synid ) = 0;
+
+  virtual bool has_syn_id( const synindex synid ) const = 0;
+
   //! size of event in units of uint_t
   virtual size_t size() = 0;
   virtual fwit& operator<<( fwit& pos ) = 0;
@@ -810,7 +814,19 @@ public:
 class GapJEvent : public SecondaryEvent
 {
 private:
+  /*
+  Conceptual there is an one-to-one mapping between a SecondaryEvent
+  and a SecondaryConnectorModel. The synindex of this particular
+  SecondaryConnectorModel is stored in the static synid_ member variable
+  on model registeration. There are however reasons (e.g. the usage of
+  CopyModel or the creation of the labeled synapse model duplicates for pyNN)
+  which make it necessary to register several SecondaryConnectorModels with
+  one SecondaryEvent. Therefore the synindices of all these models are
+  stored  in the synid_vector_. The has_syn_id()-function allows testing
+  if a particular synid is mapped with the SecondaryEvent in question.
+  */
   static synindex synid_;
+  static std::vector< synindex > synid_vector_;
   static size_t coeff_length_; // length of coeffarray
 
   CoeffArrayIterator diit_begin_;
@@ -827,7 +843,31 @@ public:
   static void
   set_syn_id( const synindex synid )
   {
-    synid_ = synid;
+    if(synid_ == invalid_synindex)
+      synid_ = synid;
+
+    synid_vector_.push_back(synid);
+  }
+
+  void
+  add_syn_id( const synindex synid )
+  {
+    synid_vector_.push_back(synid);
+  }
+
+  bool
+  has_syn_id( const synindex synid ) const
+  {
+    bool has_syn_id = false;
+    for ( unsigned int i = 0; i < synid_vector_.size(); i++ )
+    {
+      if( synid_vector_[i] == synid )
+      {
+        has_syn_id = true;
+        break;
+      }
+    }
+    return has_syn_id;
   }
 
   synindex

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -825,8 +825,7 @@ public:
 class GapJEvent : public SecondaryEvent
 {
 private:
-
-  //we chose std::vector over std::set because we expect this always to be short
+  // we chose std::vector over std::set because we expect this always to be short
   static std::vector< synindex > supported_syn_ids_;
   static size_t coeff_length_; // length of coeffarray
 
@@ -841,24 +840,24 @@ public:
   void operator()();
   GapJEvent* clone() const;
 
-/**
- * This function is needed to set the synid on model registration
- * At this point no object of this type is available and the
- * add_syn_id-function cannot be used as it is virtual in the base class
- * and therefore cannot be declared as static.
- */
+  /**
+   * This function is needed to set the synid on model registration
+   * At this point no object of this type is available and the
+   * add_syn_id-function cannot be used as it is virtual in the base class
+   * and therefore cannot be declared as static.
+   */
   static void
   set_syn_id( const synindex synid )
   {
     supported_syn_ids_.push_back( synid );
   }
 
-/**
- * This function is needed to add additional synids when the
- * corresponded connector model is copied.
- * This function needs to be a virtual function of the base class as
- * it is called from a pointer on SecondaryEvent.
- */
+  /**
+   * This function is needed to add additional synids when the
+   * corresponded connector model is copied.
+   * This function needs to be a virtual function of the base class as
+   * it is called from a pointer on SecondaryEvent.
+   */
   void
   add_syn_id( const synindex synid )
   {
@@ -881,19 +880,19 @@ public:
     coeff_length_ = ca.size();
   }
 
-/**
- * The following operator is used to read the information
- * of the GapJEvent from the buffer in Scheduler::deliver_events_
- * The synid can be skipped here as it is stored in a static vector.
- */
+  /**
+   * The following operator is used to read the information
+   * of the GapJEvent from the buffer in Scheduler::deliver_events_
+   * The synid can be skipped here as it is stored in a static vector.
+   */
   fwit& operator<<( fwit& pos );
 
-/**
- * The following operator is used to write the information
- * of the GapJEvent into the secondary_events_buffer_
- * All GapJEvents are identified by the synid of the
- * first element in supported_syn_ids_
- */
+  /**
+   * The following operator is used to write the information
+   * of the GapJEvent into the secondary_events_buffer_
+   * All GapJEvents are identified by the synid of the
+   * first element in supported_syn_ids_
+   */
   fwit& operator>>( fwit& pos );
 
   size_t size();

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -818,7 +818,7 @@ private:
   Conceptual there is an one-to-one mapping between a SecondaryEvent
   and a SecondaryConnectorModel. The synindex of this particular
   SecondaryConnectorModel is stored in the static synid_ member variable
-  on model registeration. There are however reasons (e.g. the usage of
+  on model registration. There are however reasons (e.g. the usage of
   CopyModel or the creation of the labeled synapse model duplicates for pyNN)
   which make it necessary to register several SecondaryConnectorModels with
   one SecondaryEvent. Therefore the synindices of all these models are

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -855,7 +855,8 @@ public:
   bool
   supports_syn_id( const synindex synid ) const
   {
-    return std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid ) != supported_syn_ids_.end();
+    return std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid )
+      != supported_syn_ids_.end();
   }
 
   void

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -25,6 +25,8 @@
 
 #include <cassert>
 #include <cstring>
+#include <algorithm>
+#include <vector>
 
 #include "nest.h"
 #include "nest_time.h"
@@ -734,11 +736,9 @@ class SecondaryEvent : public Event
 public:
   virtual SecondaryEvent* clone() const = 0;
 
-  virtual synindex get_syn_id() const = 0;
-
   virtual void add_syn_id( const synindex synid ) = 0;
 
-  virtual bool has_syn_id( const synindex synid ) const = 0;
+  virtual bool supports_syn_id( const synindex synid ) const = 0;
 
   //! size of event in units of uint_t
   virtual size_t size() = 0;
@@ -815,7 +815,7 @@ class GapJEvent : public SecondaryEvent
 {
 private:
   /*
-  Conceptual there is an one-to-one mapping between a SecondaryEvent
+  Conceptually, there is a one-to-one mapping between a SecondaryEvent
   and a SecondaryConnectorModel. The synindex of this particular
   SecondaryConnectorModel is stored in the static synid_ member variable
   on model registration. There are however reasons (e.g. the usage of
@@ -826,7 +826,7 @@ private:
   if a particular synid is mapped with the SecondaryEvent in question.
   */
   static synindex synid_;
-  static std::vector< synindex > synid_vector_;
+  static std::vector< synindex > supported_syn_ids_;
   static size_t coeff_length_; // length of coeffarray
 
   CoeffArrayIterator diit_begin_;
@@ -846,34 +846,19 @@ public:
     if ( synid_ == invalid_synindex )
       synid_ = synid;
 
-    synid_vector_.push_back( synid );
+    supported_syn_ids_.push_back( synid );
   }
 
   void
   add_syn_id( const synindex synid )
   {
-    synid_vector_.push_back( synid );
+    supported_syn_ids_.push_back( synid );
   }
 
   bool
-  has_syn_id( const synindex synid ) const
+  supports_syn_id( const synindex synid ) const
   {
-    bool has_syn_id = false;
-    for ( unsigned int i = 0; i < synid_vector_.size(); i++ )
-    {
-      if ( synid_vector_[ i ] == synid )
-      {
-        has_syn_id = true;
-        break;
-      }
-    }
-    return has_syn_id;
-  }
-
-  synindex
-  get_syn_id() const
-  {
-    return synid_;
+    return std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid ) != supported_syn_ids_.end();
   }
 
   void

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -843,16 +843,16 @@ public:
   static void
   set_syn_id( const synindex synid )
   {
-    if(synid_ == invalid_synindex)
+    if ( synid_ == invalid_synindex )
       synid_ = synid;
 
-    synid_vector_.push_back(synid);
+    synid_vector_.push_back( synid );
   }
 
   void
   add_syn_id( const synindex synid )
   {
-    synid_vector_.push_back(synid);
+    synid_vector_.push_back( synid );
   }
 
   bool
@@ -861,7 +861,7 @@ public:
     bool has_syn_id = false;
     for ( unsigned int i = 0; i < synid_vector_.size(); i++ )
     {
-      if( synid_vector_[i] == synid )
+      if ( synid_vector_[ i ] == synid )
       {
         has_syn_id = true;
         break;


### PR DESCRIPTION
The PR fixes the problem reported in issue #172.

With this PR it is possible to
- register more than one SecondaryConnectorModel with GapJEvents (e.g. to add gap_junction_lbl, as needed for PR #158)
- use CopyModel on the gap_junction connection model

