### PR TITLE
fix for "python -c 'import nest'" readline issues with Anaconda Python

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -23,7 +23,13 @@
 Initializer of PyNEST.
 """
 
-import sys, os, readline
+import sys, os
+
+# This is a workaround for readline import errors encountered with Anaconda
+# Python running on Ubuntu, when invoked from the terminal
+# "python -c 'import nest'"
+if 'linux' in sys.platform and 'Anaconda' in sys.version:
+    import readline
 
 # This is a workaround to avoid segmentation faults when importing
 # scipy *after* nest. See https://github.com/numpy/numpy/issues/2521

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -23,7 +23,7 @@
 Initializer of PyNEST.
 """
 
-import sys, os
+import sys, os, readline
 
 # This is a workaround to avoid segmentation faults when importing
 # scipy *after* nest. See https://github.com/numpy/numpy/issues/2521


### PR DESCRIPTION
importing nest with Anaconda Python may be broken for some due to some mismatch between the system and Anaconda-provided readline library files, such that importing nest in a running python interpreter would work, while "python -c 'import nest'" would not. Importing readline before pynestkernel takes care of that.