### PR TITLE
Add topology directory to ALL_INCLUDES (fixes #605)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ set( ALL_INCLUDES_tmp
   "${PROJECT_BINARY_DIR}/libnestutil"
   "${PROJECT_SOURCE_DIR}/librandom"
   "${PROJECT_SOURCE_DIR}/sli"
+  "${PROJECT_SOURCE_DIR}/topology"
   "${PROJECT_SOURCE_DIR}/nestkernel"
   "${PROJECT_SOURCE_DIR}/nest"
   "${LTDL_INCLUDE_DIRS}"


### PR DESCRIPTION
This PR adds the `topology` directory to the `ALL_INCLUDES` CMake variable, so that it is reported by `nest-config --includes`.  This is required so that users can add topology components such as parameter classes, masks and kernels.