### PR TITLE
Spike detector precision implicit setting and variable name

### DIFF
--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -42,21 +42,21 @@
 #include "integerdatum.h"
 
 nest::spike_detector::spike_detector()
-        : Node()
-        // record time and gid
-        , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true )
-        , has_user_set_precise_times_( false )
-        , has_proxies_( false )
-        , local_receiver_( true )
+  : Node()
+  // record time and gid
+  , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true )
+  , has_user_set_precise_times_( false )
+  , has_proxies_( false )
+  , local_receiver_( true )
 {
 }
 
 nest::spike_detector::spike_detector( const spike_detector& n )
-        : Node( n )
-        , device_( *this, n.device_ )
-        , has_user_set_precise_times_( n.has_user_set_precise_times_ )
-        , has_proxies_( false )
-        , local_receiver_( true )
+  : Node( n )
+  , device_( *this, n.device_ )
+  , has_user_set_precise_times_( n.has_user_set_precise_times_ )
+  , has_proxies_( false )
+  , local_receiver_( true )
 {
 }
 
@@ -81,18 +81,18 @@ void
 nest::spike_detector::calibrate()
 {
   if ( !has_user_set_precise_times_
-       && kernel().event_delivery_manager.get_off_grid_communication() )
+    && kernel().event_delivery_manager.get_off_grid_communication() )
   {
     device_.set_precise( true, 15 );
 
     LOG( M_INFO,
-         "spike_detector::calibrate",
-         String::compose(
-                 "Precise neuron models exist: the property precise_times "
-                         "of the %1 with gid %2 has been set to true, precision has "
-                         "been set to 15.",
-                 get_name(),
-                 get_gid() ) );
+      "spike_detector::calibrate",
+      String::compose(
+           "Precise neuron models exist: the property precise_times "
+           "of the %1 with gid %2 has been set to true, precision has "
+           "been set to 15.",
+           get_name(),
+           get_gid() ) );
   }
 
   device_.calibrate();
@@ -127,7 +127,7 @@ nest::spike_detector::get_status( DictionaryDatum& d ) const
   if ( local_receiver_ && get_thread() == 0 )
   {
     const SiblingContainer* siblings =
-            kernel().node_manager.get_thread_siblings( get_gid() );
+      kernel().node_manager.get_thread_siblings( get_gid() );
     std::vector< Node* >::const_iterator sibling;
     for ( sibling = siblings->begin() + 1; sibling != siblings->end();
           ++sibling )
@@ -142,12 +142,12 @@ nest::spike_detector::set_status( const DictionaryDatum& d )
     has_user_set_precise_times_ = true;
 
   // By setting precision value, precise_times is implicitly set.
-  if ( d->known(names::precision ) )
+  if ( d->known( names::precision ) )
   {
 
     if ( d->known( names::precise_times ) )
     {
-      if (getValue<bool>( d, names::precise_times ) )
+      if ( getValue< bool >( d, names::precise_times ) )
         device_.set_precise( true, getValue< long >( d, names::precision ) );
     }
 
@@ -171,8 +171,8 @@ nest::spike_detector::handle( SpikeEvent& e )
 
     long_t dest_buffer;
     if ( kernel()
-            .modelrange_manager.get_model_of_gid( e.get_sender_gid() )
-            ->has_proxies() )
+           .modelrange_manager.get_model_of_gid( e.get_sender_gid() )
+           ->has_proxies() )
       // events from central queue
       dest_buffer = kernel().event_delivery_manager.read_toggle();
     else
@@ -187,3 +187,4 @@ nest::spike_detector::handle( SpikeEvent& e )
     }
   }
 }
+

--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -139,7 +139,9 @@ void
 nest::spike_detector::set_status( const DictionaryDatum& d )
 {
   if ( d->known( names::precise_times ) )
+  {
     has_user_set_precise_times_ = true;
+  }
 
   // By setting precision value, precise_times is implicitly set.
   if ( d->known( names::precision ) )
@@ -148,7 +150,9 @@ nest::spike_detector::set_status( const DictionaryDatum& d )
     if ( d->known( names::precise_times ) )
     {
       if ( getValue< bool >( d, names::precise_times ) )
+      {
         device_.set_precise( true, getValue< long >( d, names::precision ) );
+      }
     }
 
     else
@@ -187,4 +191,3 @@ nest::spike_detector::handle( SpikeEvent& e )
     }
   }
 }
-

--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -45,7 +45,7 @@ nest::spike_detector::spike_detector()
   : Node()
   // record time and gid
   , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true )
-  , user_set_precise_times_( false )
+  , has_user_set_precise_times_( false )
   , has_proxies_( false )
   , local_receiver_( true )
 {
@@ -54,7 +54,7 @@ nest::spike_detector::spike_detector()
 nest::spike_detector::spike_detector( const spike_detector& n )
   : Node( n )
   , device_( *this, n.device_ )
-  , user_set_precise_times_( n.user_set_precise_times_ )
+  , has_user_set_precise_times_( n.has_user_set_precise_times_ )
   , has_proxies_( false )
   , local_receiver_( true )
 {
@@ -80,7 +80,7 @@ nest::spike_detector::init_buffers_()
 void
 nest::spike_detector::calibrate()
 {
-  if ( !user_set_precise_times_
+  if ( !has_user_set_precise_times_
     && kernel().event_delivery_manager.get_off_grid_communication() )
   {
     device_.set_precise( true, 15 );
@@ -139,7 +139,10 @@ void
 nest::spike_detector::set_status( const DictionaryDatum& d )
 {
   if ( d->known( names::precise_times ) )
-    user_set_precise_times_ = true;
+    has_user_set_precise_times_ = true;
+
+  if ( d->known( names::precision ) )
+    has_user_set_precise_times_ = true;
 
   device_.set_status( d );
 }

--- a/models/spike_detector.cpp
+++ b/models/spike_detector.cpp
@@ -42,21 +42,21 @@
 #include "integerdatum.h"
 
 nest::spike_detector::spike_detector()
-  : Node()
-  // record time and gid
-  , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true )
-  , has_user_set_precise_times_( false )
-  , has_proxies_( false )
-  , local_receiver_( true )
+        : Node()
+        // record time and gid
+        , device_( *this, RecordingDevice::SPIKE_DETECTOR, "gdf", true, true )
+        , has_user_set_precise_times_( false )
+        , has_proxies_( false )
+        , local_receiver_( true )
 {
 }
 
 nest::spike_detector::spike_detector( const spike_detector& n )
-  : Node( n )
-  , device_( *this, n.device_ )
-  , has_user_set_precise_times_( n.has_user_set_precise_times_ )
-  , has_proxies_( false )
-  , local_receiver_( true )
+        : Node( n )
+        , device_( *this, n.device_ )
+        , has_user_set_precise_times_( n.has_user_set_precise_times_ )
+        , has_proxies_( false )
+        , local_receiver_( true )
 {
 }
 
@@ -81,18 +81,18 @@ void
 nest::spike_detector::calibrate()
 {
   if ( !has_user_set_precise_times_
-    && kernel().event_delivery_manager.get_off_grid_communication() )
+       && kernel().event_delivery_manager.get_off_grid_communication() )
   {
     device_.set_precise( true, 15 );
 
     LOG( M_INFO,
-      "spike_detector::calibrate",
-      String::compose(
-           "Precise neuron models exist: the property precise_times "
-           "of the %1 with gid %2 has been set to true, precision has "
-           "been set to 15.",
-           get_name(),
-           get_gid() ) );
+         "spike_detector::calibrate",
+         String::compose(
+                 "Precise neuron models exist: the property precise_times "
+                         "of the %1 with gid %2 has been set to true, precision has "
+                         "been set to 15.",
+                 get_name(),
+                 get_gid() ) );
   }
 
   device_.calibrate();
@@ -127,7 +127,7 @@ nest::spike_detector::get_status( DictionaryDatum& d ) const
   if ( local_receiver_ && get_thread() == 0 )
   {
     const SiblingContainer* siblings =
-      kernel().node_manager.get_thread_siblings( get_gid() );
+            kernel().node_manager.get_thread_siblings( get_gid() );
     std::vector< Node* >::const_iterator sibling;
     for ( sibling = siblings->begin() + 1; sibling != siblings->end();
           ++sibling )
@@ -141,8 +141,21 @@ nest::spike_detector::set_status( const DictionaryDatum& d )
   if ( d->known( names::precise_times ) )
     has_user_set_precise_times_ = true;
 
-  if ( d->known( names::precision ) )
+  // By setting precision value, precise_times is implicitly set.
+  if ( d->known(names::precision ) )
+  {
+
+    if ( d->known( names::precise_times ) )
+    {
+      if (getValue<bool>( d, names::precise_times ) )
+        device_.set_precise( true, getValue< long >( d, names::precision ) );
+    }
+
+    else
+      device_.set_precise( true, getValue< long >( d, names::precision ) );
+
     has_user_set_precise_times_ = true;
+  }
 
   device_.set_status( d );
 }
@@ -158,8 +171,8 @@ nest::spike_detector::handle( SpikeEvent& e )
 
     long_t dest_buffer;
     if ( kernel()
-           .modelrange_manager.get_model_of_gid( e.get_sender_gid() )
-           ->has_proxies() )
+            .modelrange_manager.get_model_of_gid( e.get_sender_gid() )
+            ->has_proxies() )
       // events from central queue
       dest_buffer = kernel().event_delivery_manager.read_toggle();
     else

--- a/models/spike_detector.h
+++ b/models/spike_detector.h
@@ -182,7 +182,7 @@ private:
   RecordingDevice device_;
   Buffers_ B_;
 
-  bool user_set_precise_times_;
+  bool has_user_set_precise_times_;
   bool has_proxies_;
   bool local_receiver_;
 };

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -62,7 +62,7 @@ nest::RecordingDevice::Parameters_::Parameters_( const std::string& file_ext,
   , withgid_( withgid )
   , withtime_( withtime )
   , withweight_( withweight )
-  , precision_( 3 )
+  , precision_( 15 )
   , scientific_( false )
   , binary_( false )
   , fbuffer_size_( BUFSIZ ) // default buffer size as defined in <cstdio>


### PR DESCRIPTION
Two improvements:
1. "user_set_precise_times" is currently used to store whether the precise_times property been directly set and "precision" of the recording_device the actual value. By changing to "has_user_set_precise_times", one could readily understand the point of this variable without wasting time.
2. By setting "precision" one is implicitly setting the value of the variable above so in the set method it is necessary to set it to true if "precision" is directly set.