### PR TITLE
Clean up logging upon calls to Simulate

### DIFF
--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -225,12 +225,7 @@ get_connections( const DictionaryDatum& dict )
 void
 simulate( const double_t& time )
 {
-  std::ostringstream os;
-  os << "Simulating " << time << " ms.";
-  LOG( M_INFO, "Simulate", os.str() );
-  Time t = Time::ms( time );
-
-  kernel().simulation_manager.simulate( t );
+  kernel().simulation_manager.simulate( Time::ms( time ) );
 }
 
 void

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -115,6 +115,7 @@ NodeManager::initialize()
   /* END of code adding the root subnet. */
 
   // explicitly force construction of nodes_vec_ to ensure consistent state
+  nodes_vec_network_size_ = 0;
   ensure_valid_thread_local_ids();
 }
 

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -646,12 +646,10 @@ NodeManager::set_status_single_node_( Node& target, const DictionaryDatum& d, bo
   }
 }
 
-void
+size_t
 NodeManager::prepare_nodes()
 {
   assert( kernel().is_initialized() );
-
-  LOG( M_INFO, "NodeManager::prepare_nodes_", "Please wait. Preparing elements." );
 
   /* We initialize the buffers of each node and calibrate it. */
 
@@ -701,23 +699,20 @@ NodeManager::prepare_nodes()
     if ( exceptions_raised.at( thr ).valid() )
       throw WrappedThreadException( *( exceptions_raised.at( thr ) ) );
 
-  if ( num_active_prelim_nodes == 0 )
+  std::ostringstream os;
+  std::string tmp_str = num_active_nodes == 1 ? " node" : " nodes";
+  os << "Preparing " << num_active_nodes << tmp_str << " for simulation.";
+
+  if ( num_active_prelim_nodes != 0 )
   {
-    LOG( M_INFO,
-      "NodeManager::prepare_nodes_",
-      String::compose(
-           "Simulating %1 local node%2.", num_active_nodes, num_active_nodes == 1 ? "" : "s" ) );
+    tmp_str = num_active_prelim_nodes == 1 ? " uses " : " use ";
+    os << " " << num_active_prelim_nodes << " of them" << tmp_str
+       << "iterative solution techniques.";
   }
-  else
-  {
-    LOG( M_INFO,
-      "Scheduler::prepare_nodes",
-      String::compose( "Simulating %1 local node%2 of which %3 need%4 prelim_update.",
-           num_active_nodes,
-           num_active_nodes == 1 ? "" : "s",
-           num_active_prelim_nodes,
-           num_active_prelim_nodes == 1 ? "s" : "" ) );
-  }
+
+  LOG( M_INFO, "NodeManager::prepare_nodes", os.str() );
+
+  return num_active_nodes;
 }
 
 //!< This function is called only if the thread data structures are properly set up.
@@ -725,14 +720,12 @@ void
 NodeManager::finalize_nodes()
 {
 #ifdef _OPENMP
-  LOG( M_INFO, "NodeManager::finalize_nodes()", " using OpenMP." );
-// parallel section begins
 #pragma omp parallel
   {
     index t = kernel().vp_manager.get_thread_id();
 #else
-    for ( index t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
-    {
+  for ( index t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
+  {
 #endif
     for ( size_t idx = 0; idx < local_nodes_.size(); ++idx )
     {

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -646,7 +646,7 @@ NodeManager::set_status_single_node_( Node& target, const DictionaryDatum& d, bo
   }
 }
 
-size_t
+const size_t
 NodeManager::prepare_nodes()
 {
   assert( kernel().is_initialized() );

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -723,10 +723,10 @@ NodeManager::finalize_nodes()
 #pragma omp parallel
   {
     index t = kernel().vp_manager.get_thread_id();
-#else
+#else // clang-format off
   for ( index t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
   {
-#endif
+#endif // clang-format on
     for ( size_t idx = 0; idx < local_nodes_.size(); ++idx )
     {
       Node* node = local_nodes_.get_node_by_index( idx );

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -646,7 +646,7 @@ NodeManager::set_status_single_node_( Node& target, const DictionaryDatum& d, bo
   }
 }
 
-const size_t
+size_t
 NodeManager::prepare_nodes()
 {
   assert( kernel().is_initialized() );

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -196,7 +196,7 @@ public:
    * @see prepare_node_()
    * @returns number of nodes that will be simulated.
    */
-  const size_t prepare_nodes();
+  size_t prepare_nodes();
 
   /**
    * Invoke finalize() on nodes registered for finalization.

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -196,7 +196,7 @@ public:
    * @see prepare_node_()
    * @returns number of nodes that will be simulated.
    */
-  size_t prepare_nodes();
+  const size_t prepare_nodes();
 
   /**
    * Invoke finalize() on nodes registered for finalization.

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -194,8 +194,9 @@ public:
    * Prepare nodes for simulation and register nodes in node_list.
    * Calls prepare_node_() for each pertaining Node.
    * @see prepare_node_()
+   * @returns number of nodes that will be simulated.
    */
-  void prepare_nodes();
+  size_t prepare_nodes();
 
   /**
    * Invoke finalize() on nodes registered for finalization.

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -338,7 +338,7 @@ nest::SimulationManager::resume_( const size_t num_active_nodes )
   std::ostringstream os;
   double_t t_sim = to_do_ * Time::get_resolution().get_ms();
 
-  os << "Number of nodes: " << num_active_nodes << std::endl;
+  os << "Number of local nodes: " << num_active_nodes << std::endl;
   os << "Simulaton time (ms): " << t_sim;
 
 #ifdef _OPENMP

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -298,7 +298,7 @@ nest::SimulationManager::simulate( Time const& t )
   to_do_ += t.get_steps();
   to_do_total_ = to_do_;
 
-  size_t num_active_nodes = prepare_simulation_();
+  const size_t num_active_nodes = prepare_simulation_();
 
   // from_step_ is not touched here.  If we are at the beginning
   // of a simulation, it has been reset properly elsewhere.  If
@@ -331,7 +331,7 @@ nest::SimulationManager::simulate( Time const& t )
 }
 
 void
-nest::SimulationManager::resume_( const size_t num_active_nodes )
+nest::SimulationManager::resume_( size_t num_active_nodes )
 {
   assert( kernel().is_initialized() );
 
@@ -404,7 +404,7 @@ nest::SimulationManager::resume_( const size_t num_active_nodes )
   LOG( M_INFO, "SimulationManager::resume", "Simulation finished." );
 }
 
-const size_t
+size_t
 nest::SimulationManager::prepare_simulation_()
 {
   assert( to_do_ != 0 ); // This is checked in simulate()

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -298,7 +298,7 @@ nest::SimulationManager::simulate( Time const& t )
   to_do_ += t.get_steps();
   to_do_total_ = to_do_;
 
-  prepare_simulation_();
+  size_t num_active_nodes = prepare_simulation_();
 
   // from_step_ is not touched here.  If we are at the beginning
   // of a simulation, it has been reset properly elsewhere.  If
@@ -325,15 +325,40 @@ nest::SimulationManager::simulate( Time const& t )
       "Simulate "
       "is called repeatedly with simulation times that are not multiples of the minimal delay." );
 
-  resume_();
+  resume_( num_active_nodes );
 
   finalize_simulation_();
 }
 
 void
-nest::SimulationManager::resume_()
+nest::SimulationManager::resume_( size_t num_active_nodes )
 {
   assert( kernel().is_initialized() );
+
+  std::ostringstream os;
+  double_t t_sim = to_do_ * Time::get_resolution().get_ms();
+
+  os << "Number of nodes: " << num_active_nodes << std::endl;
+  os << "Simulaton time (ms): " << t_sim;
+
+#ifdef _OPENMP
+  os << std::endl
+     << "Number of OpenMP threads: " << kernel().vp_manager.get_num_threads();
+#else
+  os << std::endl
+     << "Not using OpenMP";
+#endif
+
+#ifdef HAVE_MPI
+  os << std::endl
+     << "Number of MPI processes: " << kernel().mpi_manager.get_num_processes();
+#else
+  os << std::endl
+     << "Not using MPI";
+#endif
+
+  LOG( M_INFO, "SimulationManager::resume", os.str() );
+
 
   terminate_ = false;
 
@@ -349,14 +374,6 @@ nest::SimulationManager::resume_()
 
   simulating_ = true;
   simulated_ = true;
-
-#ifndef _OPENMP
-  if ( kernel().vp_manager.get_num_threads() > 1 )
-  {
-    LOG(
-      M_ERROR, "SimulationManager::resume", "No multithreading available, using single threading" );
-  }
-#endif
 
   update_();
 
@@ -387,12 +404,9 @@ nest::SimulationManager::resume_()
   LOG( M_INFO, "SimulationManager::resume", "Simulation finished." );
 }
 
-void
+size_t
 nest::SimulationManager::prepare_simulation_()
 {
-  if ( to_do_ == 0 )
-    return;
-
   // find shortest and longest delay across all MPI processes
   // this call sets the member variables
   kernel().connection_builder_manager.update_delay_extrema_();
@@ -417,7 +431,7 @@ nest::SimulationManager::prepare_simulation_()
     kernel().event_delivery_manager.configure_spike_buffers();
 
   kernel().node_manager.ensure_valid_thread_local_ids();
-  kernel().node_manager.prepare_nodes();
+  size_t num_active_nodes = kernel().node_manager.prepare_nodes();
 
   kernel().model_manager.create_secondary_events_prototypes();
 
@@ -430,6 +444,8 @@ nest::SimulationManager::prepare_simulation_()
       Time::get_resolution().get_ms() * kernel().connection_builder_manager.get_min_delay();
     kernel().music_manager.enter_runtime( tick );
   }
+
+  return num_active_nodes;
 }
 
 bool
@@ -441,10 +457,6 @@ nest::SimulationManager::prelim_update_( Node* n )
 void
 nest::SimulationManager::update_()
 {
-#ifdef _OPENMP
-  LOG( M_INFO, "SimulationManager::update", "Simulating using OpenMP." );
-#endif
-
   // to store done values of the different threads
   std::vector< bool > done;
   bool done_all = true;

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -331,7 +331,7 @@ nest::SimulationManager::simulate( Time const& t )
 }
 
 void
-nest::SimulationManager::resume_( size_t num_active_nodes )
+nest::SimulationManager::resume_( const size_t num_active_nodes )
 {
   assert( kernel().is_initialized() );
 
@@ -404,7 +404,7 @@ nest::SimulationManager::resume_( size_t num_active_nodes )
   LOG( M_INFO, "SimulationManager::resume", "Simulation finished." );
 }
 
-size_t
+const size_t
 nest::SimulationManager::prepare_simulation_()
 {
   assert( to_do_ != 0 ); // This is checked in simulate()
@@ -433,7 +433,7 @@ nest::SimulationManager::prepare_simulation_()
     kernel().event_delivery_manager.configure_spike_buffers();
 
   kernel().node_manager.ensure_valid_thread_local_ids();
-  size_t num_active_nodes = kernel().node_manager.prepare_nodes();
+  const size_t num_active_nodes = kernel().node_manager.prepare_nodes();
 
   kernel().model_manager.create_secondary_events_prototypes();
 

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -407,6 +407,8 @@ nest::SimulationManager::resume_( size_t num_active_nodes )
 size_t
 nest::SimulationManager::prepare_simulation_()
 {
+  assert( to_do_ != 0 ); // This is checked in simulate()
+
   // find shortest and longest delay across all MPI processes
   // this call sets the member variables
   kernel().connection_builder_manager.update_delay_extrema_();

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -124,10 +124,10 @@ public:
   delay get_to_step() const;
 
 private:
-  void resume_( size_t );       //!< actually run simulation; TODO: review
-  size_t prepare_simulation_(); //! setup before simulation start
-  void finalize_simulation_();  //! wrap-up after simulation end
-  void update_();               //! actually perform simulation
+  void resume_( const size_t );       //!< actually run simulation; TODO: review
+  const size_t prepare_simulation_(); //! setup before simulation start
+  void finalize_simulation_();        //! wrap-up after simulation end
+  void update_();                     //! actually perform simulation
   bool prelim_update_( Node* );
   void advance_time_();   //!< Update time to next time step
   void print_progress_(); //!< TODO: Remove, replace by logging!

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -124,10 +124,10 @@ public:
   delay get_to_step() const;
 
 private:
-  void resume_( const size_t );       //!< actually run simulation; TODO: review
-  const size_t prepare_simulation_(); //! setup before simulation start
-  void finalize_simulation_();        //! wrap-up after simulation end
-  void update_();                     //! actually perform simulation
+  void resume_( size_t );       //!< actually run simulation; TODO: review
+  size_t prepare_simulation_(); //! setup before simulation start
+  void finalize_simulation_();  //! wrap-up after simulation end
+  void update_();               //! actually perform simulation
   bool prelim_update_( Node* );
   void advance_time_();   //!< Update time to next time step
   void print_progress_(); //!< TODO: Remove, replace by logging!

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -124,10 +124,10 @@ public:
   delay get_to_step() const;
 
 private:
-  void resume_();              //!< actually run simulation; TODO: review
-  void prepare_simulation_();  //! setup before simulation start
-  void finalize_simulation_(); //! wrap-up after simulation end
-  void update_();              //! actually perform simulation
+  void resume_( size_t );       //!< actually run simulation; TODO: review
+  size_t prepare_simulation_(); //! setup before simulation start
+  void finalize_simulation_();  //! wrap-up after simulation end
+  void update_();               //! actually perform simulation
   bool prelim_update_( Node* );
   void advance_time_();   //!< Update time to next time step
   void print_progress_(); //!< TODO: Remove, replace by logging!


### PR DESCRIPTION
The output upon calls to `Simulate` has previously been spread out over multiple messages and cluttered by useless messages. This was hard to read by humans and hard to parse by machines. This PR cleans and compacts logging messages and adds the number of threads and processes to the output in order to prevent problems like seen in #238.

The old output looked like this:
```
Mar 09 18:22:58 Simulate [Info]: 
    Simulating 100 ms.

Mar 09 18:22:58 NodeManager::prepare_nodes_ [Info]: 
    Please wait. Preparing elements.

Mar 09 18:22:58 NodeManager::prepare_nodes_ [Info]: 
    Simulating 1000 local nodes.

Mar 09 18:22:58 SimulationManager::update [Info]: 
    Simulating using OpenMP.

Mar 09 18:22:58 SimulationManager::resume [Info]: 
    Simulation finished.
OpenMP
Mar 09 18:22:58 NodeManager::finalize_nodes() [Info]: 
     using OpenMP.
```

The new output for the same script looks like this:
```
Mar 09 18:26:55 NodeManager::prepare_nodes [Info]: 
    Preparing 1000 nodes for simulation.

Mar 09 18:26:55 SimulationManager::resume [Info]: 
    Number of local nodes: 1000
    Simulaton time (ms): 100
    Number of OpenMP threads: 2
    Number of MPI processes: 1

Mar 09 18:26:55 SimulationManager::resume [Info]: 
    Simulation finished.
```

If NEST was compiled without support for OpenMP, the third line of the table will read
```
Not using OpenMP
```

If NEST was compiled without support for MPI, the fourth line of the table will read
```
Not using MPI
```

While testing with 0 nodes, I found a segfault, which I then also fixed in this PR for convenience reasons.