### PR TITLE
Fix: Uninitialized variable in three models

### DIFF
--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -83,6 +83,7 @@ aeif_cond_alpha_multisynapse::Parameters_::Parameters_()
   , I_e( 0.0 )        // pA
   , MAXERR( 1.0e-10 ) // mV
   , HMIN( 1.0e-3 )    // ms
+  , num_of_receptors_( 0 )
   , has_connections_( false )
 {
   taus_syn.clear();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -74,6 +74,7 @@ iaf_psc_alpha_multisynapse::Parameters_::Parameters_()
   , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
   , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
   , LowerBound_( -std::numeric_limits< double_t >::infinity() )
+  , num_of_receptors_( 0 )
   , has_connections_( false )
 {
   tau_syn_.clear();

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -72,6 +72,7 @@ iaf_psc_exp_multisynapse::Parameters_::Parameters_()
   , I_e_( 0.0 )              // in pA
   , V_reset_( -70.0 - E_L_ ) // in mV
   , Theta_( -55.0 - E_L_ )   // relative E_L_
+  , num_of_receptors_( 0 )
   , has_connections_( false )
 {
   tau_syn_.clear();


### PR DESCRIPTION
`<model>::Parameters_::num_of_receptors_` is uninitialized for the three
models:

 * `aeif_cond_alpha_multisynapse`
 * `iaf_psc_alpha_multisynapse`
 * `iaf_psc_exp_multisynapse`

By chance it seems to always be 0 in the current master branch. However,
when compiling modified source code, it can assume aribtrary values.
This leads to potential SEGFAULTs when the `calibrate()` method is
called on an unchanged node.