### PR TITLE
Use pandas if available

### DIFF
--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -19,9 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Functions for raster plotting.
-"""
+""" Functions for raster plotting."""
 
 import nest
 import numpy
@@ -29,8 +27,7 @@ import pylab
 
 
 def extract_events(data, time=None, sel=None):
-    """Extracts all events within a given time interval or are from a
-    given set of neurons.
+    """Extract all events within a given time interval.
 
     Both time and sel may be used at the same time such that all
     events are extracted for which both conditions are true.
@@ -55,7 +52,6 @@ def extract_events(data, time=None, sel=None):
     numpy.array
         List of events as (gid, t) tuples
     """
-
     val = []
 
     if time:
@@ -92,7 +88,6 @@ def from_data(data, sel=None, **kwargs):
     kwargs:
         Parameters passed to _make_plot
     """
-
     ts = data[:, 1]
     d = extract_events(data, sel=sel)
     ts1 = d[:, 1]
@@ -106,8 +101,8 @@ def from_file(fname, **kwargs):
 
     Parameters
     ----------
-    fname : str
-        Name of file
+    fname : str or tuple(str) or list(str)
+        File name or list of file names
     kwargs:
         Parameters passed to _make_plot
     """
@@ -121,9 +116,21 @@ def from_file(fname, **kwargs):
 
 def from_file_pandas(fname, **kwargs):
     """Use pandas."""
-    if isinstance(fname, (list, tuple)):
+    if isinstance(fname, str):
+        fname = fname
+        dataFrame = pandas.read_csv(
+            fname, sep='\s+', lineterminator='\n',
+            header=None, index_col=None,
+            skipinitialspace=True)
+        data = dataFrame.values
+
+    elif isinstance(fname, (list, tuple)):
         data = None
         for f in fname:
+            if not isinstance(f, str):
+                print >> sys.stderr, 'List entry is not a python2 string'
+                return None
+
             if data is None:
                 dataFrame = pandas.read_csv(
                     f, sep='\s+', lineterminator='\n',
@@ -137,27 +144,33 @@ def from_file_pandas(fname, **kwargs):
                     skipinitialspace=True)
                 newdata = dataFrame.values
                 data = numpy.concatenate((data, newdata))
+
     else:
-        dataFrame = pandas.read_csv(
-            fname, sep='\s+', lineterminator='\n',
-            header=None, index_col=None,
-            skipinitialspace=True)
-        data = dataFrame.values
+        print >> sys.stderr, 'fname should be of str/list(str)/tuple(str).'
+        return None
 
     return from_data(data, **kwargs)
 
 
 def from_file_numpy(fname, **kwargs):
     """Use numpy."""
-    if isinstance(fname, (list, tuple)):
+    if isinstance(fname, str):
+        data = numpy.loadtxt(fname)
+
+    elif isinstance(fname, (list, tuple)):
         data = None
         for f in fname:
+            if not isinstance(f, str):
+                print >> sys.stderr, 'List entry is not a python2 string'
+                return None
+
             if data is None:
                 data = numpy.loadtxt(f)
             else:
                 data = numpy.concatenate((data, numpy.loadtxt(f)))
     else:
-        data = numpy.loadtxt(fname)
+        print >> sys.stderr, 'fname should be of str/list(str)/tuple(str).'
+        return None
 
     return from_data(data, **kwargs)
 
@@ -179,7 +192,6 @@ def from_device(detec, plot_lid=False, **kwargs):
     ------
     nest.NESTError
     """
-
     if not nest.GetStatus(detec)[0]["model"] == "spike_detector":
         raise nest.NESTError("Please provide a spike_detector.")
 
@@ -219,8 +231,10 @@ def _from_memory(detec):
 
 def _make_plot(ts, ts1, gids, neurons, hist=True, hist_binwidth=5.0,
                grayscale=False, title=None, xlabel=None):
-    """Generic plotting routine that constructs a raster plot along with
-    an optional histogram (common part in all routines above).
+    """Generic plotting routine.
+
+    Constructs a raster plot along with an optional histogram (common part in
+    all routines above).
 
     Parameters
     ----------
@@ -243,7 +257,6 @@ def _make_plot(ts, ts1, gids, neurons, hist=True, hist_binwidth=5.0,
     xlabel : str, optional
         Label for x-axis
     """
-
     pylab.figure()
 
     if grayscale:
@@ -302,7 +315,7 @@ def _make_plot(ts, ts1, gids, neurons, hist=True, hist_binwidth=5.0,
 
 
 def _histogram(a, bins=10, bin_range=None, normed=False):
-    """Calculates histogram for data.
+    """Calculate histogram for data.
 
     Parameters
     ----------
@@ -357,11 +370,12 @@ def _histogram(a, bins=10, bin_range=None, normed=False):
 
 def show():
     """
+    Show figures.
+
     Call pylab.show() to show all figures and enter the GUI main loop.
     Python will block until all figure windows are closed again.
     You should call this function only once at the end of a script.
 
     See also: http://matplotlib.sourceforge.net/faq/howto_faq.html#use-show
     """
-
     pylab.show()

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -103,9 +103,10 @@ def from_file(fname, **kwargs):
     ----------
     fname : str or tuple(str) or list(str)
         File name or list of file names
-        If a list of files is given, the data from them is concatenated as if it
-        had been stored in a single file - useful when MPI is enabled and data
-        is logged separately for each MPI rank, for example.
+
+        If a list of files is given, the data from them is concatenated as if
+        it had been stored in a single file - useful when MPI is enabled and
+        data is logged separately for each MPI rank, for example.
     kwargs:
         Parameters passed to _make_plot
     """

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -106,71 +106,49 @@ def from_file(fname, **kwargs):
     kwargs:
         Parameters passed to _make_plot
     """
-    try:
-        global pandas
-        pandas = __import__('pandas')
-        from_file_pandas(fname, **kwargs)
-    except ImportError:
-        from_file_numpy(fname, **kwargs)
+    if isinstance(fname, str):
+        fname = [fname]
+
+    if isinstance(fname, (list, tuple)):
+        try:
+            global pandas
+            pandas = __import__('pandas')
+            from_file_pandas(fname, **kwargs)
+        except ImportError:
+            from_file_numpy(fname, **kwargs)
+    else:
+        print >> sys.stderr, 'fname should be of str/list(str)/tuple(str).'
+        return None
 
 
 def from_file_pandas(fname, **kwargs):
     """Use pandas."""
-    if isinstance(fname, str):
-        fname = fname
+    data = None
+    for f in fname:
         dataFrame = pandas.read_csv(
-            fname, sep='\s+', lineterminator='\n',
+            f, sep='\s+', lineterminator='\n',
             header=None, index_col=None,
             skipinitialspace=True)
-        data = dataFrame.values
+        newdata = dataFrame.values
 
-    elif isinstance(fname, (list, tuple)):
-        data = None
-        for f in fname:
-            if not isinstance(f, str):
-                print >> sys.stderr, 'List entry is not a python2 string'
-                return None
-
-            if data is None:
-                dataFrame = pandas.read_csv(
-                    f, sep='\s+', lineterminator='\n',
-                    header=None, index_col=None,
-                    skipinitialspace=True)
-                data = dataFrame.values
-            else:
-                dataFrame = pandas.read_csv(
-                    f, sep='\s+', lineterminator='\n',
-                    header=None, index_col=None,
-                    skipinitialspace=True)
-                newdata = dataFrame.values
-                data = numpy.concatenate((data, newdata))
-
-    else:
-        print >> sys.stderr, 'fname should be of str/list(str)/tuple(str).'
-        return None
+        if data is None:
+            data = newdata
+        else:
+            data = numpy.concatenate((data, newdata))
 
     return from_data(data, **kwargs)
 
 
 def from_file_numpy(fname, **kwargs):
     """Use numpy."""
-    if isinstance(fname, str):
-        data = numpy.loadtxt(fname)
+    data = None
+    for f in fname:
+        newdata = numpy.loadtxt(f)
 
-    elif isinstance(fname, (list, tuple)):
-        data = None
-        for f in fname:
-            if not isinstance(f, str):
-                print >> sys.stderr, 'List entry is not a python2 string'
-                return None
-
-            if data is None:
-                data = numpy.loadtxt(f)
-            else:
-                data = numpy.concatenate((data, numpy.loadtxt(f)))
-    else:
-        print >> sys.stderr, 'fname should be of str/list(str)/tuple(str).'
-        return None
+        if data is None:
+            data = newdata
+        else:
+            data = numpy.concatenate((data, newdata))
 
     return from_data(data, **kwargs)
 

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -111,8 +111,45 @@ def from_file(fname, **kwargs):
     kwargs:
         Parameters passed to _make_plot
     """
+    try:
+        global pandas
+        pandas = __import__('pandas')
+        from_file_pandas(fname, **kwargs)
+    except ImportError:
+        from_file_numpy(fname, **kwargs)
 
-    if nest.is_iterable(fname):
+
+def from_file_pandas(fname, **kwargs):
+    """Use pandas."""
+    if isinstance(fname, (list, tuple)):
+        data = None
+        for f in fname:
+            if data is None:
+                dataFrame = pandas.read_csv(
+                    f, sep='\s+', lineterminator='\n',
+                    header=None, index_col=None,
+                    skipinitialspace=True)
+                data = dataFrame.values
+            else:
+                dataFrame = pandas.read_csv(
+                    f, sep='\s+', lineterminator='\n',
+                    header=None, index_col=None,
+                    skipinitialspace=True)
+                newdata = dataFrame.values
+                data = numpy.concatenate((data, newdata))
+    else:
+        dataFrame = pandas.read_csv(
+            fname, sep='\s+', lineterminator='\n',
+            header=None, index_col=None,
+            skipinitialspace=True)
+        data = dataFrame.values
+
+    return from_data(data, **kwargs)
+
+
+def from_file_numpy(fname, **kwargs):
+    """Use numpy."""
+    if isinstance(fname, (list, tuple)):
         data = None
         for f in fname:
             if data is None:

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -103,6 +103,9 @@ def from_file(fname, **kwargs):
     ----------
     fname : str or tuple(str) or list(str)
         File name or list of file names
+        If a list of files is given, the data from them is concatenated as if it
+        had been stored in a single file - useful when MPI is enabled and data
+        is logged separately for each MPI rank, for example.
     kwargs:
         Parameters passed to _make_plot
     """
@@ -118,7 +121,6 @@ def from_file(fname, **kwargs):
             from_file_numpy(fname, **kwargs)
     else:
         print('fname should be of str/list(str)/tuple(str).')
-        return None
 
 
 def from_file_pandas(fname, **kwargs):

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -117,7 +117,7 @@ def from_file(fname, **kwargs):
         except ImportError:
             from_file_numpy(fname, **kwargs)
     else:
-        print >> sys.stderr, 'fname should be of str/list(str)/tuple(str).'
+        print('fname should be of str/list(str)/tuple(str).')
         return None
 
 

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -121,7 +121,7 @@ def from_file(fname, **kwargs):
         except ImportError:
             from_file_numpy(fname, **kwargs)
     else:
-        print('fname should be of str/list(str)/tuple(str).')
+        print('fname should be one of str/list(str)/tuple(str).')
 
 
 def from_file_pandas(fname, **kwargs):


### PR DESCRIPTION
It tries to load the pandas module and uses it if it can, otherwise, it
falls back to numpy.

Note that the nest.is_iterable test returns True for a string, since a
string is iterable and the function then tries to iterate over each
character in the string! I've, therefore, changed the test.

Tested this out with the gdf file generated from
`examples/nest/tsodyks_shortterm_bursts.sli` using the
`examples/nest/plot_tsodyks_shortterm_bursts.py` plotter script and it
works both with and without pandas.

Fixes #400 to begin with.