### PR TITLE
hpc_benchmark fix and cleanup

### DIFF
--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -107,13 +107,13 @@ def
   /model_params
   <<
     % Set variables for iaf_neuron
-    /E_L     0.0  mV  % Resting membrane potential [mV]
-    /C_m   250.0  pF  % Capacity of the membrane [pF]
-    /tau_m  10.0  ms  % Membrane time constant [ms]
-    /t_ref 0.5  ms  % duration of refractory period [ms]
-    /V_th   20.0  mV  % Threshold [mV]
-    /V_reset 0.0  mV  % Reset Potential [mV]
-    /tau_syn  0.32582722403722841 ms  % time const. postsynaptic excitatory currents [ms]
+    /E_L     0.0  mV  % Resting membrane potential (mV)
+    /C_m   250.0  pF  % Capacity of the membrane (pF)
+    /tau_m  10.0  ms  % Membrane time constant (ms)
+    /t_ref 0.5  ms  % duration of refractory period (ms)
+    /V_th   20.0  mV  % Threshold (mV)
+    /V_reset 0.0  mV  % Reset Potential (mV)
+    /tau_syn  0.32582722403722841 ms  % time const. postsynaptic excitatory currents (ms)
     /tau_minus 30.0 ms %time constant for STDP (depression)
     % V can be randomly initialized see below
     /V_m 5.7 mV % mean value of membrane potential
@@ -124,12 +124,12 @@ def
   /sigma_potential 7.2 mV % in the paper were used for the benchmarks on K, the values given
                           % here were used for the benchmark on JUQUEEN.
 
-  /delay  1.5 ms         % synaptic delay, all connections [ms]
+  /delay  1.5 ms         % synaptic delay, all connections (ms)
 
    % synaptic weight
   /JE 0.14 mV %peak of EPSP
 
-  /sigma_w 3.47 pA      %standard dev. of E->E synapses [pA]
+  /sigma_w 3.47 pA      %standard dev. of E->E synapses (pA)
   /g  -5.0
 
   /stdp_params

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -26,7 +26,8 @@
    multiplicative depression and power-law potentiation. A mutual
    equilibrium is obtained between the activity dynamics (low rate in
    asynchronous irregular regime) and the synaptic weight distribution
-   (unimodal).
+   (unimodal). The number of incoming connections per neuron is fixed
+   and independent of network size (indegree=11250).
 
    This is the standard network investigated in:
    Morrison et al (2007). Spike-timing-dependent plasticity in balanced random networks Neural Comput 19(6):1437-67
@@ -39,14 +40,14 @@
 % define all relevant parameters: changes should be made here
 % all data is placed in the userdict dictionary
 
-/nvp 1 def % total number of virtual processes
-/scale 0.2 def %  scaling factor of the network size, total network size = scale*11250 neurons
-/simtime 1000. def % total simulation time in ms
+/nvp 1 def              % total number of virtual processes
+/scale 2 def            % scaling factor of the network size, total network size = scale*11250 neurons
+/simtime 1000. def      % total simulation time in ms
 /presimtime 100. ms def % simulation time until reaching equilibrium
-/dt         0.1 ms def % simulation step
+/dt 0.1 ms def          % simulation step
 /record_spikes true def % switch to record spikes of excitatory neurons to file
-/path_name (.) def % path where all files will have to be written
-/log_file (log) def % naming scheme for the log files
+/path_name (.) def      % path where all files will have to be written
+/log_file (log) def     % naming scheme for the log files
 
 % -------------------------------------------------------------------------------------
 
@@ -97,17 +98,15 @@ def
 
 /brunel_params
 <<
-
-
   /NE 9000 scale mul round cvi   % number of excitatory neurons
   /NI 2250 scale mul round cvi   % number of inhibitory neurons
 
   % number of neurons to record spikes from
-  /Nrec 1000 
+  /Nrec 1000
 
   /model_params
-   <<
-   % Set variables for iaf_neuron
+  <<
+    % Set variables for iaf_neuron
     /E_L     0.0  mV  % Resting membrane potential [mV]
     /C_m   250.0  pF  % Capacity of the membrane [pF]
     /tau_m  10.0  ms  % Membrane time constant [ms]
@@ -118,16 +117,14 @@ def
     /tau_minus 30.0 ms %time constant for STDP (depression)
     % V can be randomly initialized see below
     /V_m 5.7 mV % mean value of membrane potential
-   >> 
+  >>
 
-  
-  
   /randomize_Vm true
   /mean_potential 5.7 mV  % Note that Kunkel et al. (2014) report different values. The values
   /sigma_potential 7.2 mV % in the paper were used for the benchmarks on K, the values given
                           % here were used for the benchmark on JUQUEEN.
 
-  /delay  1.5 ms         % synaptic delay, all connections [ms] 
+  /delay  1.5 ms         % synaptic delay, all connections [ms]
 
    % synaptic weight
   /JE 0.14 mV %peak of EPSP
@@ -165,7 +162,7 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
 /BuildNetwork
 {
   
-  tic % start timer on construction    
+  tic % start timer on construction
   % set global kernel parameters
   0
   <<
@@ -192,79 +189,78 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
       M_INFO (BuildNetwork)
       (Randomzing membrane potentials.) message
 
-      0 GetStatus /rng_seeds get Last 1 add 0 /vp get add 
-      rngdict/MT19937 :: exch CreateRNG 
+      0 GetStatus /rng_seeds get Last 1 add 0 /vp get add
+      rngdict/MT19937 :: exch CreateRNG
       rdevdict/normal :: CreateRDV /normal Set
 
-      [E_from E_to] Range
-      { 
-	  << /V_m mean_potential sigma_potential normal Random mul add >> 
-	  SetStatus 
+      E_net GetLocalNodes
+      {
+          << /V_m mean_potential sigma_potential normal Random mul add >>
+	  SetStatus
       } forall
 
-      [I_from I_to] Range
+      I_net GetLocalNodes
       { 
-	  << /V_m mean_potential sigma_potential normal Random mul add >> 
-	  SetStatus 
+	  << /V_m mean_potential sigma_potential normal Random mul add >>
+	  SetStatus
       } forall
   } if
-   
+
   /E_neurons E_from E_to cvgidcollection def % get memory efficient gid-collection
 
   /I_neurons I_from I_to cvgidcollection def % get memory efficient gid-collection
-  
+
   /N E_neurons size I_neurons size add def
 
   /CE NE scale cvd div iround def %number of incoming excitatory connections
-  /CI NI scale cvd div iround def %number of incomining inhibitory connections	
-
+  /CI NI scale cvd div iround def %number of incomining inhibitory connections
 
   M_INFO (BuildNetwork)
   (Creating excitatory stimulus generator.) message
 
   model_params using
-   
+
   % Convert synapse weight from mV to pA
   C_m tau_syn tau_m ConvertSynapseWeight /conversion_factor Set
   /JE_pA conversion_factor JE mul def
-  
+
   /nu_thresh V_th CE tau_m C_m div mul JE_pA mul 1.0 exp mul tau_syn mul div def
   /nu_ext nu_thresh eta mul def
   endusing
-    
-  /E_stimulus /poisson_generator Create def 
-  E_stimulus 
+
+  /E_stimulus /poisson_generator Create def
+  E_stimulus
   <<
      /rate nu_ext CE mul 1000. mul
-  >> SetStatus	 
-  
-  /I_stimulus /poisson_generator Create def  
+  >> SetStatus
+
+  /I_stimulus /poisson_generator Create def
   I_stimulus
   <<
      /rate nu_ext CE mul 1000. mul
   >> SetStatus
- 
+
   M_INFO (BuildNetwork)
   (Creating excitatory spike detector.) message
 
-  record_spikes true eq {
+  record_spikes true eq
+  {
     /detector_label  filestem (/alpha_) join stdp_params /alpha get cvs join (_spikes) join def
     /E_detector /spike_detector Create def
     E_detector
-    << 
-    /withtime true 
-    /to_file true
-    /label detector_label
+    <<
+       /withtime true
+       /to_file true
+       /label detector_label
     >> SetStatus
   } if
 
   memory_thisjob cvs ( # virt_mem_after_nodes) join logger /log call
 
   toc /BuildNodeTime Set
-  mpi_rank cvs (] ) join (BuildNode time     : ) join  =only BuildNodeTime =only ( s) =
 
   BuildNodeTime cvs ( # build_time_nodes) join logger /log call
-  
+
   tic
 
   % Create custom synapse types with appropriate values for
@@ -273,15 +269,15 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
   /static_synapse_hpc /syn_std  CopyModel
   /static_synapse_hpc /syn_ex << /weight JE_pA >> CopyModel
   /static_synapse_hpc /syn_in << /weight JE_pA g mul >> CopyModel
-      	
+
   stdp_params /weight JE_pA put	
   /stdp_pl_synapse_hom_hpc stdp_params SetDefaults
 
-  
+
   M_INFO (BuildNetwork)
   (Connecting stimulus generators.) message
-  
-  % Connect Poisson generator to neuron      
+
+  % Connect Poisson generator to neuron
 
   E_stimulus E_stimulus cvgidcollection E_neurons << /rule (all_to_all) >> << /model /syn_ex >> Connect
   E_stimulus E_stimulus cvgidcollection I_neurons << /rule (all_to_all) >> << /model /syn_ex >> Connect
@@ -296,20 +292,18 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
 
   I_neurons E_neurons << /rule (fixed_indegree) /indegree CI /autapses false /multapses true >> << /model /syn_in >> Connect
 
-  
   M_INFO (BuildNetwork)
   (Connecting excitatory -> inhibitory population.) message
-  
+
   E_neurons I_neurons << /rule (fixed_indegree) /indegree CE /autapses false /multapses true >> << /model /syn_ex >> Connect
 
-  
   M_INFO (BuildNetwork)
   (Connecting inhibitory -> inhibitory population.) message
 
   I_neurons I_neurons << /rule (fixed_indegree) /indegree CI /autapses false /multapses true >> << /model /syn_in >> Connect
 
 
-  record_spikes true eq 
+  record_spikes true eq
   {
     E_net GetLocalNodes size /local_neurons Set
 
@@ -327,10 +321,9 @@ Aborting the simulation!) message
     E_net GetLocalNodes Nrec Take [E_detector] << /rule (all_to_all) >> << /model /syn_std >> Connect
   } if
 
-  % read out time used for building    
+  % read out time used for building
   toc /BuildEdgeTime Set
-  mpi_rank cvs (] ) join (BuildEdge time     : ) join  =only BuildEdgeTime =only ( s) =
-  
+
   BuildEdgeTime cvs ( # build_edge_time ) join logger /log call
   memory_thisjob cvs ( # virt_mem_after_edges) join logger /log call
 
@@ -339,60 +332,80 @@ Aborting the simulation!) message
 /RunSimulation
 {
 
-   % open log file
-   log_file logger /init call
-   
-   ResetKernel
-   statusdict /MPI_Rank known
-    {
-      /mpi_rank statusdict /MPI_Rank get def
-    }
-    {
-      /mpi_rank 0 def   % serial version
-    }
-   ifelse  
-  %stdp_params using
+  % open log file
+  log_file logger /init call
+
+  ResetKernel
 
   memory_thisjob cvs ( # virt_mem_0) join logger /log call
-  
+
   BuildNetwork
-   
+
   tic
 
   presimtime Simulate
 
   toc /PreparationTime Set
-  mpi_rank cvs (] ) join (Preparation time   : ) join  =only PreparationTime   =only ( s\n) =
 
   memory_thisjob cvs ( # virt_mem_after_presim) join logger /log call
   PreparationTime cvs ( # presim_time) join logger /log call
 
   tic
 
-  simtime Simulate	
+  simtime Simulate
 
   toc /SimCPUTime Set
 
   memory_thisjob cvs ( # virt_mem_after_sim) join logger /log call
   SimCPUTime cvs ( # sim_time) join logger /log call
 
-  
-%(\nBRN STDP Equilibrium Simulation) =
-  mpi_rank cvs (] ) join (Simulation time   : ) join  =only SimCPUTime   =only ( s\n) =
+  record_spikes true eq
+  {
+    E_detector ComputeRate cvs ( # average rate) join logger /log call
+  } if
 
-  logger /done call  
+  logger /done call
 } def
 
+% ------------------------------------------------------------------------------------
 
+% Take spike detector, find total number of spikes registered,
+% return average rate per neuron in Hz.
+% NOTE: If you are running with several MPI processes, this
+%       function only gives an approximation to the true rate.
+%
+% spike_det ComputeRate -> rate
+/ComputeRate
+{
+  << >> begin  % anonymous dictionary for local variables
+
+    /sdet Set
+
+    % We need to guess how many neurons we record from.
+    % This assumes an even distribution of nodes across
+    % processes, as well as homogeneous activity in the
+    % network. So this is really a hack. NEST needs better
+    % support for rate calculations, such as giving the
+    % number of neurons recorded from by each spike detector.
+
+    /n_local_neurons Nrec cvd NumProcesses div def
+    sdet /n_events get cvd n_local_neurons simtime mul div
+    1000 mul         % convert from mHz to Hz, leave on stack
+
+  end
+} bind             % optional, improves performance
+def
+
+% ------------------------------------------------------------------------------------
 
 /*
-    This script defines a logger class used to properly log memory and timing
+    This function defines a logger class used to properly log memory and timing
     information from network simulations. It is used by hpc_benchmark.sli to
     store the information to the log files.
 */
 
-/logger <<
-
+/logger
+<<
     /max_rank_cout 5  % copy output to cout for ranks 0..max_rank_cout-1
     /max_rank_log 30  % write to log files for ranks 0..max_rank_log-1
     /line_counter 0
@@ -403,7 +416,7 @@ Aborting the simulation!) message
     {
 	Rank max_rank_log lt {
 
-            (_) join 
+            (_) join
 
 	    % convert rank to string, prepend 0 if necessary to make
             % numbers equally wide for all ranks
@@ -424,7 +437,7 @@ Aborting the simulation!) message
 		/Logger_init /CannotOpenFile raiseerror
 	    }
 	    ifelse
-	
+
 	} if
     }
 
@@ -450,10 +463,9 @@ Aborting the simulation!) message
 	    f close
 	} if
     }
-    
->> def
 
+>> def
 
 % ------------------------------------------------------------------------------------
 
-RunSimulation  
+RunSimulation


### PR DESCRIPTION
this PR fixes an issue that lead to poor scaling pf the `hpc_benchmark.sli` example. the issue was the use of `[E_from E_to] Range` in randomizing membrane potentials of neurons. this would allocate memory for an array containing the gids of the entire network and loop over this list on every process(!), which quickly becomes an issue for large scale benchmarks (in terms of time and memory). it is replaced by `E_net GetLocalNodes`.
in addition I have removed output via `=` which happens on every process. all output should happen via the logger, which restricts the number of processes that generate output.
I have added a rate calculation function, which was shamelessly copied from `brunel-2000.sli`.
minor changes in this PR:

- removed some whitespace at end of lines
- removed some blank lines
- fixed indentation
- replaced [unit] with (unit)
- minor addition to documentation
- changed default scale to 2 (0.2 was pointless since this amounts to a five-times fully connected network)