### PR TITLE
Fix issues around nosetest checking

### DIFF
--- a/pynest/do_tests.py.in
+++ b/pynest/do_tests.py.in
@@ -45,9 +45,6 @@ def _setup(arg):
     
     sys.stderr.write("  Running test " + MethodName + "...\n")
 
-myprint("\n")
-myprint("Phase 6: Running PyNEST tests.\n")
-myprint("------------------------------\n")
 
 import nest
 nest.init(["--verbosity=WARNING", "--quiet"])

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -544,12 +544,25 @@ fi
 
 if test "x${TEST_PYNEST}" = xtrue ; then
 
-    if command -v nosetests >/dev/null 2>&1 && nosetests --with-xunit --xunit-file=/dev/null >/dev/null 2>&1; then
+    echo
+    echo "Phase 6: Running PyNEST tests."
+    echo "------------------------------"
+    
+    # If possible, we run using nosetests. To find out if nosetests work, 
+    # we proceed in two steps:
+    # 1. Check if nosetests is available
+    # 2. Check that nosetests supports --with-xunit by running nosetests.
+    #    We need to run nosetests on a directory without any Python test
+    #    files, because if they failed that would be interpreted as lack
+    #    of support for nosetests. We use the TEST_OUTDIR as Python-free
+    #    dummy directory to search for tests.
 
-	echo
-	echo "Phase 6: Running PyNEST tests."
-	echo "------------------------------"
+    if command -v nosetests >/dev/null 2>&1 && nosetests --with-xunit --xunit-file=/dev/null --where=${TEST_OUTDIR} >/dev/null 2>&1; then
 
+        echo
+        echo "  Using nosetests."
+        echo
+        
         nosetests -v --with-xunit --xunit-file=${TEST_OUTDIR}/pynest_tests.xml @PYEXECDIR@/nest/tests 2>&1 \
             | tee -a "${TEST_LOGFILE}" | grep -i --line-buffered "\.\.\. ok\|fail\|skip\|error" | sed 's/^/  /'
 
@@ -574,6 +587,11 @@ if test "x${TEST_PYNEST}" = xtrue ; then
         PYNEST_TEST_PASSED=$(($PYNEST_TEST_TOTAL - $PYNEST_TEST_FAILED))
 
     else
+
+        echo
+        echo "  Nosetests unavailable. Using fallback test harness."
+        echo "  Fewer tests will be excuted."
+        echo
 
         "${PYTHON}" "${PYTHON_HARNESS}" >> "${TEST_LOGFILE}"
     


### PR DESCRIPTION
This PR fixes problems with nosetest detection, see also #318. 

- Checking for nosetest xunit support now uses python-free directory to avoid confusion.
- "Phase 6" heading now in one place, some info given about which test scheme is used.
- Check for nosetest commented.

@tammoippen @jougs Could you take a look?