### PR TITLE
Added mention-bot config file excluding past developers

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,3 @@
+{
+  "userBlacklist": ["otizonaizit", "tammoippen"], // users in this list will never be mentioned by mention-bot
+}


### PR DESCRIPTION
@heplesser, can you please merge? See #529 for an example, where mention-bot already commented.

The webhook was added in the [settings](https://github.com/nest/nest-simulator/settings/hooks) of the [nest/nest-simulator](https://github.com/nest/nest-simulator) repository. This PR just adds a minimal configuration file excluding some people from being mentioned. We can improve it later.