### PR TITLE
Fix178 juqueen compile failure

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -107,7 +107,7 @@ suicide( Told* connector )
 }
 
 // when to truncate the recursive instantiation
-#define K_cutoff 3
+#define K_CUTOFF 3
 
 namespace nest
 {
@@ -207,7 +207,7 @@ class Connector : public vector_like< ConnectionT >
 
 public:
   Connector( const Connector< K - 1, ConnectionT >& Cm1,
-    const ConnectionT& c ) //: syn_id_(Cm1.get_syn_id())
+    const ConnectionT& c )
   {
     for ( size_t i = 0; i < K - 1; i++ )
       C_[ i ] = Cm1.get_C()[ i ];
@@ -452,7 +452,6 @@ class Connector< 1, ConnectionT > : public vector_like< ConnectionT >
   ConnectionT C_[ 1 ];
 
 public:
-  // Connector(const ConnectionT &c, synindex syn_id) : syn_id_(syn_id)
   Connector( const ConnectionT& c )
   {
     C_[ 0 ] = c;
@@ -647,21 +646,21 @@ public:
 };
 
 
-// homogeneous connector containing >=K_cutoff entries
+// homogeneous connector containing >=K_CUTOFF entries
 // specialization to define recursion termination for push_back
 // internally use a normal vector to store elements
 template < typename ConnectionT >
-class Connector< K_cutoff, ConnectionT > : public vector_like< ConnectionT >
+class Connector< K_CUTOFF, ConnectionT > : public vector_like< ConnectionT >
 {
   std::vector< ConnectionT > C_;
 
 public:
-  Connector( const Connector< K_cutoff - 1, ConnectionT >& C, const ConnectionT& c )
-    : C_( K_cutoff ) //, syn_id_(C.get_syn_id())
+  Connector( const Connector< K_CUTOFF - 1, ConnectionT >& C, const ConnectionT& c )
+    : C_( K_CUTOFF ) //, syn_id_(C.get_syn_id())
   {
-    for ( size_t i = 0; i < K_cutoff - 1; i++ )
+    for ( size_t i = 0; i < K_CUTOFF - 1; i++ )
       C_[ i ] = C.get_C()[ i ];
-    C_[ K_cutoff - 1 ] = c;
+    C_[ K_CUTOFF - 1 ] = c;
   };
 
   /**
@@ -670,12 +669,12 @@ public:
    * in two parts, first up to the specified index and then the rest of the
    * connections after the specified index in order to
    * exclude the ith connection from the copy. As a result, returns a connector
-   * with size K_cutoff-1 from a connector of size K_cutoff.
+   * with size K_CUTOFF-1 from a connector of size K_CUTOFF.
    *
-   * @param Cm1 Original connector of size K_cutoff.
+   * @param Cm1 Original connector of size K_CUTOFF
    * @param i The index of the connection to be deleted.
    */
-  Connector( const Connector< K_cutoff, ConnectionT >& Cm1, size_t i ) //: syn_id_(Cm1.get_syn_id())
+  Connector( const Connector< K_CUTOFF, ConnectionT >& Cm1, size_t i ) //: syn_id_(Cm1.get_syn_id())
   {
     assert( i < Cm1.get_C().size() && i >= 0 );
     for ( size_t k = 0; k < i; k++ )
@@ -683,7 +682,7 @@ public:
       C_[ k ] = Cm1.get_C()[ k ];
     }
 
-    for ( size_t k = i + 1; k < K_cutoff; k++ )
+    for ( size_t k = i + 1; k < K_CUTOFF; k++ )
     {
       C_[ k ] = Cm1.get_C()[ k + 1 ];
     }

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -23,6 +23,7 @@
 #ifndef CONNECTOR_BASE_H
 #define CONNECTOR_BASE_H
 
+#include <cstdlib>
 #include <vector>
 
 #include "node.h"
@@ -302,7 +303,7 @@ public:
     return num_connections;
   }
 
-  Connector< K + 1, ConnectionT >&
+  ConnectorBase&
   push_back( const ConnectionT& c )
   {
     return *suicide_and_resurrect< Connector< K + 1, ConnectionT > >( this, c );
@@ -313,7 +314,7 @@ public:
    * @param i the index of the connection to be erased
    * @return A connector of size K-1
    */
-  Connector< K - 1, ConnectionT >&
+  ConnectorBase&
   erase( size_t i )
   {
     // try to cast the connector one size shorter
@@ -529,7 +530,7 @@ public:
     return num_connections;
   }
 
-  Connector< 2, ConnectionT >&
+  ConnectorBase&
   push_back( const ConnectionT& c )
   {
     return *suicide_and_resurrect< Connector< 2, ConnectionT > >( this, c );
@@ -537,10 +538,11 @@ public:
 
   ConnectorBase& erase( size_t )
   {
-    // Destroys the Connector
-    suicide< Connector< 1, ConnectionT > >( this );
-    ConnectorBase* p = 0;
-    return *p;
+    // erase() must never be called on a connector with just as single synapse.
+    // Delete the connector instead.
+    assert(false); 
+    std::abort();  // we must not pass this point even if compiled with -DNDEBUG
+    return *this;   // dummy value, will never be returned
   }
 
   size_t
@@ -744,14 +746,14 @@ public:
     return num_connections;
   }
 
-  Connector< K_cutoff, ConnectionT >&
+  ConnectorBase&
   push_back( const ConnectionT& c )
   {
     C_.push_back( c );
     return *this;
   }
 
-  Connector< K_cutoff, ConnectionT >&
+  ConnectorBase&
   erase( size_t i )
   {
     typename std::vector< ConnectionT >::iterator it;

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -201,7 +201,7 @@ public:
 
 // homogeneous connector containing K entries
 template < size_t K, typename ConnectionT >
-class Connector : public vector_like< ConnectionT > // unfortunately, we need the virtual base class
+class Connector : public vector_like< ConnectionT >
 {
   ConnectionT C_[ K ];
 
@@ -225,7 +225,7 @@ public:
    * @param Cm1 the original connector
    * @param i the index of the connection to be deleted
    */
-  Connector( const Connector< K + 1, ConnectionT >& Cm1, size_t i ) //: syn_id_(Cm1.get_syn_id())
+  Connector( const Connector< K + 1, ConnectionT >& Cm1, size_t i )
   {
     assert( i < K && i >= 0 );
     for ( size_t k = 0; k < i; k++ )
@@ -464,7 +464,7 @@ public:
    * @param Cm1 Original Connector of size 2
    * @param i Index of the connection to be erased
    */
-  Connector( const Connector< 2, ConnectionT >& Cm1, size_t i ) //: syn_id_(Cm1.get_syn_id())
+  Connector( const Connector< 2, ConnectionT >& Cm1, size_t i )
   {
     assert( i < 2 && i >= 0 );
     if ( i == 0 )
@@ -540,9 +540,9 @@ public:
   {
     // erase() must never be called on a connector with just as single synapse.
     // Delete the connector instead.
-    assert(false); 
-    std::abort();  // we must not pass this point even if compiled with -DNDEBUG
-    return *this;   // dummy value, will never be returned
+    assert( false );
+    std::abort(); // we must not pass this point even if compiled with -DNDEBUG
+    return *this; // dummy value, will never be returned
   }
 
   size_t

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -206,8 +206,7 @@ class Connector : public vector_like< ConnectionT >
   ConnectionT C_[ K ];
 
 public:
-  Connector( const Connector< K - 1, ConnectionT >& Cm1,
-    const ConnectionT& c )
+  Connector( const Connector< K - 1, ConnectionT >& Cm1, const ConnectionT& c )
   {
     for ( size_t i = 0; i < K - 1; i++ )
       C_[ i ] = Cm1.get_C()[ i ];


### PR DESCRIPTION
This PR fixes the circular template specialization problem on which xlC choked. Briefly, `Connector< 1, ConnectionT >::erase()` must never be called and now will trigger an assert/abort if called. `GenericConnectorModel< ConnectionT >::delete_connection()` ensures that `erase()` is not called on `vector_like< ConnectionT >` containers of size 1.

This will fix #178.