### PR TITLE
Replacing internal C++ variable U0_ by E_L.

### DIFF
--- a/examples/nest/brunel-2000.sli
+++ b/examples/nest/brunel-2000.sli
@@ -144,7 +144,7 @@ def
 /CMem    1.0 def    % membrane capacity [pF]
 /tauSyn  0.5 def    % synaptic time constant [ms]
 /tauRef  2.0 def    % refractory time [ms]
-/U0      0.0 def    % resting potential [mV]
+/E_L     0.0 def    % resting potential [mV]
 /theta  20.0 def    % threshold
 
 
@@ -212,8 +212,8 @@ statusdict/userargs :: size 1 geq
           /tau_syn_ex  tauSyn
           /tau_syn_in  tauSyn
           /t_ref       tauRef
-          /E_L     U0
-          /V_m     U0
+          /E_L     E_L
+          /V_m     E_L
           /V_th    theta
           /V_reset    10.0 % according to Brunel (2000) p 185
           /C_m     1.0     % Yes, capacitance is 1 in the Brunel model

--- a/examples/nest/brunel-2000_newconnect.sli
+++ b/examples/nest/brunel-2000_newconnect.sli
@@ -143,7 +143,7 @@ def
 /CMem    1.0 def    % membrane capacity [pF]
 /tauSyn  0.5 def    % synaptic time constant [ms]
 /tauRef  2.0 def    % refractory time [ms]
-/U0      0.0 def    % resting potential [mV]
+/E_L     0.0 def    % resting potential [mV]
 /theta  20.0 def    % threshold
 
 
@@ -211,8 +211,8 @@ statusdict/userargs :: size 1 geq
           /tau_syn_ex  tauSyn
           /tau_syn_in  tauSyn
           /t_ref       tauRef
-          /E_L     U0
-          /V_m     U0
+          /E_L     E_L
+          /V_m     E_L
           /V_th    theta
           /V_reset    10.0 % according to Brunel (2000) p 185
           /C_m     1.0     % Yes, capacitance is 1 in the Brunel model

--- a/examples/nest/brunel-2000_newconnect_dc.sli
+++ b/examples/nest/brunel-2000_newconnect_dc.sli
@@ -149,7 +149,7 @@ def
 /CMem    1.0 def    % membrane capacity [pF]
 /tauSyn  0.5 def    % synaptic time constant [ms]
 /tauRef  2.0 def    % refractory time [ms]
-/U0      0.0 def    % resting potential [mV]
+/E_L     0.0 def    % resting potential [mV]
 /theta  20.0 def    % threshold
 
 /u0_min  -0.5 theta mul def    % Initial membrane potential
@@ -226,8 +226,8 @@ statusdict/userargs :: size 1 geq
           /tau_syn_ex  tauSyn
           /tau_syn_in  tauSyn
           /t_ref       tauRef
-          /E_L     U0
-          /V_m     U0
+          /E_L     E_L
+          /V_m     E_L
           /V_th    theta
           /V_reset    10.0 % according to Brunel (2000) p 185
           /C_m     1.0     % Yes, capacitance is 1 in the Brunel model

--- a/examples/nest/brunel-sli_connect.sli
+++ b/examples/nest/brunel-sli_connect.sli
@@ -168,7 +168,7 @@ def
 /CMem    1.0 def    % membrane capacity [pF]
 /tauSyn  0.5 def    % synaptic time constant [ms]
 /tauRef  2.0 def    % refractory time [ms]
-/U0      0.0 def    % resting potential [mV]
+/E_L     0.0 def    % resting potential [mV]
 /theta  20.0 def    % threshold
 
 
@@ -218,8 +218,8 @@ M_WARNING setverbosity
           /tau_syn_ex  tauSyn
           /tau_syn_in  tauSyn
           /t_ref       tauRef
-          /E_L     U0
-          /V_m     U0
+          /E_L     E_L
+          /V_m     E_L
           /V_th    theta
           /V_reset    10.0 % according to Brunel (2000) p 185
           /C_m     1.0     % Yes, capacitance is 1 in the Brunel model

--- a/examples/nest/brunel-sli_neuron.sli
+++ b/examples/nest/brunel-sli_neuron.sli
@@ -117,7 +117,7 @@ def
   /tauMem 20.0 def    % neuron membrane time constant [ms]
   /tauSyn  0.5 def    % synaptic time constant [ms]
   /tauRef  2.0 def    % refractory time [ms]
-  /U0      0.0 def    % resting potential [mV]
+  /E_L     0.0 def    % resting potential [mV]
   /theta  20.0 def    % threshold
 
   % synaptic weights, scaled for our alpha functions, such that
@@ -154,13 +154,13 @@ def
    /tau_m       tauMem def
    /tau_syn     tauSyn def
    /t_ref       tauRef def
-   /E_L         U0 def
+   /E_L         E_L def
    /V_th        theta def
    /C_m         1.0  def % Yes, capacitance is 1 in the Brunel model
    /t_spike      -1.0 def
-   /V_m           U0 def
-   /V_reset       U0 def
-   /V_th         U0 theta add def
+   /V_m           E_L def
+   /V_reset       E_L def
+   /V_th         E_L theta add def
    /theta        theta def
    /currents      0.0 def
 

--- a/examples/nest/brunel_ps.sli
+++ b/examples/nest/brunel_ps.sli
@@ -145,7 +145,7 @@ def
 /CMem  250.0 def    % membrane capacity [pF]
 /tauSyn  0.5 def    % synaptic time constant [ms]
 /tauRef  2.0 def    % refractory time [ms]
-/U0      0.0 def    % resting potential [mV]
+/E_L     0.0 def    % resting potential [mV]
 /theta  20.0 def    % threshold
 
 
@@ -269,10 +269,10 @@ tic % start timer on construction
       /C_m     CMem
       /tau_syn tauSyn
       /t_ref   tauRef
-      /E_L     U0
+      /E_L     E_L
       /V_th    theta
-      /V_m     U0
-      /V_reset U0
+      /V_m     E_L
+      /V_reset E_L
       /C_m     1.0     % capacitance is unity in Brunel model
     >> SetStatus
 

--- a/examples/nest/tsodyks2_shortterm_bursts.sli
+++ b/examples/nest/tsodyks2_shortterm_bursts.sli
@@ -134,8 +134,8 @@ ResetKernel      % clear all existing network elements
             /tau_m   Tau
             /tau_syn_ex  Tau_psc
             /tau_syn_in  Tau_psc
-            /E_L     U0
-            /V_m     U0
+            /E_L     E_L
+            /V_m     E_L
             /V_reset Vreset
             /V_th    Theta
             /C_m     C
@@ -160,8 +160,8 @@ ResetKernel      % clear all existing network elements
                 /tau_m    Tau
                 /tau_syn_ex   Tau_psc
                 /tau_syn_in   Tau_psc
-                /E_L      U0
-                /V_m      U0
+                /E_L      E_L
+                /V_m      E_L
                 /V_reset  Vreset
                 /V_th     Theta
                 /C_m      C
@@ -471,7 +471,7 @@ userdict begin
 
       % excitatory neurons
       /Tau 30.0 def             % membrane time constant of ex./inh. neurons in ms
-      /U0 0.0 def               % resting potential of Vm for exc./inh.
+      /E_L 0.0 def              % resting potential of Vm for exc./inh.
       /Theta 15.0 def           % threshold for exc. neuron
       /Vreset 13.5 def          % reset potential of Vm after a spike
       /R 1.0 def                % membrane resistance 1 GOhm

--- a/examples/nest/tsodyks_depressing.sli
+++ b/examples/nest/tsodyks_depressing.sli
@@ -52,7 +52,7 @@ userdict begin
 
       /Tau 40.0 def          % membrane time constant
       /Theta 15.0 def        % threshold
-      /U0 0.0 def            % reset potential of Vm
+      /E_L 0.0 def           % reset potential of Vm
       /R 0.1 def             % 100 M Ohm
       /C Tau R div def       % Tau [ms] / R in NEST units
       /TauR 2.0 def          % refractory time
@@ -98,10 +98,10 @@ userdict begin
                  /tau_syn_ex Tau_psc
                  /tau_syn_in Tau_psc
                  /C_m C
-                 /V_reset U0
-                 /E_L U0
+                 /V_reset E_L
+                 /E_L E_L
                  /V_th Theta
-                 /V_m U0
+                 /V_m E_L
               >> SetStatus
       % neuron1 GetStatus info
 
@@ -112,10 +112,10 @@ userdict begin
                  /tau_syn_ex Tau_psc
                  /tau_syn_in Tau_psc
                  /C_m C
-                 /V_reset U0
-                 /E_L U0
+                 /V_reset E_L
+                 /E_L E_L
                  /V_th Theta
-                 /V_m U0
+                 /V_m E_L
               >> SetStatus
       % neuron2 GetStatus info
 

--- a/examples/nest/tsodyks_facilitating.sli
+++ b/examples/nest/tsodyks_facilitating.sli
@@ -52,7 +52,7 @@ userdict begin
 
       /Tau 60.0 def          % membrane time constant
       /Theta 15.0 def        % threshold
-      /U0 0.0 def            % reset potential of Vm
+      /E_L 0.0 def           % reset potential of Vm
       /R 1.0 def             % mambrane resistance in GOhm
       /C Tau R div def       % Tau [ms] / 1.0 GOhm in NEST units
       /TauR 2.0 def          % refractory time
@@ -100,9 +100,9 @@ userdict begin
                  /tau_syn_ex Tau_psc
                  /tau_syn_in Tau_psc
                  /C_m C
-                 /V_reset U0
-                 /E_L U0
-                 /V_m U0
+                 /V_reset E_L
+                 /E_L E_L
+                 /V_m E_L
                  /V_th Theta
       >> SetStatus
 
@@ -115,9 +115,9 @@ userdict begin
                  /tau_syn_ex Tau_psc
                  /tau_syn_in Tau_psc
                  /C_m C
-                 /V_reset U0
-                 /E_L U0
-                 /V_m U0
+                 /V_reset E_L
+                 /E_L E_L
+                 /V_m E_L
                  /V_th Theta
       >> SetStatus
 

--- a/examples/nest/tsodyks_shortterm_bursts.sli
+++ b/examples/nest/tsodyks_shortterm_bursts.sli
@@ -137,8 +137,8 @@ ResetKernel      % clear all existing network elements
             /tau_m   Tau
             /tau_syn_ex  Tau_psc
             /tau_syn_in  Tau_psc
-            /E_L     U0
-            /V_m     U0
+            /E_L     E_L
+            /V_m     E_L
             /V_reset Vreset
             /V_th    Theta
             /C_m     C
@@ -163,8 +163,8 @@ ResetKernel      % clear all existing network elements
                 /tau_m    Tau
                 /tau_syn_ex   Tau_psc
                 /tau_syn_in   Tau_psc
-                /E_L      U0
-                /V_m      U0
+                /E_L      E_L
+                /V_m      E_L
                 /V_reset  Vreset
                 /V_th     Theta
                 /C_m      C
@@ -473,7 +473,7 @@ userdict begin
 
       % excitatory neurons
       /Tau 30.0 def             % membrane time constant of ex./inh. neurons in ms
-      /U0 0.0 def               % resting potential of Vm for exc./inh.
+      /E_L 0.0 def              % resting potential of Vm for exc./inh.
       /Theta 15.0 def           % threshold for exc. neuron
       /Vreset 13.5 def          % reset potential of Vm after a spike
       /R 1.0 def                % membrane resistance 1 GOhm

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -70,7 +70,7 @@ nest::amat2_psc_exp::Parameters_::Parameters_()
   : Tau_( 10.0 )     // in ms
   , C_( 200.0 )      // in pF (R=50MOhm)
   , tau_ref_( 2.0 )  // in ms
-  , E_L_( -70.0 )     // in mV
+  , E_L_( -70.0 )    // in mV
   , I_e_( 0.0 )      // in pA
   , tau_ex_( 1.0 )   // in ms
   , tau_in_( 3.0 )   // in ms

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -70,7 +70,7 @@ nest::amat2_psc_exp::Parameters_::Parameters_()
   : Tau_( 10.0 )     // in ms
   , C_( 200.0 )      // in pF (R=50MOhm)
   , tau_ref_( 2.0 )  // in ms
-  , U0_( -70.0 )     // in mV
+  , E_L_( -70.0 )     // in mV
   , I_e_( 0.0 )      // in pA
   , tau_ex_( 1.0 )   // in ms
   , tau_in_( 3.0 )   // in ms
@@ -80,7 +80,7 @@ nest::amat2_psc_exp::Parameters_::Parameters_()
   , alpha_2_( 0.0 )  // in mV
   , beta_( 0.0 )     // in mV
   , tau_v_( 5.0 )    // in ms
-  , omega_( 5.0 )    // resting threshold relative to U0_ in mV
+  , omega_( 5.0 )    // resting threshold relative to E_L_ in mV
                      // state V_th_ is initialized with the
                      // same value
 {
@@ -106,7 +106,7 @@ nest::amat2_psc_exp::State_::State_()
 void
 nest::amat2_psc_exp::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // Resting potential
+  def< double >( d, names::E_L, E_L_ ); // Resting potential
   def< double >( d, names::I_e, I_e_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
@@ -119,16 +119,16 @@ nest::amat2_psc_exp::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::alpha_2, alpha_2_ );
   def< double >( d, names::beta, beta_ );
   def< double >( d, names::tau_v, tau_v_ );
-  def< double >( d, names::omega, omega_ + U0_ );
+  def< double >( d, names::omega, omega_ + E_L_ );
 }
 
 double
 nest::amat2_psc_exp::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   updateValue< double >( d, names::I_e, I_e_ );
   updateValue< double >( d, names::C_m, C_ );
@@ -144,7 +144,7 @@ nest::amat2_psc_exp::Parameters_::set( const DictionaryDatum& d )
   updateValue< double >( d, names::tau_v, tau_v_ );
 
   if ( updateValue< double >( d, names::omega, omega_ ) )
-    omega_ -= U0_;
+    omega_ -= E_L_;
   else
     omega_ -= delta_EL;
 
@@ -171,9 +171,9 @@ nest::amat2_psc_exp::Parameters_::set( const DictionaryDatum& d )
 void
 nest::amat2_psc_exp::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, V_m_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, V_m_ + p.E_L_ ); // Membrane potential
   def< double >(
-    d, names::V_th, p.U0_ + p.omega_ + V_th_1_ + V_th_2_ + V_th_v_ ); // Adaptive threshold
+    d, names::V_th, p.E_L_ + p.omega_ + V_th_1_ + V_th_2_ + V_th_v_ ); // Adaptive threshold
   def< double >( d, names::V_th_alpha_1, V_th_1_ );
   def< double >( d, names::V_th_alpha_2, V_th_2_ );
   def< double >( d, names::V_th_v, V_th_v_ );
@@ -183,7 +183,7 @@ void
 nest::amat2_psc_exp::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, V_m_ ) )
-    V_m_ -= p.U0_;
+    V_m_ -= p.E_L_;
   else
     V_m_ -= delta_EL;
 

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -192,7 +192,7 @@ private:
     double_t tau_ref_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
@@ -219,7 +219,7 @@ private:
 
     /** Resting threshold in mV
         (relative to resting potential).
-        The real resting threshold is (U0_+omega_).
+        The real resting threshold is (E_L_+omega_).
         Called omega in [3]. */
     double_t omega_;
 
@@ -327,12 +327,12 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.V_m_ + P_.U0_;
+    return S_.V_m_ + P_.E_L_;
   }
   double_t
   get_V_th_() const
   {
-    return P_.U0_ + P_.omega_ + S_.V_th_1_ + S_.V_th_2_ + S_.V_th_v_;
+    return P_.E_L_ + P_.omega_ + S_.V_th_1_ + S_.V_th_2_ + S_.V_th_v_;
   }
   double_t
   get_V_th_v_() const

--- a/models/iaf_neuron.cpp
+++ b/models/iaf_neuron.cpp
@@ -69,9 +69,9 @@ nest::iaf_neuron::Parameters_::Parameters_()
   , Tau_( 10.0 )            // ms
   , tau_syn_( 2.0 )         // ms
   , TauR_( 2.0 )            // ms
-  , U0_( -70.0 )            // mV
-  , V_reset_( -70.0 - U0_ ) // mV, rel to U0_
-  , Theta_( -55.0 - U0_ )   // mV, rel to U0_
+  , E_L_( -70.0 )            // mV
+  , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
+  , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
   , I_e_( 0.0 )             // pA
 {
 }
@@ -92,10 +92,10 @@ nest::iaf_neuron::State_::State_()
 void
 nest::iaf_neuron::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // Resting potential
+  def< double >( d, names::E_L, E_L_ ); // Resting potential
   def< double >( d, names::I_e, I_e_ );
-  def< double >( d, names::V_th, Theta_ + U0_ ); // threshold value
-  def< double >( d, names::V_reset, V_reset_ + U0_ );
+  def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+  def< double >( d, names::V_reset, V_reset_ + E_L_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
   def< double >( d, names::tau_syn, tau_syn_ );
@@ -105,20 +105,20 @@ nest::iaf_neuron::Parameters_::get( DictionaryDatum& d ) const
 double
 nest::iaf_neuron::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
-    V_reset_ -= U0_; // here we use the new U0_, no need for adjustments
+    V_reset_ -= E_L_; // here we use the new E_L_, no need for adjustments
   else
-    V_reset_ -= delta_EL; // express relative to new U0_
+    V_reset_ -= delta_EL; // express relative to new E_L_
 
   if ( updateValue< double >( d, names::V_th, Theta_ ) )
-    Theta_ -= U0_;
+    Theta_ -= E_L_;
   else
-    Theta_ -= delta_EL; // express relative to new U0_
+    Theta_ -= delta_EL; // express relative to new E_L_
 
   updateValue< double >( d, names::I_e, I_e_ );
   updateValue< double >( d, names::C_m, C_ );
@@ -141,14 +141,14 @@ nest::iaf_neuron::Parameters_::set( const DictionaryDatum& d )
 void
 nest::iaf_neuron::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, y3_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, y3_ + p.E_L_ ); // Membrane potential
 }
 
 void
 nest::iaf_neuron::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, y3_ ) )
-    y3_ -= p.U0_;
+    y3_ -= p.E_L_;
   else
     y3_ -= delta_EL;
 }

--- a/models/iaf_neuron.cpp
+++ b/models/iaf_neuron.cpp
@@ -65,14 +65,14 @@ RecordablesMap< iaf_neuron >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_neuron::Parameters_::Parameters_()
-  : C_( 250.0 )             // pF
-  , Tau_( 10.0 )            // ms
-  , tau_syn_( 2.0 )         // ms
-  , TauR_( 2.0 )            // ms
+  : C_( 250.0 )              // pF
+  , Tau_( 10.0 )             // ms
+  , tau_syn_( 2.0 )          // ms
+  , TauR_( 2.0 )             // ms
   , E_L_( -70.0 )            // mV
   , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
   , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
-  , I_e_( 0.0 )             // pA
+  , I_e_( 0.0 )              // pA
 {
 }
 

--- a/models/iaf_neuron.h
+++ b/models/iaf_neuron.h
@@ -181,14 +181,14 @@ private:
     double_t TauR_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** Reset value of the membrane potential, in mV.
-        @note Value is relative to resting potential U0_. */
+        @note Value is relative to resting potential E_L_. */
     double_t V_reset_;
 
     /** Threshold in mV.
-        @note Value is relative to resting potential U0_. */
+        @note Value is relative to resting potential E_L_. */
     double_t Theta_;
 
     /** External current in pA */
@@ -277,7 +277,7 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.y3_ + P_.U0_;
+    return S_.y3_ + P_.E_L_;
   }
 
   // ----------------------------------------------------------------

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -69,10 +69,10 @@ iaf_psc_alpha::Parameters_::Parameters_()
   : Tau_( 10.0 )            // ms
   , C_( 250.0 )             // pF
   , TauR_( 2.0 )            // ms
-  , U0_( -70.0 )            // mV
+  , E_L_( -70.0 )            // mV
   , I_e_( 0.0 )             // pA
-  , V_reset_( -70.0 - U0_ ) // mV, rel to U0_
-  , Theta_( -55.0 - U0_ )   // mV, rel to U0_
+  , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
+  , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
   , LowerBound_( -std::numeric_limits< double_t >::infinity() )
   , tau_ex_( 2.0 ) // ms
   , tau_in_( 2.0 ) // ms
@@ -97,11 +97,11 @@ iaf_psc_alpha::State_::State_()
 void
 iaf_psc_alpha::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // Resting potential
+  def< double >( d, names::E_L, E_L_ ); // Resting potential
   def< double >( d, names::I_e, I_e_ );
-  def< double >( d, names::V_th, Theta_ + U0_ ); // threshold value
-  def< double >( d, names::V_reset, V_reset_ + U0_ );
-  def< double >( d, names::V_min, LowerBound_ + U0_ );
+  def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+  def< double >( d, names::V_reset, V_reset_ + E_L_ );
+  def< double >( d, names::V_min, LowerBound_ + E_L_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
   def< double >( d, names::t_ref, TauR_ );
@@ -112,23 +112,23 @@ iaf_psc_alpha::Parameters_::get( DictionaryDatum& d ) const
 double
 iaf_psc_alpha::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
-    V_reset_ -= U0_;
+    V_reset_ -= E_L_;
   else
     V_reset_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_th, Theta_ ) )
-    Theta_ -= U0_;
+    Theta_ -= E_L_;
   else
     Theta_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_min, LowerBound_ ) )
-    LowerBound_ -= U0_;
+    LowerBound_ -= E_L_;
   else
     LowerBound_ -= delta_EL;
 
@@ -160,14 +160,14 @@ iaf_psc_alpha::Parameters_::set( const DictionaryDatum& d )
 void
 iaf_psc_alpha::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, y3_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, y3_ + p.E_L_ ); // Membrane potential
 }
 
 void
 iaf_psc_alpha::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, y3_ ) )
-    y3_ -= p.U0_;
+    y3_ -= p.E_L_;
   else
     y3_ -= delta_EL;
 }

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -66,11 +66,11 @@ RecordablesMap< iaf_psc_alpha >::create()
  * ---------------------------------------------------------------- */
 
 iaf_psc_alpha::Parameters_::Parameters_()
-  : Tau_( 10.0 )            // ms
-  , C_( 250.0 )             // pF
-  , TauR_( 2.0 )            // ms
+  : Tau_( 10.0 )             // ms
+  , C_( 250.0 )              // pF
+  , TauR_( 2.0 )             // ms
   , E_L_( -70.0 )            // mV
-  , I_e_( 0.0 )             // pA
+  , I_e_( 0.0 )              // pA
   , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
   , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
   , LowerBound_( -std::numeric_limits< double_t >::infinity() )

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -182,7 +182,7 @@ private:
     double_t TauR_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
@@ -191,11 +191,11 @@ private:
     double_t V_reset_;
 
     /** Threshold, RELATIVE TO RESTING POTENTIAL(!).
-        I.e. the real threshold is (U0_+Theta_). */
+        I.e. the real threshold is (E_L_+Theta_). */
     double_t Theta_;
 
     /** Lower bound, RELATIVE TO RESTING POTENTIAL(!).
-        I.e. the real lower bound is (LowerBound_+U0_). */
+        I.e. the real lower bound is (LowerBound_+E_L_). */
     double_t LowerBound_;
 
     /** Time constant of excitatory synaptic current in ms. */
@@ -294,7 +294,7 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.y3_ + P_.U0_;
+    return S_.y3_ + P_.E_L_;
   }
 
   double_t

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -66,11 +66,11 @@ RecordablesMap< iaf_psc_alpha_multisynapse >::create()
  * ---------------------------------------------------------------- */
 
 iaf_psc_alpha_multisynapse::Parameters_::Parameters_()
-  : Tau_( 10.0 )            // ms
-  , C_( 250.0 )             // pF
-  , TauR_( 2.0 )            // ms
+  : Tau_( 10.0 )             // ms
+  , C_( 250.0 )              // pF
+  , TauR_( 2.0 )             // ms
   , E_L_( -70.0 )            // mV
-  , I_e_( 0.0 )             // pA
+  , I_e_( 0.0 )              // pA
   , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
   , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
   , LowerBound_( -std::numeric_limits< double_t >::infinity() )

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -69,10 +69,10 @@ iaf_psc_alpha_multisynapse::Parameters_::Parameters_()
   : Tau_( 10.0 )            // ms
   , C_( 250.0 )             // pF
   , TauR_( 2.0 )            // ms
-  , U0_( -70.0 )            // mV
+  , E_L_( -70.0 )            // mV
   , I_e_( 0.0 )             // pA
-  , V_reset_( -70.0 - U0_ ) // mV, rel to U0_
-  , Theta_( -55.0 - U0_ )   // mV, rel to U0_
+  , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
+  , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
   , LowerBound_( -std::numeric_limits< double_t >::infinity() )
   , has_connections_( false )
 {
@@ -96,14 +96,14 @@ iaf_psc_alpha_multisynapse::State_::State_()
 void
 iaf_psc_alpha_multisynapse::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // resting potential
+  def< double >( d, names::E_L, E_L_ ); // resting potential
   def< double >( d, names::I_e, I_e_ );
-  def< double >( d, names::V_th, Theta_ + U0_ ); // threshold value
-  def< double >( d, names::V_reset, V_reset_ + U0_ );
+  def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+  def< double >( d, names::V_reset, V_reset_ + E_L_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
   def< double >( d, names::t_ref, TauR_ );
-  def< double >( d, names::V_min, LowerBound_ + U0_ );
+  def< double >( d, names::V_min, LowerBound_ + E_L_ );
   def< int >( d, "n_synapses", num_of_receptors_ );
   def< bool >( d, names::has_connections, has_connections_ );
 
@@ -114,23 +114,23 @@ iaf_psc_alpha_multisynapse::Parameters_::get( DictionaryDatum& d ) const
 double
 iaf_psc_alpha_multisynapse::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
-    V_reset_ -= U0_;
+    V_reset_ -= E_L_;
   else
     V_reset_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_th, Theta_ ) )
-    Theta_ -= U0_;
+    Theta_ -= E_L_;
   else
     Theta_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_min, LowerBound_ ) )
-    LowerBound_ -= U0_;
+    LowerBound_ -= E_L_;
   else
     LowerBound_ -= delta_EL;
 
@@ -173,7 +173,7 @@ iaf_psc_alpha_multisynapse::Parameters_::set( const DictionaryDatum& d )
 void
 iaf_psc_alpha_multisynapse::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, y3_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, y3_ + p.E_L_ ); // Membrane potential
 }
 
 void
@@ -182,7 +182,7 @@ iaf_psc_alpha_multisynapse::State_::set( const DictionaryDatum& d,
   const double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, y3_ ) )
-    y3_ -= p.U0_;
+    y3_ -= p.E_L_;
   else
     y3_ -= delta_EL;
 }

--- a/models/iaf_psc_alpha_multisynapse.h
+++ b/models/iaf_psc_alpha_multisynapse.h
@@ -114,7 +114,7 @@ private:
     double_t TauR_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
@@ -123,7 +123,7 @@ private:
     double_t V_reset_;
 
     /** Threshold, RELATIVE TO RESTING POTENTIAL(!).
-        I.e. the real threshold is (U0_+Theta_). */
+        I.e. the real threshold is (E_L_+Theta_). */
     double_t Theta_;
 
     /** Lower bound, RELATIVE TO RESTING POTENTIAL(!).
@@ -224,7 +224,7 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.y3_ + P_.U0_;
+    return S_.y3_ + P_.E_L_;
   }
   double_t
   get_current_() const

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -70,9 +70,9 @@ nest::iaf_psc_delta::Parameters_::Parameters_()
   , t_ref_( 2.0 )                                     // ms
   , E_L_( -70.0 )                                     // mV
   , I_e_( 0.0 )                                       // pA
-  , V_th_( -55.0 - E_L_ )                             // mV, rel to U0_
-  , V_min_( -std::numeric_limits< double_t >::max() ) // relative U0_-55.0-U0_
-  , V_reset_( -70.0 - E_L_ )                          // mV, rel to U0_
+  , V_th_( -55.0 - E_L_ )                             // mV, rel to E_L_
+  , V_min_( -std::numeric_limits< double_t >::max() ) // relative E_L_-55.0-E_L_
+  , V_reset_( -70.0 - E_L_ )                          // mV, rel to E_L_
   , with_refr_input_( false )
 {
 }
@@ -106,7 +106,7 @@ nest::iaf_psc_delta::Parameters_::get( DictionaryDatum& d ) const
 double
 nest::iaf_psc_delta::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
   const double ELold = E_L_;
   updateValue< double >( d, names::E_L, E_L_ );
   const double delta_EL = E_L_ - ELold;

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -184,7 +184,7 @@ private:
     double_t I_e_;
 
     /** Threshold, RELATIVE TO RESTING POTENTAIL(!).
-        I.e. the real threshold is (U0_+V_th_). */
+        I.e. the real threshold is (E_L_+V_th_). */
     double_t V_th_;
 
     /** Lower bound, RELATIVE TO RESTING POTENTAIL(!).

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -69,15 +69,15 @@ RecordablesMap< iaf_psc_exp >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_psc_exp::Parameters_::Parameters_()
-  : Tau_( 10.0 )            // in ms
-  , C_( 250.0 )             // in pF
-  , t_ref_( 2.0 )           // in ms
+  : Tau_( 10.0 )             // in ms
+  , C_( 250.0 )              // in pF
+  , t_ref_( 2.0 )            // in ms
   , E_L_( -70.0 )            // in mV
-  , I_e_( 0.0 )             // in pA
+  , I_e_( 0.0 )              // in pA
   , Theta_( -55.0 - E_L_ )   // relative E_L_
   , V_reset_( -70.0 - E_L_ ) // in mV
-  , tau_ex_( 2.0 )          // in ms
-  , tau_in_( 2.0 )          // in ms
+  , tau_ex_( 2.0 )           // in ms
+  , tau_in_( 2.0 )           // in ms
 {
 }
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -72,10 +72,10 @@ nest::iaf_psc_exp::Parameters_::Parameters_()
   : Tau_( 10.0 )            // in ms
   , C_( 250.0 )             // in pF
   , t_ref_( 2.0 )           // in ms
-  , U0_( -70.0 )            // in mV
+  , E_L_( -70.0 )            // in mV
   , I_e_( 0.0 )             // in pA
-  , Theta_( -55.0 - U0_ )   // relative U0_
-  , V_reset_( -70.0 - U0_ ) // in mV
+  , Theta_( -55.0 - E_L_ )   // relative E_L_
+  , V_reset_( -70.0 - E_L_ ) // in mV
   , tau_ex_( 2.0 )          // in ms
   , tau_in_( 2.0 )          // in ms
 {
@@ -97,10 +97,10 @@ nest::iaf_psc_exp::State_::State_()
 void
 nest::iaf_psc_exp::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // resting potential
+  def< double >( d, names::E_L, E_L_ ); // resting potential
   def< double >( d, names::I_e, I_e_ );
-  def< double >( d, names::V_th, Theta_ + U0_ ); // threshold value
-  def< double >( d, names::V_reset, V_reset_ + U0_ );
+  def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+  def< double >( d, names::V_reset, V_reset_ + E_L_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
   def< double >( d, names::tau_syn_ex, tau_ex_ );
@@ -111,18 +111,18 @@ nest::iaf_psc_exp::Parameters_::get( DictionaryDatum& d ) const
 double
 nest::iaf_psc_exp::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
-    V_reset_ -= U0_;
+    V_reset_ -= E_L_;
   else
     V_reset_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_th, Theta_ ) )
-    Theta_ -= U0_;
+    Theta_ -= E_L_;
   else
     Theta_ -= delta_EL;
 
@@ -151,14 +151,14 @@ nest::iaf_psc_exp::Parameters_::set( const DictionaryDatum& d )
 void
 nest::iaf_psc_exp::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, V_m_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, V_m_ + p.E_L_ ); // Membrane potential
 }
 
 void
 nest::iaf_psc_exp::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, V_m_ ) )
-    V_m_ -= p.U0_;
+    V_m_ -= p.E_L_;
   else
     V_m_ -= delta_EL;
 }

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -178,13 +178,13 @@ private:
     double_t t_ref_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
 
     /** Threshold, RELATIVE TO RESTING POTENTAIL(!).
-        I.e. the real threshold is (U0_+Theta_). */
+        I.e. the real threshold is (E_L_+Theta_). */
     double_t Theta_;
 
     /** reset value of the membrane potential */
@@ -287,7 +287,7 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.V_m_ + P_.U0_;
+    return S_.V_m_ + P_.E_L_;
   }
 
   double_t

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -68,10 +68,10 @@ iaf_psc_exp_multisynapse::Parameters_::Parameters_()
   : Tau_( 10.0 )            // in ms
   , C_( 250.0 )             // in pF
   , t_ref_( 2.0 )           // in ms
-  , U0_( -70.0 )            // in mV
+  , E_L_( -70.0 )            // in mV
   , I_e_( 0.0 )             // in pA
-  , V_reset_( -70.0 - U0_ ) // in mV
-  , Theta_( -55.0 - U0_ )   // relative U0_
+  , V_reset_( -70.0 - E_L_ ) // in mV
+  , Theta_( -55.0 - E_L_ )   // relative E_L_
   , has_connections_( false )
 {
   tau_syn_.clear();
@@ -92,10 +92,10 @@ iaf_psc_exp_multisynapse::State_::State_()
 void
 iaf_psc_exp_multisynapse::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // resting potential
+  def< double >( d, names::E_L, E_L_ ); // resting potential
   def< double >( d, names::I_e, I_e_ );
-  def< double >( d, names::V_th, Theta_ + U0_ ); // threshold value
-  def< double >( d, names::V_reset, V_reset_ + U0_ );
+  def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+  def< double >( d, names::V_reset, V_reset_ + E_L_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
   def< double >( d, names::t_ref, t_ref_ );
@@ -109,18 +109,18 @@ iaf_psc_exp_multisynapse::Parameters_::get( DictionaryDatum& d ) const
 double
 iaf_psc_exp_multisynapse::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
-    V_reset_ -= U0_;
+    V_reset_ -= E_L_;
   else
     V_reset_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_th, Theta_ ) )
-    Theta_ -= U0_;
+    Theta_ -= E_L_;
   else
     Theta_ -= delta_EL;
 
@@ -166,7 +166,7 @@ iaf_psc_exp_multisynapse::Parameters_::set( const DictionaryDatum& d )
 void
 iaf_psc_exp_multisynapse::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, V_m_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, V_m_ + p.E_L_ ); // Membrane potential
 }
 
 void
@@ -175,7 +175,7 @@ iaf_psc_exp_multisynapse::State_::set( const DictionaryDatum& d,
   double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, V_m_ ) )
-    V_m_ -= p.U0_;
+    V_m_ -= p.E_L_;
   else
     V_m_ -= delta_EL;
 }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -65,11 +65,11 @@ RecordablesMap< iaf_psc_exp_multisynapse >::create()
  * ---------------------------------------------------------------- */
 
 iaf_psc_exp_multisynapse::Parameters_::Parameters_()
-  : Tau_( 10.0 )            // in ms
-  , C_( 250.0 )             // in pF
-  , t_ref_( 2.0 )           // in ms
+  : Tau_( 10.0 )             // in ms
+  , C_( 250.0 )              // in pF
+  , t_ref_( 2.0 )            // in ms
   , E_L_( -70.0 )            // in mV
-  , I_e_( 0.0 )             // in pA
+  , I_e_( 0.0 )              // in pA
   , V_reset_( -70.0 - E_L_ ) // in mV
   , Theta_( -55.0 - E_L_ )   // relative E_L_
   , has_connections_( false )

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -110,7 +110,7 @@ private:
     double_t t_ref_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
@@ -119,7 +119,7 @@ private:
     double_t V_reset_;
 
     /** Threshold, RELATIVE TO RESTING POTENTIAL(!).
-        I.e. the real threshold is (U0_+Theta_). */
+        I.e. the real threshold is (E_L_+Theta_). */
     double_t Theta_;
 
     /** Time constants of synaptic currents in ms. */
@@ -218,7 +218,7 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.V_m_ + P_.U0_;
+    return S_.V_m_ + P_.E_L_;
   }
 
   /**

--- a/models/iaf_tum_2000.cpp
+++ b/models/iaf_tum_2000.cpp
@@ -70,10 +70,10 @@ nest::iaf_tum_2000::Parameters_::Parameters_()
   , C_( 250.0 )             // in pF
   , tau_ref_tot_( 2.0 )     // in ms
   , tau_ref_abs_( 2.0 )     // in ms
-  , U0_( -70.0 )            // in mV
+  , E_L_( -70.0 )            // in mV
   , I_e_( 0.0 )             // in pA
-  , Theta_( -55.0 - U0_ )   // relative U0_
-  , V_reset_( -70.0 - U0_ ) // in mV
+  , Theta_( -55.0 - E_L_ )   // relative E_L_
+  , V_reset_( -70.0 - E_L_ ) // in mV
   , tau_ex_( 2.0 )          // in ms
   , tau_in_( 2.0 )          // in ms
 {
@@ -96,10 +96,10 @@ nest::iaf_tum_2000::State_::State_()
 void
 nest::iaf_tum_2000::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // Resting potential
+  def< double >( d, names::E_L, E_L_ ); // Resting potential
   def< double >( d, names::I_e, I_e_ );
-  def< double >( d, names::V_th, Theta_ + U0_ ); // threshold value
-  def< double >( d, names::V_reset, V_reset_ + U0_ );
+  def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+  def< double >( d, names::V_reset, V_reset_ + E_L_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
   def< double >( d, names::tau_syn_ex, tau_ex_ );
@@ -111,18 +111,18 @@ nest::iaf_tum_2000::Parameters_::get( DictionaryDatum& d ) const
 double
 nest::iaf_tum_2000::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
-    V_reset_ -= U0_;
+    V_reset_ -= E_L_;
   else
     V_reset_ -= delta_EL;
 
   if ( updateValue< double >( d, names::V_th, Theta_ ) )
-    Theta_ -= U0_;
+    Theta_ -= E_L_;
   else
     Theta_ -= delta_EL;
 
@@ -153,14 +153,14 @@ nest::iaf_tum_2000::Parameters_::set( const DictionaryDatum& d )
 void
 nest::iaf_tum_2000::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, V_m_ + p.U0_ ); // Membrane potential
+  def< double >( d, names::V_m, V_m_ + p.E_L_ ); // Membrane potential
 }
 
 void
 nest::iaf_tum_2000::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, V_m_ ) )
-    V_m_ -= p.U0_;
+    V_m_ -= p.E_L_;
   else
     V_m_ -= delta_EL;
 }

--- a/models/iaf_tum_2000.cpp
+++ b/models/iaf_tum_2000.cpp
@@ -66,16 +66,16 @@ RecordablesMap< iaf_tum_2000 >::create()
  * ---------------------------------------------------------------- */
 
 nest::iaf_tum_2000::Parameters_::Parameters_()
-  : Tau_( 10.0 )            // in ms
-  , C_( 250.0 )             // in pF
-  , tau_ref_tot_( 2.0 )     // in ms
-  , tau_ref_abs_( 2.0 )     // in ms
+  : Tau_( 10.0 )             // in ms
+  , C_( 250.0 )              // in pF
+  , tau_ref_tot_( 2.0 )      // in ms
+  , tau_ref_abs_( 2.0 )      // in ms
   , E_L_( -70.0 )            // in mV
-  , I_e_( 0.0 )             // in pA
+  , I_e_( 0.0 )              // in pA
   , Theta_( -55.0 - E_L_ )   // relative E_L_
   , V_reset_( -70.0 - E_L_ ) // in mV
-  , tau_ex_( 2.0 )          // in ms
-  , tau_in_( 2.0 )          // in ms
+  , tau_ex_( 2.0 )           // in ms
+  , tau_in_( 2.0 )           // in ms
 {
 }
 

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -184,13 +184,13 @@ private:
     double_t tau_ref_abs_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
 
     /** Threshold, RELATIVE TO RESTING POTENTAIL(!).
-        I.e. the real threshold is (U0_+Theta_). */
+        I.e. the real threshold is (E_L_+Theta_). */
     double_t Theta_;
 
     /** reset value of the membrane potential */

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -69,7 +69,7 @@ nest::mat2_psc_exp::Parameters_::Parameters_()
   : Tau_( 5.0 )      // in ms
   , C_( 100.0 )      // in pF
   , tau_ref_( 2.0 )  // in ms
-  , E_L_( -70.0 )     // in mV
+  , E_L_( -70.0 )    // in mV
   , I_e_( 0.0 )      // in pA
   , tau_ex_( 1.0 )   // in ms
   , tau_in_( 3.0 )   // in ms

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -69,7 +69,7 @@ nest::mat2_psc_exp::Parameters_::Parameters_()
   : Tau_( 5.0 )      // in ms
   , C_( 100.0 )      // in pF
   , tau_ref_( 2.0 )  // in ms
-  , U0_( -70.0 )     // in mV
+  , E_L_( -70.0 )     // in mV
   , I_e_( 0.0 )      // in pA
   , tau_ex_( 1.0 )   // in ms
   , tau_in_( 3.0 )   // in ms
@@ -77,7 +77,7 @@ nest::mat2_psc_exp::Parameters_::Parameters_()
   , tau_2_( 200.0 )  // in ms
   , alpha_1_( 37.0 ) // in mV
   , alpha_2_( 2.0 )  // in mV
-  , omega_( 19.0 )   // resting threshold relative to U0_ in mV
+  , omega_( 19.0 )   // resting threshold relative to E_L_ in mV
                      // state V_th_ is initialized with the
                      // same value
 {
@@ -101,7 +101,7 @@ nest::mat2_psc_exp::State_::State_()
 void
 nest::mat2_psc_exp::Parameters_::get( DictionaryDatum& d ) const
 {
-  def< double >( d, names::E_L, U0_ ); // Resting potential
+  def< double >( d, names::E_L, E_L_ ); // Resting potential
   def< double >( d, names::I_e, I_e_ );
   def< double >( d, names::C_m, C_ );
   def< double >( d, names::tau_m, Tau_ );
@@ -112,16 +112,16 @@ nest::mat2_psc_exp::Parameters_::get( DictionaryDatum& d ) const
   def< double >( d, names::tau_2, tau_2_ );
   def< double >( d, names::alpha_1, alpha_1_ );
   def< double >( d, names::alpha_2, alpha_2_ );
-  def< double >( d, names::omega, omega_ + U0_ );
+  def< double >( d, names::omega, omega_ + E_L_ );
 }
 
 double
 nest::mat2_psc_exp::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
-  const double ELold = U0_;
-  updateValue< double >( d, names::E_L, U0_ );
-  const double delta_EL = U0_ - ELold;
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
+  const double ELold = E_L_;
+  updateValue< double >( d, names::E_L, E_L_ );
+  const double delta_EL = E_L_ - ELold;
 
   updateValue< double >( d, names::I_e, I_e_ );
   updateValue< double >( d, names::C_m, C_ );
@@ -135,7 +135,7 @@ nest::mat2_psc_exp::Parameters_::set( const DictionaryDatum& d )
   updateValue< double >( d, names::alpha_2, alpha_2_ );
 
   if ( updateValue< double >( d, names::omega, omega_ ) )
-    omega_ -= U0_;
+    omega_ -= E_L_;
   else
     omega_ -= delta_EL;
 
@@ -156,8 +156,8 @@ nest::mat2_psc_exp::Parameters_::set( const DictionaryDatum& d )
 void
 nest::mat2_psc_exp::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 {
-  def< double >( d, names::V_m, V_m_ + p.U0_ );                          // Membrane potential
-  def< double >( d, names::V_th, p.U0_ + p.omega_ + V_th_1_ + V_th_2_ ); // Adaptive threshold
+  def< double >( d, names::V_m, V_m_ + p.E_L_ );                          // Membrane potential
+  def< double >( d, names::V_th, p.E_L_ + p.omega_ + V_th_1_ + V_th_2_ ); // Adaptive threshold
   def< double >( d, names::V_th_alpha_1, V_th_1_ );
   def< double >( d, names::V_th_alpha_2, V_th_2_ );
 }
@@ -166,7 +166,7 @@ void
 nest::mat2_psc_exp::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
 {
   if ( updateValue< double >( d, names::V_m, V_m_ ) )
-    V_m_ -= p.U0_;
+    V_m_ -= p.E_L_;
   else
     V_m_ -= delta_EL;
 

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -179,7 +179,7 @@ private:
     double_t tau_ref_;
 
     /** Resting potential in mV. */
-    double_t U0_;
+    double_t E_L_;
 
     /** External current in pA */
     double_t I_e_;
@@ -200,7 +200,7 @@ private:
 
     /** Resting threshold in mV
         (relative to resting potential).
-        The real resting threshold is (U0_+omega_).
+        The real resting threshold is (E_L_+omega_).
         Called omega in [3]. */
     double_t omega_;
 
@@ -299,12 +299,12 @@ private:
   double_t
   get_V_m_() const
   {
-    return S_.V_m_ + P_.U0_;
+    return S_.V_m_ + P_.E_L_;
   }
   double_t
   get_V_th_() const
   {
-    return P_.U0_ + P_.omega_ + S_.V_th_1_ + S_.V_th_2_;
+    return P_.E_L_ + P_.omega_ + S_.V_th_1_ + S_.V_th_2_;
   }
 
   // ----------------------------------------------------------------

--- a/precise/iaf_psc_alpha_canon.cpp
+++ b/precise/iaf_psc_alpha_canon.cpp
@@ -112,7 +112,7 @@ nest::iaf_psc_alpha_canon::Parameters_::get( DictionaryDatum& d ) const
 double
 nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d )
 {
-  // if U0_ is changed, we need to adjust all variables defined relative to U0_
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
   const double ELold = E_L_;
   updateValue< double >( d, names::E_L, E_L_ );
   const double delta_EL = E_L_ - ELold;

--- a/precise/iaf_psc_delta_canon.cpp
+++ b/precise/iaf_psc_delta_canon.cpp
@@ -107,7 +107,7 @@ nest::iaf_psc_delta_canon::Parameters_::get( DictionaryDatum& d ) const
 double
 nest::iaf_psc_delta_canon::Parameters_::set( const DictionaryDatum& d )
 {
-  // if E_L_ is changed, we need to adjust all variables defined relative to U0_
+  // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
   const double ELold = E_L_;
   updateValue< double >( d, names::E_L, E_L_ );
   const double delta_EL = E_L_ - ELold;

--- a/pynest/examples/tsodyks_depressing.py
+++ b/pynest/examples/tsodyks_depressing.py
@@ -54,7 +54,7 @@ neuron and synapse parameters are stored into a dictionary.
 h       = 0.1    # simulation step size (ms)
 Tau     = 40.    # membrane time constant
 Theta   = 15.    # threshold
-U0      = 0.     # reset potential of membrane potential
+E_L     = 0.     # reset potential of membrane potential
 R       = 0.1    # 100 M Ohm
 C       = Tau/R  # Tau (ms)/R in NEST units
 TauR    = 2.     # refractory time
@@ -74,9 +74,9 @@ neuron_param = {"tau_m"    :  Tau,
                "tau_syn_ex":  Tau_psc,
                "tau_syn_in":  Tau_psc,
                "C_m"       :  C,
-               "V_reset"   :  U0,
-               "E_L"       :  U0,
-               "V_m"       :  U0,
+               "V_reset"   :  E_L,
+               "E_L"       :  E_L,
+               "V_m"       :  E_L,
                "V_th"      :  Theta}
 
 syn_param = {"tau_psc" :  Tau_psc,

--- a/pynest/examples/tsodyks_facilitating.py
+++ b/pynest/examples/tsodyks_facilitating.py
@@ -54,7 +54,7 @@ neuron and synapse parameters are stored into a dictionary.
 h       = 0.1    # simulation step size (ms)
 Tau     = 40.    # membrane time constant
 Theta   = 15.    # threshold
-U0      = 0.     # reset potential of membrane potential
+E_L     = 0.     # reset potential of membrane potential
 R       = 1.     # membrane resistance (GOhm)
 C       = Tau/R  # Tau (ms)/R in NEST units
 TauR    = 2.     # refractory time
@@ -74,9 +74,9 @@ neuron_param = {"tau_m"    :  Tau,
                "tau_syn_ex":  Tau_psc,
                "tau_syn_in":  Tau_psc,
                "C_m"       :  C,
-               "V_reset"   :  U0,
-               "E_L"       :  U0,
-               "V_m"       :  U0,
+               "V_reset"   :  E_L,
+               "E_L"       :  E_L,
+               "V_m"       :  E_L,
                "V_th"      :  Theta}
 
 syn_param = {"tau_psc" :  Tau_psc,

--- a/testsuite/mpitests/test_mini_brunel_ps.sli
+++ b/testsuite/mpitests/test_mini_brunel_ps.sli
@@ -90,7 +90,7 @@ def
 /CMem  250.0 def    % membrane capacity [pF]
 /tauSyn  0.5 def    % synaptic time constant [ms]
 /tauRef  2.0 def    % refractory time [ms]
-/U0      0.0 def    % resting potential [mV]
+/E_L     0.0 def    % resting potential [mV]
 /theta  20.0 def    % threshold
 
 
@@ -178,10 +178,10 @@ def % brunel_setup
       /C_m     CMem
       /tau_syn tauSyn
       /t_ref   tauRef
-      /E_L     U0
+      /E_L     E_L
       /V_th    theta
-      /V_m     U0
-      /V_reset U0
+      /V_m     E_L
+      /V_reset E_L
       /C_m     1.0     % capacitance is unity in Brunel model
       >> SetStatus
     } forall

--- a/testsuite/unittests/test_poisson_generator_campbell_alpha.sli
+++ b/testsuite/unittests/test_poisson_generator_campbell_alpha.sli
@@ -44,7 +44,7 @@ FirstVersion: Mar 2009
 % neuron&synapse parameters (cf. brunel*.sli)
 /tauMem 20.0 def  
 /tauSyn  0.5 def  
-/U0      0.0 def
+/E_L     0.0 def
 
 /J     0.01  def % small psp amplitude 
 /fudge 0.41363506632638 def
@@ -59,7 +59,7 @@ ResetKernel
         /tau_m       tauMem
         /tau_syn_ex  tauSyn
 	/tau_syn_in  tauSyn
-        /E_L         U0
+        /E_L         E_L
         /V_th        999. % no firing
         /C_m         1.0  
     >> SetDefaults

--- a/testsuite/unittests/test_tsodyks_depressing.sli
+++ b/testsuite/unittests/test_tsodyks_depressing.sli
@@ -55,7 +55,7 @@ userdict begin
 
       /Tau 40.0 def	     % membrane time constant
       /Theta 15.0 def	     % threshold
-      /U0 0.0 def	     % reset potential of Vm
+      /E_L 0.0 def	     % reset potential of Vm
       /R 1.0 def
       /C Tau R div def         % Tau [ms] / 1.0 GOhm in NEST units
       /TauR 2.0 def	     % refractory time
@@ -101,10 +101,10 @@ userdict begin
 		 /tau_syn_ex Tau_psc
 		 /tau_syn_in Tau_psc
 		 /C_m C
-		 /V_reset U0
-		 /E_L U0
+		 /V_reset E_L
+		 /E_L E_L
 		 /V_th Theta
-                 /V_m U0  
+		 /V_m E_L
               >> SetStatus
       % neuron1 GetStatus info
       
@@ -116,10 +116,10 @@ userdict begin
 		 /tau_syn_ex Tau_psc
 		 /tau_syn_in Tau_psc
 		 /C_m C
-		 /V_reset U0
-		 /E_L U0
+		 /V_reset E_L
+		 /E_L E_L
 		 /V_th Theta
-                 /V_m U0
+		 /V_m E_L
               >> SetStatus
     % neuron2 GetStatus info
 	      

--- a/testsuite/unittests/test_tsodyks_facilitating.sli
+++ b/testsuite/unittests/test_tsodyks_facilitating.sli
@@ -58,7 +58,7 @@ userdict begin
 
       /Tau 60.0 def	     % membrane time constant
       /Theta 15.0 def	     % threshold
-      /U0 0.0 def	     % reset potential of Vm
+      /E_L 0.0 def	     % reset potential of Vm
       /C Tau 1.0 div def     % Tau [ms] / 1.0 GOhm in NEST units
       /TauR 2.0 def	     % refractory time
       /Tau_psc 1.5 def       % time constant of PSC (=Tau_inact)
@@ -103,9 +103,9 @@ userdict begin
 		 /tau_syn_ex Tau_psc
 		 /tau_syn_in Tau_psc
 		 /C_m C
-		 /V_reset U0
-		 /E_L U0
-                 /V_m U0  
+		 /V_reset E_L
+		 /E_L E_L
+		 /V_m E_L
 		 /V_th Theta
       >> SetStatus
     
@@ -119,10 +119,10 @@ userdict begin
 		 /tau_syn_ex Tau_psc
 		 /tau_syn_in Tau_psc
 		 /C_m C
-		 /V_reset U0
-		 /E_L U0
+		 /V_reset E_L
+		 /E_L E_L
 		 /V_th Theta
-                 /V_m U0
+		 /V_m E_L
       >> SetStatus
    
       % neuron2 GetStatus info


### PR DESCRIPTION
Most neuron models use the internal variable `U0_` for the resting potential. The user interface uses the name `E_L` to conform to our policy of using Dyan&Abbot terminology wherever possible.

This is confusing and this pull request replaces `U0_` by `E_L_` and thus makes code, comments and UI wording consistent.

I suggest @heplesser and @tammoippen as reviewers.