### PR TITLE
Added: load modules from environment at startup

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -25,6 +25,7 @@ Initializer of PyNEST.
 
 import sys
 import os
+import re
 
 # This is a workaround for readline import errors encountered with Anaconda
 # Python running on Ubuntu, when invoked from the terminal
@@ -182,6 +183,9 @@ def init(argv):
         if not quiet:
             engine.run("pywelcome")
 
+        expand_sli_path()
+        load_modules()
+
         # Dirty hack to get tab-completion for models in IPython.
         try:
             __IPYTHON__
@@ -196,6 +200,40 @@ def init(argv):
 
     else:
         _kernel.NESTError("Initiatization of NEST failed.")
+
+
+def expand_sli_path():
+    """ Add paths defined in SLI_PATH to searchpath. """
+
+    sli_paths = [path for path in
+                 os.environ.get("SLI_PATH", "").split(os.path.pathsep)
+                 if path != ""]
+
+    assert_sli_valid(sli_paths)
+
+    for path in sli_paths:
+        sli_run("({}) addpath".format(path))
+
+
+def assert_sli_valid(names):
+    for n in names:
+        if re.search(r"[\(\)\\]", n):
+            raise _kernel.NESTError("Path or Module names must not contain "
+                "parentheses or backslashes.")
+
+
+
+def load_modules():
+    """ Load a list of modules that are specified via NEST_MODULES. """
+
+    modules = [module for module in
+               os.environ.get("NEST_MODULES", "").split(os.path.pathsep)
+               if module != ""]
+
+    assert_sli_valid(modules)
+
+    for module in modules:
+        sli_run("({}) Install".format(module))
 
 
 def test():


### PR DESCRIPTION
This PR adds the capability for nest to automatically load modules at startup which are specified via the environment variable `NEST_MODULES`. Furthermore, additional search paths for SLI scripts may be specified via the `SLI_PATH` variable.

We use [gnumodules](http://modules.sourceforge.net/) to manage our software installation and keep separate installations of nest and modules. Therefore we need a way for nest to know which nest modules the user wishes to automatically load.