### PR TITLE
Additional timers and local spike counter for profiling and performance measurements

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -212,10 +212,8 @@ EventDeliveryManager::init_moduli()
   slice_moduli_.resize( min_delay + max_delay );
   for ( delay d = 0; d < min_delay + max_delay; ++d )
   {
-    slice_moduli_[ d ] =
-      ( ( kernel().simulation_manager.get_clock().get_steps() + d )
-        / min_delay )
-      % nbuff;
+    slice_moduli_[ d ] = ( ( kernel().simulation_manager.get_clock().get_steps()
+                             + d ) / min_delay ) % nbuff;
   }
 }
 
@@ -250,10 +248,8 @@ EventDeliveryManager::update_moduli()
     std::ceil( static_cast< double >( min_delay + max_delay ) / min_delay ) );
   for ( delay d = 0; d < min_delay + max_delay; ++d )
   {
-    slice_moduli_[ d ] =
-      ( ( kernel().simulation_manager.get_clock().get_steps() + d )
-        / min_delay )
-      % nbuff;
+    slice_moduli_[ d ] = ( ( kernel().simulation_manager.get_clock().get_steps()
+                             + d ) / min_delay ) % nbuff;
   }
 }
 

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -598,13 +598,17 @@ EventDeliveryManager::gather_events( bool done )
 {
   // IMPORTANT: Ensure that gather_events(..) is called from a single thread and
   //            NOT from a parallel OpenMP region!!!
-  stw_collocate_.reset();
-  stw_collocate_.start();
+
+  // Stop watch for time measurements within this function
+  static Stopwatch stw_local;
+  
+  stw_local.reset();
+  stw_local.start();
   collocate_buffers_( done );
-  stw_collocate_.stop();
-  time_collocate_ += stw_collocate_.elapsed();
-  stw_communicate_.reset();
-  stw_communicate_.start();
+  stw_local.stop();
+  time_collocate_ += stw_local.elapsed();
+  stw_local.reset();
+  stw_local.start();
   if ( off_grid_spiking_ )
   {
     kernel().mpi_manager.communicate(
@@ -615,7 +619,7 @@ EventDeliveryManager::gather_events( bool done )
     kernel().mpi_manager.communicate(
       local_grid_spikes_, global_grid_spikes_, displacements_ );
   }
-  stw_communicate_.stop();
-  time_communicate_ += stw_communicate_.elapsed();
+  stw_local.stop();
+  time_communicate_ += stw_local.elapsed();
 }
 }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -589,7 +589,7 @@ EventDeliveryManager::deliver_events( thread t )
 void
 EventDeliveryManager::gather_events( bool done )
 {
-#pragma omp master
+//#pragma omp master
   {
     stw_collocate_.reset();
     stw_collocate_.start();

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -212,8 +212,10 @@ EventDeliveryManager::init_moduli()
   slice_moduli_.resize( min_delay + max_delay );
   for ( delay d = 0; d < min_delay + max_delay; ++d )
   {
-    slice_moduli_[ d ] = ( ( kernel().simulation_manager.get_clock().get_steps()
-                             + d ) / min_delay ) % nbuff;
+    slice_moduli_[ d ] =
+      ( ( kernel().simulation_manager.get_clock().get_steps() + d )
+        / min_delay )
+      % nbuff;
   }
 }
 
@@ -248,8 +250,10 @@ EventDeliveryManager::update_moduli()
     std::ceil( static_cast< double >( min_delay + max_delay ) / min_delay ) );
   for ( delay d = 0; d < min_delay + max_delay; ++d )
   {
-    slice_moduli_[ d ] = ( ( kernel().simulation_manager.get_clock().get_steps()
-                             + d ) / min_delay ) % nbuff;
+    slice_moduli_[ d ] =
+      ( ( kernel().simulation_manager.get_clock().get_steps() + d )
+        / min_delay )
+      % nbuff;
   }
 }
 
@@ -303,7 +307,7 @@ EventDeliveryManager::collocate_buffers_( bool done )
   // +1 for bool-value done
   num_spikes =
     num_grid_spikes + num_offgrid_spikes + uintsize_secondary_events + 2;
-    
+
   if ( !off_grid_spiking_ ) // on grid spiking
   {
     // make sure buffers are correctly sized
@@ -607,13 +611,13 @@ EventDeliveryManager::gather_events( bool done )
   stw_communicate_.start();
   if ( off_grid_spiking_ )
   {
-    kernel().mpi_manager.communicate( local_offgrid_spikes_,
-                                      global_offgrid_spikes_, displacements_ );
+    kernel().mpi_manager.communicate(
+      local_offgrid_spikes_, global_offgrid_spikes_, displacements_ );
   }
   else
   {
-    kernel().mpi_manager.communicate( local_grid_spikes_,
-                                      global_grid_spikes_, displacements_ );
+    kernel().mpi_manager.communicate(
+      local_grid_spikes_, global_grid_spikes_, displacements_ );
   }
   stw_communicate_.stop();
   time_communicate_ += stw_communicate_.elapsed();

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -601,7 +601,7 @@ EventDeliveryManager::gather_events( bool done )
 
   // Stop watch for time measurements within this function
   static Stopwatch stw_local;
-  
+
   stw_local.reset();
   stw_local.start();
   collocate_buffers_( done );

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -53,6 +53,7 @@ EventDeliveryManager::EventDeliveryManager()
   , comm_marker_( 0 )
   , time_collocate_( 0.0 )
   , time_communicate_( 0.0 )
+  , local_spike_counter_( 0U )
 {
 }
 
@@ -69,7 +70,7 @@ void
 EventDeliveryManager::initialize()
 {
   init_moduli();
-  reset_timers();
+  reset_timers_counters();
 }
 
 void
@@ -94,6 +95,7 @@ EventDeliveryManager::get_status( DictionaryDatum& dict )
   def< bool >( dict, "off_grid_spiking", off_grid_spiking_ );
   def< double >( dict, "time_collocate", time_collocate_ );
   def< double >( dict, "time_communicate", time_communicate_ );
+  def< ulong_t >( dict, "local_spike_counter", local_spike_counter_ );
 }
 
 void
@@ -252,10 +254,11 @@ EventDeliveryManager::update_moduli()
 }
 
 void
-EventDeliveryManager::reset_timers()
+EventDeliveryManager::reset_timers_counters()
 {
   time_collocate_ = 0.0;
   time_communicate_ = 0.0;
+  local_spike_counter_ = 0U;
 }
 
 void
@@ -281,6 +284,9 @@ EventDeliveryManager::collocate_buffers_( bool done )
     for ( jt = it->begin(); jt != it->end(); ++jt )
       num_offgrid_spikes += jt->size();
 
+  // accumulate number of generated spikes in the local spike counter
+  local_spike_counter_ += num_grid_spikes + num_offgrid_spikes;
+
   // here we need to count the secondary events and take them
   // into account in the size of the buffers
   // assume that we already serialized all secondary
@@ -297,6 +303,7 @@ EventDeliveryManager::collocate_buffers_( bool done )
   // +1 for bool-value done
   num_spikes =
     num_grid_spikes + num_offgrid_spikes + uintsize_secondary_events + 2;
+    
   if ( !off_grid_spiking_ ) // on grid spiking
   {
     // make sure buffers are correctly sized
@@ -589,25 +596,26 @@ EventDeliveryManager::deliver_events( thread t )
 void
 EventDeliveryManager::gather_events( bool done )
 {
-//#pragma omp master
+  // IMPORTANT: Ensure that gather_events(..) is called from a single thread and
+  //            NOT from a parallel OpenMP region!!!
+  stw_collocate_.reset();
+  stw_collocate_.start();
+  collocate_buffers_( done );
+  stw_collocate_.stop();
+  time_collocate_ += stw_collocate_.elapsed();
+  stw_communicate_.reset();
+  stw_communicate_.start();
+  if ( off_grid_spiking_ )
   {
-    stw_collocate_.reset();
-    stw_collocate_.start();
-    collocate_buffers_( done );
-    stw_collocate_.stop();
-    time_collocate_ += stw_collocate_.elapsed();
-    stw_communicate_.reset();
-    stw_communicate_.start();
-    if ( off_grid_spiking_ )
-    {
-      kernel().mpi_manager.communicate( local_offgrid_spikes_, global_offgrid_spikes_, displacements_ );
-    }
-    else
-    {
-      kernel().mpi_manager.communicate( local_grid_spikes_, global_grid_spikes_, displacements_ );
-    }
-    stw_communicate_.stop();
-    time_communicate_ += stw_communicate_.elapsed();
-  } // omp master
+    kernel().mpi_manager.communicate( local_offgrid_spikes_,
+                                      global_offgrid_spikes_, displacements_ );
+  }
+  else
+  {
+    kernel().mpi_manager.communicate( local_grid_spikes_,
+                                      global_grid_spikes_, displacements_ );
+  }
+  stw_communicate_.stop();
+  time_communicate_ += stw_communicate_.elapsed();
 }
 }

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -321,16 +321,6 @@ private:
   const uint_t comm_marker_;
 
   /**
-   * Stop watch to time collocation of events in MPI buffers.
-   */
-  Stopwatch stw_collocate_;
-
-  /**
-   * Stop watch to time communication of events.
-   */
-  Stopwatch stw_communicate_;
-
-  /**
    * Time that was spent on collocation of MPI buffers during the last call to
    * simulate.
    */

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -29,6 +29,7 @@
 
 // Includes from libnestutil:
 #include "manager_interface.h"
+#include "stopwatch.h"
 
 // Includes from nestkernel:
 #include "mpi_manager.h" // OffGridSpike
@@ -213,6 +214,12 @@ public:
    */
   void init_moduli();
 
+  /**
+   * Set cumulative time measurements for collocating buffers
+   * and for communication to zero
+   */
+  virtual void reset_timers();
+
 private:
   /**
    * Rearrange the spike_register into a 2-dim structure. This is
@@ -312,6 +319,26 @@ private:
    * steps during communication.
    */
   const uint_t comm_marker_;
+
+  /**
+   * Stop watch to time collocation of events in MPI buffers.
+   */
+  Stopwatch stw_collocate_;
+
+  /**
+   * Stop watch to time communication of events.
+   */
+  Stopwatch stw_communicate_;
+
+  /**
+   * Time that was spent on collocation of MPI buffers in the last mindelay interval.
+   */
+  double_t time_collocate_;
+
+  /**
+   * Time that was spent on communication of events in the last mindelay interval.
+   */
+  double_t time_communicate_;
 };
 
 

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -32,8 +32,8 @@
 #include "stopwatch.h"
 
 // Includes from nestkernel:
-#include "mpi_manager.h" // OffGridSpike
 #include "event.h"
+#include "mpi_manager.h" // OffGridSpike
 #include "nest_time.h"
 #include "nest_types.h"
 #include "node.h"
@@ -331,17 +331,20 @@ private:
   Stopwatch stw_communicate_;
 
   /**
-   * Time that was spent on collocation of MPI buffers during the last call to simulate.
+   * Time that was spent on collocation of MPI buffers during the last call to
+   * simulate.
    */
   double_t time_collocate_;
 
   /**
-   * Time that was spent on communication of events during the last call to simulate.
+   * Time that was spent on communication of events during the last call to
+   * simulate.
    */
   double_t time_communicate_;
 
   /**
-   * Number of generated spike events (both off- and on-grid) during the last call to simulate.
+   * Number of generated spike events (both off- and on-grid) during the last
+   * call to simulate.
    */
   ulong_t local_spike_counter_;
 };

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -216,9 +216,9 @@ public:
 
   /**
    * Set cumulative time measurements for collocating buffers
-   * and for communication to zero
+   * and for communication to zero; set local spike counter to zero.
    */
-  virtual void reset_timers();
+  virtual void reset_timers_counters();
 
 private:
   /**
@@ -331,14 +331,19 @@ private:
   Stopwatch stw_communicate_;
 
   /**
-   * Time that was spent on collocation of MPI buffers in the last mindelay interval.
+   * Time that was spent on collocation of MPI buffers during the last call to simulate.
    */
   double_t time_collocate_;
 
   /**
-   * Time that was spent on communication of events in the last mindelay interval.
+   * Time that was spent on communication of events during the last call to simulate.
    */
   double_t time_communicate_;
+
+  /**
+   * Number of generated spike events (both off- and on-grid) during the last call to simulate.
+   */
+  ulong_t local_spike_counter_;
 };
 
 

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -452,16 +452,14 @@ nest::SimulationManager::resume_( size_t num_active_nodes )
   os << std::endl
      << "Number of OpenMP threads: " << kernel().vp_manager.get_num_threads();
 #else
-  os << std::endl
-     << "Not using OpenMP";
+  os << std::endl << "Not using OpenMP";
 #endif
 
 #ifdef HAVE_MPI
   os << std::endl
      << "Number of MPI processes: " << kernel().mpi_manager.get_num_processes();
 #else
-  os << std::endl
-     << "Not using MPI";
+  os << std::endl << "Not using MPI";
 #endif
 
   LOG( M_INFO, "SimulationManager::resume", os.str() );
@@ -733,10 +731,10 @@ nest::SimulationManager::update_()
 
       const std::vector< Node* >& thread_local_nodes =
         kernel().node_manager.get_nodes_on_thread( thrd );
-      for (
-        std::vector< Node* >::const_iterator node = thread_local_nodes.begin();
-        node != thread_local_nodes.end();
-        ++node )
+      for ( std::vector< Node* >::const_iterator node =
+              thread_local_nodes.begin();
+            node != thread_local_nodes.end();
+            ++node )
       {
         // We update in a parallel region. Therefore, we need to catch
         // exceptions here and then handle them after the parallel region.

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -452,14 +452,16 @@ nest::SimulationManager::resume_( size_t num_active_nodes )
   os << std::endl
      << "Number of OpenMP threads: " << kernel().vp_manager.get_num_threads();
 #else
-  os << std::endl << "Not using OpenMP";
+  os << std::endl
+     << "Not using OpenMP";
 #endif
 
 #ifdef HAVE_MPI
   os << std::endl
      << "Number of MPI processes: " << kernel().mpi_manager.get_num_processes();
 #else
-  os << std::endl << "Not using MPI";
+  os << std::endl
+     << "Not using MPI";
 #endif
 
   LOG( M_INFO, "SimulationManager::resume", os.str() );
@@ -731,10 +733,10 @@ nest::SimulationManager::update_()
 
       const std::vector< Node* >& thread_local_nodes =
         kernel().node_manager.get_nodes_on_thread( thrd );
-      for ( std::vector< Node* >::const_iterator node =
-              thread_local_nodes.begin();
-            node != thread_local_nodes.end();
-            ++node )
+      for (
+        std::vector< Node* >::const_iterator node = thread_local_nodes.begin();
+        node != thread_local_nodes.end();
+        ++node )
       {
         // We update in a parallel region. Therefore, we need to catch
         // exceptions here and then handle them after the parallel region.

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -364,9 +364,6 @@ nest::SimulationManager::simulate( Time const& t )
   t_slice_begin_ = timeval();
   t_slice_end_ = timeval();
 
-  // TODO: Put into prepare_simulation_
-  kernel().event_delivery_manager.reset_timers();
-
   if ( t == Time::ms( 0.0 ) )
     return;
 
@@ -520,6 +517,9 @@ size_t
 nest::SimulationManager::prepare_simulation_()
 {
   assert( to_do_ != 0 ); // This is checked in simulate()
+
+  // Reset profiling timers within event_delivery_manager
+  kernel().event_delivery_manager.reset_timers();
 
   // find shortest and longest delay across all MPI processes
   // this call sets the member variables

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -364,6 +364,9 @@ nest::SimulationManager::simulate( Time const& t )
   t_slice_begin_ = timeval();
   t_slice_end_ = timeval();
 
+  // TODO: Put into prepare_simulation_
+  kernel().event_delivery_manager.reset_timers();
+
   if ( t == Time::ms( 0.0 ) )
     return;
 

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -518,8 +518,8 @@ nest::SimulationManager::prepare_simulation_()
 {
   assert( to_do_ != 0 ); // This is checked in simulate()
 
-  // Reset profiling timers within event_delivery_manager
-  kernel().event_delivery_manager.reset_timers();
+  // Reset profiling timers and counters within event_delivery_manager
+  kernel().event_delivery_manager.reset_timers_counters();
 
   // find shortest and longest delay across all MPI processes
   // this call sets the member variables


### PR DESCRIPTION
In this pull request two timers and one counter are added to the nest kernel.

The timers contain (1) the time spent in gather_events for spike communication via MPI and (2) the time spent in gather_events for collocating spike buffers. The counter contains the number of spike events generated on the specific rank (both on- and offgrid). All these measurements are for the last call to simulate. They are reset to zero at the beginning of a new call to simulate within prepare_simulation.

These measurements are useful for light-weight profiling and collecting of performance data.