### PR TITLE
Fix for #181: Made gap junction implementation C++-standard compliant

### DIFF
--- a/models/gap_junction.h
+++ b/models/gap_junction.h
@@ -82,7 +82,7 @@ public:
   // this line determines which common properties to use
   typedef CommonSynapseProperties CommonPropertiesType;
   typedef Connection< targetidentifierT > ConnectionBase;
-  typedef GapJEvent EventType;
+  typedef GapJunctionEvent EventType;
 
 
   /**

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -625,9 +625,10 @@ nest::hh_psc_alpha_gap::handle( GapJunctionEvent& e )
   B_.sumj_g_ij_ += e.get_weight();
 
   size_t i = 0;
-  for ( std::vector< uint_t >::iterator it = e.begin(); it != e.end(); e.next( it ) )
+  std::vector< uint_t >::iterator it = e.begin();
+  while ( it != e.end() )
   {
-    B_.interpolation_coefficients[ i ] += e.get_weight() * e.get_value( it );
+    B_.interpolation_coefficients[ i ] += e.get_weight() * e.get_coeffvalue( it );
     i++;
   }
 }

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -626,6 +626,7 @@ nest::hh_psc_alpha_gap::handle( GapJunctionEvent& e )
 
   size_t i = 0;
   std::vector< uint_t >::iterator it = e.begin();
+  // The call to get_coeffvalue( it ) in this loop also advances the iterator it
   while ( it != e.end() )
   {
     B_.interpolation_coefficients[ i ] += e.get_weight() * e.get_coeffvalue( it );

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -575,7 +575,7 @@ nest::hh_psc_alpha_gap::update_( Time const& origin,
   }
 
   // Send gap-event
-  GapJEvent ge;
+  GapJunctionEvent ge;
   ge.set_coeffarray( new_coefficients );
   network()->send_secondary( *this, ge );
 
@@ -619,13 +619,13 @@ nest::hh_psc_alpha_gap::handle( DataLoggingRequest& e )
 }
 
 void
-nest::hh_psc_alpha_gap::handle( GapJEvent& e )
+nest::hh_psc_alpha_gap::handle( GapJunctionEvent& e )
 {
 
   B_.sumj_g_ij_ += e.get_weight();
 
   size_t i = 0;
-  for ( fwit it = e.begin(); it != e.end(); e.next( it ) )
+  for ( std::vector< uint_t >::iterator it = e.begin(); it != e.end(); e.next( it ) )
   {
     B_.interpolation_coefficients[ i ] += e.get_weight() * e.get_value( it );
     i++;

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -625,9 +625,9 @@ nest::hh_psc_alpha_gap::handle( GapJEvent& e )
   B_.sumj_g_ij_ += e.get_weight();
 
   size_t i = 0;
-  for ( CoeffArrayIterator it = e.begin(); it != e.end(); ++it )
+  for ( fwit it = e.begin(); it != e.end(); e.next( it ) )
   {
-    B_.interpolation_coefficients[ i ] += e.get_weight() * ( *it );
+    B_.interpolation_coefficients[ i ] += e.get_weight() * e.get_value( it );
     i++;
   }
 }

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -124,9 +124,9 @@ References:
  Front. Neuroinform. 9:22. (2015),
  doi: 10.3389/fninf.2015.00022
 
-Sends: SpikeEvent, GapJEvent
+Sends: SpikeEvent, GapJunctionEvent
 
-Receives: SpikeEvent, GapJEvent, CurrentEvent, DataLoggingRequest
+Receives: SpikeEvent, GapJunctionEvent, CurrentEvent, DataLoggingRequest
 
 Author: Jan Hahne, Moritz Helias, Susanne Kunkel
 SeeAlso: hh_psc_alpha, hh_cond_exp_traub, gap_junction
@@ -155,15 +155,15 @@ public:
   void handle( SpikeEvent& );
   void handle( CurrentEvent& );
   void handle( DataLoggingRequest& );
-  void handle( GapJEvent& );
+  void handle( GapJunctionEvent& );
 
   port handles_test_event( SpikeEvent&, rport );
   port handles_test_event( CurrentEvent&, rport );
   port handles_test_event( DataLoggingRequest&, rport );
-  port handles_test_event( GapJEvent&, rport );
+  port handles_test_event( GapJunctionEvent&, rport );
 
   void
-  sends_secondary_event( GapJEvent& )
+  sends_secondary_event( GapJunctionEvent& )
   {
   }
 
@@ -416,7 +416,7 @@ hh_psc_alpha_gap::handles_test_event( DataLoggingRequest& dlr, rport receptor_ty
 }
 
 inline port
-hh_psc_alpha_gap::handles_test_event( GapJEvent&, rport receptor_type )
+hh_psc_alpha_gap::handles_test_event( GapJunctionEvent&, rport receptor_type )
 {
   if ( receptor_type != 0 )
     throw UnknownReceptorType( receptor_type, get_name() );

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -116,11 +116,11 @@ void DataLoggingReply::operator()()
   receiver_->handle( *this );
 }
 
-void GapJEvent::operator()()
+void GapJunctionEvent::operator()()
 {
   receiver_->handle( *this );
 }
 
-std::vector< synindex > GapJEvent::supported_syn_ids_;
-size_t GapJEvent::coeff_length_ = 0;
+std::vector< synindex > GapJunctionEvent::supported_syn_ids_;
+size_t GapJunctionEvent::coeff_length_ = 0;
 }

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -765,11 +765,14 @@ number_of_uints_covered( void )
  * it just writes the data to the position given by the iterator.
  * The function is used to write data from SecondaryEvents to the NEST communcation buffer.
  * The pos iterator is advanced during execution.
+ * For a discussion on the functionality of this function see github issue #181 and pull request
+ * #184.
  */
 template < typename T >
 void
 write_to_comm_buffer( T d, std::vector< uint_t >::iterator& pos )
 {
+  // there is no aliasing problem here, since cast to char* invalidate strict aliasing assumptions
   char* const c = reinterpret_cast< char* >( &d );
 
   const size_t num_uints = number_of_uints_covered< T >();
@@ -789,11 +792,14 @@ write_to_comm_buffer( T d, std::vector< uint_t >::iterator& pos )
  * This template function reads data of type T from a given position of a std::vector< uint_t >.
  * The function is used to read SecondaryEvents data from the NEST communcation buffer.
  * The pos iterator is advanced during execution.
+ * For a discussion on the functionality of this function see github issue #181 and pull request
+ * #184.
  */
 template < typename T >
 void
 read_from_comm_buffer( T& d, std::vector< uint_t >::iterator& pos )
 {
+  // there is no aliasing problem here, since cast to char* invalidate strict aliasing assumptions
   char* const c = reinterpret_cast< char* >( &d );
 
   const size_t num_uints = number_of_uints_covered< T >();

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -743,8 +743,8 @@ public:
 };
 
 /**
- * This template function returns the number of uints covered by a variable of
- * type T. This function is used to determine the storage demands for a variable of
+ * This template function returns the number of uints covered by a variable of type T.
+ * This function is used to determine the storage demands for a variable of
  * type T in the NEST communication buffer, which is of type std::vector< uint_t>.
  */
 template < typename T >
@@ -760,25 +760,25 @@ number_of_uints_covered( void )
 }
 
 /**
- * This template function writes data of type T to a given position of a
- * std::vector< uint_t >. Please note that this function does not increase the
- * size of the vector, it just writes the data to the position given by the iterator.
+ * This template function writes data of type T to a given position of a std::vector< uint_t >.
+ * Please note that this function does not increase the size of the vector,
+ * it just writes the data to the position given by the iterator.
  * The function is used to write data from SecondaryEvents to the NEST communcation buffer.
+ * The pos iterator is advanced during execution.
  */
 template < typename T >
 void
 write_to_comm_buffer( T d, std::vector< uint_t >::iterator& pos )
 {
-  char* c = reinterpret_cast< char* >( &d );
+  char* const c = reinterpret_cast< char* >( &d );
 
-  size_t num_uints = number_of_uints_covered< T >();
+  const size_t num_uints = number_of_uints_covered< T >();
   size_t left_to_copy = sizeof( T );
 
   for ( int i = 0; i < num_uints; i++ )
   {
-    memcpy( &( *( pos + i ) ),
-      c + i * sizeof( uint_t ),
-      left_to_copy < sizeof( uint_t ) ? left_to_copy : sizeof( uint_t ) );
+    memcpy(
+      &( *( pos + i ) ), c + i * sizeof( uint_t ), std::min( left_to_copy, sizeof( uint_t ) ) );
     left_to_copy -= sizeof( uint_t );
   }
 
@@ -788,21 +788,21 @@ write_to_comm_buffer( T d, std::vector< uint_t >::iterator& pos )
 /**
  * This template function reads data of type T from a given position of a std::vector< uint_t >.
  * The function is used to read SecondaryEvents data from the NEST communcation buffer.
+ * The pos iterator is advanced during execution.
  */
 template < typename T >
 void
 read_from_comm_buffer( T& d, std::vector< uint_t >::iterator& pos )
 {
-  char* c = reinterpret_cast< char* >( &d );
+  char* const c = reinterpret_cast< char* >( &d );
 
-  size_t num_uints = number_of_uints_covered< T >();
+  const size_t num_uints = number_of_uints_covered< T >();
   size_t left_to_copy = sizeof( T );
 
   for ( int i = 0; i < num_uints; i++ )
   {
-    memcpy( c + i * sizeof( uint_t ),
-      &( *( pos + i ) ),
-      left_to_copy < sizeof( uint_t ) ? left_to_copy : sizeof( uint_t ) );
+    memcpy(
+      c + i * sizeof( uint_t ), &( *( pos + i ) ), std::min( left_to_copy, sizeof( uint_t ) ) );
     left_to_copy -= sizeof( uint_t );
   }
 
@@ -848,7 +848,7 @@ public:
   GapJunctionEvent* clone() const;
 
   /**
-   * This function is needed to set the synid on model registration
+   * This function is needed to set the synid on model registration.
    * At this point no object of this type is available and the
    * add_syn_id-function cannot be used as it is virtual in the base class
    * and therefore cannot be declared as static.

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -915,23 +915,15 @@ public:
     return coeffarray_as_uints_end_;
   }
 
-  double_t get_value( const std::vector< uint_t >::iterator& pos );
-
-  void next( std::vector< uint_t >::iterator& pos );
+  double_t get_coeffvalue( std::vector< uint_t >::iterator& pos );
 };
 
 inline double_t
-GapJunctionEvent::get_value( const std::vector< uint_t >::iterator& pos )
+GapJunctionEvent::get_coeffvalue( std::vector< uint_t >::iterator& pos )
 {
   double_t elem = 0.0;
-  memcpy( &elem, &( *pos ), sizeof( elem ) );
+  output_stream( elem, pos );
   return elem;
-}
-
-inline void
-GapJunctionEvent::next( std::vector< uint_t >::iterator& pos )
-{
-  pos += number_of_uints_covered< double_t >();
 }
 
 inline GapJunctionEvent*

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -748,7 +748,8 @@ public:
  * type T into the NEST communication buffer, which is of type std::vector< uint_t>.
  */
 template < typename T >
-size_t number_of_uints_covered( T )
+size_t
+number_of_uints_covered( void )
 {
   size_t num_uints = sizeof( T ) / sizeof( uint_t );
   if ( num_uints * sizeof( uint_t ) < sizeof( T ) )
@@ -763,7 +764,7 @@ void
 input_stream( T d, std::vector< uint_t >::iterator& pos )
 {
   memcpy( &( *pos ), &d, sizeof( d ) );
-  pos += number_of_uints_covered( d );
+  pos += number_of_uints_covered< T >();
 }
 
 template < typename T >
@@ -771,7 +772,7 @@ void
 output_stream( T& d, std::vector< uint_t >::iterator& pos )
 {
   memcpy( &d, &( *pos ), sizeof( d ) );
-  pos += number_of_uints_covered( d );
+  pos += number_of_uints_covered< T >();
 }
 
 /**
@@ -859,15 +860,14 @@ public:
    */
   std::vector< uint_t >::iterator& operator<<( std::vector< uint_t >::iterator& pos )
   {
-    pos += number_of_uints_covered( *( supported_syn_ids_.begin() ) );
+    pos += number_of_uints_covered< synindex >();
     output_stream( sender_gid_, pos );
 
     // generating a copy of the coeffarray is too time consuming
     // therefore we save an iterator to the beginning+end of the coeffarray
     coeffarray_as_uints_begin_ = pos;
 
-    double_t elem = 0.0;
-    pos += coeff_length_ * number_of_uints_covered( elem );
+    pos += coeff_length_ * number_of_uints_covered< double_t >();
 
     coeffarray_as_uints_end_ = pos;
 
@@ -896,10 +896,9 @@ public:
   size_t
   size()
   {
-    size_t s = number_of_uints_covered( sender_gid_ )
-      + number_of_uints_covered( *( supported_syn_ids_.begin() ) );
-    double_t elem = 0.0;
-    s += number_of_uints_covered( elem ) * coeff_length_;
+    size_t s = number_of_uints_covered< synindex >();
+    s += number_of_uints_covered< index >();
+    s += number_of_uints_covered< double_t >() * coeff_length_;
 
     return s;
   }
@@ -932,8 +931,7 @@ GapJunctionEvent::get_value( const std::vector< uint_t >::iterator& pos )
 inline void
 GapJunctionEvent::next( std::vector< uint_t >::iterator& pos )
 {
-  double_t elem = 0.0;
-  pos += number_of_uints_covered( elem );
+  pos += number_of_uints_covered< double_t >();
 }
 
 inline GapJunctionEvent*

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -74,7 +74,7 @@ public:
    */
   port send_test_event( Node&, rport, synindex, bool );
 
-  void sends_secondary_event( GapJEvent& ge );
+  void sends_secondary_event( GapJunctionEvent& ge );
 
   Node const& get_prototype() const;
 
@@ -189,7 +189,7 @@ GenericModel< ElementT >::send_test_event( Node& target,
 
 template < typename ElementT >
 inline void
-GenericModel< ElementT >::sends_secondary_event( GapJEvent& ge )
+GenericModel< ElementT >::sends_secondary_event( GapJunctionEvent& ge )
 {
   return proto_.sends_secondary_event( ge );
 }

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -147,7 +147,7 @@ public:
 
   virtual port send_test_event( Node&, rport, synindex, bool ) = 0;
 
-  virtual void sends_secondary_event( GapJEvent& ge ) = 0;
+  virtual void sends_secondary_event( GapJunctionEvent& ge ) = 0;
 
   /**
    * Return the size of the prototype.

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -307,20 +307,20 @@ Node::handles_test_event( DSCurrentEvent&, rport )
 }
 
 void
-Node::handle( GapJEvent& )
+Node::handle( GapJunctionEvent& )
 {
   throw UnexpectedEvent();
 }
 
 port
-Node::handles_test_event( GapJEvent&, rport )
+Node::handles_test_event( GapJunctionEvent&, rport )
 {
   throw IllegalConnection();
   return invalid_port_;
 }
 
 void
-Node::sends_secondary_event( GapJEvent& )
+Node::sends_secondary_event( GapJunctionEvent& )
 {
   throw IllegalConnection();
 }

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -322,7 +322,7 @@ public:
 
   /**
    * Bring the node from state $t$ to $t+n*dt$, sends SecondaryEvents
-   * (e.g. GapJEvent) and resets state variables to values at $t$.
+   * (e.g. GapJunctionEvent) and resets state variables to values at $t$.
    *
    * n->prelim_update(T, from, to) performs the update steps beginning
    * at T+from .. T+to-1.
@@ -425,7 +425,7 @@ public:
   virtual port handles_test_event( DoubleDataEvent&, rport receptor_type );
   virtual port handles_test_event( DSSpikeEvent&, rport receptor_type );
   virtual port handles_test_event( DSCurrentEvent&, rport receptor_type );
-  virtual port handles_test_event( GapJEvent&, rport receptor_type );
+  virtual port handles_test_event( GapJunctionEvent&, rport receptor_type );
 
   /**
    * Required to check, if source neuron may send a SecondaryEvent.
@@ -434,7 +434,7 @@ public:
    * @ingroup event_interface
    * @throws IllegalConnection
    */
-  virtual void sends_secondary_event( GapJEvent& ge );
+  virtual void sends_secondary_event( GapJunctionEvent& ge );
 
   /**
    * Register a STDP connection
@@ -508,11 +508,11 @@ public:
 
   /**
    * Handler for gap junction events.
-   * @see handle(thread, GapJEvent&)
+   * @see handle(thread, GapJunctionEvent&)
    * @ingroup event_interface
    * @throws UnexpectedEvent
    */
-  virtual void handle( GapJEvent& e );
+  virtual void handle( GapJunctionEvent& e );
 
   /**
    * @defgroup MSP_functions Model of Structural Plasticity in NEST.

--- a/nestkernel/proxynode.cpp
+++ b/nestkernel/proxynode.cpp
@@ -50,7 +50,7 @@ proxynode::send_test_event( Node& target, rport receptor_type, synindex syn_id, 
 }
 
 void
-proxynode::sends_secondary_event( GapJEvent& ge )
+proxynode::sends_secondary_event( GapJunctionEvent& ge )
 {
   network()->get_model( get_model_id() )->sends_secondary_event( ge );
 }

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -73,7 +73,7 @@ public:
 
   port send_test_event( Node&, rport, synindex, bool );
 
-  void sends_secondary_event( GapJEvent& );
+  void sends_secondary_event( GapJunctionEvent& );
 
   void
   handle( SpikeEvent& )

--- a/nestkernel/scheduler.cpp
+++ b/nestkernel/scheduler.cpp
@@ -315,17 +315,13 @@ nest::Scheduler::configure_spike_buffers_()
   // insert the end marker for payload event (==invalid_synindex)
   // and insert the done flag (==true)
   // after min_delay 0's (== comm_marker)
-  // use the streaming operator defined in event.h
-  // because otherwise readout will be incompatible on JUQUEEN
+  // use the template functions defined in event.h
   // this only needs to be done for one process, because displacements is set to 0
   // so all processes initially read out the same positions in the
   // global spike buffer
   std::vector< uint_t >::iterator pos = global_grid_spikes_.begin() + n_threads_ * min_delay_;
-  input_stream( invalid_synindex, pos );
-  input_stream( true, pos );
-  // the following line fails on JUQUEEN, because
-  // the way of reading out by streaming operators in deliver_events differs
-  // global_grid_spikes_[n_threads_*min_delay_] = static_cast<uint_t>( invalid_synindex );
+  write_to_comm_buffer( invalid_synindex, pos );
+  write_to_comm_buffer( true, pos );
 
   global_offgrid_spikes_.clear();
   global_offgrid_spikes_.resize( recv_buffer_size, OffGridSpike( 0, 0.0 ) );
@@ -1545,9 +1541,9 @@ nest::Scheduler::collocate_buffers_( bool done )
 
     // end marker after last secondary event
     // made sure in resize that this position is still allocated
-    input_stream( invalid_synindex, pos );
+    write_to_comm_buffer( invalid_synindex, pos );
     // append the boolean value indicating whether we are done here
-    input_stream( done, pos );
+    write_to_comm_buffer( done, pos );
   }
   else // off_grid_spiking
   {
@@ -1669,7 +1665,7 @@ nest::Scheduler::deliver_events_( thread t )
         // the encoding will be different on JUQUEEN for the
         // index written into the buffer and read out of it
         synindex synid;
-        output_stream( synid, readpos );
+        read_from_comm_buffer( synid, readpos );
 
         if ( synid == invalid_synindex )
           break;
@@ -1688,7 +1684,7 @@ nest::Scheduler::deliver_events_( thread t )
       // must be a bool (same type as on the sending side)
       // otherwise the encoding will be inconsistent on JUQUEEN
       bool done_p;
-      output_stream( done_p, readpos );
+      read_from_comm_buffer( done_p, readpos );
       done = done && done_p;
     }
   }

--- a/nestkernel/scheduler.cpp
+++ b/nestkernel/scheduler.cpp
@@ -636,7 +636,7 @@ nest::Scheduler::update()
             for ( size_t i = 0; i < done.size(); i++ )
               done_all = done[ i ] && done_all;
 
-            // gather SecondaryEvents (e.g. GapJEvents)
+            // gather SecondaryEvents (e.g. GapJunctionEvents)
             gather_events_( done_all );
 
             // reset done and done_all
@@ -1661,7 +1661,7 @@ nest::Scheduler::deliver_events_( thread t )
 
     for ( size_t pid = 0; pid < ( size_t ) Communicator::get_num_processes(); ++pid )
     {
-      fwit readpos = global_grid_spikes_.begin() + pos[ pid ];
+      std::vector< uint_t >::iterator readpos = global_grid_spikes_.begin() + pos[ pid ];
 
       while ( true )
       {

--- a/nestkernel/scheduler.h
+++ b/nestkernel/scheduler.h
@@ -869,7 +869,7 @@ Scheduler::send_remote( thread t, SecondaryEvent& e )
   size_t old_size = secondary_events_buffer_[ t ].size();
 
   secondary_events_buffer_[ t ].resize( old_size + e.size() );
-  fwit it = secondary_events_buffer_[ t ].begin() + old_size;
+  std::vector< uint_t >::iterator it = secondary_events_buffer_[ t ].begin() + old_size;
   e >> it;
 }
 


### PR DESCRIPTION
This PR fixes #181 by removing the `CoeffArrayIterator` and replacing it by suitable `std::vector` iterators in `GapJEvent`.

There is however still an ongoing discussion in the issue #181, further actions might be required.