### PR TITLE
Allow overriding path to compiler for BGQ

### DIFF
--- a/cmake/Platform/BlueGeneQ_GCC.cmake
+++ b/cmake/Platform/BlueGeneQ_GCC.cmake
@@ -22,8 +22,8 @@ include( Platform/BlueGeneQ_Base )
 set( ENV{PATH} "/bgsys/drivers/ppcfloor/gnu-linux/bin:$ENV{PATH}" )
 
 # set the compiler
-set( CMAKE_C_COMPILER powerpc64-bgq-linux-gcc CACHE FILEPATH "cmake is so awesomely misdesigned")
-set( CMAKE_CXX_COMPILER powerpc64-bgq-linux-g++ CACHE FILEPATH "cmake is so awesomely misdesigned")
+set( CMAKE_C_COMPILER powerpc64-bgq-linux-gcc CACHE FILEPATH "override C compiler" )
+set( CMAKE_CXX_COMPILER powerpc64-bgq-linux-g++ CACHE FILEPATH "override C++ compiler" )
 
 if ( static-libraries )
   __bluegeneq_setup_static( GNU CXX )

--- a/cmake/Platform/BlueGeneQ_GCC.cmake
+++ b/cmake/Platform/BlueGeneQ_GCC.cmake
@@ -22,8 +22,8 @@ include( Platform/BlueGeneQ_Base )
 set( ENV{PATH} "/bgsys/drivers/ppcfloor/gnu-linux/bin:$ENV{PATH}" )
 
 # set the compiler
-set( CMAKE_C_COMPILER powerpc64-bgq-linux-gcc )
-set( CMAKE_CXX_COMPILER powerpc64-bgq-linux-g++ )
+set( CMAKE_C_COMPILER powerpc64-bgq-linux-gcc CACHE FILEPATH "cmake is so awesomely misdesigned")
+set( CMAKE_CXX_COMPILER powerpc64-bgq-linux-g++ CACHE FILEPATH "cmake is so awesomely misdesigned")
 
 if ( static-libraries )
   __bluegeneq_setup_static( GNU CXX )

--- a/cmake/Platform/BlueGeneQ_XLC.cmake
+++ b/cmake/Platform/BlueGeneQ_XLC.cmake
@@ -19,8 +19,8 @@
 
 include( Platform/BlueGeneQ_Base )
 # set the compiler
-set( CMAKE_C_COMPILER bgxlc_r CACHE FILEPATH "cmake is so awesomely misdesigned" )
-set( CMAKE_CXX_COMPILER bgxlc++_r CACHE FILEPATH "cmake is so awesomely misdesigned" )
+set( CMAKE_C_COMPILER bgxlc_r CACHE FILEPATH "override C compiler" )
+set( CMAKE_CXX_COMPILER bgxlc++_r CACHE FILEPATH "override C++ compiler" )
 
 #
 # Compile flags for different build types

--- a/cmake/Platform/BlueGeneQ_XLC.cmake
+++ b/cmake/Platform/BlueGeneQ_XLC.cmake
@@ -19,8 +19,8 @@
 
 include( Platform/BlueGeneQ_Base )
 # set the compiler
-set( CMAKE_C_COMPILER bgxlc_r )
-set( CMAKE_CXX_COMPILER bgxlc++_r )
+set( CMAKE_C_COMPILER bgxlc_r CACHE FILEPATH "cmake is so awesomely misdesigned" )
+set( CMAKE_CXX_COMPILER bgxlc++_r CACHE FILEPATH "cmake is so awesomely misdesigned" )
 
 #
 # Compile flags for different build types


### PR DESCRIPTION
Resolves #427, at least makes the compiler overrideable for mpi usages.

@wschenck @gtrensch ?
