### PR TITLE
Bugfix in FindCython.cmake

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -65,7 +65,7 @@ if ( NOT CYTHON_EXECUTABLE STREQUAL "CYTHON_EXECUTABLE-NOTFOUND" )
       OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if ( RESULT EQUAL 0 )
-    string( REGEX REPLACE ".* ([0-9]+)\\.([0-9]+).*$" "\\1.\\2" 
+    string( REGEX REPLACE ".* ([0-9]+\\.[0-9]+(\\.[0-9]+)?).*" "\\1"
                           CYTHON_VERSION "${CYTHON_VAR_OUTPUT}" )
   endif ()
 endif ()

--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -65,7 +65,7 @@ if ( NOT CYTHON_EXECUTABLE STREQUAL "CYTHON_EXECUTABLE-NOTFOUND" )
       OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if ( RESULT EQUAL 0 )
-    string( REGEX REPLACE ".* ([0-9]+\\.[0-9]+(\\.[0-9]+)?)$" "\\1" 
+    string( REGEX REPLACE ".* ([0-9]+)\\.([0-9]+).*$" "\\1.\\2" 
                           CYTHON_VERSION "${CYTHON_VAR_OUTPUT}" )
   endif ()
 endif ()


### PR DESCRIPTION
My cython version is `0.20.1post0` and `FindCython.cmake` was not able to detect it. 

This pull request is fixing this issue by changing the regex in `FindCython.cmake`.