### PR TITLE
Fix building nest without python

### DIFF
--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -46,6 +46,9 @@ target_include_directories( nest PRIVATE
     ${PROJECT_SOURCE_DIR}/nestkernel
     ${SLI_MODULE_INCLUDE_DIRS}
     )
+target_compile_definitions( nest PRIVATE
+    -D_BUILD_NEST_CLI
+)
 
 target_include_directories( nest_lib PRIVATE
     ${PROJECT_BINARY_DIR}/nest

--- a/nest/neststartup.cpp
+++ b/nest/neststartup.cpp
@@ -59,7 +59,7 @@
 #include "slistartup.h"
 #include "specialfunctionsmodule.h"
 
-#ifndef _IS_PYNEST
+#if defined( _BUILD_NEST_CLI ) && defined( HAVE_READLINE )
 #include <gnureadline.h>
 #endif
 
@@ -115,7 +115,7 @@ neststartup( int* argc,
   addmodule< OOSupportModule >( engine );
   addmodule< RandomNumbers >( engine );
 
-#if defined( HAVE_READLINE ) && !defined( _IS_PYNEST )
+#if defined( _BUILD_NEST_CLI ) && defined( HAVE_READLINE )
   addmodule< GNUReadline >( engine );
 #endif
 


### PR DESCRIPTION
The PR #323 removed GNUReadline from PyNEST, but when building nest without python the library `libnest.dylib` now expects GNUReadline, as no _IS_PYNEST is given, which does not compile (at least not on OS X). This PR allows to differentiate building the NEST CLI, PyNEST and a standalone
library.