### PR TITLE
Fix READMEs for testsuite and PyNEST [ci skip]

### DIFF
--- a/pynest/README.md
+++ b/pynest/README.md
@@ -3,13 +3,16 @@
 This directory contains the source code of PyNEST, the Python bindings
 to the NEST kernel. A detailed explanation of PyNEST can be found in
 
-    Eppler JM, Helias M, Muller E, Diesmann M and Gewaltig M-O
-    PyNEST: A convenient interface to the NEST simulator
-    Front. Neuroinform. (2009) 2:12. doi:10.3389/neuro.11.012.2008
+    Zaytsev YV and Morrison A (2014) CyNEST: a maintainable
+    Cython-based interface for the NEST simulator. Front.
+    Neuroinform. 8:23. http://dx.doi.org/10.3389/fninf.2014.00023
 
 and
 
-    
+    Eppler JM, Helias M, Muller E, Diesmann M and Gewaltig M-O PyNEST
+    (2009) A convenient interface to the NEST simulator. Front.
+    Neuroinform. 2:12. http://dx.doi.org/10.3389/neuro.11.012.2008
+
 
 PyNEST will be compiled together with NEST by default. If you want to
 disable it, pass

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -2,25 +2,50 @@
 
 When writing tests, please adhere to the following guidelines:
 
-* The test scripts in `selftests` and `mpitests` have to be written in SLI,
-  as they test for basic functionality, which has to be checked on the lowest
-  level.
+* Test scripts in `selftests` test basic functionality of the test 
+  framework and must be written in SLI.
+  
+* `mpitests` have to be written in SLI in a particular style. Please look at
+  existing tests for examples and the `unittest::distributed_*` test functions.
+  
+* Tests in `unittests` and `regressiontests` should generally be written in
+  SLI. They must be written in SLI if they require a working SLI interpreter
+  or NEST kernel. Tests should use the 
+  `unittest::{assert|pass|fail||crash|failbutnocrash}_or_die` test functions.
+  
+* Tests in `unittests` and `regressiontests` may be written in Python, but those
+  tests will not have access to a SLI interpreter or NEST kernel. Such tests
+  can be used, e.g., for source code inspection. They are run after the SLI
+  tests in the same directories.
 
-* The tests in `unittests` and `regressiontests` may be written in either
-  Python or SLI. They are executed by the corresponding executable according
-  to their filename extension. Tests that are written in Python are run after
-  SLI tests.
+* New regression tests should be called `issues-XXX.sli`, where `XXX` is the 
+  number of the Github issue which the test covers. 
 
-* Tests that need models which depend on the GSL need to be protected by a check
-  like this, which should be above all actual code in the test script:
+* Tests requiring PyNEST (NEST kernel accessible from Python) must be placed 
+  in the `pynest/nest/tests` directory. They should use the Python `unittest` 
+  framework.
 
-        % This test should only run if we have GSL
-        statusdict/have_gsl :: not {statusdict/exitcodes/success :: quit_i} if
+* Tests that need models which depend on the GSL need to be protected against
+  NEST compiled without GSL by placing the following at the beginning of
+  the test script (after loading `unittest`):
 
-* Tests that need threading, need to be protected by a check like this, which
-  should be above all actual code in the test script:
+      statusdict/have_gsl :: not { exit_test_gracefully } if
 
-        is_threaded not { exit_test_gracefully } if
+  For tests using PyNEST, define
+  
+      HAVE_GSL = nest.sli_func("statusdict/have_gsl ::")
+
+  and then apply the following decorator to all pertaining test classes
+
+      @unittest.skipIf(not HAVE_GSL, 'GSL is not available')
+  
+* Tests that need threading need to be protected in case NEST was compiled
+  without threading support by the following test at the beginning of the
+  test script (after loading `unittest`):
+  
+      is_threaded not { exit_test_gracefully } if
+
+  `test_threads.py` shows how to skip PyNEST tests that require threading. 
 
 * For more specific guidelines regarding tests in one of the different phases,
   see the README.md file in the corresponding directory.


### PR DESCRIPTION
- Add CyNEST reference
- Extend the testsuite README to provide a more comprehensive explanation about how Python tests are handled