### PR TITLE
Fixed desynchronization of MPI processes due to waveform relaxation (issue #600)

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -713,6 +713,32 @@ nest::MPIManager::grng_synchrony( unsigned long process_rnd_number )
   return true;
 }
 
+// wfr_synchrony: called at the beginning of each simulate
+bool
+nest::MPIManager::wfr_synchrony( bool any_node_uses_wfr )
+{
+  if ( get_num_processes() > 1 )
+  {
+    std::vector< char > wfr( get_num_processes() );
+    MPI_Allgather( &any_node_uses_wfr,
+      1,
+      MPI_CHAR,
+      &wfr[ 0 ],
+      1,
+      MPI_CHAR,
+      comm );
+    // check if any MPI process uses wfr
+    for ( unsigned int i = 0; i < wfr.size(); ++i )
+    {
+      if ( wfr[ i ] )
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // average communication time for a packet size of num_bytes using Allgather
 double
 nest::MPIManager::time_communicate( int num_bytes, int samples )

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -720,13 +720,8 @@ nest::MPIManager::wfr_synchrony( bool any_node_uses_wfr )
   if ( get_num_processes() > 1 )
   {
     std::vector< char > wfr( get_num_processes() );
-    MPI_Allgather( &any_node_uses_wfr,
-      1,
-      MPI_CHAR,
-      &wfr[ 0 ],
-      1,
-      MPI_CHAR,
-      comm );
+    MPI_Allgather(
+      &any_node_uses_wfr, 1, MPI_CHAR, &wfr[ 0 ], 1, MPI_CHAR, comm );
     // check if any MPI process uses wfr
     for ( unsigned int i = 0; i < wfr.size(); ++i )
     {

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -198,6 +198,7 @@ public:
   void test_links();
 
   bool grng_synchrony( unsigned long );
+  bool wfr_synchrony( bool );
 
   /** Benchmark communication time of different MPI methods
    *

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -184,8 +184,6 @@ Node::set_status_base( const DictionaryDatum& dict )
   }
 
   updateValue< bool >( dict, names::frozen, frozen_ );
-
-  updateValue< bool >( dict, names::node_uses_wfr, node_uses_wfr_ );
 }
 
 /**

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -843,6 +843,12 @@ NodeManager::finalize_nodes()
 }
 
 void
+NodeManager::set_any_node_uses_wfr( bool uses_wfr )
+{
+  any_node_uses_wfr_ = uses_wfr;
+}
+
+void
 NodeManager::print( index p, int depth )
 {
   Subnet* target = dynamic_cast< Subnet* >( get_node( p ) );

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -208,11 +208,11 @@ public:
    * Returns if any node uses waveform relaxation
    */
   bool any_node_uses_wfr() const;
-  
+
   /**
    * Allows to set any_node_uses_wfr_
    */
-  void set_any_node_uses_wfr( bool ); 
+  void set_any_node_uses_wfr( bool );
 
   /**
    * Iterator pointing to beginning of process-local nodes.

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -205,9 +205,14 @@ public:
   void finalize_nodes();
 
   /**
-   *
+   * Returns if any node uses waveform relaxation
    */
   bool any_node_uses_wfr() const;
+  
+  /**
+   * Allows to set any_node_uses_wfr_
+   */
+  void set_any_node_uses_wfr( bool ); 
 
   /**
    * Iterator pointing to beginning of process-local nodes.

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -526,11 +526,11 @@ nest::SimulationManager::prepare_simulation_()
   kernel().connection_manager.update_delay_extrema_();
   kernel().event_delivery_manager.init_moduli();
 
-  // Check for synchronicity of global rngs over processes.
-  // We need to do this ahead of any simulation in case random numbers
-  // have been consumed on the SLI level.
   if ( kernel().mpi_manager.get_num_processes() > 1 )
   {
+	// Check for synchronicity of global rngs over processes.
+    // We need to do this ahead of any simulation in case random numbers
+    // have been consumed on the SLI level.  
     if ( !kernel().mpi_manager.grng_synchrony(
            kernel().rng_manager.get_grng()->ulrand( 100000 ) ) )
     {
@@ -540,6 +540,12 @@ nest::SimulationManager::prepare_simulation_()
         "simulation." );
       throw KernelException();
     }
+	
+	// Check if any MPI process uses waveform relaxation and set
+	// kernel().node_manager.any_node_uses_wfr() correspondingly
+	kernel().node_manager.set_any_node_uses_wfr ( 
+	   kernel().mpi_manager.wfr_synchrony( 
+	       kernel().node_manager.any_node_uses_wfr() ) );
   }
 
   // if at the beginning of a simulation, set up spike buffers

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -528,9 +528,9 @@ nest::SimulationManager::prepare_simulation_()
 
   if ( kernel().mpi_manager.get_num_processes() > 1 )
   {
-	// Check for synchronicity of global rngs over processes.
+    // Check for synchronicity of global rngs over processes.
     // We need to do this ahead of any simulation in case random numbers
-    // have been consumed on the SLI level.  
+    // have been consumed on the SLI level.
     if ( !kernel().mpi_manager.grng_synchrony(
            kernel().rng_manager.get_grng()->ulrand( 100000 ) ) )
     {
@@ -540,12 +540,12 @@ nest::SimulationManager::prepare_simulation_()
         "simulation." );
       throw KernelException();
     }
-	
-	// Check if any MPI process uses waveform relaxation and set
-	// kernel().node_manager.any_node_uses_wfr() correspondingly
-	kernel().node_manager.set_any_node_uses_wfr ( 
-	   kernel().mpi_manager.wfr_synchrony( 
-	       kernel().node_manager.any_node_uses_wfr() ) );
+
+    // Check if any MPI process uses waveform relaxation and set
+    // kernel().node_manager.any_node_uses_wfr() correspondingly
+    kernel().node_manager.set_any_node_uses_wfr(
+      kernel().mpi_manager.wfr_synchrony(
+        kernel().node_manager.any_node_uses_wfr() ) );
   }
 
   // if at the beginning of a simulation, set up spike buffers


### PR DESCRIPTION
This PR fixes issue #600 and disables the possibility to set `node_uses_wfr`. 

Since there is no `MPI_BOOL` i used `MPI_CHAR` instead. This needs careful review and maybe some improvements. I suggest @heplesser and @jakobj as reviewers.