### PR TITLE
Improve get_connections performance

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1018,7 +1018,7 @@ nest::ConnectionManager::get_num_connections( synindex syn_id ) const
 ArrayDatum
 nest::ConnectionManager::get_connections( DictionaryDatum params ) const
 {
-  std::deque<ConnectionID> connectome;
+  std::deque< ConnectionID > connectome;
 
   const Token& source_t = params->lookup( names::source );
   const Token& target_t = params->lookup( names::target );
@@ -1071,7 +1071,7 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
 
   while ( !connectome.empty() )
   {
-    result.push_back( ConnectionDatum ( connectome.front() ) );
+    result.push_back( ConnectionDatum( connectome.front() ) );
     connectome.pop_front();
   }
 
@@ -1079,14 +1079,17 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
 }
 
 void
-nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
+nest::ConnectionManager::get_connections(
+  std::deque< ConnectionID >& connectome,
   TokenArray const* source,
   TokenArray const* target,
   size_t syn_id,
   long synapse_label ) const
 {
-  if ( get_num_connections( syn_id ) == 0)
+  if ( get_num_connections( syn_id ) == 0 )
+  {
     return;
+  }
 
   if ( source == 0 and target == 0 )
   {
@@ -1098,7 +1101,7 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
     for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
     {
 #endif
-      std::deque<ConnectionID> conns_in_thread;
+      std::deque< ConnectionID > conns_in_thread;
 
       for ( index source_id = 1; source_id < connections_[ t ].size();
             ++source_id )
@@ -1116,7 +1119,7 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
         {
           while ( !conns_in_thread.empty() )
           {
-            connectome.push_back(conns_in_thread.front());
+            connectome.push_back( conns_in_thread.front() );
             conns_in_thread.pop_front();
           }
         }
@@ -1135,7 +1138,7 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
     for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
     {
 #endif
-      std::deque<ConnectionID> conns_in_thread;
+      std::deque< ConnectionID > conns_in_thread;
 
       for ( index source_id = 1; source_id < connections_[ t ].size();
             ++source_id )
@@ -1163,7 +1166,7 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
         {
           while ( !conns_in_thread.empty() )
           {
-            connectome.push_back(conns_in_thread.front());
+            connectome.push_back( conns_in_thread.front() );
             conns_in_thread.pop_front();
           }
         }
@@ -1181,7 +1184,7 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
     for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
     {
 #endif
-      std::deque<ConnectionID> conns_in_thread;
+      std::deque< ConnectionID > conns_in_thread;
 
       for ( index s = 0; s < source->size(); ++s )
       {
@@ -1220,7 +1223,7 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
         {
           while ( !conns_in_thread.empty() )
           {
-            connectome.push_back(conns_in_thread.front());
+            connectome.push_back( conns_in_thread.front() );
             conns_in_thread.pop_front();
           }
         }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1078,6 +1078,21 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
   return result;
 }
 
+// Helper method, implemented as operator<<(), that removes ConnectionIDs from
+// input deque and appends them to output deque.
+static inline std::deque< nest::ConnectionID >& operator<<(
+  std::deque< nest::ConnectionID >& out,
+  std::deque< nest::ConnectionID >& in )
+{
+  while ( not in.empty() )
+  {
+    out.push_back( in.front() );
+    in.pop_front();
+  }
+
+  return out;
+}
+
 void
 nest::ConnectionManager::get_connections(
   std::deque< ConnectionID >& connectome,
@@ -1116,7 +1131,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        append_move_connections_( conns_in_thread, connectome );
+        connectome << conns_in_thread;
       }
     }
 
@@ -1157,7 +1172,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        append_move_connections_( conns_in_thread, connectome );
+        connectome << conns_in_thread;
       }
     }
     return;
@@ -1208,7 +1223,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        append_move_connections_( conns_in_thread, connectome );
+        connectome << conns_in_thread;
       }
     }
     return;

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1018,7 +1018,7 @@ nest::ConnectionManager::get_num_connections( synindex syn_id ) const
 ArrayDatum
 nest::ConnectionManager::get_connections( DictionaryDatum params ) const
 {
-  ArrayDatum connectome;
+  std::deque<ConnectionID> connectome;
 
   const Token& source_t = params->lookup( names::source );
   const Token& target_t = params->lookup( names::target );
@@ -1062,26 +1062,31 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
           syn_id < kernel().model_manager.get_num_synapse_prototypes();
           ++syn_id )
     {
-      ArrayDatum conn;
-      get_connections( conn, source_a, target_a, syn_id, synapse_label );
-      if ( conn.size() > 0 )
-        connectome.push_back( new ArrayDatum( conn ) );
+      get_connections( connectome, source_a, target_a, syn_id, synapse_label );
     }
   }
 
-  return connectome;
+  ArrayDatum result;
+  result.reserve( connectome.size() );
+
+  for (std::deque<ConnectionID>::const_iterator it = connectome.begin();
+      it != connectome.end(); ++it)
+  {
+    result.push_back( ConnectionDatum (*it) );
+  }
+
+  return result;
 }
 
 void
-nest::ConnectionManager::get_connections( ArrayDatum& connectome,
+nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
   TokenArray const* source,
   TokenArray const* target,
   size_t syn_id,
   long synapse_label ) const
 {
-  size_t num_connections = get_num_connections( syn_id );
-
-  connectome.reserve( num_connections );
+  if ( get_num_connections( syn_id ) == 0)
+    return;
 
   if ( source == 0 and target == 0 )
   {
@@ -1093,22 +1098,8 @@ nest::ConnectionManager::get_connections( ArrayDatum& connectome,
     for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
     {
 #endif
-      ArrayDatum conns_in_thread;
-      size_t num_connections_in_thread = 0;
-      // Count how many connections we will have.
-      for ( tSConnector::const_nonempty_iterator it =
-              connections_[ t ].nonempty_begin();
-            it != connections_[ t ].nonempty_end();
-            ++it )
-      {
-        num_connections_in_thread +=
-          validate_pointer( *it )->get_num_connections();
-      }
+      std::deque<ConnectionID> conns_in_thread;
 
-#ifdef _OPENMP
-#pragma omp critical( get_connections )
-#endif
-      conns_in_thread.reserve( num_connections_in_thread );
       for ( index source_id = 1; source_id < connections_[ t ].size();
             ++source_id )
       {
@@ -1122,7 +1113,7 @@ nest::ConnectionManager::get_connections( ArrayDatum& connectome,
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome.append_move( conns_in_thread );
+        connectome.insert(connectome.end(), conns_in_thread.begin(), conns_in_thread.end());
       }
     }
 
@@ -1138,22 +1129,8 @@ nest::ConnectionManager::get_connections( ArrayDatum& connectome,
     for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
     {
 #endif
-      ArrayDatum conns_in_thread;
-      size_t num_connections_in_thread = 0;
-      // Count how many connections we will have maximally.
-      for ( tSConnector::const_nonempty_iterator it =
-              connections_[ t ].nonempty_begin();
-            it != connections_[ t ].nonempty_end();
-            ++it )
-      {
-        num_connections_in_thread +=
-          validate_pointer( *it )->get_num_connections();
-      }
+      std::deque<ConnectionID> conns_in_thread;
 
-#ifdef _OPENMP
-#pragma omp critical( get_connections )
-#endif
-      conns_in_thread.reserve( num_connections_in_thread );
       for ( index source_id = 1; source_id < connections_[ t ].size();
             ++source_id )
       {
@@ -1177,7 +1154,7 @@ nest::ConnectionManager::get_connections( ArrayDatum& connectome,
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome.append_move( conns_in_thread );
+        connectome.insert(connectome.end(), conns_in_thread.begin(), conns_in_thread.end());
       }
     }
     return;
@@ -1192,22 +1169,8 @@ nest::ConnectionManager::get_connections( ArrayDatum& connectome,
     for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
     {
 #endif
-      ArrayDatum conns_in_thread;
-      size_t num_connections_in_thread = 0;
-      // Count how many connections we will have maximally.
-      for ( tSConnector::const_nonempty_iterator it =
-              connections_[ t ].nonempty_begin();
-            it != connections_[ t ].nonempty_end();
-            ++it )
-      {
-        num_connections_in_thread +=
-          validate_pointer( *it )->get_num_connections();
-      }
+      std::deque<ConnectionID> conns_in_thread;
 
-#ifdef _OPENMP
-#pragma omp critical( get_connections )
-#endif
-      conns_in_thread.reserve( num_connections_in_thread );
       for ( index s = 0; s < source->size(); ++s )
       {
         size_t source_id = source->get( s );
@@ -1242,7 +1205,7 @@ nest::ConnectionManager::get_connections( ArrayDatum& connectome,
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome.append_move( conns_in_thread );
+        connectome.insert(connectome.end(), conns_in_thread.begin(), conns_in_thread.end());
       }
     }
     return;

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1069,7 +1069,7 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
   ArrayDatum result;
   result.reserve( connectome.size() );
 
-  while ( !connectome.empty() )
+  while ( not connectome.empty() )
   {
     result.push_back( ConnectionDatum( connectome.front() ) );
     connectome.pop_front();
@@ -1116,13 +1116,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        {
-          while ( !conns_in_thread.empty() )
-          {
-            connectome.push_back( conns_in_thread.front() );
-            conns_in_thread.pop_front();
-          }
-        }
+        append_move_connections_( conns_in_thread, connectome );
       }
     }
 
@@ -1163,13 +1157,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        {
-          while ( !conns_in_thread.empty() )
-          {
-            connectome.push_back( conns_in_thread.front() );
-            conns_in_thread.pop_front();
-          }
-        }
+        append_move_connections_( conns_in_thread, connectome );
       }
     }
     return;
@@ -1220,13 +1208,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        {
-          while ( !conns_in_thread.empty() )
-          {
-            connectome.push_back( conns_in_thread.front() );
-            conns_in_thread.pop_front();
-          }
-        }
+        append_move_connections_( conns_in_thread, connectome );
       }
     }
     return;

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1113,7 +1113,13 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome.insert(connectome.end(), conns_in_thread.begin(), conns_in_thread.end());
+        {
+          while ( !conns_in_thread.empty() )
+          {
+            connectome.push_back(conns_in_thread.front());
+            conns_in_thread.pop_front();
+          }
+        }
       }
     }
 
@@ -1154,7 +1160,13 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome.insert(connectome.end(), conns_in_thread.begin(), conns_in_thread.end());
+        {
+          while ( !conns_in_thread.empty() )
+          {
+            connectome.push_back(conns_in_thread.front());
+            conns_in_thread.pop_front();
+          }
+        }
       }
     }
     return;
@@ -1205,7 +1217,13 @@ nest::ConnectionManager::get_connections( std::deque<ConnectionID>& connectome,
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome.insert(connectome.end(), conns_in_thread.begin(), conns_in_thread.end());
+        {
+          while ( !conns_in_thread.empty() )
+          {
+            connectome.push_back(conns_in_thread.front());
+            conns_in_thread.pop_front();
+          }
+        }
       }
     }
     return;

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1069,10 +1069,10 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
   ArrayDatum result;
   result.reserve( connectome.size() );
 
-  for (std::deque<ConnectionID>::const_iterator it = connectome.begin();
-      it != connectome.end(); ++it)
+  while ( !connectome.empty() )
   {
-    result.push_back( ConnectionDatum (*it) );
+    result.push_back( ConnectionDatum ( connectome.front() ) );
+    connectome.pop_front();
   }
 
   return result;

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -307,6 +307,13 @@ private:
    */
   void delete_connections_();
 
+  /**
+   * Helper method removes ConnectionIDs from input deque and
+   * appends them to output deque.
+   */
+  static void append_move_connections_( std::deque< ConnectionID >& input,
+    std::deque< ConnectionID >& output );
+
   ConnectorBase*
   validate_source_entry_( thread tid, index s_gid, synindex syn_id );
 
@@ -391,6 +398,17 @@ inline delay
 ConnectionManager::get_max_delay() const
 {
   return max_delay_;
+}
+
+inline void
+ConnectionManager::append_move_connections_( std::deque< ConnectionID >& input,
+  std::deque< ConnectionID >& output )
+{
+  while ( not input.empty() )
+  {
+    output.push_back( input.front() );
+    input.pop_front();
+  }
 }
 
 } // namespace nest

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -211,7 +211,7 @@ public:
    */
   ArrayDatum get_connections( DictionaryDatum dict ) const;
 
-  void get_connections( std::deque<ConnectionID>& connectome,
+  void get_connections( std::deque< ConnectionID >& connectome,
     TokenArray const* source,
     TokenArray const* target,
     size_t syn_id,

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -32,6 +32,7 @@
 #include "sparsetable.h"
 
 // Includes from nestkernel:
+#include "connection_id.h"
 #include "conn_builder.h"
 #include "gid_collection.h"
 #include "nest_time.h"
@@ -210,7 +211,7 @@ public:
    */
   ArrayDatum get_connections( DictionaryDatum dict ) const;
 
-  void get_connections( ArrayDatum& connectome,
+  void get_connections( std::deque<ConnectionID>& connectome,
     TokenArray const* source,
     TokenArray const* target,
     size_t syn_id,

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -307,13 +307,6 @@ private:
    */
   void delete_connections_();
 
-  /**
-   * Helper method removes ConnectionIDs from input deque and
-   * appends them to output deque.
-   */
-  static void append_move_connections_( std::deque< ConnectionID >& input,
-    std::deque< ConnectionID >& output );
-
   ConnectorBase*
   validate_source_entry_( thread tid, index s_gid, synindex syn_id );
 
@@ -398,17 +391,6 @@ inline delay
 ConnectionManager::get_max_delay() const
 {
   return max_delay_;
-}
-
-inline void
-ConnectionManager::append_move_connections_( std::deque< ConnectionID >& input,
-  std::deque< ConnectionID >& output )
-{
-  while ( not input.empty() )
-  {
-    output.push_back( input.front() );
-    input.pop_front();
-  }
 }
 
 } // namespace nest

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -150,14 +150,14 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const = 0;
+    std::deque< ConnectionID >& conns ) const = 0;
 
   virtual void get_connections( size_t source_gid,
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const = 0;
+    std::deque< ConnectionID >& conns ) const = 0;
 
   virtual void get_target_gids( std::vector< size_t >& target_gids,
     size_t thrd,
@@ -380,7 +380,7 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
@@ -399,15 +399,15 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
         if ( synapse_label == UNLABELED_CONNECTION
           || C_[ i ].get_label() == synapse_label )
           if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
-            conns.push_back( ConnectionID(
-              source_gid, target_gid, thrd, synapse_id, i ) );
+            conns.push_back(
+              ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) );
   }
 
   /**
@@ -613,7 +613,7 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
@@ -635,7 +635,7 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
@@ -643,8 +643,8 @@ public:
         || C_[ 0 ].get_label() == synapse_label )
       {
         if ( C_[ 0 ].get_target( thrd )->get_gid() == target_gid )
-          conns.push_back( ConnectionID(
-            source_gid, target_gid, thrd, synapse_id, 0 ) );
+          conns.push_back(
+            ConnectionID( source_gid, target_gid, thrd, synapse_id, 0 ) );
       }
     }
   }
@@ -850,7 +850,7 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     for ( size_t i = 0; i < C_.size(); i++ )
       if ( get_syn_id() == synapse_id )
@@ -869,15 +869,15 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     if ( get_syn_id() == synapse_id )
       for ( size_t i = 0; i < C_.size(); i++ )
         if ( synapse_label == UNLABELED_CONNECTION
           || C_[ i ].get_label() == synapse_label )
           if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
-            conns.push_back( ConnectionID(
-              source_gid, target_gid, thrd, synapse_id, i ) );
+            conns.push_back(
+              ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) );
   }
 
   void
@@ -1029,7 +1029,7 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
       at( i )->get_connections(
@@ -1042,7 +1042,7 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    std::deque<ConnectionID>& conns ) const
+    std::deque< ConnectionID >& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
       at( i )->get_connections(

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -29,6 +29,7 @@
 // C++ includes:
 #include <cstdlib>
 #include <vector>
+#include <deque>
 
 // Includes from libnestutil:
 #include "compose.hpp"
@@ -149,14 +150,14 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const = 0;
+    std::deque<ConnectionID>& conns ) const = 0;
 
   virtual void get_connections( size_t source_gid,
     size_t target_gid,
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const = 0;
+    std::deque<ConnectionID>& conns ) const = 0;
 
   virtual void get_target_gids( std::vector< size_t >& target_gids,
     size_t thrd,
@@ -379,17 +380,17 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
         if ( synapse_label == UNLABELED_CONNECTION
           || C_[ i ].get_label() == synapse_label )
-          conns.push_back( ConnectionDatum( ConnectionID( source_gid,
+          conns.push_back( ConnectionID( source_gid,
             C_[ i ].get_target( thrd )->get_gid(),
             thrd,
             synapse_id,
-            i ) ) );
+            i ) );
   }
 
   void
@@ -398,15 +399,15 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     for ( size_t i = 0; i < K; i++ )
       if ( get_syn_id() == synapse_id )
         if ( synapse_label == UNLABELED_CONNECTION
           || C_[ i ].get_label() == synapse_label )
           if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
-            conns.push_back( ConnectionDatum(
-              ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
+            conns.push_back( ConnectionID(
+              source_gid, target_gid, thrd, synapse_id, i ) );
   }
 
   /**
@@ -612,18 +613,18 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
       if ( synapse_label == UNLABELED_CONNECTION
         || C_[ 0 ].get_label() == synapse_label )
       {
-        conns.push_back( ConnectionDatum( ConnectionID( source_gid,
+        conns.push_back( ConnectionID( source_gid,
           C_[ 0 ].get_target( thrd )->get_gid(),
           thrd,
           synapse_id,
-          0 ) ) );
+          0 ) );
       }
     }
   }
@@ -634,7 +635,7 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     if ( get_syn_id() == synapse_id )
     {
@@ -642,8 +643,8 @@ public:
         || C_[ 0 ].get_label() == synapse_label )
       {
         if ( C_[ 0 ].get_target( thrd )->get_gid() == target_gid )
-          conns.push_back( ConnectionDatum(
-            ConnectionID( source_gid, target_gid, thrd, synapse_id, 0 ) ) );
+          conns.push_back( ConnectionID(
+            source_gid, target_gid, thrd, synapse_id, 0 ) );
       }
     }
   }
@@ -849,17 +850,17 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     for ( size_t i = 0; i < C_.size(); i++ )
       if ( get_syn_id() == synapse_id )
         if ( synapse_label == UNLABELED_CONNECTION
           || C_[ i ].get_label() == synapse_label )
-          conns.push_back( ConnectionDatum( ConnectionID( source_gid,
+          conns.push_back( ConnectionID( source_gid,
             C_[ i ].get_target( thrd )->get_gid(),
             thrd,
             synapse_id,
-            i ) ) );
+            i ) );
   }
 
   void
@@ -868,15 +869,15 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     if ( get_syn_id() == synapse_id )
       for ( size_t i = 0; i < C_.size(); i++ )
         if ( synapse_label == UNLABELED_CONNECTION
           || C_[ i ].get_label() == synapse_label )
           if ( C_[ i ].get_target( thrd )->get_gid() == target_gid )
-            conns.push_back( ConnectionDatum(
-              ConnectionID( source_gid, target_gid, thrd, synapse_id, i ) ) );
+            conns.push_back( ConnectionID(
+              source_gid, target_gid, thrd, synapse_id, i ) );
   }
 
   void
@@ -1028,7 +1029,7 @@ public:
     size_t thrd,
     synindex synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
       at( i )->get_connections(
@@ -1041,7 +1042,7 @@ public:
     size_t thrd,
     size_t synapse_id,
     long synapse_label,
-    ArrayDatum& conns ) const
+    std::deque<ConnectionID>& conns ) const
   {
     for ( size_t i = 0; i < size(); i++ )
       at( i )->get_connections(


### PR DESCRIPTION
Hi All,

I found that GetConnections is quite slow and consumes unreasonable amount of memory. Quick investigation has shown that ConnectionManager::get_connections pre-allocates memory for all connections in the model even if user requests connections of a single node. It reserves space only for Token (16 bytes), but that become megabytes in large models. In addition the memory consumption is doubled by similar per-thread reservation. Obviously it also decreases the performance.

This PR improves get_connections by:
 - Using stl deque for collecting connection data. Only final result is converted to ArrayDatum. This allows to avoid memory pre-allocation.
 - Removing per-thread connection number calculation since reservation is not required anymore.
 - Skipping iteration through thread connections if there are no connections with specified syn_id.

The simple test shows significant improvement of get_connection performance. It's about 118 times faster for requsting connections of a single source node. 55 times faster for a single target node. And 50% faster for requesting all connections (BTW, most time is spent outside c++ get_connection method).

The Python script measures average time of GetConnection call duration. It was run on my desktop with enabled OpenMP (16 threads).

```
Configuration:
Num of source nodes = 2500
Num of target nodes = 2500
Num of connections per node = 701
Num of all connections = 1757571
```
```
Master
------------------------------------------
Average time for getting connection is
per source =  0:00:00.463445
per target =  0:00:00.586650
all        =  0:00:01.772015
```
```
deque based
------------------------------------------
Average time for getting connection is
per source =  0:00:00.003906
per target =  0:00:00.010477
all        =  0:00:01.171967
```