### PR TITLE
Fixing #264: Raise exceptions on incommensurate times

### DIFF
--- a/nestkernel/device.cpp
+++ b/nestkernel/device.cpp
@@ -73,17 +73,15 @@ nest::Device::Parameters_::get( DictionaryDatum& d ) const
 }
 
 void
-nest::Device::Parameters_::update_( const DictionaryDatum& d,
-		                            const Name& name,
-		                            Time& value )
+nest::Device::Parameters_::update_( const DictionaryDatum& d, const Name& name, Time& value )
 {
   /* We cannot update the Time values directly, since updateValue()
-	 doesn't support Time objects. We thus read the value in ms into
-	 a double first and then update the time object if a value was
-	 given.
+         doesn't support Time objects. We thus read the value in ms into
+         a double first and then update the time object if a value was
+         given.
 
-	 To be valid, time values must either be on the time grid,
-	 or be infinite. Infinite values are handled gracefully.
+         To be valid, time values must either be on the time grid,
+         or be infinite. Infinite values are handled gracefully.
   */
 
   double_t val;
@@ -102,9 +100,9 @@ nest::Device::Parameters_::update_( const DictionaryDatum& d,
 void
 nest::Device::Parameters_::set( const DictionaryDatum& d )
 {
-   update_( d, names::origin, origin_ );
-   update_( d, names::start, start_ );
-   update_( d, names::stop, stop_ );
+  update_( d, names::origin, origin_ );
+  update_( d, names::start, start_ );
+  update_( d, names::stop, stop_ );
 
   if ( stop_ < start_ )
   {

--- a/nestkernel/device.cpp
+++ b/nestkernel/device.cpp
@@ -75,21 +75,53 @@ nest::Device::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::Device::Parameters_::set( const DictionaryDatum& d )
 {
-  double_t v;
+  double_t v = 0.0;
 
   /* We cannot update the Time values directly, since updateValue()
      doesn't support Time objects. We thus read the value in ms into
      a double first and then update the time object if a value was
      given.
+
+     To be valid, time values must either be on the time grid,
+     or be infinite. Infinite values are handled gracefully.
   */
   if ( updateValue< double_t >( d, names::origin, v ) )
-    origin_ = Time::ms( v );
+  {
+    const Time t = Time::ms( v );
+    if ( t.is_finite() && not t.is_grid_time() )
+    {
+      throw BadProperty( names::origin.toString() +  " must be a multiple "
+			              "of the simulation resolution." );
+    }
+    origin_ = t;
+  }
 
   if ( updateValue< double_t >( d, names::start, v ) )
-    start_ = Time::ms( v );
+  {
+    const Time t = Time::ms( v );
+    if ( t.is_finite() && not t.is_grid_time() )
+    {
+      throw BadProperty( names::start.toString() + " must be a multiple "
+			              "of the simulation resolution." );
+    }
+    start_ = t;
+  }
 
   if ( updateValue< double_t >( d, names::stop, v ) )
-    stop_ = Time::ms( v );
+  {
+    const Time t = Time::ms( v );
+    if ( t.is_finite() && not t.is_grid_time() )
+    {
+      throw BadProperty( names::stop.toString() + " must be a multiple "
+			              "of the simulation resolution." );
+    }
+    stop_ = t;
+  }
+
+  if ( stop_ < start_ )
+  {
+    throw BadProperty( "stop >= start required." );
+  }
 }
 
 

--- a/nestkernel/device.h
+++ b/nestkernel/device.h
@@ -182,7 +182,6 @@ private:
   private:
     //! Update given Time parameter including error checking
     static void update_( const DictionaryDatum&, const Name&, Time& );
-
   };
 
 

--- a/nestkernel/device.h
+++ b/nestkernel/device.h
@@ -178,6 +178,11 @@ private:
 
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
     void set( const DictionaryDatum& ); //!< Set values from dictionary
+
+  private:
+    //! Update given Time parameter including error checking
+    static void update_( const DictionaryDatum&, const Name&, Time& );
+
   };
 
 

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -229,11 +229,11 @@ simulate( const double_t& time )
 
   if ( time < 0 )
   {
-	throw BadParameter( "The simulation time cannot be negative." );
+    throw BadParameter( "The simulation time cannot be negative." );
   }
   if ( not t_sim.is_finite() )
   {
-	throw BadParameter( "The simulation time must be finite." );
+    throw BadParameter( "The simulation time must be finite." );
   }
   if ( not t_sim.is_grid_time() )
   {

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -225,12 +225,19 @@ get_connections( const DictionaryDatum& dict )
 void
 simulate( const double_t& time )
 {
+  const Time t_sim = Time::ms( time );
+  if ( not t_sim.is_grid_time() )
+  {
+    throw BadParameter(
+      "The simulation time must be a multiple "
+      "of the simulation resolution." );
+  }
+
   std::ostringstream os;
   os << "Simulating " << time << " ms.";
   LOG( M_INFO, "Simulate", os.str() );
-  Time t = Time::ms( time );
 
-  kernel().simulation_manager.simulate( t );
+  kernel().simulation_manager.simulate( t_sim );
 }
 
 void

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -226,6 +226,15 @@ void
 simulate( const double_t& time )
 {
   const Time t_sim = Time::ms( time );
+
+  if ( time < 0 )
+  {
+	throw BadParameter( "The simulation time cannot be negative." );
+  }
+  if ( not t_sim.is_finite() )
+  {
+	throw BadParameter( "The simulation time must be finite." );
+  }
   if ( not t_sim.is_grid_time() )
   {
     throw BadParameter(

--- a/pynest/nest/tests/test_parrot_neuron_ps.py
+++ b/pynest/nest/tests/test_parrot_neuron_ps.py
@@ -33,7 +33,7 @@ def _round_up(simtime):
     """
     
     res = nest.GetKernelStatus('resolution')
-    return res * math.ceil(simtime / res)
+    return res * math.ceil(float(simtime) / float(res))
 
 
 @nest.check_stack

--- a/pynest/nest/tests/test_parrot_neuron_ps.py
+++ b/pynest/nest/tests/test_parrot_neuron_ps.py
@@ -27,6 +27,15 @@ import unittest
 import math
 
 
+def _round_up(simtime):
+    """
+    Returns simulation time rounded up to next multiple of resolution.
+    """
+    
+    res = nest.GetKernelStatus('resolution')
+    return res * math.ceil(simtime / res)
+
+
 @nest.check_stack
 class ParrotNeuronPSTestCase(unittest.TestCase):
     """Check parrot_neuron spike repetition properties"""
@@ -54,7 +63,7 @@ class ParrotNeuronPSTestCase(unittest.TestCase):
 
         # connect with arbitrary delay
         nest.Connect(self.source, self.parrot, syn_spec={"delay": self.delay})
-        nest.Simulate(self.spike_time + 2 * self.delay)
+        nest.Simulate(_round_up(self.spike_time + 2 * self.delay))
 
         # get spike from parrot neuron
         events = nest.GetStatus(self.spikes)[0]["events"]
@@ -71,7 +80,7 @@ class ParrotNeuronPSTestCase(unittest.TestCase):
         # connect with arbitrary delay to port 1
         nest.Connect(self.source, self.parrot, 
                      syn_spec={"receptor_type": 1, "delay": self.delay})
-        nest.Simulate(self.spike_time + 2. * self.delay)
+        nest.Simulate(_round_up(self.spike_time + 2. * self.delay))
 
         # get spike from parrot neuron, assert it was ignored
         events = nest.GetStatus(self.spikes)[0]["events"]
@@ -90,7 +99,7 @@ class ParrotNeuronPSTestCase(unittest.TestCase):
         # connect twice
         nest.Connect(self.source, self.parrot, syn_spec={"delay": self.delay})
         nest.Connect(self.source, self.parrot, syn_spec={"delay": self.delay})
-        nest.Simulate(self.spike_time + 2. * self.delay)
+        nest.Simulate(_round_up(self.spike_time + 2. * self.delay))
 
         # get spikes from parrot neuron, assert two were transmitted
         events = nest.GetStatus(self.spikes)[0]["events"]
@@ -147,7 +156,7 @@ class ParrotNeuronPSPoissonTestCase(unittest.TestCase):
         nest.Connect(parrots[:1], parrots[1:], syn_spec={'delay': delay})
         nest.Connect(parrots[1:], detect)
         
-        nest.Simulate(t_sim)
+        nest.Simulate(_round_up(t_sim))
         
         n_spikes = nest.GetStatus(detect)[0]['n_events']
         assert n_spikes > spikes_expected - 3 * spikes_std, \
@@ -220,7 +229,7 @@ class ParrotNeuronPSSTDPTestCase(unittest.TestCase):
         w_pre = syn_status['weight']
 
         last_time = max(pre_times[-1], post_times[-1])
-        nest.Simulate(last_time + 2 * delay)
+        nest.Simulate(_round_up(last_time + 2 * delay))
 
         # get weight post protocol
         syn_status = nest.GetStatus(syn)[0]

--- a/testsuite/regressiontests/issue-264.sli
+++ b/testsuite/regressiontests/issue-264.sli
@@ -1,0 +1,87 @@
+/*
+ *  issue-264.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* BeginDocumentation
+
+Name: testsuite::issue-264 Ensure error is raised on times incommensurate with resolution
+
+Synopsis: (issue-264) run -> NEST exits if test fails
+
+Description:
+This test ensures that NEST raises an error if the requested simulation
+time is not a multiple of the resolution, or if one attempts to set
+start/stop/origin for devices that are not multiples of the resolution.
+
+Author: Hans E Plesser, 2016-03-08
+ */
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+% Check incommensurate simulation time
+{
+  ResetKernel
+  0 << /resolution 1.0 >> SetStatus
+  1.5 Simulate
+} fail_or_die
+
+% Check start, stop, origin on defaults
+[ /start /stop /origin ]
+{
+  /item Set
+  
+  % stimulating device
+  {
+    ResetKernel
+    0 << /resolution 1.0 >> SetStatus
+    /spike_generator << item 1.5 >> SetDefaults
+  } fail_or_die
+    
+  % recording device
+  {
+    ResetKernel
+    0 << /resolution 1.0 >> SetStatus
+    /spike_detector << item 1.5 >> SetDefaults
+  } fail_or_die
+} forall
+
+% Check start, stop, origin on device
+[ /start /stop /origin ]
+{
+  /item Set
+  
+  % stimulating device
+  {
+    ResetKernel
+    0 << /resolution 1.0 >> SetStatus
+    /spike_generator Create << item 1.5 >> SetStatus
+  } fail_or_die
+    
+  % recording device
+  {
+    ResetKernel
+    0 << /resolution 1.0 >> SetStatus
+    /spike_detector Create << item 1.5 >> SetStatus
+  } fail_or_die
+} forall

--- a/testsuite/regressiontests/issue-264.sli
+++ b/testsuite/regressiontests/issue-264.sli
@@ -39,10 +39,16 @@ Author: Hans E Plesser, 2016-03-08
 
 M_ERROR setverbosity
 
+
+% Note: To ensure that the resolution 1.0 and test value 1.5 can be
+%       represented exactly in tics, we set tics_per_ms below to the
+%       usual default. This handles the unusual case where NEST is
+%       compiled with a different value. 
+
 % Check incommensurate simulation time
 {
   ResetKernel
-  0 << /resolution 1.0 >> SetStatus
+  0 << /resolution 1.0 /tics_per_ms 1000 >> SetStatus
   1.5 Simulate
 } fail_or_die
 
@@ -54,14 +60,14 @@ M_ERROR setverbosity
   % stimulating device
   {
     ResetKernel
-    0 << /resolution 1.0 >> SetStatus
+    0 << /resolution 1.0 /tics_per_ms 1000 >> SetStatus
     /spike_generator << item 1.5 >> SetDefaults
   } fail_or_die
     
   % recording device
   {
     ResetKernel
-    0 << /resolution 1.0 >> SetStatus
+    0 << /resolution 1.0 /tics_per_ms 1000 >> SetStatus
     /spike_detector << item 1.5 >> SetDefaults
   } fail_or_die
 } forall
@@ -74,14 +80,14 @@ M_ERROR setverbosity
   % stimulating device
   {
     ResetKernel
-    0 << /resolution 1.0 >> SetStatus
+    0 << /resolution 1.0 /tics_per_ms 1000 >> SetStatus
     /spike_generator Create << item 1.5 >> SetStatus
   } fail_or_die
     
   % recording device
   {
     ResetKernel
-    0 << /resolution 1.0 >> SetStatus
+    0 << /resolution 1.0 /tics_per_ms 1000 >> SetStatus
     /spike_detector Create << item 1.5 >> SetStatus
   } fail_or_die
 } forall

--- a/testsuite/unittests/test_spike_poisson_ps.sli
+++ b/testsuite/unittests/test_spike_poisson_ps.sli
@@ -62,20 +62,22 @@ Author: Plesser, Diesmann
 
 M_ERROR setverbosity
 
+
 /Transmission
 {
 /h Set
 
-% end of stimulation period
+% End of stimulation period
 /stimtime 30.0 def
 
-% Make simulation time long enough so that
-% at least one full min-delay passes after
-% end of stimulation even if resolution does 
-% not divide 1.0ms. Otherwise, not all spikes
-% will reach the spike_detector.
-% We then restrict the simulation time to the grid.
-/simtime stimtime 2.0 add h div cvi h mul def
+% We need to ensure that all spikes arrive at the spike detector.
+% Thus, the simulation time needs to exceed the end of stimulation
+% by at least two multiples of the delay, which is 1 ms by default.
+% We also need to ensure that the simulation time is a multiple of 
+% the resolution.
+% To be on the safe side, we add 3 ms and then round up to the
+% nearest multiple of the resolution. 
+/simtime stimtime 3.0 add h div ceil h mul def
 
 ResetKernel
 

--- a/testsuite/unittests/test_spike_poisson_ps.sli
+++ b/testsuite/unittests/test_spike_poisson_ps.sli
@@ -69,12 +69,13 @@ M_ERROR setverbosity
 % end of stimulation period
 /stimtime 30.0 def
 
-% make simulation time long enough so that
+% Make simulation time long enough so that
 % at least one full min-delay passes after
 % end of stimulation even if resolution does 
 % not divide 1.0ms. Otherwise, not all spikes
 % will reach the spike_detector.
-/simtime stimtime 2.0 add def 
+% We then restrict the simulation time to the grid.
+/simtime stimtime 2.0 add h div cvi h mul def
 
 ResetKernel
 


### PR DESCRIPTION
Simulate now raises exception if simulation time is not multiple of the resolution. SetStatus on devices do the same if start, stop, origin are not multiples of the resolution. Some tests needed minor adaptation.

@jougs @apeyser Would you take a look?