### PR TITLE
Fix Travis log parsing error introduced by #380.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,7 +109,8 @@ if [ ! -f "$HOME/.cache/bin/cppcheck" ]; then
   rm -rf ./clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04
 fi
 
-export PATH=$PATH:$HOME/.cache/bin
+# Prepend cache to PATH so we find stuff we have installed ourselves first
+export PATH=$HOME/.cache/bin:$PATH
 
 vera++ --version
 cppcheck --version 

--- a/build.sh
+++ b/build.sh
@@ -98,16 +98,18 @@ if [ ! -f "$HOME/.cache/bin/cppcheck" ]; then
 
   cd ..
   
-  wget http://llvm.org/releases/3.6.0/clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  tar xvf clang+llvm-3.6.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  cp -R clang+llvm-3.6.0-x86_64-linux-gnu/* $HOME/.cache
+  wget http://llvm.org/releases/3.6.2/clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  tar xvf clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+  cp -R clang+llvm-3.6.2-x86_64-linux-gnu/* $HOME/.cache
   
   # remove directories, otherwise copyright-header check complains
   rm -rf ./cppcheck
-  rm -rf ./clang+llvm-3.6.0-x86_64-linux-gnu
+  rm -rf ./clang+llvm-3.6.2-x86_64-linux-gnu
 fi
 
 export PATH=$PATH:$HOME/.cache/bin
+
+vera++ --version
 cppcheck --version 
 clang-format --version
 

--- a/build.sh
+++ b/build.sh
@@ -100,11 +100,13 @@ if [ ! -f "$HOME/.cache/bin/cppcheck" ]; then
   
   wget http://llvm.org/releases/3.6.2/clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04.tar.xz
   tar xvf clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-  cp -R clang+llvm-3.6.2-x86_64-linux-gnu/* $HOME/.cache
+  
+  # copy, not move, since .cache may contain other files in subdirs already
+  cp -R clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04/* $HOME/.cache
   
   # remove directories, otherwise copyright-header check complains
   rm -rf ./cppcheck
-  rm -rf ./clang+llvm-3.6.2-x86_64-linux-gnu
+  rm -rf ./clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04
 fi
 
 export PATH=$PATH:$HOME/.cache/bin

--- a/extras/include_checker.py
+++ b/extras/include_checker.py
@@ -261,6 +261,3 @@ if __name__ == '__main__':
 
     else:
         usage(3)
-
-# These lines are only added to provoke a PEP8 error in Travis to check it is handled properly.
-   # The lines will be removed after the test is complete.

--- a/extras/include_checker.py
+++ b/extras/include_checker.py
@@ -261,3 +261,6 @@ if __name__ == '__main__':
 
     else:
         usage(3)
+
+# These lines are only added to provoke a PEP8 error in Travis to check it is handled properly.
+   # The lines will be removed after the test is complete.

--- a/extras/parse_travis_log.py
+++ b/extras/parse_travis_log.py
@@ -112,7 +112,7 @@ def process_cppcheck(f, filename):
             return res
 
         # Exit condition: after cppcheck, clang-format is executed
-        if line.startswith('+clang-format-'):
+        if line.startswith('+clang-format'):
             return res
 
         if line.startswith('[' + filename):


### PR DESCRIPTION
After merging #380, the Travis log was no longer parsed correctly if clang-format led to diffs. This is fixed here.