### PR TITLE
Minimal fix for #517 (SLI issue). 

### DIFF
--- a/lib/sli/helpinit.sli
+++ b/lib/sli/helpinit.sli
@@ -1191,7 +1191,7 @@ SeeAlso: SetOptions, help, helpindex
 /:helpdesk_complete_command
 {
   /helpdesk /command GetOption
-  statusdict/hostos :: 6 Take (darwin) eq
+  (^darwin) statusdict/hostos :: regex_find
   {
     % OSX, must use open -a <cmd> <url>
     (open -a ) exch join


### PR DESCRIPTION
NEST/PyNEST will now no longer report a `RangeCheck` error if the requested browser is not installed, but instead report a failed subprocess.

I haven't really found a good way to output the actual command that fails. Since we will most likely soon change to other ways of launching help, I don't think it is worth spending much time investigating the details of `system` and `spoon`.

I suggest @jougs as reviewer.