### PR TITLE
Refractory implementation aeif models (fixes #547)

### DIFF
--- a/doc/model_details/aeif_models_implementation.ipynb
+++ b/doc/model_details/aeif_models_implementation.ipynb
@@ -265,11 +265,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "libsundials_nvecserial.so.2: cannot open shared object file: No such file or directory",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-6fb744ce4318>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0massimulo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msolvers\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mLSODAR\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0massimulo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mproblem\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mExplicit_Problem\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0mExtended_Problem\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mExplicit_Problem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python2.7/dist-packages/assimulo/solvers/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0meuler\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mExplicitEuler\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mImplicitEuler\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mradau5\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mRadau5ODE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mRadau5DAE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_Radau5ODE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_Radau5DAE\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 24\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0msundials\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mIDA\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mCVode\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     25\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mkinsol\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mKINSOL\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mrunge_kutta\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mRungeKutta34\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mRungeKutta4\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDopri5\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: libsundials_nvecserial.so.2: cannot open shared object file: No such file or directory"
+     ]
+    }
+   ],
    "source": [
     "from assimulo.solvers import LSODAR\n",
     "from assimulo.problem import Explicit_Problem\n",
@@ -834,21 +847,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -413,7 +413,7 @@ nest::aeif_cond_alpha::init_buffers_()
   B_.sys_.jacobian = NULL;
   B_.sys_.dimension = State_::STATE_VEC_SIZE;
   B_.sys_.params = reinterpret_cast< void* >( this );
-  B_.sys_.function = aeif_psc_alpha_dynamics;
+  B_.sys_.function = aeif_cond_alpha_dynamics;
 
   B_.I_stim_ = 0.0;
 }

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -116,9 +116,10 @@ nest::aeif_cond_alpha_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    is_refractory ? 0 : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike
-    - I_syn_exc - I_syn_inh - w + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::DG_EXC ] = -dg_ex / node.P_.tau_syn_ex;
   // Synaptic Conductance (nS)
@@ -499,7 +500,7 @@ nest::aeif_cond_alpha::update( Time const& origin,
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        
+
         // initialize refractory steps, adding 1 to compensate for immediate
         // subtraction after the while loop
         S_.r_ = V_.refractory_counts_ + 1;

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -87,8 +87,6 @@ nest::aeif_cond_alpha_dynamics( double,
   const nest::aeif_cond_alpha& node =
     *( reinterpret_cast< nest::aeif_cond_alpha* >( pnode ) );
 
-  const bool is_refractory = node.S_.r_ > 0;
-
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
@@ -98,8 +96,7 @@ nest::aeif_cond_alpha_dynamics( double,
   // Clamp membrane potential to V_reset while refractory, otherwise bound
   // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
   // Delta_T == 0.
-  const double& V =
-    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
+  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
   // shorthand for the other state variables
   const double& dg_ex = y[ S::DG_EXC ];
   const double& g_ex = y[ S::G_EXC ];
@@ -116,10 +113,9 @@ nest::aeif_cond_alpha_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] = is_refractory
-    ? 0
-    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
-        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] =
+    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
+      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::DG_EXC ] = -dg_ex / node.P_.tau_syn_ex;
   // Synaptic Conductance (nS)
@@ -494,8 +490,10 @@ nest::aeif_cond_alpha::update( Time const& origin,
 
       // spikes are handled inside the while-loop
       // due to spike-driven adaptation
-      if ( S_.r_ > 0 )
+      if ( S_.r_ > 0 && S_.r_ <= V_.refractory_counts_ )
+      {
         S_.y_[ State_::V_M ] = P_.V_reset_;
+      }
       else if ( S_.y_[ State_::V_M ] >= V_.V_peak )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -87,6 +87,8 @@ nest::aeif_cond_alpha_dynamics( double,
   const nest::aeif_cond_alpha& node =
     *( reinterpret_cast< nest::aeif_cond_alpha* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
@@ -96,7 +98,8 @@ nest::aeif_cond_alpha_dynamics( double,
   // Clamp membrane potential to V_reset while refractory, otherwise bound
   // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
   // Delta_T == 0.
-  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
+  const double& V =
+    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
   // shorthand for the other state variables
   const double& dg_ex = y[ S::DG_EXC ];
   const double& g_ex = y[ S::G_EXC ];
@@ -113,9 +116,10 @@ nest::aeif_cond_alpha_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
-      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::DG_EXC ] = -dg_ex / node.P_.tau_syn_ex;
   // Synaptic Conductance (nS)
@@ -490,7 +494,7 @@ nest::aeif_cond_alpha::update( Time const& origin,
 
       // spikes are handled inside the while-loop
       // due to spike-driven adaptation
-      if ( S_.r_ > 0 && S_.r_ <= V_.refractory_counts_ )
+      if ( S_.r_ > 0 )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
       }
@@ -499,9 +503,13 @@ nest::aeif_cond_alpha::update( Time const& origin,
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
 
-        // initialize refractory steps, adding 1 to compensate for immediate
-        // subtraction after the while loop
-        S_.r_ = V_.refractory_counts_ + 1;
+        /* Initialize refractory step counter.
+         * - We need to add 1 to compensate for count-down immediately after
+         *   while loop.
+         * - If neuron has no refractory time, set to 0 to avoid refractory
+         *   artifact inside while loop.
+         */
+        S_.r_ = V_.refractory_counts_ > 0 ? V_.refractory_counts_ + 1 : 0;
 
         set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
         SpikeEvent se;

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -102,7 +102,7 @@ Integration parameters
                           GSL integrator. Reduce it if NEST complains about
                           numerical instabilities.
 
-Author: Marc-Oliver Gewaltig
+Author: Marc-Oliver Gewaltig; full revision by Tanguy Fardet on December 2016
 
 Sends: SpikeEvent
 
@@ -283,6 +283,7 @@ public:
     gsl_odeiv_step* s_;    //!< stepping function
     gsl_odeiv_control* c_; //!< adaptive stepsize control function
     gsl_odeiv_evolve* e_;  //!< evolution function
+    gsl_odeiv_system sys_; //!< struct describing the GSL system
 
     // IntergrationStep_ should be reset with the neuron on ResetNetwork,
     // but remain unchanged during calibration. Since it is initialized with
@@ -319,8 +320,6 @@ public:
      * P.V_th if Delta_T == 0.
      */
     double V_peak;
-
-    gsl_odeiv_system sys_; //!< struct describing the GSL system
 
     unsigned int refractory_counts_;
   };

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -118,9 +118,10 @@ nest::aeif_cond_exp_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    is_refractory ? 0 : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike
-    - I_syn_exc - I_syn_inh - w + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::G_EXC ] = -g_ex / node.P_.tau_syn_ex; // Synaptic Conductance (nS)
 
@@ -487,7 +488,7 @@ nest::aeif_cond_exp::update( const Time& origin,
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        
+
         // initialize refractory steps, adding 1 to compensate for immediate
         // subtraction after the while loop
         S_.r_ = V_.refractory_counts_ + 1;

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -91,27 +91,36 @@ nest::aeif_cond_exp_dynamics( double,
   const nest::aeif_cond_exp& node =
     *( reinterpret_cast< nest::aeif_cond_exp* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
 
-  // shorthand for state variables
-  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
+  // Clamp membrane potential to V_reset while refractory, otherwise bound
+  // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
+  // Delta_T == 0.
+  const double& V =
+    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
+  // shorthand for the other state variables
   const double& g_ex = y[ S::G_EXC ];
   const double& g_in = y[ S::G_INH ];
   const double& w = y[ S::W ];
 
   const double I_syn_exc = g_ex * ( V - node.P_.E_ex );
   const double I_syn_inh = g_in * ( V - node.P_.E_in );
-  const double I_spike =
-    node.P_.Delta_T * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T );
+
+  const double I_spike = node.P_.Delta_T == 0.
+    ? 0.
+    : ( node.P_.g_L * node.P_.Delta_T
+        * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
   f[ S::V_M ] =
-    ( -node.P_.g_L * ( ( V - node.P_.E_L ) - I_spike ) - I_syn_exc - I_syn_inh
-      - w + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+    is_refractory ? 0 : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike
+    - I_syn_exc - I_syn_inh - w + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::G_EXC ] = -g_ex / node.P_.tau_syn_ex; // Synaptic Conductance (nS)
 
@@ -123,48 +132,6 @@ nest::aeif_cond_exp_dynamics( double,
   return GSL_SUCCESS;
 }
 
-extern "C" int
-nest::aeif_cond_exp_dynamics_DT0( double,
-  const double y[],
-  double f[],
-  void* pnode )
-{
-  // a shorthand
-  typedef nest::aeif_cond_exp::State_ S;
-
-  // get access to node so we can almost work as in a member function
-  assert( pnode );
-  const nest::aeif_cond_exp& node =
-    *( reinterpret_cast< nest::aeif_cond_exp* >( pnode ) );
-
-  // y[] here is---and must be---the state vector supplied by the integrator,
-  // not the state vector in the node, node.S_.y[].
-
-  // The following code is verbose for the sake of clarity. We assume that a
-  // good compiler will optimize the verbosity away ...
-
-  // shorthand for state variables
-  const double& V = y[ S::V_M ];
-  const double& g_ex = y[ S::G_EXC ];
-  const double& g_in = y[ S::G_INH ];
-  const double& w = y[ S::W ];
-
-  const double I_syn_exc = g_ex * ( V - node.P_.E_ex );
-  const double I_syn_inh = g_in * ( V - node.P_.E_in );
-
-  // dv/dt
-  f[ S::V_M ] = ( -node.P_.g_L * ( V - node.P_.E_L ) - I_syn_exc - I_syn_inh - w
-                  + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
-
-  f[ S::G_EXC ] = -g_ex / node.P_.tau_syn_ex; // Synaptic Conductance (nS)
-
-  f[ S::G_INH ] = -g_in / node.P_.tau_syn_in; // Synaptic Conductance (nS)
-
-  // Adaptation current w.
-  f[ S::W ] = ( node.P_.a * ( V - node.P_.E_L ) - w ) / node.P_.tau_w;
-
-  return GSL_SUCCESS;
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
@@ -436,6 +403,11 @@ nest::aeif_cond_exp::init_buffers_()
   else
     gsl_odeiv_evolve_reset( B_.e_ );
 
+  B_.sys_.jacobian = NULL;
+  B_.sys_.dimension = State_::STATE_VEC_SIZE;
+  B_.sys_.params = reinterpret_cast< void* >( this );
+  B_.sys_.function = aeif_psc_alpha_dynamics;
+
   B_.I_stim_ = 0.0;
 }
 
@@ -445,19 +417,14 @@ nest::aeif_cond_exp::calibrate()
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 
-  V_.sys_.jacobian = NULL;
-  V_.sys_.dimension = State_::STATE_VEC_SIZE;
-  V_.sys_.params = reinterpret_cast< void* >( this );
   // set the right threshold and GSL function depending on Delta_T
   if ( P_.Delta_T > 0. )
   {
     V_.V_peak = P_.V_peak_;
-    V_.sys_.function = aeif_cond_exp_dynamics;
   }
   else
   {
     V_.V_peak = P_.V_th; // same as IAF dynamics for spikes if Delta_T == 0.
-    V_.sys_.function = aeif_cond_exp_dynamics_DT0;
   }
 
   V_.refractory_counts_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
@@ -483,9 +450,6 @@ nest::aeif_cond_exp::update( const Time& origin,
   {
     double t = 0.0;
 
-    if ( S_.r_ > 0 )
-      --S_.r_;
-
     // numerical integration with adaptive step size control:
     // ------------------------------------------------------
     // gsl_odeiv_evolve_apply performs only a single numerical
@@ -501,7 +465,7 @@ nest::aeif_cond_exp::update( const Time& origin,
       const int status = gsl_odeiv_evolve_apply( B_.e_,
         B_.c_,
         B_.s_,
-        &V_.sys_,             // system of ODE
+        &B_.sys_,             // system of ODE
         &t,                   // from t
         B_.step_,             // to t <= step
         &B_.IntegrationStep_, // integration step size
@@ -523,13 +487,24 @@ nest::aeif_cond_exp::update( const Time& origin,
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        S_.r_ = V_.refractory_counts_;
+        
+        // initialize refractory steps, adding 1 to compensate for immediate
+        // subtraction after the while loop
+        S_.r_ = V_.refractory_counts_ + 1;
 
         set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
         SpikeEvent se;
         kernel().event_delivery_manager.send( *this, se, lag );
       }
     }
+
+    // decrement refractory count
+    if ( S_.r_ > 0 )
+    {
+      --S_.r_;
+    }
+
+    // apply spikes
     S_.y_[ State_::G_EXC ] += B_.spike_exc_.get_value( lag );
     S_.y_[ State_::G_INH ] += B_.spike_inh_.get_value( lag );
 

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -406,7 +406,7 @@ nest::aeif_cond_exp::init_buffers_()
   B_.sys_.jacobian = NULL;
   B_.sys_.dimension = State_::STATE_VEC_SIZE;
   B_.sys_.params = reinterpret_cast< void* >( this );
-  B_.sys_.function = aeif_psc_alpha_dynamics;
+  B_.sys_.function = aeif_cond_exp_dynamics;
 
   B_.I_stim_ = 0.0;
 }

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -91,6 +91,8 @@ nest::aeif_cond_exp_dynamics( double,
   const nest::aeif_cond_exp& node =
     *( reinterpret_cast< nest::aeif_cond_exp* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
@@ -100,7 +102,8 @@ nest::aeif_cond_exp_dynamics( double,
   // Clamp membrane potential to V_reset while refractory, otherwise bound
   // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
   // Delta_T == 0.
-  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
+  const double& V =
+    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
   // shorthand for the other state variables
   const double& g_ex = y[ S::G_EXC ];
   const double& g_in = y[ S::G_INH ];
@@ -115,9 +118,10 @@ nest::aeif_cond_exp_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
-      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike - I_syn_exc - I_syn_inh - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::G_EXC ] = -g_ex / node.P_.tau_syn_ex; // Synaptic Conductance (nS)
 
@@ -478,7 +482,7 @@ nest::aeif_cond_exp::update( const Time& origin,
 
       // spikes are handled inside the while-loop
       // due to spike-driven adaptation
-      if ( S_.r_ > 0 && S_.r_ <= V_.refractory_counts_ )
+      if ( S_.r_ > 0 )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
       }
@@ -487,9 +491,13 @@ nest::aeif_cond_exp::update( const Time& origin,
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
 
-        // initialize refractory steps, adding 1 to compensate for immediate
-        // subtraction after the while loop
-        S_.r_ = V_.refractory_counts_ + 1;
+        /* Initialize refractory step counter.
+         * - We need to add 1 to compensate for count-down immediately after
+         *   while loop.
+         * - If neuron has no refractory time, set to 0 to avoid refractory
+         *   artifact inside while loop.
+         */
+        S_.r_ = V_.refractory_counts_ > 0 ? V_.refractory_counts_ + 1 : 0;
 
         set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
         SpikeEvent se;

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -106,7 +106,7 @@ Integration parameters
                           GSL integrator. Reduce it if NEST complains about
                           numerical instabilities.
 
-Author: Adapted from aeif_cond_alpha by Lyle Muller
+Author: Adapted from aeif_cond_alpha by Lyle Muller; full revision by Tanguy Fardet on December 2016
 
 Sends: SpikeEvent
 
@@ -284,6 +284,7 @@ public:
     gsl_odeiv_step* s_;    //!< stepping function
     gsl_odeiv_control* c_; //!< adaptive stepsize control function
     gsl_odeiv_evolve* e_;  //!< evolution function
+    gsl_odeiv_system sys_; //!< struct describing the GSL system
 
     // IntergrationStep_ should be reset with the neuron on ResetNetwork,
     // but remain unchanged during calibration. Since it is initialized with
@@ -314,8 +315,6 @@ public:
      * P.V_th if Delta_T == 0.
      */
     double V_peak;
-
-    gsl_odeiv_system sys_; //!< struct describing the GSL system
 
     unsigned int refractory_counts_;
   };

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -106,7 +106,8 @@ Integration parameters
                           GSL integrator. Reduce it if NEST complains about
                           numerical instabilities.
 
-Author: Adapted from aeif_cond_alpha by Lyle Muller; full revision by Tanguy Fardet on December 2016
+Author: Adapted from aeif_cond_alpha by Lyle Muller; full revision by Tanguy
+Fardet on December 2016
 
 Sends: SpikeEvent
 

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -113,9 +113,10 @@ nest::aeif_psc_alpha_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    is_refractory ? 0 : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
-      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::DI_EXC ] = -dI_syn_ex / node.P_.tau_syn_ex;
   // Exc. synaptic current (pA)
@@ -489,7 +490,7 @@ nest::aeif_psc_alpha::update( Time const& origin,
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        
+
         // initialize refractory steps, adding 1 to compensate for immediate
         // subtraction after the while loop
         S_.r_ = V_.refractory_counts_ + 1;

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -87,8 +87,6 @@ nest::aeif_psc_alpha_dynamics( double,
   const nest::aeif_psc_alpha& node =
     *( reinterpret_cast< nest::aeif_psc_alpha* >( pnode ) );
 
-  const bool is_refractory = node.S_.r_ > 0;
-
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
@@ -98,8 +96,7 @@ nest::aeif_psc_alpha_dynamics( double,
   // Clamp membrane potential to V_reset while refractory, otherwise bound
   // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
   // Delta_T == 0.
-  const double& V =
-    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
+  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
   // shorthand for the other state variables
   const double& dI_syn_ex = y[ S::DI_EXC ];
   const double& I_syn_ex = y[ S::I_EXC ];
@@ -113,10 +110,9 @@ nest::aeif_psc_alpha_dynamics( double,
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] = is_refractory
-    ? 0
-    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
-        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] =
+    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
+      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::DI_EXC ] = -dI_syn_ex / node.P_.tau_syn_ex;
   // Exc. synaptic current (pA)
@@ -484,8 +480,10 @@ nest::aeif_psc_alpha::update( Time const& origin,
 
       // spikes are handled inside the while-loop
       // due to spike-driven adaptation
-      if ( S_.r_ > 0 )
+      if ( S_.r_ > 0 && S_.r_ <= V_.refractory_counts_ )
+      {
         S_.y_[ State_::V_M ] = P_.V_reset_;
+      }
       else if ( S_.y_[ State_::V_M ] >= V_.V_peak )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -99,7 +99,7 @@ Integration parameters
                           GSL integrator. Reduce it if NEST complains about
                           numerical instabilities.
 
-Author: adapted from aeif_cond_alpha by Tanguy Fardet
+Author: Tanguy Fardet
 
 Sends: SpikeEvent
 

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -87,6 +87,8 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
   const nest::aeif_psc_exp& node =
     *( reinterpret_cast< nest::aeif_psc_exp* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
@@ -96,7 +98,8 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
   // Clamp membrane potential to V_reset while refractory, otherwise bound
   // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
   // Delta_T == 0.
-  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
+  const double& V =
+    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
   // shorthand for the other state variables
   const double& I_syn_ex = y[ S::I_EXC ];
   const double& I_syn_in = y[ S::I_INH ];
@@ -108,9 +111,10 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
-      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::I_EXC ] = -I_syn_ex / node.P_.tau_syn_ex; // Exc. synaptic current (pA)
 
@@ -462,7 +466,7 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
 
       // spikes are handled inside the while-loop
       // due to spike-driven adaptation
-      if ( S_.r_ > 0 && S_.r_ <= V_.refractory_counts_ )
+      if ( S_.r_ > 0 )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
       }
@@ -471,9 +475,13 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
 
-        // initialize refractory steps, adding 1 to compensate for immediate
-        // subtraction after the while loop
-        S_.r_ = V_.refractory_counts_ + 1;
+        /* Initialize refractory step counter.
+         * - We need to add 1 to compensate for count-down immediately after
+         *   while loop.
+         * - If neuron has no refractory time, set to 0 to avoid refractory
+         *   artifact inside while loop.
+         */
+        S_.r_ = V_.refractory_counts_ > 0 ? V_.refractory_counts_ + 1 : 0;
 
         set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
         SpikeEvent se;

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -87,8 +87,6 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
   const nest::aeif_psc_exp& node =
     *( reinterpret_cast< nest::aeif_psc_exp* >( pnode ) );
 
-  const bool is_refractory = node.S_.r_ > 0;
-
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
@@ -98,8 +96,7 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
   // Clamp membrane potential to V_reset while refractory, otherwise bound
   // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
   // Delta_T == 0.
-  const double& V =
-    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
+  const double& V = std::min( y[ S::V_M ], node.P_.V_peak_ );
   // shorthand for the other state variables
   const double& I_syn_ex = y[ S::I_EXC ];
   const double& I_syn_in = y[ S::I_INH ];
@@ -111,10 +108,9 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] = is_refractory
-    ? 0
-    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
-        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] =
+    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
+      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::I_EXC ] = -I_syn_ex / node.P_.tau_syn_ex; // Exc. synaptic current (pA)
 
@@ -466,8 +462,10 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
 
       // spikes are handled inside the while-loop
       // due to spike-driven adaptation
-      if ( S_.r_ > 0 )
+      if ( S_.r_ > 0 && S_.r_ <= V_.refractory_counts_ )
+      {
         S_.y_[ State_::V_M ] = P_.V_reset_;
+      }
       else if ( S_.y_[ State_::V_M ] >= V_.V_peak )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -111,9 +111,10 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
         * std::exp( ( V - node.P_.V_th ) / node.P_.Delta_T ) );
 
   // dv/dt
-  f[ S::V_M ] =
-    is_refractory ? 0 : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
-      + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
+  f[ S::V_M ] = is_refractory
+    ? 0
+    : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
+        + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::I_EXC ] = -I_syn_ex / node.P_.tau_syn_ex; // Exc. synaptic current (pA)
 
@@ -471,7 +472,7 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        
+
         // initialize refractory steps, adding 1 to compensate for immediate
         // subtraction after the while loop
         S_.r_ = V_.refractory_counts_ + 1;
@@ -487,7 +488,7 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
     {
       --S_.r_;
     }
-    
+
     S_.y_[ State_::I_EXC ] += B_.spike_exc_.get_value( lag );
     S_.y_[ State_::I_INH ] += B_.spike_inh_.get_value( lag );
 

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -87,15 +87,20 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
   const nest::aeif_psc_exp& node =
     *( reinterpret_cast< nest::aeif_psc_exp* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
-  // good compiler will optimize the verbosity away ...
+  // good compiler will optimize the verbosity away...
 
-  // shorthand for state variables
+  // Clamp membrane potential to V_reset while refractory, otherwise bound
+  // it to V_peak. Do not use V_.V_peak_ here, since that is set to V_th if
+  // Delta_T == 0.
   const double& V =
-    std::min( y[ S::V_M ], node.P_.V_peak_ ); // enforce upper limit on V_m
+    is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_peak_ );
+  // shorthand for the other state variables
   const double& I_syn_ex = y[ S::I_EXC ];
   const double& I_syn_in = y[ S::I_INH ];
   const double& w = y[ S::W ];
@@ -107,7 +112,7 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
 
   // dv/dt
   f[ S::V_M ] =
-    ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex + I_syn_in - w
+    is_refractory ? 0 : ( -node.P_.g_L * ( V - node.P_.E_L ) + I_spike + I_syn_ex - I_syn_in - w
       + node.P_.I_e + node.B_.I_stim_ ) / node.P_.C_m;
 
   f[ S::I_EXC ] = -I_syn_ex / node.P_.tau_syn_ex; // Exc. synaptic current (pA)
@@ -429,9 +434,6 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
   {
     double t = 0.0;
 
-    if ( S_.r_ > 0 )
-      --S_.r_;
-
     // numerical integration with adaptive step size control:
     // ------------------------------------------------------
     // gsl_odeiv_evolve_apply performs only a single numerical
@@ -469,13 +471,23 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
       {
         S_.y_[ State_::V_M ] = P_.V_reset_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        S_.r_ = V_.refractory_counts_;
+        
+        // initialize refractory steps, adding 1 to compensate for immediate
+        // subtraction after the while loop
+        S_.r_ = V_.refractory_counts_ + 1;
 
         set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
         SpikeEvent se;
         kernel().event_delivery_manager.send( *this, se, lag );
       }
     }
+
+    // decrement refractory count
+    if ( S_.r_ > 0 )
+    {
+      --S_.r_;
+    }
+    
     S_.y_[ State_::I_EXC ] += B_.spike_exc_.get_value( lag );
     S_.y_[ State_::I_INH ] += B_.spike_inh_.get_value( lag );
 

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -103,7 +103,7 @@ Integration parameters
                           GSL integrator. Reduce it if NEST complains about
                           numerical instabilities.
 
-Author: adapted from aeif_cond_exp by Tanguy Fardet
+Author: Tanguy Fardet
 
 Sends: SpikeEvent
 

--- a/pynest/nest/tests/test_aeif_lsodar.py
+++ b/pynest/nest/tests/test_aeif_lsodar.py
@@ -245,7 +245,9 @@ class AEIFTestCase(unittest.TestCase):
         '''
         for model, di_rel_diff in iter(rel_diff.items()):
             for var, diff in iter(di_rel_diff.items()):
-                self.assertTrue(diff < di_tol[model][var])
+                self.assertTrue(diff < di_tol[model][var],
+                                "{} failed test: {} > {}.".format(
+                                    model, diff, di_tol[model][var]))
 
     def test_closeness_nest_lsodar(self):
         '''

--- a/pynest/nest/tests/test_aeif_lsodar.py
+++ b/pynest/nest/tests/test_aeif_lsodar.py
@@ -246,8 +246,8 @@ class AEIFTestCase(unittest.TestCase):
         for model, di_rel_diff in iter(rel_diff.items()):
             for var, diff in iter(di_rel_diff.items()):
                 self.assertTrue(diff < di_tol[model][var],
-                                "{} failed test: {} > {}.".format(
-                                    model, diff, di_tol[model][var]))
+                                "{} failed test for {}: {} > {}.".format(
+                                    model, var, diff, di_tol[model][var]))
 
     def test_closeness_nest_lsodar(self):
         '''


### PR DESCRIPTION
Following #547, this corrects the refractory implementation for:
* aeif_cond_alpha
* aeif_cond_exp
* aeif _psc_exp
* aeif_psc_alpha

This PR also removes the ``DT0`` dynamics function in the ``aeif_cond_alpha/exp`` models.