### PR TITLE
Libneurosim build error.

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -156,7 +156,7 @@ endif ()
 
 # Static modules
 set( SLI_MODULES models precise topology )
-if ( with-libneurosim )
+if ( HAVE_LIBNEUROSIM )
   set( SLI_MODULES ${SLI_MODULES} conngen )
 endif ()
 


### PR DESCRIPTION
Only add `conngen`, when libneurosim is actually found. See #307.