### PR TITLE
Remove GNUReadline link dependency from PyNEST 

### DIFF
--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -27,7 +27,8 @@ add_executable( nest main.cpp ${nest_sources} )
 add_library( nest_lib ${nest_sources} )
 
 target_link_libraries( nest
-    nestutil nestkernel random sli_lib ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} )
+    nestutil nestkernel random sli_lib sli_readline
+    ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} )
 
 target_link_libraries( nest_lib
     nestutil nestkernel random sli_lib ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} )

--- a/sli/CMakeLists.txt
+++ b/sli/CMakeLists.txt
@@ -86,8 +86,13 @@ set( sli_sources
 add_library( sli_lib ${sli_sources} )
 target_link_libraries( sli_lib nestutil )
 
+# Make a separate target for linking against readline, so that
+# pynestkernel does not need to link against readline and make
+# loading different readlines a problem for Python. See this
+# pull request for more information:
+# https://github.com/nest/nest-simulator/pull/323
 add_library( sli_readline gnureadline.cc gnureadline.h )
-target_link_libraries( sli_readline sli_lib ${READLINE_LIBRARIES} )
+target_link_libraries( sli_readline sli_lib nestutil ${READLINE_LIBRARIES} )
 
 # add the executable
 add_executable( sli puresli.cc )

--- a/sli/CMakeLists.txt
+++ b/sli/CMakeLists.txt
@@ -36,7 +36,6 @@ set( sli_sources
     functiondatum.cc functiondatum.h
     genericdatum.h
     get_mem.c
-    gnureadline.cc gnureadline.h
     integerdatum.cc integerdatum.h
     interpret.cc interpret.h
     iostreamdatum.cc iostreamdatum.h
@@ -85,11 +84,14 @@ set( sli_sources
     )
 
 add_library( sli_lib ${sli_sources} )
-target_link_libraries( sli_lib nestutil ${READLINE_LIBRARIES} )
+target_link_libraries( sli_lib nestutil )
+
+add_library( sli_readline gnureadline.cc gnureadline.h )
+target_link_libraries( sli_readline sli_lib ${READLINE_LIBRARIES} )
 
 # add the executable
 add_executable( sli puresli.cc )
-target_link_libraries( sli sli_lib )
+target_link_libraries( sli sli_lib sli_readline )
 
 target_include_directories( sli PRIVATE
     ${PROJECT_SOURCE_DIR}/libnestutil
@@ -101,13 +103,18 @@ target_include_directories( sli_lib PRIVATE
     ${PROJECT_BINARY_DIR}/libnestutil
     )
 
+target_include_directories( sli_readline PRIVATE
+    ${PROJECT_SOURCE_DIR}/libnestutil
+    ${PROJECT_BINARY_DIR}/libnestutil
+    )
+
 target_compile_definitions( sli_lib PRIVATE
     -DPKGDATADIR=\"${PKGDATADIR}\"
     -DPKGDOCDIR=\"${PKGDOCDIR}\"
     -DPKGSOURCEDIR=\"${PROJECT_SOURCE_DIR}\"
     )
 
-install( TARGETS sli_lib sli
+install( TARGETS sli_readline sli_lib sli
     LIBRARY DESTINATION ${INSTALL_LIB_DIR}
     ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
     RUNTIME DESTINATION ${INSTALL_BIN_DIR}


### PR DESCRIPTION
Only the executables `sli` and `nest` use the GNUReadline interaction. All other libraries and modules, e.g. PyNEST, do not need to be linked against the GNUReadline library. In this PR I create a separate target `sli_readline` that contains all the code necessary for the GNUReadline interaction and link it only to sli and nest executable. This way PyNEST is not linked against GNUReadline (and Python can use its readline library) and problems discussed in #210 and #209 will not occur anymore.