### PR TITLE
Added MUSIC support to recording_device

### DIFF
--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -139,6 +139,7 @@
 #include "music_event_out_proxy.h"
 #include "music_cont_in_proxy.h"
 #include "music_message_in_proxy.h"
+#include "music_connection.h"
 #endif
 
 namespace nest
@@ -383,6 +384,13 @@ ModelsModule::init( SLIInterpreter* )
 
      SeeAlso: synapsedict, static_synapse
   */
+#ifdef HAVE_MUSIC
+  kernel()
+    .model_manager
+    .register_connection_model< MusicConnection< TargetIdentifierPtrRport > >(
+      "music_synapse" );
+#endif
+
   kernel()
     .model_manager
     .register_connection_model< StaticConnection< TargetIdentifierPtrRport > >(

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -339,8 +339,10 @@ nest::Multimeter::set_status( const DictionaryDatum& d )
   if ( updateValue< bool >( d, names::frozen, freeze ) && freeze )
     throw BadProperty( "Multimeter cannot be frozen." );
 
+
   Parameters_ ptmp = P_;
   ptmp.set( d, B_ );
+
 
   // Set properties in device. As a side effect, this will clear data_,
   // if /clear_events set in d

--- a/models/music_connection.h
+++ b/models/music_connection.h
@@ -1,5 +1,5 @@
 /*
- *  static_connection.h
+ *  music_connection.h
  *
  *  This file is part of NEST.
  *
@@ -39,11 +39,11 @@
   SeeAlso: synapsedict, tsodyks_synapse, stdp_synapse
 */
 
-#ifndef STATICCONNECTION_H
-#define STATICCONNECTION_H
+#ifndef MUSIC_CONNECTION_H
+#define MUSIC_CONNECTION_H
 
 // Includes from nestkernel:
-#include "connection.h"
+#include "static_connection.h"
 
 namespace nest
 {
@@ -56,24 +56,23 @@ namespace nest
 
 
 template < typename targetidentifierT >
-class StaticConnection : public Connection< targetidentifierT >
+class MusicConnection: public StaticConnection< targetidentifierT >
 {
-protected:
-  double weight_;
+  long music_channel_;
 
 public:
-  // this line determines which common properties to use
+  /* // this line determines which common properties to use */
   typedef CommonSynapseProperties CommonPropertiesType;
 
-  typedef Connection< targetidentifierT > ConnectionBase;
+  typedef StaticConnection< targetidentifierT > StaticConnectionBase;
 
   /**
    * Default Constructor.
    * Sets default values for all parameters. Needed by GenericConnectorModel.
    */
-  StaticConnection()
-    : ConnectionBase()
-    , weight_( 1.0 )
+  MusicConnection()
+    : StaticConnectionBase()
+    , music_channel_( 0 )
   {
   }
 
@@ -81,9 +80,9 @@ public:
    * Copy constructor from a property object.
    * Needs to be defined properly in order for GenericConnector to work.
    */
-  StaticConnection( const StaticConnection& rhs )
-    : ConnectionBase( rhs )
-    , weight_( rhs.weight_ )
+  MusicConnection( const MusicConnection& rhs )
+    : StaticConnectionBase( rhs )
+    , music_channel_( rhs.music_channel_ )
   {
   }
 
@@ -91,111 +90,43 @@ public:
   // ConnectionBase. This avoids explicit name prefixes in all places these
   // functions are used. Since ConnectionBase depends on the template parameter,
   // they are not automatically found in the base class.
-  using ConnectionBase::get_delay_steps;
-  using ConnectionBase::get_rport;
-  using ConnectionBase::get_target;
-
-
-  class ConnTestDummyNode : public ConnTestDummyNodeBase
-  {
-  public:
-    // Ensure proper overriding of overloaded virtual functions.
-    // Return values from functions are ignored.
-    using ConnTestDummyNodeBase::handles_test_event;
-    port
-    handles_test_event( SpikeEvent&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( RateEvent&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( DataLoggingRequest&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( CurrentEvent&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( ConductanceEvent&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( DoubleDataEvent&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( DSSpikeEvent&, rport )
-    {
-      return invalid_port_;
-    }
-    port
-    handles_test_event( DSCurrentEvent&, rport )
-    {
-      return invalid_port_;
-    }
-  };
-
-  void
-  check_connection( Node& s,
-    Node& t,
-    rport receptor_type,
-    double,
-    const CommonPropertiesType& )
-  {
-    ConnTestDummyNode dummy_target;
-    ConnectionBase::check_connection_( dummy_target, s, t, receptor_type );
-  }
-
-  void
-  send( Event& e, thread t, double, const CommonSynapseProperties& )
-  {
-    e.set_weight( weight_ );
-    e.set_delay( get_delay_steps() );
-    e.set_receiver( *get_target( t ) );
-    e.set_rport( get_rport() );
-    e();
-  }
+  using StaticConnectionBase::get_delay_steps;
+  using StaticConnectionBase::get_rport;
+  using StaticConnectionBase::get_target;
+  using StaticConnectionBase::set_weight;
+  using StaticConnectionBase::check_connection;
+  using StaticConnectionBase::send;
 
   void get_status( DictionaryDatum& d ) const;
 
   void set_status( const DictionaryDatum& d, ConnectorModel& cm );
 
   void
-  set_weight( double w )
+  set_music_channel( long music_channel )
   {
-    weight_ = w;
+	music_channel_ = music_channel;
   }
-
 };
 
 template < typename targetidentifierT >
 void
-StaticConnection< targetidentifierT >::get_status( DictionaryDatum& d ) const
+MusicConnection< targetidentifierT >::get_status( DictionaryDatum& d ) const
 {
 
-  ConnectionBase::get_status( d );
-  def< double >( d, names::weight, weight_ );
+  StaticConnectionBase::get_status( d );
+  def< long >( d, names::music_channel, music_channel_ );
   def< long >( d, names::size_of, sizeof( *this ) );
 }
 
 template < typename targetidentifierT >
 void
-StaticConnection< targetidentifierT >::set_status( const DictionaryDatum& d,
+MusicConnection< targetidentifierT >::set_status( const DictionaryDatum& d,
   ConnectorModel& cm )
 {
-  ConnectionBase::set_status( d, cm );
-  updateValue< double >( d, names::weight, weight_ );
+  StaticConnectionBase::set_status( d, cm );
+  updateValue< long >( d, names::music_channel, music_channel_ );
 }
 
 } // namespace
 
-#endif /* #ifndef STATICCONNECTION_H */
+#endif /* #ifndef MUSIC_CONNECTION */

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -150,10 +150,6 @@ void
 GenericConnectorModel< ConnectionT >::set_status( const DictionaryDatum& d )
 {
   updateValue< long >( d, names::receptor_type, receptor_type_ );
-#ifdef HAVE_MUSIC
-  // We allow music_channel as alias for receptor_type during connection setup
-  updateValue< long >( d, names::music_channel, receptor_type_ );
-#endif
 
   // If the parameter dict d contains /delay, this should set the delay
   // on the default connection, but not affect the actual min/max_delay
@@ -337,10 +333,6 @@ GenericConnectorModel< ConnectionT >::add_connection( Node& src,
   // receptor type. We must not change the receptor_type_ data member, because
   // that represents the *default* value. See #921.
   rport actual_receptor_type = receptor_type_;
-#ifdef HAVE_MUSIC
-  // We allow music_channel as alias for receptor_type during connection setup
-  updateValue< long >( p, names::music_channel, actual_receptor_type );
-#endif
   updateValue< long >( p, names::receptor_type, actual_receptor_type );
 
   return add_connection( src, tgt, conn, syn_id, c, actual_receptor_type );

--- a/nestkernel/music_manager.h
+++ b/nestkernel/music_manager.h
@@ -138,6 +138,10 @@ public:
     int channel,
     nest::Node* mp );
 
+  void register_music_cont_out_port( std::string portname,
+    std::vector< MUSIC::GlobalIndex >& music_index_map,
+	int max_buffered);
+
   /**
    * Set the acceptable latency (latency) for a music input port (portname).
    */
@@ -164,6 +168,36 @@ public:
     int max_buffered;
   };
 
+  struct MusicContPortData
+  {
+    MusicContPortData( unsigned long channels, std::vector< MUSIC::GlobalIndex >& index_map, int m )
+      : data( channels )
+	  , index_map( index_map )
+      , max_buffered( m )
+    {
+    }
+
+    MusicContPortData()
+	  : data()
+	  , index_map()
+	  , max_buffered( 1 )
+    {
+    }
+	std::vector< double > data;
+	std::vector< MUSIC::GlobalIndex > index_map;
+    int max_buffered;
+  };
+
+  std::vector< double >* get_music_cont_out_buffer( std::string port_name );
+
+  /**
+   * The mapping between MUSIC continous output ports identified by portname
+   * and the corresponding port variables and parameters.
+   * @see register_music_in_port()
+   * @see unregister_music_in_port()
+   */
+  std::map< std::string, MusicContPortData > music_cont_out_portlist_;
+
   /**
    * The mapping between MUSIC input ports identified by portname
    * and the corresponding port variables and parameters.
@@ -188,11 +222,14 @@ public:
    */
   std::map< std::string, MusicEventHandler > music_in_portmap_;
 
+
   /**
    * Publish all MUSIC input ports that were registered using
    * Network::register_music_event_in_proxy().
    */
   void publish_music_in_ports_();
+
+  void publish_music_cont_out_ports_();
 
   /**
    * Call update() for each of the registered MUSIC event handlers

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -187,6 +187,7 @@ const Name linear( "linear" );
 const Name local( "local" );
 const Name local_id( "local_id" );
 
+const Name max_buffered( "max_buffered" );
 const Name make_symmetric( "make_symmetric" );
 const Name MAXERR( "MAXERR" );
 const Name mean( "mean" );
@@ -195,6 +196,7 @@ const Name model( "model" );
 const Name mother_rng( "mother_rng" );
 const Name mother_seed( "mother_seed" );
 const Name multapses( "multapses" );
+const Name music( "music" );
 const Name music_channel( "music_channel" );
 
 const Name n( "n" );
@@ -332,6 +334,7 @@ const Name time_in_steps( "time_in_steps" );
 const Name times( "times" );
 const Name to_accumulator( "to_accumulator" );
 const Name to_file( "to_file" );
+const Name to_music( "to_music" );
 const Name to_memory( "to_memory" );
 const Name to_screen( "to_screen" );
 const Name Tstart( "Tstart" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -248,6 +248,7 @@ extern const Name linear;            //!< Parameter for MSP growth curves
 extern const Name local;             //!< Node parameter
 extern const Name local_id;          //!< Node
 
+extern const Name max_buffered; //!< MUSIC-related
 extern const Name make_symmetric; //!< Connectivity-related
 extern const Name MAXERR; //!< Largest permissible error for adaptive stepsize
                           //!< (Brette & Gerstner 2005)
@@ -257,6 +258,7 @@ extern const Name model;  //!< Node parameter
 extern const Name mother_rng;    //!< Specific to mip_generator
 extern const Name mother_seed;   //!< Specific to mip_generator
 extern const Name multapses;     //!< Connectivity-related
+extern const Name music; //!< MUSIC-related
 extern const Name music_channel; //!< Parameters for MUSIC devices
 
 extern const Name
@@ -420,6 +422,7 @@ extern const Name time_in_steps;   //!< Recorder parameter
 extern const Name times;           //!< Recorder parameter
 extern const Name to_accumulator;  //!< Recorder parameter
 extern const Name to_file;         //!< Recorder parameter
+extern const Name to_music;
 extern const Name to_memory;       //!< Recorder parameter
 extern const Name to_screen;       //!< Recorder parameter
 extern const Name Tstart;          //!< Specific to correlation and

--- a/pynest/examples/music_cont_out/compute_node.py
+++ b/pynest/examples/music_cont_out/compute_node.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import music
+import numpy as np
+from itertools import takewhile, dropwhile
+
+music_setup = music.Setup()
+
+stoptime = music_setup.config("stoptime")
+
+# In PyMusic, the timestep is given in seconds, in NEST however, we are
+# dealing with milliseconds
+timestep = music_setup.config("timestep")
+cont_portwidth = int(music_setup.config("cont_portwidth"))
+
+# MPI related
+mpi_comm = music_setup.comm
+mpi_rank = mpi_comm.Get_rank()
+
+# event_out = music_setup.publishEventOutput("event_out")
+# event_out.map(music.Index.GLOBAL,
+#               base=0,
+#               size=event_out.width(),
+#               maxBuffered=1)
+
+cont_in = music_setup.publishContInput("cont_in")
+cont_in_data = np.zeros(cont_portwidth, dtype=np.double)
+cont_in.map(cont_in_data, delay=0., interpolate=False)
+
+runtime = music_setup.runtime(timestep)
+maxtime = stoptime + timestep
+
+data_view = cont_in_data.view().reshape((20,2))
+data_view = cont_in_data.view(dtype=[('V_m', np.double), ('g_ex', np.double)])
+
+# Comment this out for printing
+start = dropwhile(lambda t: t < timestep, runtime)
+times = takewhile(lambda t: t < maxtime, start)
+
+for time in times:
+    print("t={time}\treceiver {receiver}: received {received}\n"
+          .format(time=time, receiver=mpi_rank, received=data_view))
+

--- a/pynest/examples/music_cont_out/music_cont.music
+++ b/pynest/examples/music_cont_out/music_cont.music
@@ -1,0 +1,14 @@
+timestep = 0.1
+stoptime = 2
+cont_portwidth = 40
+
+[simulator_node]
+np = 2
+binary = ./music_example.py
+args = nest
+
+[compute_node]
+np = 1
+binary = ./compute_node.py
+
+simulator_node.cont_out -> compute_node.cont_in [40]

--- a/pynest/examples/music_cont_out/music_example.py
+++ b/pynest/examples/music_cont_out/music_example.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import nest
+
+
+# encoding: utf-8
+
+import numpy
+
+
+import nest
+
+g = nest.Create('sinusoidal_poisson_generator', n=1, params=[{'rate': 1000.0,
+                                                              'amplitude': 5000.0,
+                                                              'frequency': 100.0,
+                                                              'phase': 0.0}])
+
+f = nest.Create('iaf_cond_exp', 20)
+# gen = nest.Create('poisson_generator')
+# nest.SetStatus(gen, {'rate': 10000.})
+nest.Connect(g, f, 'all_to_all', {'weight': 500.})
+
+multi = nest.Create('multimeter')
+nest.SetStatus(multi, {'to_music': True,
+                       'to_memory': False,
+                       'port_name': 'cont_out',
+                       'record_from': ['V_m', 'g_ex'],
+                       'interval': 1.
+                       })
+
+for i, neuron in enumerate(f):
+    nest.Connect(multi, [neuron], 'one_to_one', {'model': 'music_synapse', 'music_channel': i})
+
+
+# We create an event port just to close the MUSIC loop
+# event_in = nest.Create('music_event_in_proxy', 20)
+# nest.SetAcceptableLatency('event_in', 20.)
+# nest.SetStatus(event_in, {'port_name': 'event_in'})
+# for i, proxy in enumerate(event_in):
+#     nest.SetStatus([proxy], 'music_channel', i)
+
+nest.Simulate(2000.0)
+


### PR DESCRIPTION
## **Proposal:**

- Added a 'music_connector' to unify the user-interface to specify music_channel ids
- Adding to_music (MUSIC support) to the recording_device class, if compiled with MUSIC. This enables **all** recorders such as multimeter and weight_recorder to stream their data via MPI without much effort in changing their code

## **Discussion:**
**Cont. Out. Port Streaming**
I would like to strap the MUSIC-related code out of the music_cont_out_proxy into a module that can be re-used by any recording neuron which handles continuous data. Two plausible options are to add the code to a new class or to stuff it into the recording_device (as it has been done in this pull request). The phrase 'to stuff it into' is not far from the truth; 

Even though it appears to me very natural to have a to_music flag in the recording device there are two things that were disturbing during the implementation:  

1. The multimeter is already kind of overloaded with functionality
2. The DataLoggingReply contains an array of arrays with the recorded values, but without going into misusing MUSIC-channels to also stream older values out, we are actually only interested in the most recent value vector, thus throwing away the other values contained within a single DataLoggingReply. This also implies that a sampling interval parameter (as given in the multimeter) is not very useful as it only describes a lower-bound on the refresh-rate of the MUSIC-buffer values but the upper bound is given by the MUSIC scheduling (when data gets streamed out). 
3. Quite a few pre-processor flags are required in the code

An alternative solution could be to strip the code out into an external class, keep the multimeter as it is and just refactor the music_cont_out_proxy and all other devices that should be able to use the continuous ports. 

**Music_synapse**
A second thing is the music_channel indexing; The issue here is that each NEST-process must know how to map each local neuron onto a global MUSIC id. This requires global knowledge which is not given out-of-the-box and should be done such that the user does not have to do much work. The best ways are to provide the channel-assignment via synapses ( mapping the music_channel property onto the receptor port number ) or to let the user pass a global index map via StatusDictionary. The receptor-port mapping only works for synapses that are inbound, e. g. the music_event_out_port. So this seems not to be a valid option for all kinds of recording devices. 

A global index map is a real option ( as it is implemented in the music_cont_out_proxy ), however, it is not very intuitive for a user to use synapse parameters for music_event_out_proxy and index maps for a music_cont_out_proxy/multimeter/...  Therefore, I propose to derive a synapse (from a static_connector) with an additional music_channel parameter. I assume that no learning synapse is directly connected to a device/neuron that interfaces MUSIC so a static_synapse should be sufficient. 


## **TODO:**

- Decide whether to include the Cont. Port functionality in recording_device or not
- Decide whether to use global index maps or music_synapses 
- Adapt music_event_out_proxy to read out channel ids from music_synapses or revert it to use receptor ports (I've removed them from the connector_base.h)
- Code cleaning
- Unittests (I don't really feel comfortable with SLI though :) )

If there is a need, the same thing could also be done for Cont. Input Ports to steer internals of generators etc. 

Please let me know your opinions!

 