### PR TITLE
Structural Plasticity steering

### DIFF
--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -303,10 +303,10 @@ nest::Archiving_Node::set_status( const DictionaryDatum& d )
       }
     }
   }
-    if ( not d->known( names::synaptic_elements ) )
-    {
-      return;
-    }
+  if ( not d->known( names::synaptic_elements ) )
+  {
+    return;
+  }
   // we replace the existing synaptic_elements_map_ by the new one
   DictionaryDatum synaptic_elements_d;
   std::pair< std::map< Name, SynapticElement >::iterator, bool > insert_result;

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -285,10 +285,21 @@ nest::Archiving_Node::set_status( const DictionaryDatum& d )
     clear_history();
   }
 
-  if ( not d->known( names::synaptic_elements ) )
+  
+  if ( d->known( names::update_synaptic_elements ) )
   {
-    return;
+    const DictionaryDatum synaptic_elements_a = getValue< DictionaryDatum >( d, names::update_synaptic_elements );
+    for ( std::map< Name, SynapticElement >::iterator it = synaptic_elements_map_.begin();
+        it != synaptic_elements_map_.end();
+        ++it )
+    {
+          it->second.set(synaptic_elements_a);
+    }
   }
+    if ( not d->known( names::synaptic_elements ) )
+    {
+      return;
+    }
   // we replace the existing synaptic_elements_map_ by the new one
   DictionaryDatum synaptic_elements_d;
   std::pair< std::map< Name, SynapticElement >::iterator, bool > insert_result;

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -285,7 +285,6 @@ nest::Archiving_Node::set_status( const DictionaryDatum& d )
     clear_history();
   }
 
-
   if ( d->known( names::synaptic_elements_param ) )
   {
     const DictionaryDatum synaptic_elements_dict =

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -288,12 +288,20 @@ nest::Archiving_Node::set_status( const DictionaryDatum& d )
   
   if ( d->known( names::update_synaptic_elements ) )
   {
-    const DictionaryDatum synaptic_elements_a = getValue< DictionaryDatum >( d, names::update_synaptic_elements );
-    for ( std::map< Name, SynapticElement >::iterator it = synaptic_elements_map_.begin();
-        it != synaptic_elements_map_.end();
-        ++it )
+    const DictionaryDatum synaptic_elements_dict =
+      getValue< DictionaryDatum >( d, names::update_synaptic_elements );
+
+    for ( std::map< Name, SynapticElement >::iterator it =
+            synaptic_elements_map_.begin();
+          it != synaptic_elements_map_.end();
+          ++it )
     {
-          it->second.set(synaptic_elements_a);
+      if ( synaptic_elements_dict->known( it->first ) )
+      {
+        const DictionaryDatum synaptic_elements_a =
+          getValue< DictionaryDatum >( synaptic_elements_dict, it->first );
+        it->second.set( synaptic_elements_a );
+      }
     }
   }
     if ( not d->known( names::synaptic_elements ) )

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -285,11 +285,11 @@ nest::Archiving_Node::set_status( const DictionaryDatum& d )
     clear_history();
   }
 
-  
-  if ( d->known( names::update_synaptic_elements ) )
+
+  if ( d->known( names::synaptic_elements_param ) )
   {
     const DictionaryDatum synaptic_elements_dict =
-      getValue< DictionaryDatum >( d, names::update_synaptic_elements );
+      getValue< DictionaryDatum >( d, names::synaptic_elements_param );
 
     for ( std::map< Name, SynapticElement >::iterator it =
             synaptic_elements_map_.begin();

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -487,6 +487,7 @@ const Name update( "update" );
 const Name update_node( "update_node" );
 const Name use_gid_in_filename( "use_gid_in_filename" );
 const Name use_wfr( "use_wfr" );
+const Name update_synaptic_elements( "update_synaptic_elements" );
 
 const Name V_act_NMDA( "V_act_NMDA" );
 const Name V_epsp( "V_epsp" );

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -396,6 +396,7 @@ const Name synapse_label( "synapse_label" );
 const Name synapse_model( "synapse_model" );
 const Name synapse_modelid( "synapse_modelid" );
 const Name synaptic_elements( "synaptic_elements" );
+const Name synaptic_elements_param( "synaptic_elements_param" );
 
 const Name t_lag( "t_lag" );
 const Name T_min( "T_min" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -550,9 +550,10 @@ extern const Name U_std;
 extern const Name U_upper;
 extern const Name update;      //!< Command to execute the neuron (sli_neuron)
 extern const Name update_node; //!< Command to execute the neuron (sli_neuron)
+extern const Name update_synaptic_elements; //!< Command to update parameters
+                                            //!< of synaptic elements
+extern const Name use_wfr;                  //!< Simulation-related
 extern const Name use_gid_in_filename; //!< use gid in the filename
-extern const Name use_wfr;             //!< Simulation-related
-extern const Name update_synaptic_elements;
 
 extern const Name V_act_NMDA; //!< specific to Hill & Tononi 2005
 extern const Name V_epsp;     //!< Specific to iaf_chs_2008 neuron

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -452,6 +452,8 @@ extern const Name synapse_modelid;     //!< Connection parameters
 extern const Name synapses_per_driver; //!< Used by stdp_connection_facetshw_hom
 extern const Name synaptic_elements;   //!< Synaptic elements used in structural
                                        //!< plasticity
+extern const Name synaptic_elements_param; //!< Used to update parameters
+                                           //!< of synaptic elements
 
 extern const Name t_lag;     //!< Lag within a time slice
 extern const Name T_min;     //!< Minimum time
@@ -550,8 +552,6 @@ extern const Name U_std;
 extern const Name U_upper;
 extern const Name update;      //!< Command to execute the neuron (sli_neuron)
 extern const Name update_node; //!< Command to execute the neuron (sli_neuron)
-extern const Name update_synaptic_elements; //!< Command to update parameters
-                                            //!< of synaptic elements
 extern const Name use_wfr;                  //!< Simulation-related
 extern const Name use_gid_in_filename; //!< use gid in the filename
 

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -552,6 +552,7 @@ extern const Name update;      //!< Command to execute the neuron (sli_neuron)
 extern const Name update_node; //!< Command to execute the neuron (sli_neuron)
 extern const Name use_gid_in_filename; //!< use gid in the filename
 extern const Name use_wfr;             //!< Simulation-related
+extern const Name update_synaptic_elements;
 
 extern const Name V_act_NMDA; //!< specific to Hill & Tononi 2005
 extern const Name V_epsp;     //!< Specific to iaf_chs_2008 neuron

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -552,7 +552,7 @@ extern const Name U_std;
 extern const Name U_upper;
 extern const Name update;      //!< Command to execute the neuron (sli_neuron)
 extern const Name update_node; //!< Command to execute the neuron (sli_neuron)
-extern const Name use_wfr;                  //!< Simulation-related
+extern const Name use_wfr;     //!< Simulation-related
 extern const Name use_gid_in_filename; //!< use gid in the filename
 
 extern const Name V_act_NMDA; //!< specific to Hill & Tononi 2005

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -92,13 +92,17 @@ SPManager::get_status( DictionaryDatum& d )
         i++ )
   {
     sp_synapse = DictionaryDatum( new Dictionary() );
-    def< std::string >(
-      sp_synapse, names::pre_synaptic_element, ( *i )->get_pre_synaptic_element_name() );
-    def< std::string >(
-      sp_synapse, names::post_synaptic_element, ( *i )->get_post_synaptic_element_name() );
+    def< std::string >( sp_synapse,
+      names::pre_synaptic_element,
+      ( *i )->get_pre_synaptic_element_name() );
+    def< std::string >( sp_synapse,
+      names::post_synaptic_element,
+      ( *i )->get_post_synaptic_element_name() );
     def< std::string >( sp_synapse,
       names::model,
-       kernel().model_manager.get_synapse_prototype( ( *i )->get_synapse_model(), 0 ).get_name() );
+      kernel()
+        .model_manager.get_synapse_prototype( ( *i )->get_synapse_model(), 0 )
+        .get_name() );
     std::stringstream syn_name;
     syn_name << "syn" << ( sp_conn_builders_.end() - i );
     def< DictionaryDatum >( sp_synapses, syn_name.str(), sp_synapse );

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -92,12 +92,13 @@ SPManager::get_status( DictionaryDatum& d )
         i++ )
   {
     sp_synapse = DictionaryDatum( new Dictionary() );
+    def< std::string >(
+      sp_synapse, names::pre_synaptic_element, ( *i )->get_pre_synaptic_element_name() );
+    def< std::string >(
+      sp_synapse, names::post_synaptic_element, ( *i )->get_post_synaptic_element_name() );
     def< std::string >( sp_synapse,
-      names::pre_synaptic_element,
-      ( *i )->get_pre_synaptic_element_name() );
-    def< std::string >( sp_synapse,
-      names::post_synaptic_element,
-      ( *i )->get_post_synaptic_element_name() );
+      names::model,
+       kernel().model_manager.get_synapse_prototype( ( *i )->get_synapse_model(), 0 ).get_name() );
     std::stringstream syn_name;
     syn_name << "syn" << ( sp_conn_builders_.end() - i );
     def< DictionaryDatum >( sp_synapses, syn_name.str(), sp_synapse );

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -121,10 +121,10 @@ nest::SynapticElement::set( const DictionaryDatum& d )
 
   // Store values
   if ( d->known( names::growth_rate ) )
-    growth_rate_ = getValue< double_t >( d, names::growth_rate );
-  else
-    updateValue< double_t >( d, names::growth_rate, growth_rate_ );
-  updateValue< double_t >( d, names::tau_vacant, new_tau_vacant );
+  {
+    growth_rate_ = getValue< double >( d, names::growth_rate );
+  }
+  updateValue< double >( d, names::tau_vacant, new_tau_vacant );
   updateValue< bool >( d, names::continuous, continuous_ );
   updateValue< double >( d, names::z, z_ );
 

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -120,8 +120,11 @@ nest::SynapticElement::set( const DictionaryDatum& d )
   double new_tau_vacant = tau_vacant_;
 
   // Store values
-  updateValue< double >( d, names::growth_rate, growth_rate_ );
-  updateValue< double >( d, names::tau_vacant, new_tau_vacant );
+  if ( d->known( names::growth_rate ) )
+    growth_rate_ = getValue< double_t >( d, names::growth_rate );
+  else
+    updateValue< double_t >( d, names::growth_rate, growth_rate_ );
+  updateValue< double_t >( d, names::tau_vacant, new_tau_vacant );
   updateValue< bool >( d, names::continuous, continuous_ );
   updateValue< double >( d, names::z, z_ );
 

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -120,10 +120,7 @@ nest::SynapticElement::set( const DictionaryDatum& d )
   double new_tau_vacant = tau_vacant_;
 
   // Store values
-  if ( d->known( names::growth_rate ) )
-  {
-    growth_rate_ = getValue< double >( d, names::growth_rate );
-  }
+  updateValue< double >( d, names::growth_rate, growth_rate_ );
   updateValue< double >( d, names::tau_vacant, new_tau_vacant );
   updateValue< bool >( d, names::continuous, continuous_ );
   updateValue< double >( d, names::z, z_ );

--- a/pynest/nest/tests/test_sp/test_disconnect.py
+++ b/pynest/nest/tests/test_sp/test_disconnect.py
@@ -75,16 +75,14 @@ class TestDisconnectSingle(unittest.TestCase):
                 conns = nest.GetConnections(
                     [neurons[0]], [neurons[2]], syn_model)
                 if mpi_test:
-                    connstotal = None
-                    conns = self.comm.allgather(conns, connstotal)
+                    conns = self.comm.allgather(conns)
                     conns = filter(None, conns)
                 assert len(conns) == 1
                 nest.DisconnectOneToOne(neurons[0], neurons[2], syn_dict)
                 conns = nest.GetConnections(
                     [neurons[0]], [neurons[2]], syn_model)
                 if mpi_test:
-                    connstotal = None
-                    conns = self.comm.allgather(conns, connstotal)
+                    conns = self.comm.allgather(conns)
                     conns = filter(None, conns)
                 assert len(conns) == 0
 
@@ -92,8 +90,7 @@ class TestDisconnectSingle(unittest.TestCase):
                 conns1 = nest.GetConnections(
                     [neurons[0]], [neurons[1]], syn_model)
                 if mpi_test:
-                    connstotal1 = None
-                    conns1 = self.comm.allgather(conns1, connstotal1)
+                    conns1 = self.comm.allgather(conns1)
                     conns1 = filter(None, conns1)
                 assert len(conns1) == 0
                 try:

--- a/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
+++ b/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
@@ -67,7 +67,7 @@ class TestUpdateSynapticElements(unittest.TestCase):
             structural_p_elements[u'Den_ex'], neuron_synaptic_elements[u'Den_ex'])
 
         # Update Axon elements
-        nest.SetStatus(neuron, 'update_synaptic_elements', elements_to_update)
+        nest.SetStatus(neuron, 'synaptic_elements_param', elements_to_update)
         neuron_synaptic_elements = nest.GetStatus(
             neuron, 'synaptic_elements')[0]
         self.assertIn('Den_ex', neuron_synaptic_elements)

--- a/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
+++ b/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
@@ -80,10 +80,10 @@ class TestUpdateSynapticElements(unittest.TestCase):
         self.assertDictContainsSubset(
             structural_p_elements[u'Den_ex'], neuron_synaptic_elements[u'Den_ex'])
 
+
 def suite():
     test_suite = unittest.makeSuite(TestUpdateSynapticElements, 'test')
     return test_suite
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
+++ b/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
@@ -62,9 +62,11 @@ class TestUpdateSynapticElements(unittest.TestCase):
         self.assertIn('Axon', neuron_synaptic_elements)
 
         self.assertDictContainsSubset(
-            structural_p_elements[u'Axon'], neuron_synaptic_elements[u'Axon'])
+            structural_p_elements[u'Axon'],
+            neuron_synaptic_elements[u'Axon'])
         self.assertDictContainsSubset(
-            structural_p_elements[u'Den_ex'], neuron_synaptic_elements[u'Den_ex'])
+            structural_p_elements[u'Den_ex'],
+            neuron_synaptic_elements[u'Den_ex'])
 
         # Update Axon elements
         nest.SetStatus(neuron, 'synaptic_elements_param', elements_to_update)
@@ -78,7 +80,8 @@ class TestUpdateSynapticElements(unittest.TestCase):
             elements_to_update[u'Axon'], neuron_synaptic_elements[u'Axon'])
         # Should be unchanged
         self.assertDictContainsSubset(
-            structural_p_elements[u'Den_ex'], neuron_synaptic_elements[u'Den_ex'])
+            structural_p_elements[u'Den_ex'],
+            neuron_synaptic_elements[u'Den_ex'])
 
 
 def suite():

--- a/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
+++ b/pynest/nest/tests/test_sp/test_update_synaptic_elements.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# test_update_synaptic_elements.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import nest
+import unittest
+
+
+class TestUpdateSynapticElements(unittest.TestCase):
+
+    def setUp(self):
+        nest.ResetKernel()
+
+    def test_update_synaptic_elements(self):
+        growth_curve_axonal = {
+            'growth_curve': "gaussian",
+            'growth_rate': 0.0001,  # Beta (elements/ms)
+            'eta': 0.4,
+            'eps': 0.7,
+        }
+        growth_curve_dendritic_E = {
+            'growth_curve': "gaussian",
+            'growth_rate': 0.0001,  # Beta (elements/ms)
+            'eta': 0.1,
+            'eps': 0.7,
+        }
+        structural_p_elements = {
+            'Den_ex': growth_curve_dendritic_E,
+            'Axon': growth_curve_axonal
+        }
+
+        new_growth_curve_axonal = {
+            'eta': 0.0,
+            'eps': 0.0,
+        }
+        elements_to_update = {
+            'Axon': new_growth_curve_axonal
+        }
+
+        neuron = nest.Create('iaf_neuron', 1)
+        nest.SetStatus(neuron, {'synaptic_elements': structural_p_elements})
+        neuron_synaptic_elements = nest.GetStatus(
+            neuron, 'synaptic_elements')[0]
+        self.assertIn('Den_ex', neuron_synaptic_elements)
+        self.assertIn('Axon', neuron_synaptic_elements)
+
+        self.assertDictContainsSubset(
+            structural_p_elements[u'Axon'], neuron_synaptic_elements[u'Axon'])
+        self.assertDictContainsSubset(
+            structural_p_elements[u'Den_ex'], neuron_synaptic_elements[u'Den_ex'])
+
+        # Update Axon elements
+        nest.SetStatus(neuron, 'update_synaptic_elements', elements_to_update)
+        neuron_synaptic_elements = nest.GetStatus(
+            neuron, 'synaptic_elements')[0]
+        self.assertIn('Den_ex', neuron_synaptic_elements)
+        self.assertIn('Axon', neuron_synaptic_elements)
+
+        # Should have been updated
+        self.assertDictContainsSubset(
+            elements_to_update[u'Axon'], neuron_synaptic_elements[u'Axon'])
+        # Should be unchanged
+        self.assertDictContainsSubset(
+            structural_p_elements[u'Den_ex'], neuron_synaptic_elements[u'Den_ex'])
+
+def suite():
+    test_suite = unittest.makeSuite(TestUpdateSynapticElements, 'test')
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This pull request enables the dynamic steering of structural plasticity parameters. This can be used to progressively explore the connectivity parameter space in a network and allows the stable creation of connections. It is specially useful in networks with multiple populations, where each must reach different target activity or when a base fixed connectivity is provided and strong activity dependencies between populations are present.
