### PR TITLE
Fix TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,20 @@ dist: trusty
 
 env:
   matrix:
-    - xGSL=0 xMPI=0 xPYTHON=0
-    - xGSL=0 xMPI=0 xPYTHON=1
-    - xGSL=0 xMPI=1 xPYTHON=0
-    - xGSL=0 xMPI=1 xPYTHON=1
-    - xGSL=1 xMPI=0 xPYTHON=0
-    - xGSL=1 xMPI=0 xPYTHON=1
-    - xGSL=1 xMPI=1 xPYTHON=0
-    - xGSL=1 xMPI=1 xPYTHON=1
+    - xGSL=0 xMPI=0 xPYTHON=1 CACHE_NAME=JOB
+    - xGSL=0 xMPI=0 xPYTHON=0 CACHE_NAME=JOB
+    - xGSL=0 xMPI=1 xPYTHON=0 CACHE_NAME=JOB
+    - xGSL=0 xMPI=1 xPYTHON=1 CACHE_NAME=JOB
+    - xGSL=1 xMPI=0 xPYTHON=0 CACHE_NAME=JOB
+    - xGSL=1 xMPI=0 xPYTHON=1 CACHE_NAME=JOB
+    - xGSL=1 xMPI=1 xPYTHON=0 CACHE_NAME=JOB
+    - xGSL=1 xMPI=1 xPYTHON=1 CACHE_NAME=JOB
 matrix:
   # do notify immediately about it when a job of a build fails.
   fast_finish: true
 cache:
-  apt: true
-  ccache: true
-  pip: true
+  directory:
+    - $HOME/.cache
 
 before_install:
   - echo $PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,12 @@ matrix:
   # do notify immediately about it when a job of a build fails.
   fast_finish: true
 cache:
-  apt: true 
+  apt: true
   ccache: true
   pip: true
 
 before_install:
   - echo $PATH
-
-  # get repository for clang-3.6 stuff (including clang-format-3.6)
-  - sudo sh -c 'echo -n "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" >> /etc/apt/sources.list'
-  # add key from ^ repository
-  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 
   # update package repository status (-qq is more quiet)
   - sudo rm -rf /var/lib/apt/lists/*
@@ -55,7 +50,7 @@ before_install:
   - sudo apt-get install -y python-nose
 
   # static code analysis
-  - sudo apt-get install -y libllvm3.6 clang-format-3.6 vera++ pep8
+  - sudo apt-get install -y vera++ pep8
 
   # used for building cppcheck-1.69
   - sudo apt-get install -y libpcre3 libpcre3-dev
@@ -63,7 +58,7 @@ before_install:
   # process json output from github api
   - sudo apt-get install -y jq
 
-install: 
+install:
   - which cython
   - cython --version
   - which python
@@ -73,7 +68,7 @@ install:
   - cmake --version
 
 before_script:
-  - chmod +x build.sh 
+  - chmod +x build.sh
 
 script:
   - set -o pipefail
@@ -83,12 +78,12 @@ script:
 before_deploy:
   - cd $TRAVIS_BUILD_DIR/build
   - tar -zcvf logfiles.tar.gz ./*.log
-  - tar -zcvf reports.tar.gz ./reports 
+  - tar -zcvf reports.tar.gz ./reports
   - mkdir -p $TRAVIS_BUILD_DIR/build/artefacts_upload
   - mv logfiles.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
   - mv reports.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
 
-#S3 deployment    
+#S3 deployment
 
 deploy:
   provider: s3
@@ -105,4 +100,3 @@ deploy:
   local-dir: "$TRAVIS_BUILD_DIR/build/artefacts_upload"
   upload-dir: "$TRAVIS_REPO_SLUG/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER"
   acl: bucket_owner_full_control
-

--- a/build.sh
+++ b/build.sh
@@ -84,25 +84,32 @@ set rules {
 }
 EOF
 
-# initialize and build cppcheck 1.69
-git clone https://github.com/danmar/cppcheck.git
-# go into source directory of cppcheck
-cd cppcheck
-# set git to 1.69 version
-git checkout tags/1.69
-# build cppcheck => now there is an executable ./cppcheck
-mkdir -p install
-make PREFIX=$PWD/install CFGDIR=$PWD/install/cfg HAVE_RULES=yes install
-# make cppcheck available
-export PATH=$PATH:$PWD/install/bin
-# check everything is alright
-cppcheck --version
-# go back to NEST sources
-cd ..
 
-wget http://llvm.org/releases/3.6.0/clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-tar xvf clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-export PATH=$PATH:$PWD/clang+llvm-3.6.0-x86_64-linux-gnu/bin
+if [ ! -f "$HOME/.cache/bin/cppcheck" ]; then
+  # initialize and build cppcheck 1.69
+  git clone https://github.com/danmar/cppcheck.git
+  # go into source directory of cppcheck
+  cd cppcheck
+  # set git to 1.69 version
+  git checkout tags/1.69
+  # build cppcheck => now there is an executable ./cppcheck
+  mkdir -p install
+  make PREFIX=$HOME/.cache CFGDIR=$HOME/.cache/cfg HAVE_RULES=yes install
+
+  cd ..
+  
+  wget http://llvm.org/releases/3.6.0/clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  tar xvf clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  cp -R clang+llvm-3.6.0-x86_64-linux-gnu/* $HOME/.cache
+  
+  # remove directories, otherwise copyright-header check complains
+  rm -rf ./cppcheck
+  rm -rf ./clang+llvm-3.6.0-x86_64-linux-gnu
+fi
+
+export PATH=$PATH:$HOME/.cache/bin
+cppcheck --version 
+clang-format --version
 
 # Extracting changed files in PR / push
 echo "Extract changed files..."
@@ -183,9 +190,6 @@ for f in $file_names; do
   esac
 done
 
-# Remove cppcheck files, otherwise 'regressiontests/ticket-659-copyright.py' will complain
-rm -rf ./cppcheck
-rm -rf ./clang+llvm-3.6.0-x86_64-linux-gnu
 
 cd "$NEST_VPATH"
 

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ cat > $HOME/.nestrc <<EOF
      ] {join} Fold
     } Function def
 EOF
- 
+
     CONFIGURE_MPI="-Dwith-mpi=ON"
 
 else
@@ -44,7 +44,7 @@ fi
 NEST_VPATH=build
 NEST_RESULT=result
 
-mkdir "$NEST_VPATH" "$NEST_RESULT" 
+mkdir "$NEST_VPATH" "$NEST_RESULT"
 mkdir "$NEST_VPATH/reports"
 
 NEST_RESULT=$(readlink -f $NEST_RESULT)
@@ -100,6 +100,10 @@ cppcheck --version
 # go back to NEST sources
 cd ..
 
+wget http://llvm.org/releases/3.6.0/clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+tar xvf clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+export PATH=$PATH:$PWD/clang+llvm-3.6.0-x86_64-linux-gnu/bin
+
 # Extracting changed files in PR / push
 echo "Extract changed files..."
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
@@ -131,7 +135,7 @@ for f in $file_names; do
     *.h | *.c | *.cc | *.hpp | *.cpp )
       echo "Static analysis on file $f:"
       f_base=$NEST_VPATH/reports/`basename $f`
-      # Vera++ checks the specified list of rules given in the profile 
+      # Vera++ checks the specified list of rules given in the profile
       # nest which is placed in the <vera++ root>/lib/vera++/profile
       vera++ --root ./vera_home --profile nest $f > ${f_base}_vera.txt 2>&1
       echo "\n - vera++ for $f:"
@@ -142,8 +146,8 @@ for f in $file_names; do
       cat ${f_base}_cppcheck.txt
 
       # clang format creates tempory formatted file
-      clang-format-3.6 $f > ${f_base}_formatted_$TRAVIS_COMMIT.txt
-      # compare the committed file and formatted file and 
+      clang-format $f > ${f_base}_formatted_$TRAVIS_COMMIT.txt
+      # compare the committed file and formatted file and
       # writes the differences to a temp file
       echo "\n - clang-format for $f:"
       diff $f ${f_base}_formatted_$TRAVIS_COMMIT.txt | tee ${f_base}_clang_format.txt
@@ -152,7 +156,7 @@ for f in $file_names; do
       # remove temporary files
       rm ${f_base}_formatted_$TRAVIS_COMMIT.txt
 
-      if [ -s ${f_base}_clang_format.txt ]; then 
+      if [ -s ${f_base}_clang_format.txt ]; then
         # file exists and has size greater than zero
         format_error_files="$format_error_files $f"
       fi
@@ -181,6 +185,7 @@ done
 
 # Remove cppcheck files, otherwise 'regressiontests/ticket-659-copyright.py' will complain
 rm -rf ./cppcheck
+rm -rf ./clang+llvm-3.6.0-x86_64-linux-gnu
 
 cd "$NEST_VPATH"
 
@@ -206,4 +211,3 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   echo "WARNING: Not uploading results as this is a pull request" >&2
   exit 0
 fi
-


### PR DESCRIPTION
The [llvm.org/apt](http://llvm.org/apt) seams to be down due to 'excess load':

> APT mirror was temporary switched off due to excess load. We are working on bringing it back. Stay tuned!

Since we get `clang-format` from them, all current build jobs will fail. In this PR we get the pre-built binaries for `clang-format` and install them manually (similar to `cppcheck`). See 2daa77f for this.

We are not sure, if we are responsible for the 'excess load', hence we want to use the TravisCI caching feature (d3e2fa2), which does not work at the moment, as we are not using the 'container-based' infrastructure ([here](https://docs.travis-ci.com/user/migrating-from-legacy/)) and/or a payed plan, i.e. private repository([here](https://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies) at the end).

We propose @heplesser and @tammoippen as reviewers.