### PR TITLE
Rename DataConnect related functions

### DIFF
--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -173,16 +173,27 @@ public:
   void subnet_connect( Subnet&, Subnet&, int, index syn );
 
   /**
-   * Connect from an array of dictionaries.
+   * Connect, using a dictionary with arrays.
+   * The connection rule is based on the details of the dictionary entries
+   * source and target.
+   * If source and target are both either a GID or a list of GIDs with equal
+   * size, then source and target are connected one-to-one.
+   * If source is a gid and target is a list of GIDs then the sources is
+   * connected to all targets.
+   * If source is a list of GIDs and target is a GID, then all sources are
+   * connected to the target.
+   * At this stage, the task of connect is to separate the dictionary into one
+   * for each thread and then to forward the connect call to the connectors who
+   * can then deal with the details of the connection.
    */
-  bool connect( ArrayDatum& connectome );
+  bool data_connect_connectome( const ArrayDatum& connectome );
 
   /**
    * Connect one source node with many targets.
-   * The dictionary d contains arrays for all the connections of type syn.
-   * AKA DataConnect
+   * The dictionary d contains arrays for all the outgoing connections of type
+   * syn.
    */
-  void divergent_connect( index s, DictionaryDatum d, index syn );
+  void data_connect_single( const index s, DictionaryDatum d, const index syn );
 
   // aka conndatum GetStatus
   DictionaryDatum

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -785,7 +785,7 @@ NestModule::DataConnect_i_D_sFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 3 );
 
-  index source = getValue< long >( i->OStack.pick( 2 ) );
+  const index source = getValue< long >( i->OStack.pick( 2 ) );
   DictionaryDatum params = getValue< DictionaryDatum >( i->OStack.pick( 1 ) );
   const Name synmodel_name = getValue< std::string >( i->OStack.pick( 0 ) );
 
@@ -795,7 +795,8 @@ NestModule::DataConnect_i_D_sFunction::execute( SLIInterpreter* i ) const
     throw UnknownSynapseType( synmodel_name.toString() );
   const index synmodel_id = static_cast< index >( synmodel );
 
-  kernel().connection_manager.divergent_connect( source, params, synmodel_id );
+  kernel().connection_manager.data_connect_single(
+    source, params, synmodel_id );
 
   ALL_ENTRIES_ACCESSED(
     *params, "Connect", "The following synapse parameters are unused: " );
@@ -840,9 +841,9 @@ void
 NestModule::DataConnect_aFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 1 );
-  ArrayDatum connectome = getValue< ArrayDatum >( i->OStack.top() );
+  const ArrayDatum connectome = getValue< ArrayDatum >( i->OStack.top() );
 
-  kernel().connection_manager.connect( connectome );
+  kernel().connection_manager.data_connect_connectome( connectome );
   i->OStack.pop();
   i->EStack.pop();
 }


### PR DESCRIPTION
This PR proposes to rename the functions used only by `DataConnect`, since the previous names (`divergent_connect`, `connect`) were rather confusing considering the NewConnect framework. The names are only suggestions, and I am happy to hear other (better) ideas.
I propose @hannahbos and @heplesser as reviewers.