### PR TITLE
Solve path problems with imports on Python 3.5

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -50,7 +50,7 @@ except:
 
 
 from . import pynestkernel as _kernel
-import lib.hl_api_helper as hl_api
+import nest.lib.hl_api_helper as hl_api
 
 engine = _kernel.NESTEngine()
 
@@ -174,7 +174,7 @@ def test():
     hl_api.set_debug(debug)
 
 from .pynestkernel import *
-from lib.hl_api_helper import *
+from nest.lib.hl_api_helper import *
 
 # We search through the subdirectory "lib" of the "nest" module
 # directory and import the content of all Python files therein into
@@ -182,7 +182,7 @@ from lib.hl_api_helper import *
 # and those of extra modules available to the user.
 for name in os.listdir(os.path.join(os.path.dirname(__file__), "lib")):
     if name.endswith(".py") and not name.startswith('__'):
-        exec("from lib.{0} import *".format(name[:-3]))
+        exec("from nest.lib.{0} import *".format(name[:-3]))
 
 if not 'DELAY_PYNEST_INIT' in os.environ:
     init(sys.argv)

--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -22,31 +22,31 @@
 import unittest
 import nest
 
-from . import compatibility
+from nest.tests import compatibility
 
-from . import test_errors
-from . import test_stack
-from . import test_create
-from . import test_status
-from . import test_onetooneconnect
-from . import test_convergent_divergent_connect
-from . import test_connect_all_to_all
-from . import test_connect_fixed_indegree
-from . import test_connect_fixed_outdegree
-from . import test_connect_fixed_total_number
-from . import test_connect_one_to_one
-from . import test_connect_pairwise_bernoulli
-from . import test_findconnections
-from . import test_getconnections
-from . import test_dataconnect
-from . import test_events
-from . import test_networks
-from . import test_threads
-from . import test_csa
-from . import test_quantal_stp_synapse
-from . import test_sp
-from . import test_parrot_neuron
-from . import test_stdp_triplet_synapse
+from nest.tests import test_errors
+from nest.tests import test_stack
+from nest.tests import test_create
+from nest.tests import test_status
+from nest.tests import test_onetooneconnect
+from nest.tests import test_convergent_divergent_connect
+from nest.tests import test_connect_all_to_all
+from nest.tests import test_connect_fixed_indegree
+from nest.tests import test_connect_fixed_outdegree
+from nest.tests import test_connect_fixed_total_number
+from nest.tests import test_connect_one_to_one
+from nest.tests import test_connect_pairwise_bernoulli
+from nest.tests import test_findconnections
+from nest.tests import test_getconnections
+from nest.tests import test_dataconnect
+from nest.tests import test_events
+from nest.tests import test_networks
+from nest.tests import test_threads
+from nest.tests import test_csa
+from nest.tests import test_quantal_stp_synapse
+from nest.tests import test_sp
+from nest.tests import test_parrot_neuron
+from nest.tests import test_stdp_triplet_synapse
 
 
 def suite():
@@ -55,7 +55,7 @@ def suite():
 
     suite.addTest(test_errors.suite())
     suite.addTest(test_stack.suite())
-    suite.addTest(test_create.suite())                    
+    suite.addTest(test_create.suite())
     suite.addTest(test_status.suite())
     suite.addTest(test_onetooneconnect.suite())
     suite.addTest(test_convergent_divergent_connect.suite())
@@ -65,17 +65,17 @@ def suite():
     suite.addTest(test_connect_fixed_total_number.suite())
     suite.addTest(test_connect_one_to_one.suite())
     suite.addTest(test_connect_pairwise_bernoulli.suite())
-    suite.addTest(test_findconnections.suite())    
+    suite.addTest(test_findconnections.suite())
     suite.addTest(test_getconnections.suite())
     suite.addTest(test_dataconnect.suite())
     suite.addTest(test_events.suite())
     suite.addTest(test_networks.suite())
-    suite.addTest(test_threads.suite())    
+    suite.addTest(test_threads.suite())
     suite.addTest(test_csa.suite())
     suite.addTest(test_quantal_stp_synapse.suite())
     suite.addTest(test_sp.suite())
     suite.addTest(test_parrot_neuron.suite())
-    suite.addTest(test_stdp_triplet_synapse.suite())    
+    suite.addTest(test_stdp_triplet_synapse.suite())
 
     return suite
 

--- a/pynest/nest/tests/test_sp/__init__.py
+++ b/pynest/nest/tests/test_sp/__init__.py
@@ -20,6 +20,6 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 __author__ = 'naveau'
 
-from . import test_all
+from nest.tests.test_sp import test_all
 
 suite = test_all.suite

--- a/pynest/nest/tests/test_sp/test_all.py
+++ b/pynest/nest/tests/test_sp/test_all.py
@@ -23,12 +23,12 @@ __author__ = 'naveau'
 import unittest
 import nest
 
-from . import test_synaptic_elements
-from . import test_conn_builder
-from . import test_growth_curves
-from . import test_sp_manager
-from . import test_disconnect
-from . import test_disconnect_multiple
+from nest.tests.test_sp import test_synaptic_elements
+from nest.tests.test_sp import test_conn_builder
+from nest.tests.test_sp import test_growth_curves
+from nest.tests.test_sp import test_sp_manager
+from nest.tests.test_sp import test_disconnect
+from nest.tests.test_sp import test_disconnect_multiple
 
 
 def suite():

--- a/pynest/nest/tests/test_sp/test_conn_builder.py
+++ b/pynest/nest/tests/test_sp/test_conn_builder.py
@@ -77,7 +77,7 @@ class TestSPBuilder(unittest.TestCase):
             try:
                 nest.Connect(neurons, neurons, conn_dict, syn_dict)
             except nest.NESTError as e:
-                self.assertRegexpMatches(e.message, 'This connection rule is not implemented for structural plasticity')
+                self.assertRegexpMatches(str(e), 'This connection rule is not implemented for structural plasticity')
 
 
 def suite():

--- a/pynest/nest/tests/test_sp/test_sp_manager.py
+++ b/pynest/nest/tests/test_sp/test_sp_manager.py
@@ -22,15 +22,15 @@ __author__ = 'naveau'
 
 import nest
 import unittest
-from .utils import extract_dict_a_from_b
+from nest.tests.test_sp.utils import extract_dict_a_from_b
 
 
 class TestStructuralPlasticityManager(unittest.TestCase):
     def setUp(self):
         nest.ResetKernel()
         nest.set_verbosity('M_INFO')
-        self.exclude_synapse_model = ['stdp_dopamine_synapse', 'stdp_dopamine_synapse_lbl', 
-                                      'stdp_dopamine_synapse_hpc', 'stdp_dopamine_synapse_hpc_lbl', 
+        self.exclude_synapse_model = ['stdp_dopamine_synapse', 'stdp_dopamine_synapse_lbl',
+                                      'stdp_dopamine_synapse_hpc', 'stdp_dopamine_synapse_hpc_lbl',
                                       'gap_junction', 'gap_junction_lbl']
 
     def test_register_synapses(self):
@@ -83,7 +83,7 @@ class TestStructuralPlasticityManager(unittest.TestCase):
 
                 self.assertEqual(20, len(nest.GetConnections(neurons, neurons, syn_model)))
                 break
-    
+
 
 def suite():
     test_suite = unittest.makeSuite(TestStructuralPlasticityManager, 'test')


### PR DESCRIPTION
All tests are passing when I run from Python 3.5:

```
import nest
nest.test()
```

Would be nice to have travis testing nest against Python 3 also, so this kind of regression doesn't happen.