### PR TITLE
Fix for #406 (ascii issue)

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -88,9 +88,11 @@ def catching_sli_run(cmd):
         def decode(s):
             return s
     else:
-        def encode(s): return s.encode('utf-8')
+        def encode(s):
+            return s.encode('utf-8')
 
-        def decode(s): return s.decode('utf-8')
+        def decode(s):
+            return s.decode('utf-8')
     engine.run('{%s} runprotected' % decode(cmd))
     if not sli_pop():
         errorname = sli_pop()

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -93,6 +93,7 @@ def catching_sli_run(cmd):
 
         def decode(s):
             return s.decode('utf-8')
+
     engine.run('{%s} runprotected' % decode(cmd))
     if not sli_pop():
         errorname = sli_pop()

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -82,19 +82,21 @@ def catching_sli_run(cmd):
     """
 
     if sys.version_info >= (3,):
-        engine.run('{%s} runprotected' % cmd)  # Python 3
+        def encode(s): return s
+
+        def decode(s): return s
     else:
-        engine.run('{%s} runprotected' % cmd.decode('utf-8'))  # Python 2
+        def encode(s): return s.encode('utf-8')
+
+        def decode(s): return s.decode('utf-8')
+    engine.run('{%s} runprotected' % decode(cmd))
     if not sli_pop():
         errorname = sli_pop()
         message = sli_pop()
         commandname = sli_pop()
         engine.run('clear')
         errorstring = '%s in %s%s' % (errorname, commandname, message)
-        if sys.version_info >= (3,):
-            raise _kernel.NESTError(errorstring)  # Python 3
-        else:
-            raise _kernel.NESTError(errorstring.encode('utf-8'))  # Python 2
+        raise _kernel.NESTError(encode(errorstring))
 
 sli_run = hl_api.sr = catching_sli_run
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -80,21 +80,21 @@ def catching_sli_run(cmd):
     NESTError
         SLI errors are bubbled to the Python API as NESTErrors.
     """
-    
+
     if sys.version_info >= (3,):
-        engine.run('{%s} runprotected' % cmd) # Python 3
+        engine.run('{%s} runprotected' % cmd)  # Python 3
     else:
-        engine.run('{%s} runprotected' % cmd.decode('utf-8')) # Python 2
+        engine.run('{%s} runprotected' % cmd.decode('utf-8'))  # Python 2
     if not sli_pop():
         errorname = sli_pop()
         message = sli_pop()
         commandname = sli_pop()
         engine.run('clear')
-        errorstring = '%s in %s%s' %(errorname, commandname, message)
-        if sys.version_info >= (3,): 
-            raise _kernel.NESTError(errorstring) # Python 3
+        errorstring = '%s in %s%s' % (errorname, commandname, message)
+        if sys.version_info >= (3,):
+            raise _kernel.NESTError(errorstring)  # Python 3
         else:
-            raise _kernel.NESTError(errorstring.encode('utf-8')) # Python 2
+            raise _kernel.NESTError(errorstring.encode('utf-8'))  # Python 2
 
 sli_run = hl_api.sr = catching_sli_run
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -82,9 +82,11 @@ def catching_sli_run(cmd):
     """
 
     if sys.version_info >= (3,):
-        def encode(s): return s
+        def encode(s):
+            return s
 
-        def decode(s): return s
+        def decode(s):
+            return s
     else:
         def encode(s): return s.encode('utf-8')
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -80,15 +80,21 @@ def catching_sli_run(cmd):
     NESTError
         SLI errors are bubbled to the Python API as NESTErrors.
     """
-
-    engine.run('{%s} runprotected' % cmd)
+    if sys.version_info >= (3,):
+        engine.run('{%s} runprotected' % cmd) # Python 3
+    else:
+        engine.run('{%s} runprotected' % cmd.decode('utf-8')) # Python 2
     if not sli_pop():
         errorname = sli_pop()
         message = sli_pop()
         commandname = sli_pop()
         engine.run('clear')
-        raise _kernel.NESTError("{0} in {1}{2}".format(
-            errorname, commandname, message))
+        errorstring = '%s in %s%s' %(errorname, commandname, message)
+        print (type(errorstring))
+        if sys.version_info >= (3,): 
+            raise _kernel.NESTError(errorstring) # Python 3
+        else:
+            raise _kernel.NESTError(errorstring.encode('utf-8')) # Python 2
 
 sli_run = hl_api.sr = catching_sli_run
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -80,6 +80,7 @@ def catching_sli_run(cmd):
     NESTError
         SLI errors are bubbled to the Python API as NESTErrors.
     """
+    
     if sys.version_info >= (3,):
         engine.run('{%s} runprotected' % cmd) # Python 3
     else:
@@ -90,7 +91,6 @@ def catching_sli_run(cmd):
         commandname = sli_pop()
         engine.run('clear')
         errorstring = '%s in %s%s' %(errorname, commandname, message)
-        print (type(errorstring))
         if sys.version_info >= (3,): 
             raise _kernel.NESTError(errorstring) # Python 3
         else:

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -212,7 +212,7 @@ cdef class NESTEngine(object):
         return True
 
     def run(self, cmd):
-        
+
         if self.pEngine is NULL:
             raise NESTError("engine uninitialized")
         cdef string cmd_bytes

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -215,18 +215,22 @@ cdef class NESTEngine(object):
 
         if self.pEngine is NULL:
             raise NESTError("engine uninitialized")
-
-        cdef string cmd_bytes = cmd.encode()
-
+        cdef string cmd_bytes
+        try:
+            cmd_bytes = cmd.encode()
+        except UnicodeDecodeError:
+            raise NESTError("Please use only ascii characters.")
         self.pEngine.execute(cmd_bytes)
 
     def push(self, obj):
 
         if self.pEngine is NULL:
             raise NESTError("engine uninitialized")
-
-        self.pEngine.OStack.push(python_object_to_datum(obj))
-
+        try:
+            self.pEngine.OStack.push(python_object_to_datum(obj))
+        except UnicodeEncodeError:
+            raise NESTError("Please use only ascii characters.")
+            
     def pop(self):
 
         if self.pEngine is NULL:
@@ -236,9 +240,12 @@ cdef class NESTEngine(object):
             raise NESTError("interpreter stack is empty")
 
         cdef Datum* dat = (addr_tok(self.pEngine.OStack.top())).datum()
-
-        ret = sli_datum_to_object(dat)
-
+        
+        try:
+            ret = sli_datum_to_object(dat)
+        except UnicodeDecodeError:
+            raise NESTError("Please use only ascii characters.")
+            
         self.pEngine.OStack.pop()
 
         return ret

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -212,13 +212,11 @@ cdef class NESTEngine(object):
         return True
 
     def run(self, cmd):
+        
         if self.pEngine is NULL:
             raise NESTError("engine uninitialized")
         cdef string cmd_bytes
-        try:
-            cmd_bytes = cmd.encode('utf-8')
-        except UnicodeEncodeError:
-            cmd_bytes = cmd.encode()
+        cmd_bytes = cmd.encode('utf-8')
         self.pEngine.execute(cmd_bytes)
 
     def push(self, obj):

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -226,7 +226,7 @@ cdef class NESTEngine(object):
         if self.pEngine is NULL:
             raise NESTError("engine uninitialized")
         self.pEngine.OStack.push(python_object_to_datum(obj))
-            
+
     def pop(self):
 
         if self.pEngine is NULL:
@@ -236,9 +236,9 @@ cdef class NESTEngine(object):
             raise NESTError("interpreter stack is empty")
 
         cdef Datum* dat = (addr_tok(self.pEngine.OStack.top())).datum()
-        
+
         ret = sli_datum_to_object(dat)
-        
+
         self.pEngine.OStack.pop()
 
         return ret
@@ -273,7 +273,7 @@ cdef inline Datum* python_object_to_datum(obj) except NULL:
     cdef DictionaryDatum* dd = NULL
 
     cdef string obj_str
-    
+
     if isinstance(obj, bool):
         ret = <Datum*> new BoolDatum(obj)
     elif isinstance(obj, (int, long)):
@@ -319,7 +319,7 @@ cdef inline Datum* python_object_to_datum(obj) except NULL:
         if ret is NULL:
             raise NESTError("failed to unpack passed connection generator object")
     else:
-    
+
         try:
             ret = python_buffer_to_datum[buffer_int_1d_t, long](obj)
         except (ValueError, TypeError):


### PR DESCRIPTION
PyNEST will now raise a `NESTError` when trying to use non-ascii characters under Python 2.7.

We did not manage to find a way to make PyNEST work with non-ascii characters under Python 2.7. Note that this works under Python 3. 