### PR TITLE
Changed order of setting parameters for synapse models

### DIFF
--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -313,18 +313,21 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
 
   // create a new instance of the default connection
   ConnectionT c = ConnectionT( default_connection_ );
-  if ( !p->empty() )
-    c.set_status( p, *this ); // reference to connector model needed here to
-                              // check delay (maybe this
-                              // could be done one level above?)
+
   if ( not numerics::is_nan( weight ) )
   {
     c.set_weight( weight );
   }
+
   if ( not numerics::is_nan( delay ) )
   {
     c.set_delay( delay );
   }
+
+  if ( !p->empty() )
+    c.set_status( p, *this ); // reference to connector model needed here to
+                              // check delay (maybe this
+                              // could be done one level above?)
 
   // We must use a local variable here to hold the actual value of the
   // receptor type. We must not change the receptor_type_ data member, because


### PR DESCRIPTION
In #284, I modified the stdp synapse model to allow inhibitory synapses (`weight` with negative signs). Also, I wanted to throw an exception if the parameters `weight` and `Wmax` don't have the same sign.

While creating a new connection the parameter `weight` is set in the function `set_weight` and parameters like `Wmax` are set in `set_status`. In the current implementation, `set_status` is called before `set_weight`, which has the effect that `weight` is not yet updated in `set_status`.

For asserting that `weight` and `Wmax` has the same sign in `set_status`, I had to change the order in which `set_weight` and `set_status` is called. Now, `set_status` is called after `set_weight` (and `set_delay`) which ensures all parameters are up to date in `set_status`.