### PR TITLE
BugFix: RandomFunction

### DIFF
--- a/librandom/binomial_randomdev.cpp
+++ b/librandom/binomial_randomdev.cpp
@@ -235,6 +235,7 @@ librandom::BinomialRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::BinomialRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
   def< double >( d, "p", p_ );
   def< long >( d, "n", n_ );
 }

--- a/librandom/exp_randomdev.cpp
+++ b/librandom/exp_randomdev.cpp
@@ -42,5 +42,7 @@ librandom::ExpRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::ExpRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "lambda", lambda_ );
 }

--- a/librandom/gamma_randomdev.cpp
+++ b/librandom/gamma_randomdev.cpp
@@ -118,6 +118,8 @@ librandom::GammaRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::GammaRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "order", a );
   def< double >( d, "scale", b_ );
 }

--- a/librandom/gsl_binomial_randomdev.cpp
+++ b/librandom/gsl_binomial_randomdev.cpp
@@ -119,6 +119,8 @@ librandom::GSL_BinomialRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::GSL_BinomialRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "p", p_ );
   def< long >( d, "n", n_ );
 }

--- a/librandom/lognormal_randomdev.cpp
+++ b/librandom/lognormal_randomdev.cpp
@@ -67,6 +67,8 @@ librandom::LognormalRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::LognormalRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "mu", mu_ );
   def< double >( d, "sigma", sigma_ );
 }

--- a/librandom/normal_randomdev.cpp
+++ b/librandom/normal_randomdev.cpp
@@ -67,6 +67,8 @@ librandom::NormalRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::NormalRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "mu", mu_ );
   def< double >( d, "sigma", sigma_ );
 }

--- a/librandom/poisson_randomdev.cpp
+++ b/librandom/poisson_randomdev.cpp
@@ -122,6 +122,8 @@ librandom::PoissonRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::PoissonRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "lambda", mu_ );
 }
 

--- a/librandom/random.cpp
+++ b/librandom/random.cpp
@@ -106,15 +106,17 @@ librandom::random_array( RdvDatum& rdv, const size_t n )
   return ArrayDatum( result );
 }
 
-long
+Token
 librandom::random( RdvDatum& rdv )
 {
   if ( rdv->has_ldev() )
   {
-    return rdv->ldev();
+    // returns long
+    return Token( rdv->ldev() );
   }
   else
   {
-    return ( *rdv )();
+    // returns double
+    return Token( ( *rdv )() );
   }
 }

--- a/librandom/random.h
+++ b/librandom/random.h
@@ -29,6 +29,7 @@
 // Includes from sli:
 #include "arraydatum.h"
 #include "dictdatum.h"
+#include "token.h"
 
 namespace librandom
 {
@@ -45,7 +46,7 @@ unsigned long irand( const long N, RngDatum& rng );
 double drand( RngDatum& rng );
 
 ArrayDatum random_array( RdvDatum& rdv, const size_t n );
-long random( RdvDatum& rdv );
+Token random( RdvDatum& rdv );
 }
 
 #endif /* RANDOM_H */

--- a/librandom/random_numbers.cpp
+++ b/librandom/random_numbers.cpp
@@ -306,7 +306,7 @@ RandomNumbers::RandomArrayFunction::execute( SLIInterpreter* i ) const
   ArrayDatum result = librandom::random_array( rdv, n );
 
   i->OStack.pop( 2 );
-  i->OStack.push( ArrayDatum( result ) );
+  i->OStack.push( result );
   i->EStack.pop();
 }
 
@@ -318,9 +318,9 @@ RandomNumbers::RandomFunction::execute( SLIInterpreter* i ) const
 
   librandom::RdvDatum rdv = getValue< librandom::RdvDatum >( i->OStack.top() );
 
-  long result = librandom::random( rdv );
-
   i->OStack.pop();
+  Token result = librandom::random( rdv );
+
   i->OStack.push( result );
   i->EStack.pop();
 }

--- a/librandom/randomdev.cpp
+++ b/librandom/randomdev.cpp
@@ -31,7 +31,8 @@ long librandom::RandomDev::ldev( RngPtr ) const
   return 0;
 }
 
-void librandom::RandomDev::get_status( DictionaryDatum& dict ) const
+void
+librandom::RandomDev::get_status( DictionaryDatum& dict ) const
 {
   def< bool >( dict, "is_discrete", has_ldev() );
 }

--- a/librandom/randomdev.cpp
+++ b/librandom/randomdev.cpp
@@ -22,8 +22,16 @@
 
 #include "randomdev.h"
 
+// Includes from sli:
+#include "dictutils.h"
+
 long librandom::RandomDev::ldev( RngPtr ) const
 {
   assert( false );
   return 0;
+}
+
+void librandom::RandomDev::get_status( DictionaryDatum& dict ) const
+{
+  def< bool >( dict, "is_discrete", has_ldev() );
 }

--- a/librandom/randomdev.h
+++ b/librandom/randomdev.h
@@ -205,7 +205,7 @@ public:
    * of a SLI dictionary.  This function is meant only to
    * provide access from the SLI interface.
    */
-  virtual void get_status( DictionaryDatum& ) const = 0;
+  virtual void get_status( DictionaryDatum& ) const;
 
 protected:
   RngPtr rng_; //!< store underlying RNG

--- a/librandom/uniform_randomdev.cpp
+++ b/librandom/uniform_randomdev.cpp
@@ -66,6 +66,8 @@ librandom::UniformRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::UniformRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< double >( d, "low", low_ );
   def< double >( d, "high", high_ );
 }

--- a/librandom/uniformint_randomdev.cpp
+++ b/librandom/uniformint_randomdev.cpp
@@ -108,6 +108,8 @@ librandom::UniformIntRandomDev::set_status( const DictionaryDatum& d )
 void
 librandom::UniformIntRandomDev::get_status( DictionaryDatum& d ) const
 {
+  RandomDev::get_status( d );
+
   def< long >( d, "low", nmin_ );
   def< long >( d, "high", nmax_ );
 }

--- a/testsuite/unittests/test_rdv_discreteness.sli
+++ b/testsuite/unittests/test_rdv_discreteness.sli
@@ -38,46 +38,41 @@ FirstVersion: 160304
 (unittest) run
 /unittest using
 
-/skip_list [ /gsl_binomial ] def
-
-rngdict /knuthlfg get 123456789 CreateRNG /rng Set
+rngdict /gsl_knuthran known { /gsl_knuthran } { /knuthlfg } ifelse
+rngdict exch get 123456789 CreateRNG /rng Set
 
 % check all random deviations
 rdevdict keys
 {
   /rdv_name Set
 
-  % except for those in the skip_list
-  skip_list rdv_name MemberQ not
-  {
-    rng rdevdict rdv_name get CreateRDV /rdv Set
+  rng rdevdict rdv_name get CreateRDV /rdv Set
 
-    rdv GetStatus /is_discrete get
+  rdv GetStatus /is_discrete get
+  {
+    % check discrete RDV
+    0 1 10 % try 10 random numbers
     {
-      % check discrete RDV
-      0 1 10 % try 10 random numbers
       {
-        {
-          rdv Random IntegerQ exch ;
-        } assert_or_die
-      } for
-      {
-        rdv 10 RandomArray 
-        true exch { IntegerQ exch ; and } Fold
+        rdv Random IntegerQ exch ;
       } assert_or_die
-    }
+    } for
     {
-      % check continuous RDV
-      0 1 10 % try 10 random numbers
-      {
-        true {
-          rdv Random DoubleQ exch ;
-        } assert_or_die
-      } for
-      {
-        rdv 10 RandomArray 
-        true exch { DoubleQ exch ; and } Fold
+      rdv 10 RandomArray 
+      true exch { IntegerQ exch ; and } Fold
+    } assert_or_die
+  }
+  {
+    % check continuous RDV
+    0 1 10 % try 10 random numbers
+    {
+      true {
+        rdv Random DoubleQ exch ;
       } assert_or_die
-    } ifelse
-  } if
+    } for
+    {
+      rdv 10 RandomArray 
+      true exch { DoubleQ exch ; and } Fold
+    } assert_or_die
+  } ifelse
 } forall

--- a/testsuite/unittests/test_rdv_discreteness.sli
+++ b/testsuite/unittests/test_rdv_discreteness.sli
@@ -1,0 +1,83 @@
+/*
+ *  test_rdv_discreteness.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/* BeginDocumentation
+Name: testsuite::test_rdv_discreteness - test discreteness of random distributions
+
+Synopsis: (test_rdv_discreteness.sli) run -> dies if assertion fails
+
+Description:
+Test that discrete random distributions actually return integer values for
+Random and RandomArray and continuous random distributions return double values
+for Random and RandomArray.
+
+Author: Ippen
+FirstVersion: 160304
+*/
+
+(unittest) run
+/unittest using
+
+/skip_list [ /gsl_binomial ] def
+
+rngdict /knuthlfg get 123456789 CreateRNG /rng Set
+
+% check all random deviations
+rdevdict keys
+{
+  /rdv_name Set
+
+  % except for those in the skip_list
+  skip_list rdv_name MemberQ not
+  {
+    rng rdevdict rdv_name get CreateRDV /rdv Set
+
+    rdv GetStatus /is_discrete get
+    {
+      % check discrete RDV
+      0 1 10 % try 10 random numbers
+      {
+        {
+          rdv Random IntegerQ exch ;
+        } assert_or_die
+      } for
+      {
+        rdv 10 RandomArray 
+        true exch { IntegerQ exch ; and } Fold
+      } assert_or_die
+    }
+    {
+      % check continuous RDV
+      0 1 10 % try 10 random numbers
+      {
+        true {
+          rdv Random DoubleQ exch ;
+        } assert_or_die
+      } for
+      {
+        rdv 10 RandomArray 
+        true exch { DoubleQ exch ; and } Fold
+      } assert_or_die
+    } ifelse
+  } if
+} forall


### PR DESCRIPTION
During refactoring I was not aware, that the `librandom::randomFunction` returns either a double or a long to the sli stack, depending on the RdvDatum argument. Now the API encapsulates the returned random value in a Token.

Additionally, the `RandomArray` was encapsulated twice in a `ArrayDatum`. Fixed it here.