### PR TITLE
Update to fix C++11 compilation error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ if [ ! -f "$HOME/.cache/bin/cppcheck" ]; then
   rm -rf ./clang+llvm-3.6.0-x86_64-linux-gnu
 fi
 
-export PATH=$HOME/.cache/bin:$PATH
+export PATH=$PATH:$HOME/.cache/bin
 cppcheck --version 
 clang-format --version
 

--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ if [ ! -f "$HOME/.cache/bin/cppcheck" ]; then
   rm -rf ./clang+llvm-3.6.0-x86_64-linux-gnu
 fi
 
-export PATH=$PATH:$HOME/.cache/bin
+export PATH=$HOME/.cache/bin:$PATH
 cppcheck --version 
 clang-format --version
 

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -71,14 +71,17 @@ SLIStartup::checkpath( std::string const& path, std::string& result ) const
   const std::string fullname = fullpath + "/" + startupfilename;
 
   std::ifstream in( fullname.c_str() );
-  if ( in )
+
+  if ( in.good() )
   {
     result = fullname;
+    return true;
   }
   else
+  {
     result.erase();
-
-  return ( in );
+    return false;
+  }
 }
 
 


### PR DESCRIPTION
This seems to be the only one at the moment. Fixes #220

System info:
``` bash
$ gcc -v
Using built-in specs.
COLLECT_GCC=/usr/bin/gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/6.1.1/lto-wrapper
Target: x86_64-redhat-linux
Configured with: ../configure --enable-bootstrap
--enable-languages=c,c++,objc,obj-c++,fortran,ada,go,lto --prefix=/usr
--mandir=/usr/share/man --infodir=/usr/share/info
--with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared
--enable-threads=posix --enable-checking=release --enable-multilib
--with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions
--enable-gnu-unique-object --enable-linker-build-id
--with-linker-hash-style=gnu --enable-plugin --enable-initfini-array
--disable-libgcj --with-isl --enable-libmpx
--enable-gnu-indirect-function --with-tune=generic --with-arch_32=i686
--build=x86_64-redhat-linux
Thread model: posix
gcc version 6.1.1 20160510 (Red Hat 6.1.1-2) (GCC)

$ cat /etc/os-release
NAME=Fedora
VERSION="24 (Workstation Edition)"
```