### PR TITLE
Add documentation for building NEST with GCC on BG/Q [skip ci]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -166,6 +166,11 @@ environment variables are set properly:
     # makes HOME and PYTHONPATH available for python
     runjob --exp-env HOME --exp-env PYTHONPATH ... : python script.py
 
+Compiling NEST with the GCC (`-DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_GCC`)
+might require you to use a GSL library compiled by the GCC, otherwise undefined
+symbols break your build. Changing the compiler should be done in the file
+`<src>/cmake/Platform/BlueGeneQ_GCC.cmake`.
+
 Compiling for Fujitsu Sparc64
 =============================
 

--- a/INSTALL
+++ b/INSTALL
@@ -133,16 +133,24 @@ Compiling for BlueGene/Q
 NEST provides a cmake tool-chain file for cross compilation for BlueGene/Q. When
 configuring NEST use the following `cmake` line:
 
-    cmake -DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_XLC 
-          -DCMAKE_INSTALL_PREFIX:PATH=</install/path>
-          -Dwith-python=OFF
-          -Dstatic-libraries=ON
+    cmake -DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_XLC \
+          -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+          -Dwith-python=OFF \
+          -Dstatic-libraries=ON \
           </path/to/NEST/src>
 
-It is recommended to build statically on larger BlueGene/Q systems. If you need
-PyNEST on BlueGene/Q, you have to compile dynamically, i.e. `-Dstatic-libraries=OFF`
-and you have to cythonize the `pynest/pynestkernel.pyx/.pxd`
-on a machine with Cython installed:
+It is recommended to build statically on larger BlueGene/Q systems. If you compile
+dynamically, be aware that the BlueGene/Q system might not provide a `ltdl`
+library. If you want to dynamically load an external user module, you have to
+compile and install a `ltdl` yourself and add `-Dwith-ltdl=<ltdl-install-dir>`
+to the `cmake` line. Otherwise add `-Dwith-ltdl=OFF`.
+
+BlueGene/Q and PyNEST
+---------------------
+
+Building PyNEST on BlueGene/Q requires you to compile dynamically, i.e. 
+`-Dstatic-libraries=OFF`. Further, you have to cythonize the
+`pynest/pynestkernel.pyx/.pxd` on a machine with Cython installed:
 
     cythonize pynestkernel.pyx
 
@@ -158,6 +166,18 @@ if the they are not found, e.g.:
     -DPYTHON_LIBRARY=/bgsys/tools/Python-2.7/lib64/libpython2.7.so.1.0
     -DPYTHON_INCLUDE_DIR=/bgsys/tools/Python-2.7/include/python2.7
 
+A complete `cmake` line for PyNEST could look like this:
+
+    cmake -DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_XLC \
+          -DCMAKE_INSTALL_PREFIX=</install/path> \
+          -Dstatic-libraries=OFF \
+          -Dcythonize-pynest=OFF \
+          -Dwith-python=/bgsys/tools/Python-2.7/bin/hostpython \
+          -DPYTHON_LIBRARY=/bgsys/tools/Python-2.7/lib64/libpython2.7.so.1.0 \
+          -DPYTHON_INCLUDE_DIR=/bgsys/tools/Python-2.7/include/python2.7 \
+          -Dwith-ltdl=OFF \
+          <nest-src>
+
 Further, for running PyNEST, make sure all python dependencies are installed and
 environment variables are set properly:
 
@@ -166,10 +186,22 @@ environment variables are set properly:
     # makes HOME and PYTHONPATH available for python
     runjob --exp-env HOME --exp-env PYTHONPATH ... : python script.py
 
+BlueGene/Q and GCC
+------------------
+
 Compiling NEST with GCC (`-DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_GCC`)
 might require you to use a GSL library compiled using GCC, otherwise undefined
-symbols break your build. Changing the compiler should be done in the file
-`<src>/cmake/Platform/BlueGeneQ_GCC.cmake`.
+symbols break your build. After the GSL is build with GCC and installed in
+<gsl-install-dir>, add `-Dwith-gsl=<gsl-install-dir>` to the `cmake` line.
+
+BlueGene/Q and changing the compiler
+------------------------------------
+
+Both toolchain files (`BlueGeneQ_GCC` and `BlueGeneQ_XLC`) have the default 
+compiler hardcoded - look for the two variable assignments after the comment
+`# set the compiler`. If you want to use a different compiler, e.g. a newer
+GCC version, you have to replace the compiler there and not as an argument to
+`cmake`.
 
 Compiling for Fujitsu Sparc64
 =============================

--- a/INSTALL
+++ b/INSTALL
@@ -5,7 +5,7 @@ http://www.nest-simulator.org/installation
 Introduction
 ============
 
-NEST is installed with cmake (at least v2.8.12). In the simplest case, the commands
+NEST is installed with `cmake` (at least v2.8.12). In the simplest case, the commands
 
     cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> </path/to/NEST/src>
     make
@@ -73,8 +73,9 @@ Set default libraries:
                                                  a specific library, set install path.
                                                  [default=ON]
     -Dwith-ltdl=[OFF|ON|</path/to/ltdl>]         Find a ltdl library. To set a specific
-                                                 ltdl, set install path.
-                                                 [default=ON]
+                                                 ltdl, set install path. NEST uses the
+                                                 ltdl for dynamic loading of external
+                                                 user modules. [default=ON]
     -Dwith-python=[OFF|ON|</path/to/python>]     Build PyNEST. To set a specific Python,
                                                  set install path. [default=ON]
     -Dcythonize-pynest=[OFF|ON]                  Use Cython to cythonize pynestkernel.pyx.
@@ -85,13 +86,13 @@ Set default libraries:
 Change compilation behavior:
 
     -Dstatic-libraries=[OFF|ON]     Build static executable and libraries. [default=OFF]
-    -Dwith-optimize=[OFF|ON|<list;off;flags>] Enable user defined optimizations. Separate
+    -Dwith-optimize=[OFF|ON|<list;of;flags>]  Enable user defined optimizations. Separate
                                               multiple flags by ';'.
                                               [default OFF, when ON, defaults to '-O3']
-    -Dwith-warning=[OFF|ON|<list;off;flags>]  Enable user defined warnings. Separate
+    -Dwith-warning=[OFF|ON|<list;of;flags>]   Enable user defined warnings. Separate
                                               multiple flags by ';'.
                                               [default ON, when ON, defaults to '-Wall']
-    -Dwith-debug=[OFF|ON|<list;off;flags>]    Enable user defined debug flags. Separate
+    -Dwith-debug=[OFF|ON|<list;of;flags>]     Enable user defined debug flags. Separate
                                               multiple flags by ';'.
                                               [default OFF, when ON, defaults to '-g']
     -Dwith-libraries=<list;of;libraries>      Link additional libraries. Give full path.

--- a/INSTALL
+++ b/INSTALL
@@ -166,8 +166,8 @@ environment variables are set properly:
     # makes HOME and PYTHONPATH available for python
     runjob --exp-env HOME --exp-env PYTHONPATH ... : python script.py
 
-Compiling NEST with the GCC (`-DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_GCC`)
-might require you to use a GSL library compiled by the GCC, otherwise undefined
+Compiling NEST with GCC (`-DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_GCC`)
+might require you to use a GSL library compiled using GCC, otherwise undefined
 symbols break your build. Changing the compiler should be done in the file
 `<src>/cmake/Platform/BlueGeneQ_GCC.cmake`.
 

--- a/INSTALL
+++ b/INSTALL
@@ -227,25 +227,25 @@ On the K Computer:
       tar -xzf gsl-2.1.tar.gz
       mkdir gsl-2.1.build gsl-2.1.install
       cd gsl-2.1.build
-      ../gsl-2.1/configure --prefix=$PWD/../gsl-2.1.install/
-                           CC=mpifccpx
-                           CXX=mpiFCCpx
-                           CFLAGS="-Nnoline"
-                           CXXFLAGS="--alternative_tokens -O3 -Kfast,openmp, -Nnoline, -Nquickdbg -NRtrap"
-                           --host=sparc64-unknown-linux-gnu
+      ../gsl-2.1/configure --prefix=$PWD/../gsl-2.1.install/ \
+                           CC=mpifccpx \
+                           CXX=mpiFCCpx \
+                           CFLAGS="-Nnoline" \
+                           CXXFLAGS="--alternative_tokens -O3 -Kfast,openmp, -Nnoline, -Nquickdbg -NRtrap" \
+                           --host=sparc64-unknown-linux-gnu \
                            --build=x86_64-unknown-linux-gnu
       gmake -j4
       gmake install
 
   To install NEST, use the following `cmake` line:
 
-      cmake -DCMAKE_TOOLCHAIN_FILE=Platform/Fujitsu-Sparc64
-            -DCMAKE_INSTALL_PREFIX:PATH=</install/path>
-            -Dwith-gsl=/path/to/gsl-2.1.install/\
-            -Dwith-optimize="-Kfast"
-            -Dwith-defines="-DUSE_PMA"
-            -Dwith-python=OFF
-            -Dwith-warning=OFF
+      cmake -DCMAKE_TOOLCHAIN_FILE=Platform/Fujitsu-Sparc64 \
+            -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+            -Dwith-gsl=/path/to/gsl-2.1.install/ \
+            -Dwith-optimize="-Kfast" \
+            -Dwith-defines="-DUSE_PMA" \
+            -Dwith-python=OFF \
+            -Dwith-warning=OFF \
             </path/to/NEST/src>
       make -j4
       make install

--- a/cmake/Platform/BlueGeneQ_XLC.cmake
+++ b/cmake/Platform/BlueGeneQ_XLC.cmake
@@ -35,7 +35,7 @@ set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -qarch=qp -qtune=qp -DNDEBUG" CACHE 
 set( OpenMP_C_FLAGS "-qsmp=omp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
 set( OpenMP_CXX_FLAGS "-qsmp=omp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
 
-set( with-warning "-qinfo=all" CACHE STRING "Enable user defined warnings. [default ON, when ON, defaults to '-Wall']" FORCE )
+set( with-warning "-qinfo=all" CACHE STRING "Enable user defined warnings. [default ON, when ON, defaults to '-Wall']" )
 
 if ( static-libraries )
   __bluegeneq_setup_static( XL CXX )


### PR DESCRIPTION
This PR adds documentation on how to build NEST with GCC on BG/Q.