### PR TITLE
Changed default "precision" value of recording_device

### DIFF
--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -62,7 +62,7 @@ nest::RecordingDevice::Parameters_::Parameters_( const std::string& file_ext,
   , withgid_( withgid )
   , withtime_( withtime )
   , withweight_( withweight )
-  , precision_( 3 )
+  , precision_( 15 )
   , scientific_( false )
   , binary_( false )
   , fbuffer_size_( BUFSIZ ) // default buffer size as defined in <cstdio>


### PR DESCRIPTION
The default value of "precision" of a recording_device is 3. If precise a model exists, a spike_detector prints a warning and sets the precision value to 15. But if the property "precise_times" is set on a spike_detector, this warning does not get printed and one would expect the value to be set to 15 too, but this would not be the case; it would be 3. This pull requests fixes this discrepancy and makes sure that if the value is not specified, it will always be 15. 