### PR TITLE
Correct versions in FindXXX.cmake

### DIFF
--- a/cmake/FindLibNeurosim.cmake
+++ b/cmake/FindLibNeurosim.cmake
@@ -42,9 +42,9 @@ find_library( PYNEUROSIM_LIBRARY
     )
 
 if ( EXISTS "${LIBNEUROSIM_INCLUDE_DIRS}/neurosim/version.h" )
-  file( STRINGS "${LIBNEUROSIM_INCLUDE_DIRS}/neurosim/version.h" 
+  file( STRINGS "${LIBNEUROSIM_INCLUDE_DIRS}/neurosim/version.h"
                 version_h_contents REGEX "define LIBNEUROSIM_VERSION" )
-  string( REGEX REPLACE ".*([0-9].[0-9].[0-9]).*" "\\1" 
+  string( REGEX REPLACE ".*([0-9]+.[0-9]+.[0-9]+).*" "\\1" 
                         LIBNEUROSIM_VERSION ${version_h_contents} )
 endif ()
 

--- a/cmake/FindLibNeurosim.cmake
+++ b/cmake/FindLibNeurosim.cmake
@@ -44,7 +44,7 @@ find_library( PYNEUROSIM_LIBRARY
 if ( EXISTS "${LIBNEUROSIM_INCLUDE_DIRS}/neurosim/version.h" )
   file( STRINGS "${LIBNEUROSIM_INCLUDE_DIRS}/neurosim/version.h"
                 version_h_contents REGEX "define LIBNEUROSIM_VERSION" )
-  string( REGEX REPLACE ".*([0-9]+.[0-9]+.[0-9]+).*" "\\1" 
+  string( REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" 
                         LIBNEUROSIM_VERSION ${version_h_contents} )
 endif ()
 

--- a/cmake/FindMusic.cmake
+++ b/cmake/FindMusic.cmake
@@ -50,7 +50,7 @@ if ( NOT MUSIC_EXECUTABLE STREQUAL "MUSIC_EXECUTABLE-NOTFOUND" )
       OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if ( RESULT EQUAL 0 )
-    string( REGEX REPLACE "^MUSIC ([0-9]\\.[0-9]\\.[0-9]).*" "\\1"
+    string( REGEX REPLACE "^MUSIC ([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1"
                           MUSIC_VERSION ${MUSIC_VAR_OUTPUT} )
   endif ()
 endif ()


### PR DESCRIPTION
I missed in these two FindXXX.cmake files, that versions can have more than one digit and with
MUSIC already at version 1.1.15 (see [here](https://github.com/INCF/MUSIC/blob/master/configure.ac#L2)), this might become relevant.