### PR TITLE
Reduce the number of build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ env:
     # We don't have to run a full matrix here, because most of the options are
     # independent. This means that we can test them together in the full build.
     # See also https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices
-    - xTHREADING=0 xMPI=0 xGSL=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # minimal
-    - xTHREADING=0 xMPI=1 xGSL=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # only MPI
-    - xTHREADING=1 xMPI=0 xGSL=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # only threading
-    - xTHREADING=1 xMPI=1 xGSL=1 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # full
+    - xTHREADING=0 xMPI=0 xGSL=0 xLTDL=0 xREADLINE=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # minimal
+    - xTHREADING=0 xMPI=1 xGSL=0 xLTDL=1 xREADLINE=1 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # only MPI
+    - xTHREADING=1 xMPI=0 xGSL=0 xLTDL=1 xREADLINE=1 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # only threading
+    - xTHREADING=1 xMPI=1 xGSL=1 xLTDL=1 xREADLINE=1 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # full
 matrix:
   # do notify immediately about it when a job of a build fails.
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ dist: trusty
 
 env:
   matrix:
-    - xGSL=0 xMPI=0 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=0 xMPI=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=0 xMPI=1 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=0 xMPI=1 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=1 xMPI=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=1 xMPI=0 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=1 xMPI=1 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
-    - xGSL=1 xMPI=1 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB
+    # We don't have to run a full matrix here, because most of the options are
+    # independent. This means that we can test them together in the full build.
+    # See also https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices
+    - xTHREADING=0 xMPI=0 xGSL=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # minimal
+    - xTHREADING=0 xMPI=1 xGSL=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # only MPI
+    - xTHREADING=1 xMPI=0 xGSL=0 xPYTHON=0 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # only threading
+    - xTHREADING=1 xMPI=1 xGSL=1 xPYTHON=1 xSTATIC_ANALYSIS=1 CACHE_NAME=JOB   # full
 matrix:
   # do notify immediately about it when a job of a build fails.
   fast_finish: true

--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,20 @@ else
     CONFIGURE_GSL="-Dwith-gsl=OFF"
 fi
 
+if [ "$xLTDL" = "1" ] ; then
+    CONFIGURE_LTDL="-Dwith-ltdl=ON"
+else
+    CONFIGURE_LTDL="-Dwith-ltdl=OFF"
+fi
+
+if [ "$xREADLINE" = "1" ] ; then
+    CONFIGURE_READLINE="-Dwith-readline=ON"
+else
+    CONFIGURE_READLINE="-Dwith-readline=OFF"
+fi
+
+
+
 NEST_VPATH=build
 NEST_RESULT=result
 

--- a/build.sh
+++ b/build.sh
@@ -17,14 +17,18 @@ set -e
 
 mkdir -p $HOME/.matplotlib
 cat > $HOME/.matplotlib/matplotlibrc <<EOF
-    # ZYV
     backend : svg
 EOF
+
+if [ "$xTHREADING" = "1" ] ; then
+    CONFIGURE_THREADING="-Dwith-openmp=ON"
+else
+    CONFIGURE_THREADING="-Dwith-openmp=OFF"
+fi
 
 if [ "$xMPI" = "1" ] ; then
 
 cat > $HOME/.nestrc <<EOF
-    % ZYV: NEST MPI configuration
     /mpirun
     [/integertype /stringtype]
     [/numproc     /slifile]
@@ -233,6 +237,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX="$NEST_RESULT" \
   -Dwith-optimize=ON \
   -Dwith-warning=ON \
+  $CONFIGURE_THREADING \
   $CONFIGURE_MPI \
   $CONFIGURE_PYTHON \
   $CONFIGURE_GSL \

--- a/extras/userdoc/md/documentation/continuous-integration.md
+++ b/extras/userdoc/md/documentation/continuous-integration.md
@@ -28,12 +28,12 @@ of efforts to fix them will be significantly decreased.
 ### Build jobs
 
 The CI system is set up to run upon commits to branches that are
-related to a pull request, or for commits that are in a fork, for
+related to a pull request, or for commits that are in a fork for
 which CI is enabled. Whenever changes are detected, the latest source
 code is downloaded to an executor machine and the following actions
 are performed:
 
-- Install optional and mandatory packages that NEST can use
+- Install optional and mandatory packages that NEST may use
 - Perform static source code analysis using
   [Vera++](https://bitbucket.org/verateam/vera/wiki/Home)
 - Perform static source code analysis using

--- a/extras/userdoc/md/documentation/continuous-integration.md
+++ b/extras/userdoc/md/documentation/continuous-integration.md
@@ -1,116 +1,51 @@
 # Continuous Integration
 
-## Introduction
+[**Continuous
+Integration**](http://en.wikipedia.org/wiki/Continuous_integration)
+(CI) is a software development practice where quality control is
+continuously applied to the product as opposed to the traditional
+procedure of applying quality control *after* completing all
+development (during the so called *integration phase*). In essence, it
+is a way of decreasing the risks associated with the integration by
+spreading required efforts over time, which helps to improve on the
+quality of software, and to reduce the time taken to deliver it.
 
-[**Continuous Integration**](http://en.wikipedia.org/wiki/Continuous_integration) (CI)
-is a software development practice where quality control is continuously
-applied to the product as opposed to the traditional procedure of
-applying quality control *after* completing all development (during the
-so called *integration phase*). In essence, it is a way of decreasing
-the risks associated with the integration by spreading required efforts
-over time, which helps to improve on the quality of software, and to
-reduce the time taken to deliver it.
+Given the limited amount of available resources, it is impossible for
+a single developer to test all combinations of configuration options
+and different compiler and library versions on all target platforms
+upon a commit. In order to address this problem, the [TravisCI system]
+(https://travis-ci.org/nest/nest-simulator) is triggered for every
+[pull
+request](http://nest.github.io/nest-simulator/development_workflow) to
+the [central source code
+repository](https://github.com/nest/nest-simulator).
 
-Stringent quality control is particularly important in the context of
-NEST, a neuronal network simulator with the emphasis on correctness,
-reproducibility and performance. However, given the limited amount of
-the available resources, it is wasteful to transfer the responsibility
-to re-run the test suite for all target platforms on every single code
-base change to the shoulders of the developers.
-
-In order to address this problem, a
-[Jenkins](http://jenkins-ci.org/)-based CI infrastructure was created
-during the [NEST Google Summer of Code
-2011](http://www.google-melange.com/gsoc/project/google/gsoc2011/zaytsev/17001)
-project, which would allow for regular testing of changes that are
-getting into the tree and timely reporting of identified problems. This
-way, issues will be discovered earlier and the amount of efforts to fix
-them will be significantly decreased (hopefully).
-
-## Continuous Integration at NEST Initiative
-
-The current CI implementation is now available at the following URL:
-
-<https://qa.nest-initiative.org/>
-The site is secured with a Class 1 SSL certificate issued by StartCom
-Ltd.
+This allows for regular and automated testing of changes that are
+getting into the tree and timely reporting of identified
+problems. This way, issues will be discovered earlier and the amount
+of efforts to fix them will be significantly decreased.
 
 ### Build jobs
 
-The CI system is set up to regularly poll the version control repository
-hosting the main official NEST source tree. Whenever changes are
-detected, the latest source code is downloaded to a build executor
-machine and the following actions are performed:
+The CI system is set up to run upon commits to branches that are
+related to a pull request, or for commits that are in a fork, for
+which CI is enabled. Whenever changes are detected, the latest source
+code is downloaded to an executor machine and the following actions
+are performed:
 
--   Bootstrap the build system
--   Build and install NEST
--   Run the test suite
--   Bootstrap MyModule
--   Build and install MyModule
+- Install optional and mandatory packages that NEST can use
+- Perform static source code analysis using
+  [Vera++](https://bitbucket.org/verateam/vera/wiki/Home)
+- Perform static source code analysis using
+  [Cppcheck](http://cppcheck.sourceforge.net/)
+- Check [source code formatting](https://nest.github.io/nest-simulator/coding_guidelines_c++)
+  using [ClangFormat](http://clang.llvm.org/docs/ClangFormat.html)
+- Bootstrap the build system
+- Build and install NEST
+- Run the test suite
 
 If any of these steps fails (returns a non-zero exit code), the build is
-marked as failed and a notification is sent to the developers mailing
-list.
-
-Additionally, a number of metrics are collected from the build log to
-obtain a cumulative project "health" indicators:
-
--   Build status:
-
-    -   *Success* (all steps completed successfully)
-
-    -   *Unstable* (some publishers reported non-fatal errors, e.g.
-        there were failed tests)
-
-    -   *Failed* (a fatal error happened during the build, e.g. non-zero
-        exit code was returned)
-
--   Weather report (how many failures there were out of 5 latest builds)
-
--   Test suite report (all JUnit-compatible reports are aggregated)
-
--   Compiler warnings report (all GCC4 / LD warnings are aggregated)
-
-The values of these indicators are archived along with the build logs
-and trends can be graphed for arbitrary periods of time.
-
-### User registration
-
-NEST developers, using the system as registered users enjoy a number of
-benefits as compared to the anonymous users. Most notably they may:
-
--   Access projects workspace on the build executors
--   Schedule / remove / edit builds manually
--   Be granted personal build jobs for their branches
--   Be allowed to create jobs (to be discussed)
-
-Project workspace access allows one to view the source code and build
-directories / logs as they are on the build executor machines, which can
-be helpful in diagnosing build problems.
-
-If you'd like to register with the system, please contact the
-administrators!
-
-### Technical details
-
-The infrastructure resides on a Dell PowerEdge R710 server hosted in a
-private BCF rack at Uni Freiburg running KVM hypervisor which controls
-virtual machines that host Jenkins and build executors.
-
-The repositories hosting the up to date versions of the configuration
-([*anubis-puppet*](http://git.zaytsev.net/?p=anubis-puppet.git;a=summary))
-and documentation
-([*anubis-docs*](http://git.zaytsev.net/?p=anubis-docs.git;a=summary))
-are available online. Please refer to these repositories for more
-detailed documentation regarding the setup, which is out of the scope of
-this brief user manual.
-
-### Administrators
-
-At the moment, the following NEST developers have administrative access
-to the build system:
-
--   Yury V. Zaytsev
+marked as failed and a notification is added to the commit or pull request on GitHub.
 
 ## Further reading
 

--- a/testsuite/mpitests/test_gsd_distribution_threaded.sli
+++ b/testsuite/mpitests/test_gsd_distribution_threaded.sli
@@ -38,6 +38,8 @@ FirstVersion: April 2014
 (unittest) run
 /unittest using
 
+is_threaded not { exit_test_gracefully } if
+
 
 [2 3]
 {

--- a/testsuite/mpitests/test_gsd_threaded.sli
+++ b/testsuite/mpitests/test_gsd_threaded.sli
@@ -39,6 +39,8 @@ FirstVersion: February 2014
 (unittest) run
 /unittest using
 
+is_threaded not { exit_test_gracefully } if
+
 
 [2 3]
 {

--- a/testsuite/regressiontests/issue-211.sli
+++ b/testsuite/regressiontests/issue-211.sli
@@ -37,6 +37,8 @@ SeeAlso:
 (unittest) run
 /unittest using
 
+is_threaded not { exit_test_gracefully } if
+
 M_ERROR setverbosity
 
 ResetKernel


### PR DESCRIPTION
Many configuration options of NEST are actually independent. This means we don't have to run the full matrix, but just a minimal job, a maximal job, and some jobs for dependent options.

This PR simplifies the matrix from 8 runs to 4 runs while also adding a new option for builds with and without threading (04c668b).

Using this, I already found 3 tests that were failing when building without threading (5387bbc).

I suggest @heplesser and @lekshmideepu as reviewers.