### PR TITLE
Make NEST compile statically on BlueGene again

### DIFF
--- a/cmake/Platform/BlueGeneQ_XLC.cmake
+++ b/cmake/Platform/BlueGeneQ_XLC.cmake
@@ -35,6 +35,8 @@ set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -qarch=qp -qtune=qp -DNDEBUG" CACHE 
 set( OpenMP_C_FLAGS "-qsmp=omp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
 set( OpenMP_CXX_FLAGS "-qsmp=omp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
 
+set( with-warning "-qinfo=all" CACHE STRING "Enable user defined warnings. [default ON, when ON, defaults to '-Wall']" FORCE )
+
 if ( static-libraries )
   __bluegeneq_setup_static( XL CXX )
   __bluegeneq_setup_static( XL C )

--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -23,6 +23,13 @@ set( nest_sources
     )
 
 add_executable( nest main.cpp ${nest_sources} )
+if ( IS_BLUEGENE AND static-libraries )
+    set_target_properties( nest
+        PROPERTIES
+        LINK_SEARCH_END_STATIC TRUE
+        LINK_SEARCH_START_STATIC TRUE
+        )
+endif ()
 
 add_library( nest_lib ${nest_sources} )
 set_target_properties( nest_lib


### PR DESCRIPTION
@jakobj Encountered that compiling NEST statically on JUQUEEN generated some `undefined symbols`.

CMake replaces library paths of libraries in implicit link directories by their `-l<name>` version. When building statically, it also adds linker flags, like `-Wl,-Bstatic -lfoo -Wl,-Bdynamic`. See [CMP0060](https://cmake.org/cmake/help/v3.3/policy/CMP0060.html) for more information.

This commit sets `LINK_SEARCH_END_STATIC` and `LINK_SEARCH_START_STATIC` to `TRUE` in the case of BlueGene and static linking. This should allow NEST to compile again. (I tried both static and dynamic construction of NEST.)

I suggest @jakobj, @jougs and/or @heplesser as reviewers.