### PR TITLE
Use 1.5x vector growth factor for connections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set( NEST_VERSION_PRGNAME "${PROJECT_NAME}-${NEST_VERSION_VERSION}" )
 # set NEST defaults
 set( tics_per_ms "1000.0" CACHE STRING "Specify elementary unit of time. [default 1000.0]" )
 set( tics_per_step "100" CACHE STRING "Specify resolution. [default 100]" )
+set( connector_cutoff "3" CACHE STRING "Specify when to truncate the recursive instantiation of the connector. [default 3]" )
 option( with-ps-arrays "Use PS array construction semantics. [default=ON]" ON )
 
 # add user modules

--- a/libnestutil/config.h.in
+++ b/libnestutil/config.h.in
@@ -58,6 +58,9 @@
 /* tics per step in simulation */
 #define CONFIG_TICS_PER_STEP @tics_per_step@
 
+/* when to truncate the recursive instantiation of the connector */
+#define CONFIG_CONNECTOR_CUTOFF @connector_cutoff@
+
 /* define if the compiler does not include *.h headers ISO conformant */
 #cmakedefine HAVE_ALPHA_CXX_STD_BUG 1
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -74,6 +74,9 @@ nest::ConnectionManager::ConnectionManager()
   , connbuilder_factories_()
   , min_delay_( 1 )
   , max_delay_( 1 )
+  , init_conn_capacity_(CONFIG_CONNECTOR_CUTOFF)
+  , large_conn_limit_(CONFIG_CONNECTOR_CUTOFF * 2)
+  , large_conn_growth_(1.5)
 {
 }
 
@@ -130,6 +133,45 @@ nest::ConnectionManager::finalize()
 void
 nest::ConnectionManager::set_status( const DictionaryDatum& d )
 {
+  long init_cap = init_conn_capacity_;
+  if ( updateValue< long >( d, "init_connector_capacity", init_cap ) )
+  {
+    if ( init_cap < CONFIG_CONNECTOR_CUTOFF )
+    {
+      throw KernelException(
+        "The initial connector capacity should be higher or equal to "
+        "connector_cutoff value specified via cmake flag [default 3]");
+    }
+
+    init_conn_capacity_ = init_cap;
+  }
+
+  long large_lim = large_conn_limit_;
+  if ( updateValue< long >( d, "large_connector_limit", large_lim ) )
+  {
+    if ( large_lim < CONFIG_CONNECTOR_CUTOFF )
+    {
+      throw KernelException(
+        "The large connector limit should be higher or equal to "
+        "connector_cutoff value specified via cmake flag [default 3]");
+    }
+
+    large_conn_limit_ = large_lim;
+  }
+
+  double large_growth = large_conn_growth_;
+  if ( updateValue< double >( d, "large_connector_growth", large_growth ) )
+  {
+    if ( large_growth <= 1.0 )
+    {
+      throw KernelException(
+        "The large connector capacity growth factor should be higher than "
+        "1.0");
+    }
+
+    large_conn_growth_ = large_growth;
+  }
+
   for ( size_t i = 0; i < delay_checkers_.size(); ++i )
   {
     delay_checkers_[ i ].set_status( d );
@@ -148,6 +190,10 @@ nest::ConnectionManager::get_status( DictionaryDatum& d )
   update_delay_extrema_();
   def< double >( d, "min_delay", Time( Time::step( min_delay_ ) ).get_ms() );
   def< double >( d, "max_delay", Time( Time::step( max_delay_ ) ).get_ms() );
+
+  def< long >( d, "init_connector_capacity", init_conn_capacity_ );
+  def< long >( d, "large_connector_limit", large_conn_limit_ );
+  def< double >( d, "large_connector_growth", large_conn_growth_ );
 
   size_t n = get_num_connections();
   def< long >( d, "num_connections", n );

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -74,9 +74,9 @@ nest::ConnectionManager::ConnectionManager()
   , connbuilder_factories_()
   , min_delay_( 1 )
   , max_delay_( 1 )
-  , init_conn_capacity_(CONFIG_CONNECTOR_CUTOFF)
-  , large_conn_limit_(CONFIG_CONNECTOR_CUTOFF * 2)
-  , large_conn_growth_(1.5)
+  , init_conn_capacity_( CONFIG_CONNECTOR_CUTOFF )
+  , large_conn_limit_( CONFIG_CONNECTOR_CUTOFF * 2 )
+  , large_conn_growth_( 1.5 )
 {
 }
 
@@ -140,7 +140,7 @@ nest::ConnectionManager::set_status( const DictionaryDatum& d )
     {
       throw KernelException(
         "The initial connector capacity should be higher or equal to "
-        "connector_cutoff value specified via cmake flag [default 3]");
+        "connector_cutoff value specified via cmake flag [default 3]" );
     }
 
     init_conn_capacity_ = init_cap;
@@ -153,7 +153,7 @@ nest::ConnectionManager::set_status( const DictionaryDatum& d )
     {
       throw KernelException(
         "The large connector limit should be higher or equal to "
-        "connector_cutoff value specified via cmake flag [default 3]");
+        "connector_cutoff value specified via cmake flag [default 3]" );
     }
 
     large_conn_limit_ = large_lim;
@@ -166,7 +166,7 @@ nest::ConnectionManager::set_status( const DictionaryDatum& d )
     {
       throw KernelException(
         "The large connector capacity growth factor should be higher than "
-        "1.0");
+        "1.0" );
     }
 
     large_conn_growth_ = large_growth;

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -294,6 +294,25 @@ public:
    */
   DelayChecker& get_delay_checker();
 
+  /**
+   * Returns initial connector capacity.
+   * When a connector is first created, it starts with this capacity
+   * (if >= connector_cutoff).
+   */
+  size_t get_init_conn_capacity() const;
+
+  /**
+   * Return large connector limit.
+   * Capacity doubling is used up to this limit.
+   */
+  size_t get_large_conn_limit() const;
+
+  /**
+   * Returns large connector growth factor.
+   * This capacity growth factor is used beyond the large connector limit.
+   */
+  double get_large_conn_growth() const;
+
 private:
   /**
    * Update delay extrema to current values.
@@ -388,6 +407,18 @@ private:
   delay min_delay_; //!< Value of the smallest delay in the network.
 
   delay max_delay_; //!< Value of the largest delay in the network in steps.
+
+  /**
+   * When a connector is first created, it starts with this capacity
+   * (if >= connector_cutoff)
+   */
+  size_t init_conn_capacity_;
+
+  //! Capacity doubling is used up to this limit
+  size_t large_conn_limit_;
+
+  //! Capacity growth factor to use beyond the limit
+  double large_conn_growth_;
 };
 
 inline DictionaryDatum&
@@ -406,6 +437,24 @@ inline delay
 ConnectionManager::get_max_delay() const
 {
   return max_delay_;
+}
+
+inline size_t
+ConnectionManager::get_init_conn_capacity() const
+{
+  return init_conn_capacity_;
+}
+
+inline size_t
+ConnectionManager::get_large_conn_limit() const
+{
+  return large_conn_limit_;
+}
+
+inline double
+ConnectionManager::get_large_conn_growth() const
+{
+  return large_conn_growth_;
 }
 
 } // namespace nest

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -869,7 +869,7 @@ public:
     if ( sz == C_.capacity()
       and sz >= kernel().connection_manager.get_large_conn_limit() )
     {
-      const size_t cap = static_cast<double>( sz )
+      const size_t cap = static_cast< double >( sz )
         * kernel().connection_manager.get_large_conn_growth();
 
       C_.reserve( cap > sz ? cap : sz + 1 );

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -120,7 +120,8 @@ suicide( Told* connector )
 }
 
 // when to truncate the recursive instantiation
-#define K_CUTOFF 3
+// can be specified via cmake flag -Dconnector_cutoff=value
+#define K_CUTOFF CONFIG_CONNECTOR_CUTOFF
 
 // when to use 1.5x grow strategy for connection vector
 #define K_SLOW_GROWING 6

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -861,9 +861,9 @@ public:
   push_back( const ConnectionT& c )
   {
     // Replace default vector grow strategy that is quite bad for our case.
-    // Use vector grow strategy 1.5 then size >= K_SLOW_GROWING.
-    // Call vector::reserve() manually then size() == capacity().
-    const size_t sz( C_.size() );
+    // Use vector grow strategy 1.5 when size >= K_SLOW_GROWING.
+    // Call vector::reserve() manually if size() == capacity().
+    const size_t sz = C_.size();
 
     if ( sz == C_.capacity() and sz >= K_SLOW_GROWING )
     {

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -122,6 +122,9 @@ suicide( Told* connector )
 // when to truncate the recursive instantiation
 #define K_CUTOFF 3
 
+// when to use 1.5x grow strategy for connection vector
+#define K_SLOW_GROWING 6
+
 namespace nest
 {
 
@@ -857,6 +860,16 @@ public:
   ConnectorBase&
   push_back( const ConnectionT& c )
   {
+    // Replace default vector grow strategy that is quite bad for our case.
+    // Use vector grow strategy 1.5 then size >= K_SLOW_GROWING.
+    // Call vector::reserve() manually then size() == capacity().
+    const size_t sz( C_.size() );
+
+    if ( sz == C_.capacity() and sz >= K_SLOW_GROWING )
+    {
+      C_.reserve( ( sz * 3 + 1 ) / 2 );
+    }
+
     C_.push_back( c );
     return *this;
   }

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -866,11 +866,11 @@ public:
     // Call vector::reserve() manually if size() == capacity().
     const size_t sz = C_.size();
 
-    if ( sz == C_.capacity() and
-        sz >= kernel().connection_manager.get_large_conn_limit() )
+    if ( sz == C_.capacity()
+      and sz >= kernel().connection_manager.get_large_conn_limit() )
     {
-      const size_t cap = static_cast<double>( sz ) *
-          kernel().connection_manager.get_large_conn_growth();
+      const size_t cap = static_cast<double>( sz )
+        * kernel().connection_manager.get_large_conn_growth();
 
       C_.reserve( cap > sz ? cap : sz + 1 );
     }

--- a/nestkernel/kernel_manager.h
+++ b/nestkernel/kernel_manager.h
@@ -72,6 +72,12 @@
  off_grid_spiking         booltype    - Whether to transmit precise spike times in MPI
                                         communication (read only)
 
+ Connector configuration
+ init_connector_capacity  integertype - When a connector is first created, it starts with this
+                                        capacity (if >= connector_cutoff)
+ large_connector_limit    integertype - Capacity doubling is used up to this limit
+ large_connector_growth   doubletype  - Capacity growth factor to use beyond the limit
+
  Random number generators
  grng_seed                integertype - Seed for global random number generator used
                                         synchronously by all virtual processes to


### PR DESCRIPTION
Hi,

I did some measurements of connection memory consumption and found that connections consumes 50% more memory than it's expected.

The reason is that the current implementation of `Connector` (with 3 and more connections) use `std::vector` to store the connections. It is well known that a capacity of `std::vector` grows exponentially, in particular, gcc libstdc++ uses a growth factor of 2. In other words, vector doubles capacity each time when it needs to extend. That explains 50% overhead since this is average value for large number of vectors.

The growth factor 2 is not a good choice for several reason even for generic use case (very good explanation can be found [here](https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md)). And it's even worse for connecton storage case.

This PR provides very simple fix that forces `std::vector` to use 1.5x grow factor. This factor is most popular choice of modern c++ libraries (unfortunatelly except gcc). It allows to decrease average overhead of connection memory consumption from 50% to 25%. The cost is more reallocations but with 1.5x grow factor it's not very significant.

I used one of my models to test these changes. This model includes several types of synapses with `17338400` connections in total. The sum of all vector sizes in bytes is `595840000`.

With default (2x) `std::vector` growth factor:

```
Capacity: 26289600
CapacityBytes: 900556800
Memory overhead: 50%
Number of reallocations: 1901600
```

With growth factor 1.5x:

```
Capacity: 20875200
CapacityBytes: 713011200
Memory overhead: 19%
Number of reallocations: 2119200 (111% of default)
```

Overall memory consumed by linux process decreased from 1.1 GiB to 909.9 MiB.
I didn't test performance of connection creation but we can guess looking at number of reallocations.
