### PR TITLE
Improvement of iterative solution framework

### DIFF
--- a/examples/nest/gap_junction/inhibitory_network.py
+++ b/examples/nest/gap_junction/inhibitory_network.py
@@ -43,6 +43,7 @@ network resulting in an average of 60 gap-junction connections per neuron.
 import pylab
 import nest
 import random
+import numpy
 
 n_neuron = 500
 gap_per_neuron = 60
@@ -64,23 +65,42 @@ random.seed(1)
 
 nest.ResetKernel()
 
-nest.SetKernelStatus({'resolution': 0.05, 'total_num_virtual_procs': threads})
-nest.SetKernelStatus({'max_num_prelim_iterations': 15, 'prelim_interpolation_order': 3, 'prelim_tol': 0.0001})
+nest.SetKernelStatus({'resolution': 0.05, 
+                      'total_num_virtual_procs': threads,
+                      'print_time': True,
+# Settings for waveform relaxation
+# 'use_wfr': False uses communication in every step 
+# instead of an iterative solution
+                      'use_wfr': True,
+                      'wfr_comm_interval': 1.0,
+                      'wfr_tol': 0.0001,
+                      'wfr_max_iterations': 15,
+                      'wfr_interpolation_order': 3})
 
-neuron = nest.Create('hh_psc_alpha_gap',n_neuron)
+neurons = nest.Create('hh_psc_alpha_gap',n_neuron)
 
 sd = nest.Create("spike_detector", params={'to_file': False, 'to_memory': True})
 pg = nest.Create("poisson_generator",params={'rate': 500.0})
 
-conn_dict = {'rule': 'fixed_indegree', 'indegree': inh_per_neuron, 'autapses': False, 'multapses': True}
-syn_dict = {'model': 'static_synapse', 'weight': j_inh, 'delay': delay}
-nest.Connect(neuron, neuron, conn_dict, syn_dict)
+conn_dict = {'rule': 'fixed_indegree', 
+             'indegree': inh_per_neuron, 
+             'autapses': False, 
+             'multapses': True}
 
-nest.Connect(pg,neuron,'all_to_all',syn_spec={'model': 'static_synapse', 'weight': j_exc, 'delay': delay})
-nest.Connect(neuron,sd,'all_to_all')
+syn_dict = {'model': 'static_synapse', 
+            'weight': j_inh, 
+            'delay': delay}
+
+nest.Connect(neurons, neurons, conn_dict, syn_dict)
+
+nest.Connect(pg,neurons,'all_to_all',syn_spec={'model': 'static_synapse', 
+                                              'weight': j_exc, 
+                                              'delay': delay})
+
+nest.Connect(neurons,sd)
 
 for i in range(n_neuron):
-  nest.SetStatus([neuron[i]], { 'V_m': (-40. - 40. * random.random()) })
+  nest.SetStatus([neurons[i]], { 'V_m': (-40. - 40. * random.random()) })
 
 """
 We must not use the 'fixed_indegree' oder 'fixed_outdegree' functionality of nest.Connect
@@ -90,23 +110,28 @@ need to make sure that the same neurons are connected in both ways.
 
 # create gap_junction connections
 n_connection = n_neuron * gap_per_neuron / 2
-connection = [random.sample(range(n_neuron),2) for i in range(n_connection)]    
-for i in range(n_connection):
-  nest.Connect([neuron[connection[i][0]]], [neuron[connection[i][1]]], syn_spec={'model': 'gap_junction', 'weight': gap_weight})
-  nest.Connect([neuron[connection[i][1]]], [neuron[connection[i][0]]], syn_spec={'model': 'gap_junction', 'weight': gap_weight})
+connections = numpy.transpose([random.sample(neurons,2) for _ in range(n_connection)])   
+
+# sources -> targets
+nest.Connect(connections[0], connections[1],
+             'one_to_one',
+             {'model': 'gap_junction', 'weight': gap_weight})
+# targets -> sources
+nest.Connect(connections[1], connections[0],
+             'one_to_one',
+             {'model': 'gap_junction', 'weight': gap_weight})
 
 nest.Simulate(simtime)
 
-times_sd = nest.GetStatus(sd, 'events')[0]['times']
+times = nest.GetStatus(sd, 'events')[0]['times']
 spikes = nest.GetStatus(sd, 'events')[0]['senders']
 n_spikes = nest.GetStatus(sd, 'n_events')[0]
 
 hz_rate = (1000.0*n_spikes/simtime)/n_neuron
 
 pylab.figure(1)
-pylab.plot(times_sd,spikes,'o')
+pylab.plot(times,spikes,'o')
 pylab.title('Average spike rate (Hz): %.2f' % hz_rate)
 pylab.xlabel('time (ms)')
 pylab.ylabel('neuron no')
 pylab.show()
-

--- a/examples/nest/gap_junction/two_neurons.py
+++ b/examples/nest/gap_junction/two_neurons.py
@@ -32,11 +32,22 @@ import numpy
 
 nest.ResetKernel()
 
-nest.SetKernelStatus({'resolution': 0.05})  
-nest.SetKernelStatus({'max_num_prelim_iterations': 15, 'prelim_interpolation_order': 3, 'prelim_tol': 0.0001})
+nest.SetKernelStatus({'resolution': 0.05,
+# Settings for waveform relaxation
+# 'use_wfr': False uses communication in every step 
+# instead of an iterative solution
+                      'use_wfr': True,
+                      'wfr_comm_interval': 1.0,
+                      'wfr_tol': 0.0001,
+                      'wfr_max_iterations': 15,
+                      'wfr_interpolation_order': 3})
 
 neuron = nest.Create('hh_psc_alpha_gap',2)
-vm = nest.Create('voltmeter', params={ "to_file": False, 'withgid': True, 'withtime': True, 'interval': 0.1})
+
+vm = nest.Create('voltmeter', params={'to_file': False,
+                                      'withgid': True,
+                                      'withtime': True,
+                                      'interval': 0.1})
 
 nest.SetStatus(neuron, {'I_e': 100.})
 nest.SetStatus([neuron[0]], {'V_m': -10.})
@@ -46,28 +57,27 @@ nest.Connect(vm, neuron, 'all_to_all')
 """
 Use 'all_to_all' to connect neurons.
 This is equivalent to:
-nest.Connect([neuron[0]],[neuron[1]], 'one_to_one', syn_spec={'model': 'gap_junction', 'weight': 0.5})
-nest.Connect([neuron[1]],[neuron[0]], 'one_to_one', syn_spec={'model': 'gap_junction', 'weight': 0.5})
+nest.Connect([neuron[0]],[neuron[1]], 
+             'one_to_one',
+             {'model': 'gap_junction', 'weight': 0.5})
+nest.Connect([neuron[1]],[neuron[0]],
+             'one_to_one',
+             {'model': 'gap_junction', 'weight': 0.5})
 """
-nest.Connect(neuron,neuron, 'all_to_all', syn_spec={'model': 'gap_junction', 'weight': 0.5})
+
+nest.Connect(neuron,neuron, 
+             {'rule':'all_to_all', 'autapses': False},
+             {'model': 'gap_junction', 'weight': 0.5})
 
 nest.Simulate(351.)
 
-senders_vm = nest.GetStatus(vm, 'events')[0]['senders']
-times_vm = nest.GetStatus(vm, 'events')[0]['times']
-V_vm = nest.GetStatus(vm, 'events')[0]['V_m']
-
-V = [[] for i in range(2)]
-times = [[] for i in range(2)]
-for i in range(len(senders_vm)):
-  V[senders_vm[i]-1].append(V_vm[i])
-  times[senders_vm[i]-1].append(times_vm[i])
-V = numpy.array(V)
-times = numpy.array(times)
+senders = nest.GetStatus(vm, 'events')[0]['senders']
+times = nest.GetStatus(vm, 'events')[0]['times']
+V = nest.GetStatus(vm, 'events')[0]['V_m']
 
 pylab.figure(1)
-pylab.plot(times[0,:],V[0,:],'r-')
-pylab.plot(times[0,:],V[1,:],'g-')
+pylab.plot(times[numpy.where(senders==1)],V[numpy.where(senders==1)],'r-')
+pylab.plot(times[numpy.where(senders==2)],V[numpy.where(senders==2)],'g-')
 pylab.xlabel('time (ms)')
 pylab.ylabel('membrane potential (mV)')
 pylab.show()

--- a/models/gap_junction.h
+++ b/models/gap_junction.h
@@ -131,7 +131,6 @@ public:
   send( Event& e, thread t, double_t, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
-    e.set_delay( get_delay_steps() );
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -152,6 +152,7 @@ public:
    */
   using Node::handle;
   using Node::handles_test_event;
+  using Node::sends_secondary_event;
 
   port send_test_event( Node& target, rport receptor_type, synindex, bool );
 
@@ -200,7 +201,7 @@ private:
   void calibrate();
   bool update_( Time const&, const long_t, const long_t, const bool );
   void update( Time const&, const long_t, const long_t );
-  bool prelim_update( Time const&, const long_t, const long_t );
+  bool wfr_update( Time const&, const long_t, const long_t );
 
   // END Boilerplate function declarations ----------------------------
 
@@ -316,7 +317,7 @@ private:
 
     // remembers current lag for piecewise interpolation
     long_t lag_;
-    // remembers y_values from last prelim_update
+    // remembers y_values from last wfr_update
     std::vector< double_t > last_y_values;
     // summarized gap weight
     double_t sumj_g_ij_;
@@ -379,12 +380,12 @@ hh_psc_alpha_gap::update( Time const& origin,
 }
 
 inline bool
-hh_psc_alpha_gap::prelim_update( Time const& origin,
+hh_psc_alpha_gap::wfr_update( Time const& origin,
   const long_t from,
   const long_t to )
 {
   bool done = false;
-  State_ old_state = S_; // save state before prelim update
+  State_ old_state = S_; // save state before wfr_update
   done = update_( origin, from, to, true );
   S_ = old_state; // restore old state
 

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -351,6 +351,19 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
   ConnectionT& c,
   rport receptor_type )
 {
+  // Let connections without delay contribute to the delay extrema with
+  // wfr_comm_interval. For those connections the min_delay is important
+  // as it determines the length of the global communication interval.
+  // The call to assert_valid_delay_ms needs to happen only once
+  // (either here or in used_default_delay()) when the first connection
+  // without delay is created.
+  if ( default_delay_needs_check_ && not has_delay_ )
+  {
+    kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
+      kernel().simulation_manager.get_wfr_comm_interval() );
+    default_delay_needs_check_ = false;
+  }
+
   // here we need to distinguish several cases:
   // - neuron src has no target on this machine yet (case 0)
   // - neuron src has n targets on this machine, all of same type
@@ -474,19 +487,6 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
           b_has_secondary || ( !is_primary_ ) );
       }
     }
-  }
-
-  // Let connections without delay contribute to the delay extrema with
-  // wfr_comm_interval. For those connections the min_delay is important
-  // as it determines the length of the global communication interval.
-  // The call to assert_valid_delay_ms needs to happen only once
-  // (either here or in used_default_delay()) when the first connection
-  // without delay is created.
-  if ( default_delay_needs_check_ && not has_delay_ )
-  {
-    kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
-      kernel().simulation_manager.get_wfr_comm_interval() );
-    default_delay_needs_check_ = false;
   }
 
   return conn;

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -190,10 +190,8 @@ GenericConnectorModel< ConnectionT >::used_default_delay()
           default_connection_.get_delay() );
       }
       // Let connections without delay contribute to the delay extrema with
-      // wfr_comm_interval
-      // For those connections the min_delay is important as it determines the
-      // length
-      // of the global communication interval.
+      // wfr_comm_interval. For those connections the min_delay is important
+      // as it determines the length of the global communication interval.
       else
       {
         kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
@@ -245,10 +243,8 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
         delay );
     }
     // Let connections without delay contribute to the delay extrema with
-    // wfr_comm_interval
-    // For those connections the min_delay is important as it determines the
-    // length
-    // of the global communication interval.
+    // wfr_comm_interval. For those connections the min_delay is important
+    // as it determines the length of the global communication interval.
     else
     {
       kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
@@ -299,10 +295,8 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
         delay );
     }
     // Let connections without delay contribute to the delay extrema with
-    // wfr_comm_interval
-    // For those connections the min_delay is important as it determines the
-    // length
-    // of the global communication interval.
+    // wfr_comm_interval. For those connections the min_delay is important
+    // as it determines the length of the global communication interval.
     else
     {
       kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
@@ -327,10 +321,8 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
           delay );
       }
       // Let connections without delay contribute to the delay extrema with
-      // wfr_comm_interval
-      // For those connections the min_delay is important as it determines the
-      // length
-      // of the global communication interval.
+      // wfr_comm_interval. For those connections the min_delay is important
+      // as it determines the length of the global communication interval.
       else
       {
         kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -189,6 +189,16 @@ GenericConnectorModel< ConnectionT >::used_default_delay()
         kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
           default_connection_.get_delay() );
       }
+      // Let connections without delay contribute to the delay extrema with
+      // wfr_comm_interval
+      // For those connections the min_delay is important as it determines the
+      // length
+      // of the global communication interval.
+      else
+      {
+        kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
+          kernel().simulation_manager.get_wfr_comm_interval() );
+      }
     }
     catch ( BadDelay& e )
     {
@@ -227,9 +237,24 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
   double_t delay,
   double_t weight )
 {
-  if ( not numerics::is_nan( delay ) && has_delay_ )
-    kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
-      delay );
+  if ( not numerics::is_nan( delay ) )
+  {
+    if ( has_delay_ )
+    {
+      kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
+        delay );
+    }
+    // Let connections without delay contribute to the delay extrema with
+    // wfr_comm_interval
+    // For those connections the min_delay is important as it determines the
+    // length
+    // of the global communication interval.
+    else
+    {
+      kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
+        kernel().simulation_manager.get_wfr_comm_interval() );
+    }
+  }
 
   // create a new instance of the default connection
   ConnectionT c = ConnectionT( default_connection_ );
@@ -273,6 +298,16 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
       kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
         delay );
     }
+    // Let connections without delay contribute to the delay extrema with
+    // wfr_comm_interval
+    // For those connections the min_delay is important as it determines the
+    // length
+    // of the global communication interval.
+    else
+    {
+      kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
+        kernel().simulation_manager.get_wfr_comm_interval() );
+    }
 
     if ( p->known( names::delay ) )
       throw BadParameter(
@@ -290,6 +325,16 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
       {
         kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
           delay );
+      }
+      // Let connections without delay contribute to the delay extrema with
+      // wfr_comm_interval
+      // For those connections the min_delay is important as it determines the
+      // length
+      // of the global communication interval.
+      else
+      {
+        kernel().connection_manager.get_delay_checker().assert_valid_delay_ms(
+          kernel().simulation_manager.get_wfr_comm_interval() );
       }
     }
     else

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -77,6 +77,7 @@ class Node;
  * @see CurrentEvent
  * @see CurrentEvent
  * @see ConductanceEvent
+ * @see GapJunctionEvent
  * @ingroup event_interface
  */
 

--- a/nestkernel/kernel_manager.h
+++ b/nestkernel/kernel_manager.h
@@ -46,13 +46,13 @@
 // clang-format off
 /* BeginDocumentation
  Name: kernel - Global properties of the simulation kernel.
- 
+
  Description:
  Global properties of the simulation kernel.
- 
+
  Parameters:
  The following parameters are available in the kernel status dictionary.
- 
+
  Time and resolution
  resolution               doubletype  - The resolution of the simulation (in ms)
  time                     doubletype  - The current simulation time
@@ -64,7 +64,7 @@
  tics_per_step            integertype - The number of tics per simulation time step
  T_max                    doubletype  - The largest representable time value (read only)
  T_min                    doubletype  - The smallest representable time value (read only)
- 
+
  Parallel processing
  total_num_virtual_procs  integertype - The total number of virtual processes
  local_num_threads        integertype - The local number of threads
@@ -73,7 +73,7 @@
  num_sim_processes        integertype - The number of MPI processes reserved for simulating neurons
  off_grid_spiking         booltype    - Whether to transmit precise spike times in MPI
                                         communication (read only)
- 
+
  Random number generators
  grng_seed                integertype - Seed for global random number generator used
                                         synchronously by all virtual processes to
@@ -84,24 +84,29 @@
                                         Array with one integer per virtual process,
                                         all must be unique and differ from
                                         grng_seed (write only).
- 
+
  Output
  data_path                stringtype  - A path, where all data is written to
                                         (default is the current directory)
  data_prefix              stringtype  - A common prefix for all data files
  overwrite_files          booltype    - Whether to overwrite existing data files
  print_time               booltype    - Whether to print progress information during the simulation
- 
+
  Network information
  network_size             integertype - The number of nodes in the network (read only)
  num_connections          integertype - The number of connections in the network
                                         (read only, local only)
- 
+
+ Waveform relaxation method (wfr)
+ use_wfr                  booltype    - Whether to use waveform relaxation method
+ wfr_comm_interval        doubletype  - Desired waveform relaxation communication interval
+ wfr_tol                  doubletype  - Convergence tolerance of waveform relaxation method
+ wfr_max_iterations       integertype - Maximal number of iterations used for waveform relaxation
+ wfr_interpolation_order  integertype - Interpolation order of polynomial used in wfr iterations
+
  Miscellaneous
- dict_miss_is_error         booltype    - Whether missed dictionary entries are treated as errors
- prelim_tol                 doubletype  - Tolerance of prelim iterations
- prelim_interpolation_order integertype - Interpolation order of polynomial used in prelim iterations
- 
+ dict_miss_is_error       booltype    - Whether missed dictionary entries are treated as errors
+
  SeeAlso: Simulate, Node
  */
 // clang-format on

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -200,8 +200,8 @@ const Name N( "N" );
 const Name N_channels( "N_channels" );
 const Name n_events( "n_events" );
 const Name n_proc( "n_proc" );
-const Name needs_prelim_update( "needs_prelim_update" );
 const Name neuron( "neuron" );
+const Name node_uses_wfr( "node_uses_wfr" );
 const Name noise( "noise" );
 const Name ns( "ns" );
 

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -235,18 +235,18 @@ extern const Name mother_seed;   //!< Specific to mip_generator
 extern const Name multapses;     //!< Connectivity-related
 extern const Name music_channel; //!< Parameters for MUSIC devices
 
-extern const Name n;          //!< Number of synaptic release sites (int >=0)
-                              //!< (Tsodyks2_connection)
-extern const Name N;          //!< Specific to population point process model
-                              //!< (pp_pop_psc_delta)
-extern const Name N_channels; //!< Specific to correlomatrix_detector
-extern const Name n_events;   //!< Recorder parameter
-extern const Name n_proc;     //!< Number of component processes of ppd_sup_/
-                              //!< gamma_sup_generator
-extern const Name needs_prelim_update; //!< Node parameter
-extern const Name neuron;              //!< Node type
-extern const Name noise;               //!< Specific to iaf_chs_2008 neuron
-extern const Name ns; //!< Number of release sites (property arrays)
+extern const Name n;             //!< Number of synaptic release sites (int >=0)
+                                 //!< (Tsodyks2_connection)
+extern const Name N;             //!< Specific to population point process model
+                                 //!< (pp_pop_psc_delta)
+extern const Name N_channels;    //!< Specific to correlomatrix_detector
+extern const Name n_events;      //!< Recorder parameter
+extern const Name n_proc;        //!< Number of component processes of ppd_sup_/
+                                 //!< gamma_sup_generator
+extern const Name neuron;        //!< Node type
+extern const Name node_uses_wfr; //!< Node parameter
+extern const Name noise;         //!< Specific to iaf_chs_2008 neuron
+extern const Name ns;            //!< Number of release sites (property arrays)
 
 extern const Name offset;  //!< Miscellaneous parameters
 extern const Name offsets; //!< Recorder parameter

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -49,7 +49,7 @@ Node::Node()
   , vp_( invalid_thread_ )
   , frozen_( false )
   , buffers_initialized_( false )
-  , needs_prelim_up_( false )
+  , node_uses_wfr_( false )
 {
 }
 
@@ -64,7 +64,7 @@ Node::Node( const Node& n )
   , frozen_( n.frozen_ )
   // copy must always initialized its own buffers
   , buffers_initialized_( false )
-  , needs_prelim_up_( n.needs_prelim_up_ )
+  , node_uses_wfr_( n.node_uses_wfr_ )
 {
 }
 
@@ -137,7 +137,7 @@ Node::get_status_base()
   {
     ( *dict )[ names::global_id ] = get_gid();
     ( *dict )[ names::frozen ] = is_frozen();
-    ( *dict )[ names::needs_prelim_update ] = needs_prelim_update();
+    ( *dict )[ names::node_uses_wfr ] = node_uses_wfr();
     ( *dict )[ names::thread ] = get_thread();
     ( *dict )[ names::vp ] = get_vp();
     if ( parent_ )
@@ -184,15 +184,15 @@ Node::set_status_base( const DictionaryDatum& dict )
 
   updateValue< bool >( dict, names::frozen, frozen_ );
 
-  updateValue< bool >( dict, names::needs_prelim_update, needs_prelim_up_ );
+  updateValue< bool >( dict, names::node_uses_wfr, node_uses_wfr_ );
 }
 
 /**
- * Default implementation of prelim_update just
+ * Default implementation of wfr_update just
  * throws UnexpectedEvent
  */
 bool
-Node::prelim_update( Time const&, const long_t, const long_t )
+Node::wfr_update( Time const&, const long_t, const long_t )
 {
   throw UnexpectedEvent();
 }

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -245,15 +245,15 @@ public:
   bool is_frozen() const;
 
   /**
-   * Returns true if the node requires a preliminary update step
+   * Returns true if the node uses the waveform relaxation method
    */
-  bool needs_prelim_update() const;
+  bool node_uses_wfr() const;
 
   /**
-   * Sets needs_prelim_up_ member variable
+   * Sets node_uses_wfr_ member variable
    * (to be able to set it to "true" for any class derived from Node)
    */
-  void set_needs_prelim_update( const bool );
+  void set_node_uses_wfr( const bool );
 
   /**
    * Returns true if the node is allocated in the local process.
@@ -328,7 +328,7 @@ public:
    * Bring the node from state $t$ to $t+n*dt$, sends SecondaryEvents
    * (e.g. GapJunctionEvent) and resets state variables to values at $t$.
    *
-   * n->prelim_update(T, from, to) performs the update steps beginning
+   * n->wfr_update(T, from, to) performs the update steps beginning
    * at T+from .. T+to-1.
    *
    * Does not emit spikes, does not log state variables.
@@ -340,7 +340,7 @@ public:
    * @param long_t post-final step inside time slice
    *
    */
-  virtual bool prelim_update( Time const&, const long_t, const long_t );
+  virtual bool wfr_update( Time const&, const long_t, const long_t );
 
   /**
    * @defgroup status_interface Configuration interface.
@@ -868,7 +868,7 @@ private:
   thread vp_;                //!< virtual process node is assigned to
   bool frozen_;              //!< node shall not be updated if true
   bool buffers_initialized_; //!< Buffers have been initialized
-  bool needs_prelim_up_;     //!< node requires preliminary update step
+  bool node_uses_wfr_;       //!< node uses waveform relaxation method
 };
 
 inline bool
@@ -878,15 +878,15 @@ Node::is_frozen() const
 }
 
 inline bool
-Node::needs_prelim_update() const
+Node::node_uses_wfr() const
 {
-  return needs_prelim_up_;
+  return node_uses_wfr_;
 }
 
 inline void
-Node::set_needs_prelim_update( const bool npu )
+Node::set_node_uses_wfr( const bool uwfr )
 {
-  needs_prelim_up_ = npu;
+  node_uses_wfr_ = uwfr;
 }
 
 inline bool

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -189,7 +189,7 @@ public:
   /**
    * Get list of nodes on given thread.
    */
-  const std::vector< Node* >& get_nodes_prelim_up_on_thread( thread ) const;
+  const std::vector< Node* >& get_wfr_nodes_on_thread( thread ) const;
 
   /**
    * Prepare nodes for simulation and register nodes in node_list.
@@ -207,7 +207,7 @@ public:
   /**
    *
    */
-  bool needs_prelim_update() const;
+  bool any_node_uses_wfr() const;
 
 private:
   /**
@@ -259,11 +259,10 @@ private:
    */
   std::vector< std::vector< Node* > > nodes_vec_;
   std::vector< std::vector< Node* > >
-    nodes_prelim_up_vec_;    //!< Nodelists for unfrozen nodes that require an
-                             //!< additional preliminary update (e.g. gap
-                             //!< junctions)
-  bool needs_prelim_update_; //!< there is at least one neuron model that needs
-                             //!< preliminary update
+    wfr_nodes_vec_;        //!< Nodelists for unfrozen nodes that
+                           //!< use the waveform relaxation method
+  bool any_node_uses_wfr_; //!< there is at least one neuron model that uses
+                           //!< waveform relaxation
   //! Network size when nodes_vec_ was last updated
   index nodes_vec_network_size_;
 };
@@ -317,15 +316,15 @@ NodeManager::get_nodes_on_thread( thread t ) const
 }
 
 inline const std::vector< Node* >&
-NodeManager::get_nodes_prelim_up_on_thread( thread t ) const
+NodeManager::get_wfr_nodes_on_thread( thread t ) const
 {
-  return nodes_prelim_up_vec_.at( t );
+  return wfr_nodes_vec_.at( t );
 }
 
 inline bool
-NodeManager::needs_prelim_update() const
+NodeManager::any_node_uses_wfr() const
 {
-  return needs_prelim_update_;
+  return any_node_uses_wfr_;
 }
 
 } // namespace

--- a/nestkernel/ring_buffer.h
+++ b/nestkernel/ring_buffer.h
@@ -109,7 +109,7 @@ public:
    * @param  offs  Offset of element to read within slice.
    * @returns value
    */
-  double get_value_prelim( const long_t offs );
+  double get_value_wfr_update( const long_t offs );
 
   /**
    * Initialize the buffer with noughts.
@@ -173,7 +173,7 @@ RingBuffer::get_value( const long_t offs )
 }
 
 inline double
-RingBuffer::get_value_prelim( const long_t offs )
+RingBuffer::get_value_wfr_update( const long_t offs )
 {
   assert( 0 <= offs && ( size_t ) offs < buffer_.size() );
   assert( ( delay ) offs < kernel().connection_manager.get_min_delay() );

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -180,10 +180,8 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "tics per ms and resolution changed." );
 
         // make sure that wfr communication interval is always greater or equal
-        // to resolution
-        // if no wfr is used explicitly set wfr_comm_interval to resolution
-        // because
-        // communication in every step is needed
+        // to resolution if no wfr is used explicitly set wfr_comm_interval
+        // to resolution because communication in every step is needed
         if ( wfr_comm_interval_ < Time::get_resolution().get_ms()
           || not use_wfr_ )
         {
@@ -213,10 +211,8 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "Temporal resolution changed." );
 
         // make sure that wfr communication interval is always greater or equal
-        // to resolution
-        // if no wfr is used explicitly set wfr_comm_interval to resolution
-        // because
-        // communication in every step is needed
+        // to resolution if no wfr is used explicitly set wfr_comm_interval
+        // to resolution because communication in every step is needed
         if ( wfr_comm_interval_ < Time::get_resolution().get_ms()
           || not use_wfr_ )
         {
@@ -245,16 +241,14 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
       LOG( M_ERROR,
         "SimulationManager::set_status",
         "Cannot enable/disable usage of waveform relaxation after nodes have "
-        "been created. "
-        "Please call ResetKernel first." );
+        "been created. Please call ResetKernel first." );
       throw KernelException();
     }
     else
     {
       use_wfr_ = wfr;
       // if no wfr is used explicitly set wfr_comm_interval to resolution
-      // because
-      // communication in every step is needed
+      // because communication in every step is needed
       if ( not use_wfr_ )
       {
         wfr_comm_interval_ = Time::get_resolution().get_ms();
@@ -263,10 +257,8 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
   }
 
   // wfr_comm_interval_ can only be changed if use_wfr_ is true and before
-  // connections
-  // are created. If use_wfr_ is false wfr_comm_interval_ is set to the
-  // resolution
-  // whenever the resolution changes.
+  // connections are created. If use_wfr_ is false wfr_comm_interval_ is set to
+  // the resolution whenever the resolution changes.
   double_t wfr_interval;
   if ( updateValue< double_t >( d, "wfr_comm_interval", wfr_interval ) )
   {
@@ -275,8 +267,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
       LOG( M_ERROR,
         "SimulationManager::set_status",
         "Cannot set waveform communication interval when usage of waveform "
-        "relaxation "
-        "is disabled. Set use_wfr to true first." );
+        "relaxation is disabled. Set use_wfr to true first." );
       throw KernelException();
     }
     else if ( kernel().connection_manager.get_num_connections() != 0 )
@@ -284,8 +275,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
       LOG( M_ERROR,
         "SimulationManager::set_status",
         "Cannot change waveform communication interval after connections have "
-        "been created. "
-        "Please call ResetKernel first." );
+        "been created. Please call ResetKernel first." );
       throw KernelException();
     }
     else if ( wfr_interval < Time::get_resolution().get_ms() )
@@ -293,8 +283,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
       LOG( M_ERROR,
         "SimulationManager::set_status",
         "Communication interval of the waveform relaxation must be greater or "
-        "equal "
-        "to the resolution of the simulation." );
+        "equal to the resolution of the simulation." );
       throw KernelException();
     }
     else
@@ -326,8 +315,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
       LOG( M_ERROR,
         "SimulationManager::set_status",
         "Maximal number of iterations  for the waveform relaxation must be "
-        "positive."
-        "To disable waveform relaxation set use_wfr instead." );
+        "positive. To disable waveform relaxation set use_wfr instead." );
     else
       wfr_max_iterations_ = max_iter;
   }

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -67,14 +67,24 @@ public:
   void terminate();
 
   /**
-   *
+   * Returns true if waveform relaxation is used.
    */
-  size_t get_prelim_interpolation_order() const;
+  bool use_wfr() const;
 
   /**
-   *
+   * Get the desired communication interval for the waveform relaxation
    */
-  double_t get_prelim_tol() const;
+  double_t get_wfr_comm_interval() const;
+
+  /**
+   * Get the convergence tolerance of the waveform relaxation method
+   */
+  double_t get_wfr_tol() const;
+
+  /**
+   * Get the interpolation order of the waveform relaxation method
+   */
+  size_t get_wfr_interpolation_order() const;
 
   /**
    * Get the time at the beginning of the current time slice.
@@ -128,7 +138,7 @@ private:
   size_t prepare_simulation_(); //! setup before simulation start
   void finalize_simulation_();  //! wrap-up after simulation end
   void update_();               //! actually perform simulation
-  bool prelim_update_( Node* );
+  bool wfr_update_( Node* );
   void advance_time_();   //!< Update time to next time step
   void print_progress_(); //!< TODO: Remove, replace by logging!
 
@@ -147,11 +157,14 @@ private:
                    //!< simulated for sometime
   bool print_time_; //!< Indicates whether time should be printed during
                     //!< simulations (or not)
-  long max_num_prelim_iterations_; //!< maximal number of iterations used for
-                                   //!< preliminary update
-  //! interpolation order for prelim iterations
-  size_t prelim_interpolation_order_;
-  double_t prelim_tol_; //!< Tolerance of prelim iterations
+  bool use_wfr_;    //!< Indicates wheter waveform relaxation is used
+  double_t wfr_comm_interval_; //!< Desired waveform relaxation communication
+                               //!< interval (in ms)
+  double_t wfr_tol_; //!< Convergence tolerance of waveform relaxation method
+  long wfr_max_iterations_; //!< maximal number of iterations used for waveform
+                            //!< relaxation
+  size_t wfr_interpolation_order_; //!< interpolation order for waveform
+                                   //!< relaxation method
 };
 
 inline void
@@ -203,16 +216,28 @@ SimulationManager::get_to_step() const
   return to_step_;
 }
 
-inline size_t
-SimulationManager::get_prelim_interpolation_order() const
+inline bool
+SimulationManager::use_wfr() const
 {
-  return prelim_interpolation_order_;
+  return use_wfr_;
 }
 
 inline double_t
-SimulationManager::get_prelim_tol() const
+SimulationManager::get_wfr_comm_interval() const
 {
-  return prelim_tol_;
+  return wfr_comm_interval_;
+}
+
+inline double_t
+SimulationManager::get_wfr_tol() const
+{
+  return wfr_tol_;
+}
+
+inline size_t
+SimulationManager::get_wfr_interpolation_order() const
+{
+  return wfr_interpolation_order_;
 }
 }
 

--- a/testsuite/mpitests/test_gap_junctions_mpi.sli
+++ b/testsuite/mpitests/test_gap_junctions_mpi.sli
@@ -57,9 +57,11 @@ if
   0 << 
         /total_num_virtual_procs total_vps 
         /resolution h
-        /prelim_tol 0.0001
-        /prelim_interpolation_order 3
-        /max_num_prelim_iterations 10
+        /use_wfr true
+        /wfr_tol 0.0001
+        /wfr_interpolation_order 3
+        /wfr_max_iterations 10
+        /wfr_comm_interval 1.0
     >> SetStatus
       
   /hh_psc_alpha_gap Create /neuron1 Set

--- a/testsuite/unittests/test_gap_junction.sli
+++ b/testsuite/unittests/test_gap_junction.sli
@@ -49,6 +49,9 @@ M_ERROR setverbosity
 
 ResetKernel
 
+2.0 /wfr_comm Set
+0 << /wfr_comm_interval wfr_comm >> SetStatus
+
 /iaf_neuron Create /neuron_no_gap Set
 /hh_psc_alpha_gap Create /neuron_gap Set
 
@@ -62,7 +65,20 @@ ResetKernel
   neuron_gap neuron_gap << /delay 2.0 >> /gap_junction Connect
 } fail_or_die
 
-% The delay of gap junction connections should not influence the min_delay and max_delay
+% Connections without delay contribute to the min_delay and max_delay with wfr_comm_interval
+% This is needed to control the length of the iteration interval
+
+ResetKernel
+
+2.0 /wfr_comm Set
+0 << /wfr_comm_interval wfr_comm >> SetStatus
+
+/iaf_neuron Create /neuron_no_gap Set
+/hh_psc_alpha_gap Create /neuron_gap Set
+
+% Create one connection to change min_delay, max_delay 
+neuron_no_gap neuron_no_gap Connect
+
 0 /max_delay get /old_max Set
 0 /min_delay get /old_min Set
 
@@ -71,7 +87,21 @@ neuron_gap neuron_gap 4.0 4.0 /gap_junction Connect
 0 /max_delay get /new_max Set
 0 /min_delay get /new_min Set
 
-{ old_min new_min eq old_max new_max eq and }assert_or_die
+old_min wfr_comm leq 
+{ 
+  { old_min new_min eq }assert_or_die 
+}
+{
+  { wfr_comm new_min eq }assert_or_die   
+} ifelse
+
+old_max wfr_comm geq 
+{ 
+  { old_max new_max eq }assert_or_die 
+}
+{
+  { wfr_comm new_max eq }assert_or_die   
+} ifelse
 
 % Check if illegal gap-junction connections can be created
 {

--- a/testsuite/unittests/test_hh_psc_alpha_gap.sli
+++ b/testsuite/unittests/test_hh_psc_alpha_gap.sli
@@ -67,9 +67,11 @@ ResetKernel
 0 << 
       /local_num_threads 1 
       /resolution h
-      /prelim_tol 0.0001
-      /prelim_interpolation_order 3
-      /max_num_prelim_iterations 10
+      /use_wfr true
+      /wfr_tol 0.0001
+      /wfr_interpolation_order 3
+      /wfr_max_iterations 10
+      /wfr_comm_interval 1.0
     >> SetStatus
     
 /hh_psc_alpha_gap Create /neuron1 Set

--- a/testsuite/unittests/test_wfr_settings.sli
+++ b/testsuite/unittests/test_wfr_settings.sli
@@ -1,0 +1,148 @@
+/*
+ *  test_wfr_settings.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+  /* BeginDocumentation
+
+    Name: testsuite::test_wfr_settings - Tests the possible settings for the waveform relaxation method
+
+    Synopsis: (test_wfr_settings) run -> NEST exits if test fails
+
+    Description:
+    The waveform relaxation method is used for iterative solution when connections
+    without delay are present (e.g. gap junctions)
+    
+    This test ensures that 
+    - use_wfr can only be set before nodes are created
+    - wfr_comm_interval can only be set greater or equal the resolution and if use_wfr = true
+    - setting of use_wfr = false sets wfr_comm_interval to resolution
+    - wfr_comm_interval is updated when resolution is changed and use_wfr = false
+    - use_wfr is set correctly in created nodes
+
+    Author: Jan Hahne, March 2016
+    SeeAlso: testsuite::test_hh_psc_alpha_gap, hh_psc_alpha_gap, gap_junction
+  */
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+ResetKernel
+
+% Check if use_wfr can be set
+{
+  0 << /use_wfr false >> SetStatus
+} pass_or_die
+
+% Check that use_wfr cannot be set after nodes are created
+{
+  /iaf_neuron Create
+  0 << /use_wfr true >> SetStatus
+} fail_or_die
+
+ResetKernel
+0 << /use_wfr true >> SetStatus
+
+% Check that wfr_comm_interval cannot be set lower as the resolution
+{
+  0 << /resolution 0.1 >> SetStatus
+  0 << /wfr_comm_interval 0.05 >> SetStatus
+} fail_or_die
+
+ResetKernel
+
+% Check that wfr_comm_interval cannot be set if use_wfr = false
+{
+  0 << /use_wfr false >> SetStatus
+  0 << /wfr_comm_interval 0.5 >> SetStatus
+} fail_or_die
+
+ResetKernel
+0 << /use_wfr true >> SetStatus
+0 << /wfr_comm_interval 0.5 >> SetStatus
+
+% Check that wfr_comm_interval is set to resolution if use_wfr = false is set
+0 << /resolution 0.1
+     /use_wfr false
+  >> SetStatus
+
+0 /wfr_comm_interval get /wfr_comm Set  
+
+{wfr_comm 0.1 eq}assert_or_die
+
+
+% Check that wfr_comm_interval is updated with resolution if use_wfr = false
+0 << /resolution 0.2 >> SetStatus
+
+0 /wfr_comm_interval get /wfr_comm Set  
+
+{wfr_comm 0.2 eq}assert_or_die
+
+ResetKernel
+
+% Check that wfr_comm_interval is not updated with resolution if use_wfr = true
+0 << /use_wfr true
+     /wfr_comm_interval 2.0
+  >> SetStatus
+
+0 << /resolution 0.1 >> SetStatus  
+  
+0 /wfr_comm_interval get /wfr_comm Set  
+
+{wfr_comm 2.0 eq}assert_or_die
+
+% The now following test needs the model hh_psc_alpha_gap, so
+% this test should only run if we have GSL
+statusdict/have_gsl :: not
+{
+  exit_test_gracefully
+}
+if
+
+ResetKernel
+
+% Check that setting of use_wfr is correctly set in created nodes
+% case use_wfr = true
+0 << /use_wfr true >> SetStatus
+
+/hh_psc_alpha_gap Create /neuron_gap Set
+
+5.0 Simulate
+
+neuron_gap /node_uses_wfr get /wfr Set
+
+{wfr true eq}assert_or_die
+
+ResetKernel
+
+% case use_wfr = false
+0 << /use_wfr false >> SetStatus
+
+/hh_psc_alpha_gap Create /neuron_gap Set
+
+5.0 Simulate
+
+neuron_gap /node_uses_wfr get /wfr Set
+
+{wfr false eq}assert_or_die
+
+endusing


### PR DESCRIPTION
This PR improves the iterative solution framework used for connections without delay (so far only gap junctions, but there is more to come).

- Renamed several internal and kernel variables from rather unspecific names to names of typ `wfr_*` in order to indicate that they belong to the iterative waveform relaxation (wfr) scheme.
```
max_num_prelim_iterations -> wfr_max_iterations
prelim_tol -> wfr_tol
prelim_interpolation_order -> wfr_interpolation_order
prelim_update -> wfr_update
needs_prelim_update -> node_uses_wfr
...
```

- Added kernel variable `wfr_comm_interval`. All connections without delay contribute with `wfr_comm_interval` to the `min_delay` and `max_delay`. The communication of the waveform relaxation method uses the regular communication points in intervals of the minimal network delay. Therefore it is desirable to be able to influence the `min_delay` for simulations with connections without delay

- Added kernel flag `use_wfr` to disable usage of iterative waveform relaxation method and use communication in every step instead ( single step method ). This is achieved by setting `wfr_comm_interval = resolution` and will be useful for rate models without delay where wfr is not always necessary and to reproduce data of the single step method from our gap-junction paper.

- Added a new unit test `test_wfr_settings.sli` that checks that `wfr_comm_interval` and `use_wfr` work properly and can only be set in a reasonable order. Adapted `test_gap_junction.sli` due to functionality of `wfr_comm_interval`.

- Improved and corrected Python-Code in both gap-junction examples

Most certainly there will be a small conflict with PR #269 in `node_manager.cpp`. I will adapt this PR once #269 is merged.


