### PR TITLE
Add more and document existing environment variables

### DIFF
--- a/extras/userdoc/md/documentation/environment-variables.md
+++ b/extras/userdoc/md/documentation/environment-variables.md
@@ -33,14 +33,14 @@ runs.
     installations or to accomodate different machine setups.
 
 `SLI_PATH`
-  : A colon separated list of paths, in which NEST searches for SLI
+  : A colon separated list of paths in which NEST searches for SLI
     files. These are added to the search path.
 
 In addition to the NEST specific environment variables above, NEST
 also respects the following standard POSIX shell variables:
 
 `COLUMNS`
-  : A number of columns, to which NEST adapt the width of its textual
+  : A number of columns to which NEST adapt the width of its textual
     output (errors, warnings, etc.).
 
 `EDITOR`

--- a/extras/userdoc/md/documentation/environment-variables.md
+++ b/extras/userdoc/md/documentation/environment-variables.md
@@ -1,0 +1,53 @@
+# Environment variables
+
+NEST's behavior can be influenced by several environment variables in
+order to allow easy embedding of simulations into scripts for multiple
+runs.
+
+`DELAY_PYNEST_INIT`
+  : If set to 1, this prevents the call of PyNEST's `init()` function
+    when importing the `nest` module. This is used in advanced
+    scenarions, e.g. when additional commandline arguments have to be
+    added to the `argv` variable of the NEST kernel. When using this,
+    `init()` has to be called manually.
+
+`NEST_DATA_PATH`
+  : The directory, where all recording files of NEST will be written
+    to. This makes automated runs of NEST easier, as the result files
+    of different runs can be sorted to different directories without
+    changing the script.
+
+`NEST_MODULE_PATH`
+  : This defines the serach path for extension modules. The content of
+    this variable is passed to libltdl's `lt_dlsetsearchpath()`
+    function.  See the documentation of libltdl for details.
+
+`NEST_MODULES`
+  : A colon separated list of extensions that will be loaded upon
+    startup using the `Install` SLI command. The path of the modules
+    has to be set using `NEST_MODULE_PATH`
+
+`NESTRCFILENAME`
+  : The name of NEST's configuration file (default: `~/.nestrc`). This
+    can be used to set different configurations for different
+    installations or to accomodate different machine setups.
+
+`SLI_PATH`
+  : A colon separated list of paths, in which NEST searches for SLI
+    files. These are added to the search path.
+
+In addition to the NEST specific environment variables above, NEST
+also respects the following standard POSIX shell variables:
+
+`COLUMNS`
+  : A number of columns, to which NEST adapt the width of its textual
+    output (errors, warnings, etc.).
+
+`EDITOR`
+  : The editor to be used when editing files on the fly.
+
+`PAGER`
+  : The pager to be used for displaying the help paged.
+
+`TERM`
+  : The terminal program to be used when forking an external program.

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -1422,3 +1422,8 @@ Description:
   statusdict /exitcodes get /userabort get
   statusdict /is_mpi get { MPI_Abort }{ quit_i } ifelse
 } bind def
+
+
+% Install modules in environment variable NEST_MODULES. Modules have
+% to be separated by colon.
+(NEST_MODULES) getenv { (:) breakup { Install } forall } if

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -2347,3 +2347,8 @@ mark
     { statusdict /rcsinfo () put }
   ifelse
 ] ;
+
+
+% Add directories in environment variable SLI_PATH to the search path
+% for SLI files. Directories have to be separated by colon.
+(SLI_PATH) getenv { (:) breakup { addpath } forall } if

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -950,31 +950,6 @@ begin
 end
 
 
-
-/*
- * SLIHOME is obsolete. It may disappear anytime.
- * DO NOT USE !!!
- */
-systemdict begin
-  /SLIHOME 
-  {
-    M_WARNING (sli-init.sli) (The variable 'systemdict::SLIHOME' is obsolete. It may disappear anytime.) message    
-    M_WARNING (sli-init.sli) (  Go and fix your SLI code. It WILL break in the future.) message  
-    M_WARNING (sli-init.sli) (  Replacements:) message  
-    M_WARNING (sli-init.sli) (    (1) If you want to locate a file in the NEST distribution, use 'SLISearchPath <filename> LocateFileNames'.) message  
-    M_WARNING (sli-init.sli) (        For more information, type '/LocateFileNames help'.) message
-    M_WARNING (sli-init.sli) (        If you think a file is missing from the distribution, ask a developer to add it to the installation list.) message  
-    M_WARNING (sli-init.sli) (    (2) If you want to locate a file in a custom searchpath, use '[<searchpath>] <filename> LocateFileNames'.) message  
-    M_WARNING (sli-init.sli) (    (3) If you need the path to NEST's installation directory, use 'statusdict::prgdatadir'.) message
-    M_WARNING (sli-init.sli) (        For more information, type '/statusdict help'.) message  
-    M_WARNING (sli-init.sli) (    WARNING: NEVER try to locate a file in NEST's source directory, it may not exist any longer!) message  
-
-    % As a temporary workaround, this is where SLIHOME used to point to:
-    statusdict /slihomepath get_d
-  } def
-end  
-
-
 /SLISearchPath
   [ statusdict /prgdatadir get_d (/sli) join_s ]
 def


### PR DESCRIPTION
This is a replacement for #418, which adds the environment variables `SLI_PATH` for adding paths to the SLI search path and `NEST_MODULES` for loading modules on startup on the SLI level. It also adds a new documentation file that describes all environment variables that NEST reads.

I propose @obreitwi, @heplesser and @apeyser as reviewers. 