### PR TITLE
Restore Data Connect

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -805,7 +805,6 @@ nest::ConnectionManager::divergent_connect( index source_id,
 
       // here we fill a parameter dictionary with the values of the current loop
       // index.
-      par_i->clear();
       for ( di_s = ( *pars ).begin(); di_s != ( *pars ).end(); ++di_s )
       {
         DoubleVectorDatum const* tmp =


### PR DESCRIPTION
The connection routine DataConnect was made thread safe and some parts were rewritten. The routine now takes at least double the time to create sparse networks, compared to its performance in NEST 2.10. DataConnect is sped up again by removing a clearing instruction of the data dictionary  after initialisation. As reviewers I suggest @heplesser and @jougs.