### PR TITLE
Partial fix for #178: incorrect declarations hindering clang compilation

### DIFF
--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -51,6 +51,7 @@ namespace nest
  */
 class Archiving_Node : public Node
 {
+  using Node::get_synaptic_elements;
 
 public:
   /**

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -571,7 +571,7 @@ public:
    * @ingroup MSP_functions
    */
   virtual std::map< Name, double_t >
-  get_synaptic_elements()
+  get_synaptic_elements() const
   {
     return std::map< Name, double >();
   }


### PR DESCRIPTION
This fixes the following error when compiling with clang:
```
In file included from ../../src/nestkernel/archiving_node.cpp:30:
../../src/nestkernel/archiving_node.h:101:30: warning: 'nest::Archiving_Node::get_synaptic_elements' hides overloaded virtual function [-Woverloaded-virtual]
  std::map< Name, double_t > get_synaptic_elements() const;
                             ^
../../src/nestkernel/node.h:574:3: note: hidden overloaded virtual function 'nest::Node::get_synaptic_elements' declared here: different qualifiers
      (none vs const)
  get_synaptic_elements()
```

Suggested reviewers: @janhahne @tammoippen 