### PR TITLE
Check if sparsetable has any targets before getting them

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1312,7 +1312,7 @@ nest::ConnectionManager::get_targets( std::vector< index > sources,
     target_it = targets.begin();
     for ( ; source_it != sources.end(); source_it++, target_it++ )
     {
-      if ( ( *it ).get( *source_it ) != 0 )
+      if ( not( *it ).empty() and ( *it ).get( *source_it ) != 0 )
       {
         validate_pointer( ( *it ).get( *source_it ) )
           ->get_target_gids( ( *target_it ), thread_id, synapse_model );


### PR DESCRIPTION
The get() method does not first check to see if the sparsetable
contains any entries. Instead, it uses an assert() statement to check
if the ith entry is a valid one. This assert causes simulations to crash in
certain scenarios. One example scenario:

- two mpi ranks with one thread each, so two virtual processes vp0, vp1
- two sparsetables, one for each rank - sparsetable0, sparsetable1
- one neuron, so, on rank1. rank0 has no nodes
- structural plasticity enabled
- when the neuron forms a connection (autapse), both source and target
  are on rank1/vp1 - so sparsetable1 is valid and non empty.
- rank0/vp0 has no targets, sparsetable0 is empty
- when neuron needs to delete connections to reduce synaptic elements,
  on each rank, it gets the global ids of all neurons that need to
  delete an element. Then, it tries to get targets for these global ids
  on its rank. Since sparsetable0 is empty, this causes the assert in
  the get() in sparsetable.h to fail, causing the simulation to crash.


Example testcase simulation: https://github.com/nest/nest-simulator/files/634198/testcase-crash-1.txt

This fix is related to issue #576 but I'm not sure if it fixes both crashes that I've documented there.