### PR TITLE
Ignore MUSIC devices in multiplicity test

### DIFF
--- a/testsuite/unittests/test_neurons_handle_multiplicity.sli
+++ b/testsuite/unittests/test_neurons_handle_multiplicity.sli
@@ -47,6 +47,12 @@ M_ERROR setverbosity
              /parrot_neuron
              /parrot_neuron_ps
              /iaf_cond_alpha_mc    % cannot readout V_m directly
+             /music_event_in_proxy        % music device
+             /music_event_out_proxy       % music device
+             /music_cont_in_proxy         % music device
+             /music_cont_out_proxy        % music device
+             /music_message_in_proxy      % music device
+             /music_message_out_proxy     % music device
            ] def    
 
 % The following models require connections to rport 1:


### PR DESCRIPTION
Since MUSIC devices do not have a membrane potential, test_neurons_handle_multicplicity.sli fails when trying to retrieve the value of the membrane potential of a MUSIC device. These should hence be ignored in this test. I suggest @heplesser and @weidel-p as reviewers.
Fixes #442 