### PR TITLE
Replace operator<< with regular function to avoid issues with K compiler

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1087,8 +1087,8 @@ nest::ConnectionManager::get_connections( DictionaryDatum params ) const
 
 // Helper method, implemented as operator<<(), that removes ConnectionIDs from
 // input deque and appends them to output deque.
-static inline std::deque< nest::ConnectionID >& operator<<(
-  std::deque< nest::ConnectionID >& out,
+static inline std::deque< nest::ConnectionID >&
+extend_connectome( std::deque< nest::ConnectionID >& out,
   std::deque< nest::ConnectionID >& in )
 {
   while ( not in.empty() )
@@ -1138,7 +1138,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome << conns_in_thread;
+        extend_connectome( connectome, conns_in_thread );
       }
     }
 
@@ -1179,7 +1179,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome << conns_in_thread;
+        extend_connectome( connectome, conns_in_thread );
       }
     }
     return;
@@ -1230,7 +1230,7 @@ nest::ConnectionManager::get_connections(
 #ifdef _OPENMP
 #pragma omp critical( get_connections )
 #endif
-        connectome << conns_in_thread;
+        extend_connectome( connectome, conns_in_thread );
       }
     }
     return;


### PR DESCRIPTION
This PR fixes an incompatibility with the K compiler as discussed in #581.
I suggest @janhahne and @JanneM as reviewers.