### PR TITLE
Fix #375 installation documentation update

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,25 +12,22 @@ NEST is installed with `cmake` (at least v2.8.12). In the simplest case, the com
     make install
 
 should build and install NEST to <install-path>. Detailed installation 
-instructions can be found below.
+instructions can be found below, including instructions for macOS, BlueGene/Q
+and Fujitsu Sparc64 systems.
 
 Choice of CMake Version
 =======================
 
-We recommend to use `cmake` v3.4, even though installing NEST with
+We recommend to use `cmake` v3.4 or later, even though installing NEST with
 `cmake` v2.8.12 will in most cases work properly.
 For more detailed information please see below: `Python3 Binding (PyNEST)`
 
 Choice of compiler
 ==================
 
-NEST has successfully been compiled with a range of compilers, including
-GNU gcc/g++, Intel icc/icpc, Pathscale, Portland and IBM compilers.
-
-One caveat: you should compile NEST with the same compiler and version as
-your Python. Strange crashes have been observed on importing NEST when
-compiling NEST with g++ 4.3 or later on OSX and importing it into Python
-compiled with the standard gcc 4.0 compiler.
+The default compiler for NEST is GNU gcc/g++, but NEST has also successfully 
+been compiled with other compilers, including Intel icc/icpc, Pathscale, 
+Portland and IBM compilers.
 
 To select a specific compiler, please add the following flags to your `cmake`
 line:
@@ -158,6 +155,25 @@ and its corresponding libraries correctly. To circumvent such a problem followin
         -DPYTHON_INCLUDE_DIR=/usr/include/python3.4 \
         -DPYTHON_INCLUDE_DIR2=/usr/include/x86_64-linux-gnu/python3.4m \
         </path/to/NEST/src>
+        
+Compiling for Apple OSX/macOS
+=============================
+
+NEST can currently not be compiled with the clang/clang++ compilers shipping
+with macOS. Therefore, you first need to install GCC 6.3 or later. The easiest
+way to install all required software is using Homebrew (from http://brew.sh).
+
+  brew install gcc cmake gsl open-mpi libtool
+  
+will install all required prequisites. You can then configure NEST with 
+
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+        -DCMAKE_C_COMPILER=gcc-6\
+        -DCMAKE_CXX_COMPILER=g++-6 \
+        </path/to/NEST/src>
+
+For detailed information on installing NEST under OSX/macOS, please see the
+"macOS" section of http://www.nest-simulator.org/installation.
 
 Compiling for BlueGene/Q
 ========================

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -195,10 +195,10 @@ package manager:
     2.  For information on what options NEST has and what will be installed,
         run `brew info nest`
         
-    3.  To install nest, execute 'brew install nest'
+    3.  To install nest, execute `brew install nest`
 
 Options have to be appended, e.g. to install NEST with PyNEST run
-brew install nest --with-python`.
+brew install nest `--with-python`.
 
 ### Manual installation
 
@@ -220,7 +220,7 @@ for information when using MacPorts.
 
 3.  Install dependencies via Homebrew
 
-    brew install gcc cmake gsl open-mpi libtool
+     brew install gcc cmake gsl open-mpi libtool
 
 4.  Create a directory for building and installing NEST (you should always build
     NEST outside the source code directory; installing NEST in a "place of its
@@ -236,14 +236,14 @@ for information when using MacPorts.
 
 6.  Configure and build NEST inside the build directory:
 
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
-          -DCMAKE_C_COMPILER=gcc-6 \
-          -DCMAKE_CXX_COMPILER=g++-6 \
-          </path/to/NEST/src>
+     cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+           -DCMAKE_C_COMPILER=gcc-6 \
+           -DCMAKE_CXX_COMPILER=g++-6 \
+           </path/to/NEST/src>
 
-    make -j4         # -j4 builds in parallel using 4 processes
-    make install
-    make installcheck
+     make -j4         # -j4 builds in parallel using 4 processes
+     make install
+     make installcheck
 
 To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
 

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -1,18 +1,14 @@
 # Installation
 
-These installation instructions are for NEST 2.12 and later as well as the
-most recent version obtained from [Github](https://github.com/nest/nest-simulator). 
-Installation instructions for NEST 2.10 and earlier are provided 
-[below](#instructions-for-nest-2-10-and-earlier).
+These installation instructions are for NEST 2.12 and later as well as the most recent version obtained from [Github](https://github.com/nest/nest-simulator). 
+
+Installation instructions for NEST 2.10 and earlier are provided [below](#instructions-for-nest-2-10-and-earlier).
 
 ## Introduction
 
-NEST compiles and runs on most Unix-like operating systems. 
-The installation instructions here should work on recent versions of Ubuntu or 
-Debian, while additional instructions for 
-[OS X/macOS are given below](#mac-os-x). 
-For more generic installation instructions, see the `INSTALL` file in the top source
-directory. For using NEST on Microsoft Windows, see [below](#windows).
+NEST compiles and runs on most Unix-like operating systems. The installation instructions here should work on recent versions of Ubuntu or Debian, while additional instructions for [OS X/macOS are given below](#mac-os-x). 
+
+For more generic installation instructions, see the `INSTALL` file in the top source directory. For using NEST on Microsoft Windows, see [below](#windows).
 
 Following are the basic steps to compile and install NEST from source code:
 
@@ -28,70 +24,40 @@ additional `cmake` options as needed (see `INSTALL` file)
 1.  See the [Getting started](getting-started.md) pages to
     find out how to get going with NEST
 
-Please see the sections on [minimal](#minimal-configuration) and
-[standard configuration](#standard-configuration)
-below for details.
+Please see the sections on [minimal](#minimal-configuration) and [standard configuration](#standard-configuration) below for details.
 
 ## What gets installed where
 
-By default, everything will be installed to the subdirectories
-`/install/path/{bin,lib,share}`, where `/install/path` is the install path given to `cmake`:
+By default, everything will be installed to the subdirectories `/install/path/{bin,lib,share}`, where `/install/path` is the install path given to `cmake`:
 
-Executables   
-`/install/path/bin`
+- Executables `/install/path/bin`
+- Dynamic libraries `/install/path/lib/`
+- SLI libraries `/install/path/share/nest/sli`
+- Documentation `/install/path/share/doc/nest`
+- Examples `/install/path/share/doc/nest/examples`
+- PyNEST `/install/path/lib/pythonX.Y/site-packages/nest`
+- PyNEST examples `/install/path/share/doc/nest/examples/pynest`
+- Extras `/install/path/share/nest/extras/`
 
-Dynamic libraries   
-`/install/path/lib/`
-
-SLI libraries   
-`/install/path/share/nest/sli`
-
-Documentation   
-`/install/path/share/doc/nest`
-
-Examples   
-`/install/path/share/doc/nest/examples`
-
-PyNEST   
-`/install/path/lib/pythonX.Y/site-packages/nest`
-
-PyNEST examples   
-`/install/path/share/doc/nest/examples/pynest`
-
-Extras   
-`/install/path/share/nest/extras/`
-
-If you want to run the `nest` executable or use the `nest` Python module without
-providing explicit paths, you have to add the installation directory to your
-search paths. For example, if you are using bash:
+If you want to run the `nest` executable or use the `nest` Python module without providing explicit paths, you have to add the installation directory to your search paths. For example, if you are using bash:
 
     export PATH=$PATH:/install/path/bin
     export PYTHONPATH=/install/path/lib/pythonX.Y/site-packages:$PYTHONPATH
 
+The script `/install/path/bin/nest_vars.sh` can be sourced in `.bashrc` and will set these paths for you. This also allows to switch between NEST installations in a convenient manner.
+
+
 ## Dependencies
 
-NEST needs a few third party tools and libraries to work. On many operating
-systems, these can be installed using a *package manager* such as `apt` or `brew` 
-(see [Standard configuration](#standard-configuration)).
+NEST needs a few third-party tools and libraries to work. On many operating systems, these can be installed using a *package manager* such as `apt` or `brew` (see [Standard configuration](#standard-configuration)).
 
-To build NEST, you need recent versions of [CMake](http://cmake.org) and
-[libtool](https://www.gnu.org/software/libtool/libtool.html); the latter
-should be available for most systems and is probably already installed.
+To build NEST, you need recent versions of [CMake](https://cmake.org) and [libtool](https://www.gnu.org/software/libtool/libtool.html); the latter should be available for most systems and is probably already installed.
 
-The [GNU readline library](http://www.gnu.org/software/readline/) is recommended
-if you use NEST interactively without Python. Although most Linux distributions
-have GNU readline installed, you still need to install its development package
-if want to use GNU readline with NEST. GNU readline itself depends on
-[libncurses](http://www.gnu.org/software/ncurses/) (or libtermcap on older
-systems). Again, the development packages are needed to compile NEST.
+The [GNU readline library](http://www.gnu.org/software/readline/) is recommended if you use NEST interactively without Python. Although most Linux distributions have GNU readline installed, you still need to install its development package if want to use GNU readline with NEST. GNU readline itself depends on [libncurses](http://www.gnu.org/software/ncurses/) (or libtermcap on older systems). Again, the development packages are needed to compile NEST.
 
-The [GNU Scientific Library](http://www.gnu.org/software/gsl/) is needed by
-several neuron models, in particular those with conductance based synapses. If
-you want these models, please install the GNU Scientific Library along with its
-development packages. 
+The [GNU Scientific Library](http://www.gnu.org/software/gsl/) is needed by several neuron models, in particular those with conductance based synapses. If you want these models, please install the GNU Scientific Library along with its development packages. 
 
-If you want to use PyNEST, we recommend to install the following along with
-their development packages:
+If you want to use PyNEST, we recommend to install the following along with their development packages:
 
 - [Python](http://www.python.org)
 - [NumPy](http://www.scipy.org)
@@ -102,15 +68,12 @@ their development packages:
 
 ## Minimal configuration
 
-NEST can be compiled without any external packages; such a configuration may be
-useful e.g. for initial porting to a new supercomputer. However, this implies
-several restrictions: First, some neuron and synapse models will not be
-available, as they depend on ODE solvers from the GNU Scientific Library.
-Second, the Python extension will not be available, and third, multi-threading
-and parallel computing facilities will be disabled.
+NEST can be compiled without any external packages; such a configuration may be useful e.g. for initial porting to a new supercomputer. However, this implies several restrictions: 
 
-To configure NEST for compilation without external packages, use the following 
-command line:
+- Some neuron and synapse models will not be available, as they depend on ODE solvers from the GNU Scientific Library.
+- The Python extension will not be available, and third, multi-threading and parallel computing facilities will be disabled.
+
+To configure NEST for compilation without external packages, use the following  command line:
 
     cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
           -Dwith-python=OFF \
@@ -122,8 +85,7 @@ command line:
           
 ## Standard configuration
 
-To install the packages required for the standard installation use the following
-command line:
+To install the packages required for the standard installation use the following command line:
 
     sudo apt-get install -y build-essential cmake libltdl7-dev libreadline6-dev \
     libncurses5-dev libgsl0-dev python-all-dev python-numpy python-scipy \ 
@@ -137,9 +99,7 @@ Then configure NEST using:
 
 ## Choice of compiler
 
-Most NEST developers use the GNU gcc/g++ compilers. We also regularly compile 
-NEST using the IBM xlc/xlC compilers. You can find the version of your compiler 
-by, e.g.,
+Most NEST developers use the GNU gcc/g++ compilers. We also regularly compile NEST using the IBM xlc/xlC compilers. You can find the version of your compiler by, e.g.,
 
     g++ -v
 
@@ -148,83 +108,66 @@ by, e.g.,
 
 NEST has reasonable default compiler options for the most common compilers.
 
-When compiling with the Portland compiler, use the `-Kieee` flag to ensure that 
-computations obey the IEEE754 standard for floating point numerics.
+When compiling with the Portland compiler, use the `-Kieee` flag to ensure that computations obey the IEEE754 standard for floating point numerics.
 
 ## Configuration options
 
-If you need special features, e.g., support for 
-[distributed computing](parallel-computing.md), please see the `INSTALL` file 
-in the main source code directory for available options.
+If you need special features, e.g., support for [distributed computing](parallel-computing.md), please see the `INSTALL` file in the main source code directory for available options.
 
 ### Set up the integrated helpdesk
 
-The command `helpdesk` needs to know which browser to launch in order to display
-the help pages. The browser is set as an option of `helpdesk`. Please see the
-file `~/.nestrc` for an example setting `firefox` as browser. Please note that
-the command `helpdesk` does not work if you have compiled NEST with MPI support,
-but you have to enter the address of the helpdesk
-(`file:///install/path/share/doc/nest/index.html`) manually into the browser.
-Please replace `/install/path` with the path under which NEST is installed.
+The command `helpdesk` needs to know which browser to launch in order to display the help pages. The browser is set as an option of `helpdesk`. Please see the file `~/.nestrc` for an example setting `firefox` as browser. Please note that the command `helpdesk` does not work if you have compiled NEST with MPI support, but you have to enter the address of the helpdesk (`file:///install/path/share/doc/nest/index.html`) manually into the browser. Please replace `/install/path` with the path under which NEST is installed.
 
 ### Tell NEST about your MPI setup
 
-If you compiled NEST with support for distributed computing via MPI, you have
-to tell it how your`mpirun`/`mpiexec` command works by defining the function
-mpirun in your `~/.nestrc` file. This file already contains an example
-implementation that should work with [OpenMPI](http://www.openmpi.org/).
+If you compiled NEST with support for distributed computing via MPI, you have to tell it how your`mpirun`/`mpiexec` command works by defining the function mpirun in your `~/.nestrc` file. This file already contains an example implementation that should work with [OpenMPI](http://www.openmpi.org/).
 
 ## Mac OS X
 
-On the Mac, you can install NEST either via Homebrew or manually. 
-If you want to use PyNEST, you need to have a version of Python with some 
-science packages installed, see the 
-[section Python on Mac](#python-on-mac) for details. 
+On the Mac, you can install NEST either via Homebrew or manually. If you want to use PyNEST, you need to have a version of Python with some science packages installed, see the [section Python on Mac](#python-on-mac) for details. 
 
 ### Installation via Homebrew
 
-The easiest way to install NEST on a Mac is to install it via the Homebrew
-package manager:
+The easiest way to install NEST on a Mac is to install it via the Homebrew package manager:
 
 1.  To install homebrew, follow the instructions at [brew.sh](http://brew.sh/)
 
 2.  Then, in a terminal
 
-    1.  Add the homebrew/science tap by running `brew tap homebrew/science`
+    1.  Add the homebrew/science tap by running 
+    
+        `brew tap homebrew/science`
     
     2.  For information on what options NEST has and what will be installed,
-        run `brew info nest`
+        run 
         
-    3.  To install nest, execute `brew install nest`
+        `brew info nest`
+        
+    3.  To install nest, execute 
+    
+        `brew install nest`
 
 Options have to be appended, e.g. to install NEST with PyNEST run
-brew install nest `--with-python`.
+
+    brew install nest --with-python
 
 ### Manual installation
 
-The clang/clang++ compiler that ships with OS X/macOS does not support OpenMP
-threads and creates code that fails some tests. You therefore need to use GCC 
-to compile NEST under OS X/macOS.
+The clang/clang++ compiler that ships with OS X/macOS does not support OpenMP threads and creates code that fails some tests. You therefore need to use GCC to compile NEST under OS X/macOS.
 
-Installation instructions here have been tested under OS X 10.11 *El Capitan* 
-and macOS 10.12 *Sierra* with [Anaconda Python 2 and 3](https://www.continuum.io/anaconda-overview)
-and all other dependencies installed via [Homebrew](http://brew.sh). See below
-for information when using MacPorts.
+Installation instructions here have been tested under OS X 10.11 *El Capitan* and macOS 10.12 *Sierra* with [Anaconda Python 2 and 3](https://www.continuum.io/anaconda-overview) and all other dependencies installed via [Homebrew](http://brew.sh). See below for information when using MacPorts.
 
 1.  Install Xcode from the AppStore.
 
-2.  Install the Xcode command line tools by executing the following line in the
-    Terminal and following the instructions in the windows that will pop up
+2.  Install the Xcode command line tools by executing the following line in the Terminal and following the instructions in the windows that will pop up
 
         xcode-select --install
 
 3.  Install dependencies via Homebrew
 
-     brew install gcc cmake gsl open-mpi libtool
+        brew install gcc cmake gsl open-mpi libtool
 
-4.  Create a directory for building and installing NEST (you should always build
-    NEST outside the source code directory; installing NEST in a "place of its
-    own" makes it easy to remove NEST later).
+4.  Create a directory for building and installing NEST (you should always build NEST outside the source code directory; installing NEST in a "place of its own" makes it easy to remove NEST later).
 
 5.  Extract the NEST tarball as a subdirectory in that directory or clone NEST from Github into a subdirectory. 
 
@@ -236,91 +179,71 @@ for information when using MacPorts.
 
 6.  Configure and build NEST inside the build directory:
 
-     cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
-           -DCMAKE_C_COMPILER=gcc-6 \
-           -DCMAKE_CXX_COMPILER=g++-6 \
-           </path/to/NEST/src>
-
-     make -j4         # -j4 builds in parallel using 4 processes
-     make install
-     make installcheck
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+              -DCMAKE_C_COMPILER=gcc-6 \
+              -DCMAKE_CXX_COMPILER=g++-6 \
+              </path/to/NEST/src>
+  
+        make -j4         # -j4 builds in parallel using 4 processes
+        make install
+        make installcheck
 
 To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
 
 #### Manual installation with dependencies from MacPorts
 
-The following should work if you install dependencies using MacPorts (only
-steps that differ from the instructions above are shown):
+The following should work if you install dependencies using MacPorts (only steps that differ from the instructions above are shown):
 
 3. Install dependencies via MacPorts
 
-    sudo port install gcc6 cmake gsl openmpi-default libtool python27 py27-cython py27-nose doxygen
+        sudo port install gcc6 cmake gsl openmpi-default libtool \
+        python27 py27-cython py27-nose doxygen
     
 6. Configure and build NEST inside the build directory:
 
-    cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
-          -DPYTHON_LIBRARY=/opt/local/lib/libpython2.7.dylib \
-          -DPYTHON_INCLUDE_DIR=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 \
-          -DCMAKE_C_COMPILER=/opt/local/bin/gcc-mp-6 \
-          -DCMAKE_CXX_COMPILER=/opt/local/bin/g++-mp-6 \
-          </path/to/NEST/src>
-
-    make -j4         # -j4 builds in parallel using 4 processes
-    make install
-    make installcheck
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+              -DPYTHON_LIBRARY=/opt/local/lib/libpython2.7.dylib \ 
+              -DPYTHON_INCLUDE_DIR=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 \
+              -DCMAKE_C_COMPILER=/opt/local/bin/gcc-mp-6 \
+              -DCMAKE_CXX_COMPILER=/opt/local/bin/g++-mp-6 \
+              </path/to/NEST/src>
+  
+        make -j4         # -j4 builds in parallel using 4 processes
+        make install
+        make installcheck
 
 To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
 
 
 ### Python on Mac
 
-The version of Python shipping with OS X/macOS is rather dated and does not
-include key packages such as NumPy. Therefore, you need to install Python via
-a channel that provides scientific packages.
+The version of Python shipping with OS X/macOS is rather dated and does not include key packages such as NumPy. Therefore, you need to install Python via a channel that provides scientific packages.
 
-One well-tested source is the [Anaconda](https://www.continuum.io/anaconda-overview) 
-Python distribution for both Python 2 and 3. If you do not want to install the
-full Anaconda distribution, you can also install [Miniconda](http://conda.pydata.org/miniconda.html)
-and then install the packages needed by NEST by running
+One well-tested source is the [Anaconda](https://www.continuum.io/anaconda-overview) Python distribution for both Python 2 and 3. If you do not want to install the full Anaconda distribution, you can also install [Miniconda](http://conda.pydata.org/miniconda.html) and then install the packages needed by NEST by running
 
-    conda install numpy scipy matplotlib ipython cython nose
+        conda install numpy scipy matplotlib ipython cython nose
 
-Alternatively, you should be able to install the necessary Python packages via Homebrew, but
-this has not been tested.
+Alternatively, you should be able to install the necessary Python packages via Homebrew, but this has not been tested.
 
 ## Troubleshooting
 
-If your operating system does not find the `nest` executable or Python does not
-find the `nest` module, your path variables may not be set correctly. This may
-also be the case if Python cannot load the `nest` module due to missing or
-incompatible libraries. In this case, please run
+If your operating system does not find the `nest` executable or Python does not find the `nest` module, your path variables may not be set correctly. This may also be the case if Python cannot load the `nest` module due to missing or incompatible libraries. In this case, please run
 
-    source </path/to/nest_install_dir>/bin/nest_vars.sh
+        source </path/to/nest_install_dir>/bin/nest_vars.sh
 
-to set the necessary environment variables. You may want to include this line
-in your `.bashrc` file, so that the environment variables are set automatically.
+to set the necessary environment variables. You may want to include this line in your `.bashrc` file, so that the environment variables are set automatically.
 
 ## Windows
 
-Windows and Linux differ considerably. This is the reason why it is difficult
-to compile NEST natively under Windows. However, it is still possible to use
-NEST under Windows using one of the following methods:
+Windows and Linux differ considerably. This is the reason why it is difficult to compile NEST natively under Windows. However, it is still possible to use NEST under Windows using one of the following methods:
 
 ### Virtual Machines
 
-A virtual machine is a software that lets you use Linux on top of Windows.
-Popular virtual machine packages are [VirtualBox](http://www.virtualbox.org) 
-and [VMWare](http://www.vmware.com). Once you have installed a virtual machine
-package, you can [download OVA images containing NEST](download.md) and import
-them into your virtual machine. 
+A virtual machine is a software that lets you use Linux on top of Windows. Popular virtual machine packages are [VirtualBox](http://www.virtualbox.org) and [VMWare](http://www.vmware.com). Once you have installed a virtual machine package, you can [download OVA images containing NEST](download.md) and import them into your virtual machine. 
 
 ### Cygwin
 
-Cywin is a software layer which emulates Unix system calls. NEST should compile
-and install under Cygwin with the generic installation instructions, but we have 
-not tested this for a long time and do not support NEST under Cygwin at present.
-Compilation under Cygwin is very slow, but the execution times are comparable
-to an equivalent Linux installation.
+Cywin is a software layer which emulates Unix system calls. NEST should compile and install under Cygwin with the generic installation instructions, but we have not tested this for a long time and do not support NEST under Cygwin at present. Compilation under Cygwin is very slow, but the execution times are comparable to an equivalent Linux installation.
 
 
 ## Instructions for NEST 2.10 and earlier
@@ -470,32 +393,3 @@ need to deactivate/uninstall the conflicting MPI installation. It is
 unfortunately not trivial to ignore other MPI installations. One brutal
 work-around is to edit the `nest/Makefile,` in the build directory and add
 `-L/usr/lib` before all other `-L` options in the line building NEST.
-
-#### Compilation issues
-
-If building NEST with PyNEST and you get an error message like this while
-compiling PyNEST,
-
-    g++ -arch ppc -arch i386 -isysroot /Developer/SDKs/MacOSX10.4u.sdk -g
-    -bundle -undefined dynamic_lookup /temp/safari/nest-1.9.8316/pynest/
-    build/temp.macosx-10.3-fat-2.6/temp/safari/nest-1.9.8316/pynest/
-
-    [snip]
-
-    nest-1.9.8316/pynest/build/lib.macosx-10.3-fat-2.6/nest/
-    pynestkernel.so -Wl,-rpath,/usr/local/lib/nest
-    ld: -rpath can only be used when targeting Mac OS X 10.5 or later
-    collect2: ld returned 1 exit status
-    ld: -rpath can only be used when targeting Mac OS X 10.5 or later
-    collect2: ld returned 1 exit status
-    lipo: can't open input file: /var/folders/Sg/SgWx-i0h2RWLn++8ZRFtG+++
-    +TY/-Tmp-//ccKGzq7b.out (No such file or directory)
-    error: command 'g++' failed with exit status 1
-    make[1]: *** [all] Error 1
-    make: *** [all-recursive] Error 1
-
-please try making NEST as follows:
-
-    env MACOSX_DEPLOYMENT_TARGET=10.5 make
-
-Thanks to Harold Gutch for this hint.

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -3,88 +3,80 @@
 These installation instructions are for NEST 2.12 and later as well as the
 most recent version obtained from [Github](https://github.com/nest/nest-simulator). 
 Installation instructions for NEST 2.10 and earlier are provided 
-[below](installation.md#instructions-for-nest-2.10-and-earlier).
+[below](#instructions-for-nest-2.10-and-earlier).
 
 ## Introduction
 
 NEST compiles and runs on most Unix-like operating systems. 
 The installation instructions here should work on recent versions of Ubuntu or 
 Debian, while additional instructions for 
-[OSX/macOS are given below](installation.md#macos). 
-For more generic installation instructions, `INSTALL` file in the top source
-directory. For using NEST on Microsoft Windows, see [below](installation.md#windows).
+[OS X/macOS are given below](#macos). 
+For more generic installation instructions, see the `INSTALL` file in the top source
+directory. For using NEST on Microsoft Windows, see [below](#windows).
 
 Following are the basic steps to compile and install NEST from source code:
 
 1.  [Download NEST](download.md)
-
-2.  Unpack the tarball: `tar -xzvf nest-x.y.z.tar.gz`
-
-3.  Create a build directory: `mkdir nest-x.y.z-build`
-
-4.  Change to the build directory: `cd nest-x.y.z-build`
-
-5.  Configure NEST: `cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> </path/to/NEST/src>` with
+1.  Unpack the tarball: `tar -xzvf nest-x.y.z.tar.gz`
+1.  Create a build directory: `mkdir nest-x.y.z-build`
+1.  Change to the build directory: `cd nest-x.y.z-build`
+1.  Configure NEST: `cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> </path/to/NEST/src>` with
 additional `cmake` options as needed (see `INSTALL` file)
-
-6.  Compile by running `make `
-
-7.  Install by running `make install`
-
-8.  Run tests by running `make installcheck
-
-8.  See the [Getting started](getting-started.md) pages to
+1.  Compile by running `make`
+1.  Install by running `make install`
+1.  Run tests by running `make installcheck`
+1.  See the [Getting started](getting-started.md) pages to
     find out how to get going with NEST
 
-Please see the sections on [minimal](installation.md#minimal-configuration) and
-[standard configuration](installation.md#standard-configuration)
+Please see the sections on [minimal](#minimal-configuration) and
+[standard configuration](#standard-configuration)
 below for details.
 
 ## What gets installed where
 
 By default, everything will be installed to the subdirectories
-`$PREFIX/{bin,lib,share}`, where `$PREFIX` is the install path given to `cmake:
+`/install/path/{bin,lib,share}`, where `/install/path` is the install path given to `cmake`:
 
 Executables   
-`$PREFIX/bin`
+`/install/path/bin`
 
 Dynamic libraries   
-`$PREFIX/lib/`
+`/install/path/lib/`
 
 SLI libraries   
-`$PREFIX/share/nest/sli`
+`/install/path/share/nest/sli`
 
 Documentation   
-`$PREFIX/share/doc/nest`
+`/install/path/share/doc/nest`
 
 Examples   
-`$PREFIX/share/doc/nest/examples`
+`/install/path/share/doc/nest/examples`
 
 PyNEST   
-`$PREFIX/lib/pythonX.Y/site-packages/nest`
+`/install/path/lib/pythonX.Y/site-packages/nest`
 
 PyNEST examples   
-`$PREFIX/share/doc/nest/examples/pynest`
+`/install/path/share/doc/nest/examples/pynest`
 
 Extras   
-`$PREFIX/share/nest/extras/`
+`/install/path/share/nest/extras/`
 
 If you want to run the `nest` executable or use the `nest` Python module without
 providing explicit paths, you have to add the installation directory to your
 search paths. For example, if you are using bash:
 
-    export PATH=$PATH:$PREFIX/bin
-    export PYTHONPATH=$PREFIX/lib/pythonX.Y/site-packages:$PYTHONPATH
+    export PATH=$PATH:/install/path/bin
+    export PYTHONPATH=/install/path/lib/pythonX.Y/site-packages:$PYTHONPATH
 
 ## Dependencies
 
 NEST needs a few third party tools and libraries to work. On many operating
 systems, these can be installed using a *package manager* such as `apt` or `brew` 
-(see [Standard configuration](installation.md#standard-configuration)).
+(see [Standard configuration](#standard-configuration)).
 
 To build NEST, you need recent versions of [CMake](http://cmake.org) and
 [libtool](https://www.gnu.org/software/libtool/libtool.html); the latter
-should be available on most systems.
+should be available for most systems and is probably already installed.
 
 The [GNU readline library](http://www.gnu.org/software/readline/) is recommended
 if you use NEST interactively without Python. Although most Linux distributions
@@ -101,24 +93,24 @@ development packages.
 If you want to use PyNEST, we recommend to install the following along with
 their development packages:
 
--   Python (<http://www.python.org/download>)
--   NumPy (<http://www.scipy.org/Download>)
--   SciPy (<http://www.scipy.org/Download>)
--   matplotlib (<http://matplotlib.sourceforge.net/>)
--   IPython (<http://ipython.scipy.org/moin/Download>)
+- [Python](http://www.python.org)
+- [NumPy](http://www.scipy.org)
+- [SciPy](http://www.scipy.org)
+- [matplotlib](http://matplotlib.org)
+- [IPython](http://ipython.org)
 
 
 ## Minimal configuration
 
-NEST can be compiled without any external packages; such configuration may be
+NEST can be compiled without any external packages; such a configuration may be
 useful e.g. for initial porting to a new supercomputer. However, this implies
 several restrictions: First, some neuron and synapse models will not be
-available, as they depend on ODE solvers from the GNU scientific library.
+available, as they depend on ODE solvers from the GNU Scientific Library.
 Second, the Python extension will not be available, and third, multi-threading
 and parallel computing facilities will be disabled.
 
-To compile NEST without external packages, use the following command line to
-configure it:
+To configure NEST for compilation without external packages, use the following 
+command line:
 
     cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
           -Dwith-python=OFF \
@@ -154,8 +146,7 @@ by, e.g.,
 
 ### Compiler-specific options
 
-NEST is pre-configured with a reasonable set of compiler options for the most 
-common compilers.
+NEST has reasonable default compiler options for the most common compilers.
 
 When compiling with the Portland compiler, use the `-Kieee` flag to ensure that 
 computations obey the IEEE754 standard for floating point numerics.
@@ -173,24 +164,22 @@ the help pages. The browser is set as an option of `helpdesk`. Please see the
 file `~/.nestrc` for an example setting `firefox` as browser. Please note that
 the command `helpdesk` does not work if you have compiled NEST with MPI support,
 but you have to enter the address of the helpdesk
-(`file://$PREFIX/share/doc/nest/index.html`) manually into the browser.
-Please replace `$PREFIX` with the prefix you chose during the configuration of
-NEST. If you did not explicitly specify one, it is most likely set to `/usr` or
-`/usr/local` depending on what system you are.
+(`file:///install/path/share/doc/nest/index.html`) manually into the browser.
+Please replace `/install/path` with the path under which NEST is installed.
 
 ### Tell NEST about your MPI setup
 
 If you compiled NEST with support for distributed computing via MPI, you have
 to tell it how your`mpirun`/`mpiexec` command works by defining the function
 mpirun in your `~/.nestrc` file. This file already contains an example
-implementation that should work with [OpenMPI](http://www.openmpi.org/) library.
+implementation that should work with [OpenMPI](http://www.openmpi.org/).
 
 ## Mac OS X
 
-On the Mac, you can install NEST either via Homebrew or manually. If you 
-want to use PyNEST, you need to have a version of Python with some science
-packages installed, see the [section Python on Mac](installation.md#python-on-mac) 
-for details. 
+On the Mac, you can install NEST either via Homebrew or manually. 
+If you want to use PyNEST, you need to have a version of Python with some 
+science packages installed, see the 
+[section Python on Mac](#python-on-mac) for details. 
 
 ### Installation via Homebrew
 
@@ -211,16 +200,16 @@ package manager:
 Options have to be appended, e.g. to install NEST with PyNEST run
 brew install nest --with-python`.
 
-
 ### Manual installation
 
-The clang/clang++ compiler that ships with OSX/macOS does not support OpenMP
+The clang/clang++ compiler that ships with OS X/macOS does not support OpenMP
 threads and creates code that fails some tests. You therefore need to use GCC 
-to compile NEST under OSX/macOS.
+to compile NEST under OS X/macOS.
 
-Installation instructions here have been tested under OSX 10.11 *El Capitan* 
+Installation instructions here have been tested under OS X 10.11 *El Capitan* 
 and macOS 10.12 *Sierra* with [Anaconda Python 2 and 3](https://www.continuum.io/anaconda-overview)
-and all other dependencies installed via [Homebrew](http://brew.sh).
+and all other dependencies installed via [Homebrew](http://brew.sh). See below
+for information when using MacPorts.
 
 1.  Install Xcode from the AppStore.
 
@@ -241,14 +230,14 @@ and all other dependencies installed via [Homebrew](http://brew.sh).
 
         mkdir NEST       # directory for all NEST stuff
         cd NEST
-        tar zxf  nest-2.12.0.tar.gz
+        tar zxf nest-2.12.0.tar.gz
         mkdir bld
         cd bld
 
-6.  Configure and build NEST inside that directory:
+6.  Configure and build NEST inside the build directory:
 
     cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
-          -DCMAKE_C_COMPILER=gcc-6\
+          -DCMAKE_C_COMPILER=gcc-6 \
           -DCMAKE_CXX_COMPILER=g++-6 \
           </path/to/NEST/src>
 
@@ -258,9 +247,34 @@ and all other dependencies installed via [Homebrew](http://brew.sh).
 
 To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
 
+#### Manual installation with dependencies from MacPorts
+
+The following should work if you install dependencies using MacPorts (only
+steps that differ from the instructions above are shown):
+
+3. Install dependencies via MacPorts
+
+    sudo port install gcc6 cmake gsl openmpi-default libtool python27 py27-cython py27-nose doxygen
+    
+6. Configure and build NEST inside the build directory:
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+          -DPYTHON_LIBRARY=/opt/local/lib/libpython2.7.dylib \
+          -DPYTHON_INCLUDE_DIR=/opt/local/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 \
+          -DCMAKE_C_COMPILER=/opt/local/bin/gcc-mp-6 \
+          -DCMAKE_CXX_COMPILER=/opt/local/bin/g++-mp-6 \
+          </path/to/NEST/src>
+
+    make -j4         # -j4 builds in parallel using 4 processes
+    make install
+    make installcheck
+
+To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
+
+
 ### Python on Mac
 
-The version of Python shipping with OSX/macOS is rather dated and does not
+The version of Python shipping with OS X/macOS is rather dated and does not
 include key packages such as NumPy. Therefore, you need to install Python via
 a channel that provides scientific packages.
 
@@ -292,22 +306,13 @@ Windows and Linux differ considerably. This is the reason why it is difficult
 to compile NEST natively under Windows. However, it is still possible to use
 NEST under Windows using one of the following methods:
 
-### Using the NEST LiveCD
-
-This is the easiest way to use NEST without having to install anything on your
-computer. The LiveCD can be used in almost any computer and boots directly into
-a complete Ubuntu system, which already has NEST, Python, and some analysis
-tools installed.
-The CD image is available on the [download page](download.md).
-
 ### Virtual Machines
 
-A virtual machine is a software that lets you use Linux in parallel to Windows.
-We recommend to use VirtualBox, which is free software and can be downloaded
-from <http://www.virtualbox.org/>. Another popular virtual machine software is <http://www.vmware.com/>.
-The easiest way to get started is to download the NEST LiveCD from the [download page](download.md)
-and either just boot the CD image directly or install it into a virtual hard
-disk.
+A virtual machine is a software that lets you use Linux on top of Windows.
+Popular virtual machine packages are [VirtualBox](http://www.virtualbox.org) 
+and [VMWare](http://www.vmware.com). Once you have installed a virtual machine
+package, you can [download OVA images containing NEST](download.md) and import
+them into your virtual machine. 
 
 ### Cygwin
 
@@ -320,11 +325,8 @@ to an equivalent Linux installation.
 
 ## Instructions for NEST 2.10 and earlier
 
-NEST compiles and runs on most Unix-like operating systems including Linux and
-Mac OS X. For using NEST on Microsoft Windows, see [below](installation.md#windows).
-The installation instructions here should work on all recent versions of Debian
-or Ubuntu. For more generic installation instructions, see the files README and
-INSTALL in the top source directory.
+Note: These instructions contain only information on points that differ from
+current versions of NEST.
 
 Following are the basic steps to compile and install NEST from source code:
 
@@ -337,7 +339,7 @@ Following are the basic steps to compile and install NEST from source code:
 4.  Change to the build directory: `cd nest-x.y.z-build`
 
 5.  Configure NEST: `../nest-x.y.z/configure` with appropriate
-     configuration options (**prefix**, etc.)
+     configuration options
 
 6.  Compile by running `make`
 
@@ -346,25 +348,7 @@ Following are the basic steps to compile and install NEST from source code:
 8.  See the [Getting started](getting-started.md) pages to
     find out how to get going with NEST
 
-Please see the sections on [minimal](installation.md#minimal-configuration) and
-[standard configuration](installation.md#standard-configuration)
-below for details.
-
-
 ## Dependencies
-
-NEST needs a few third party tools and libraries to work. On many operating
-systems, these can be installed using a *package manager* like `apt`, `port` or
-`fink`
-(see [Standard configuration](installation.md#standard-configuration)).
-
-If you are building NEST from the SVN sources, you need the GNU autotools
-installed on your system to bootstrap the build system. These consist of
-
--   autoconf
--   automake
--   libtool
--   libltdl
 
 The [GNU readline library](http://www.gnu.org/software/readline/) is recommended
 if you use NEST interactively without Python. Although most Linux distributions
@@ -382,18 +366,18 @@ Scientific Library v1.11 or later.
 If you want to use PyNEST, we recommend to install the following along with
 their development packages:
 
--   Python (<http://www.python.org/download>)
--   NumPy (<http://www.scipy.org/Download>)
--   SciPy (<http://www.scipy.org/Download>)
--   matplotlib (<http://matplotlib.sourceforge.net/>)
--   IPython (<http://ipython.scipy.org/moin/Download>)
+- [Python](http://www.python.org)
+- [NumPy](http://www.scipy.org)
+- [SciPy](http://www.scipy.org)
+- [matplotlib](http://matplotlib.org)
+- [IPython](http://ipython.org)
 
 Additionally, NEST depends on a few POSIX libraries which are usually present
 on all UNIX like operating systems (Linux, Mac OS), so don't worry. But if you
 wonder why NEST is difficult to compile on Windows, it is because of these:
 
--   libpthread, for threading support
--   libregexp, for regular expressions.
+- libpthread, for threading support
+- libregexp, for regular expressions.
 
 ## Minimal configuration
 
@@ -408,7 +392,6 @@ To compile NEST without external packages, use the following command line to
 configure it:
 
     tar -xzvf nest-x.y.z.tar.gz
-
     mkdir nest-x.y.z-build
     cd nest-x.y.z-build
 
@@ -431,157 +414,15 @@ Then configure NEST using:
 
     ../nest-x.y.z/configure --prefix=$HOME/opt/nest
 
-## Choice of compiler
-
-Most NEST developers use the GNU gcc/g++ compilers. We also regularly compile 
-NEST using the IBM xlc/xlC compilers. You can find the version of your compiler 
-by, e.g.,
-
-    g++ -v
-
-
-### Compiler-specific options
-
-NEST is pre-configured with a reasonable set of compiler options for the most
-common compilers.
-
-When compiling with the Portland compiler, use the `-Kieee` flag to ensure that
-computations obey the IEEE754 standard for floating point numerics.
-
 ## Configuration options
 
 If you need special features, like e.g. support for [distributed computing](parallel-computing.md),
 you can add command line switches to the call to configure. `./configure --help`
 will show you all available options. For more information on the installation of
-NEST, please see the file INSTALL that is included in the distribution archive.
+NEST, please see the file INSTALL that is included in the distribution archive
+for the version of NEST you want to install.
 
-### Set up the integrated helpdesk
-
-The command `helpdesk` needs to know which browser to launch in order to display
-the help pages. The browser is set as an option of `helpdesk`. Please see the
-file `~/.nestrc` for an example setting `firefox` as browser. Please note that
-the command `helpdesk` does not work if you have compiled NEST with MPI support,
-but you have to enter the address of the helpdesk
-(`file://$PREFIX/share/doc/nest/index.html`) manually into the browser.
-Please replace `$PREFIX` with the prefix you chose during the configuration of
-NEST. If you did not explicitly specify one, it is most likely set to `/usr` or
-`/usr/local` depending on what system you are.
-
-### Tell NEST about your MPI setup
-
-If you compiled NEST with support for distributed computing via MPI, you have
-to tell it how your`mpirun`/`mpiexec` command works by defining the function
-mpirun in your `~/.nestrc` file. This file already contains an example
-implementation that should work with [OpenMPI](http://www.openmpi.org/) library.
-
-## Mac OS X
-
-The easiest way to install NEST on a Mac is to install it via the Homebrew
-package manager:
-
-1.  To install homebrew, follow the instructions here: <http://brew.sh/>
-
-2.  Then, in a terminal
-
-    1.  Add the homebrew/science tap: execute 'brew tap homebrew/science'
-
-    2.  For information on what options NEST has and what will be installed,
-        execute 'brew info nest'
-
-    3.  To install nest, execute 'brew install nest'
-
-Options have to be appended, e.g. to install NEST with PyNEST execute
-'brew install nest --with-python'.
-
-#Sorry, the following instructions are a little bit outdated!#
-A more detailed up-to-date instruction for installation on OSX will
-follow soon.
-
-### Installation on OSX 10.9 Mavericks
-
-The clang compiler that ships with OSX 10.9 does not support OpenMP threads.
-You therefore need to use GCC to compile NEST. Below you will find instructions
-to install all necessary software for building NEST without and with MPI
-support.
-
-#### NEST without MPI
-
-1.  Install Xcode from the AppStore.
-
-2.  Install the Xcode command line tools by executing the following line in the
-    Terminal and following the instructions in the windows that will pop up
-
-        xcode-select --install
-
-3.  Install the GNU Compiler Collection, the GNU Science Library, and Python
-    from [MacPorts](http://en.wikipedia.org/wiki/Macports) (you could use Fink
-    or Homebrew, too, but instructions here are based on MacPorts; if you
-    have installed a complete Python from another source, e.g. Anaconda,
-    you do not need Python from MacPorts):
-
-        sudo port install gcc48                   # GCC compiler collection
-        sudo port select gcc mp-gcc48      # make gcc-48 the default compiler
-        sudo port install gsl +gcc48           # install GNU Science Library,
-        use GCC 4.8 compiler
-        sudo port install autoconf automake libtool    # build tools
-
-        # now the Python stuff
-        sudo port install python27
-        sudo port select python python27   # make MacPorts Python 2.7 the default
-        sudo port install py27-cython
-        sudo port select cython cython27   # make Python 2.7 python the default cython
-        sudo port install py27-numpy py27-scipy py27-matplotlib py27-ipython
-        sudo port select ipython ipython27   # set default
-
-4.  Create a directory for building and installing NEST (you should always build
-    NEST outside the source code directory; installing NEST in a "place of its
-    own" makes it easy to remove NEST later).
-
-5.  Extract the NEST tarball as a subdirectory in that directory, create a
-    build-directory next to the source code directory
-
-        cd ~                  # move to home directory
-        mkdir NEST       # directory for all NEST stuff
-        cd NEST
-        mkdir nest22    # directory for all NEST 2.2 stuff
-        cd nest22
-        tar zxf  nest-2.2.2.tar.gz
-        mkdir bld
-        cd bld
-
-6.  Configure and build NEST inside that directory:
-
-        ../nest-2.2.2/configure --prefix=<home dir>/NEST/nest22/ins
-        make -j4         # -j4 builds in parallel using 4 processes
-        make install
-        make installcheck
-
-#### NEST with MPI
-
-To compile NEST with MPI, you need to install OpenMPI first. Unfortunately,
-recent OpenMPI 1.7 versions do not work with NEST under Mavericks. You therefore
-need to trick MacPorts into installing OpenMPI 1.6.4. Proceed as follows:
-
-1.  Perform Steps 1-3 as for NEST without MPI above.
-
-2.  Download the MacPorts [Portfile-openmpi-1.6.4.txt](../../diff/Portfile-openmpi-1.6.4.txt)
-    and save it under the name `Portfile` in an arbitrary directory
-
-3.  In Terminal, move to the directory containing `Portfile` and run
-
-        sudo port install +gcc48 +threads configure.compiler=macports-gcc-4.8
-
-4.  Perform steps 4 and 5 as above.
-
-5.  Configure and build NEST as follows
-
-        ../nest-2.2.2/configure CXX=openmpicxx --with-mpi --prefix=<home dir>/NEST/nest22/ins
-        make -j4
-        make install
-        make installcheck
-
-
-### Known problems
+### Known problems for NEST 2.10 and earlier
 
 ####  Using the correct compiler
 
@@ -658,34 +499,3 @@ please try making NEST as follows:
     env MACOSX_DEPLOYMENT_TARGET=10.5 make
 
 Thanks to Harold Gutch for this hint.
-
-## Windows
-
-Windows and Linux differ considerably. This is the reason why it is difficult
-to compile NEST natively under Windows. However, it is still possible to use
-NEST under Windows using one of the following methods:
-
-### Using the NEST LiveCD
-
-This is the easiest way to use NEST without having to install anything on your
-computer. The LiveCD can be used in almost any computer and boots directly into
-a complete Ubuntu system, which already has NEST, Python, and some analysis
-tools installed.
-The CD image is available on the [download page](download.md).
-
-### Virtual Machines
-
-A virtual machine is a software that lets you use Linux in parallel to Windows.
-We recommend to use VirtualBox, which is free software and can be downloaded
-from <http://www.virtualbox.org/>. Another popular virtual machine software is <http://www.vmware.com/>.
-The easiest way to get started is to download the NEST LiveCD from the [download page](download.md)
-and either just boot the CD image directly or install it into a virtual hard
-disk.
-
-### Cygwin
-
-Cywin is a software layer which emulates Unix system calls. NEST should compile
-and install under Cygwin with the generic installation instructions, but we do
-not tests this regularly and do not support NEST under Cygwin at present.
-Compilation under Cygwin is very slow, but the execution times are comparable
-to an equivalent Linux installation.

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -3,14 +3,14 @@
 These installation instructions are for NEST 2.12 and later as well as the
 most recent version obtained from [Github](https://github.com/nest/nest-simulator). 
 Installation instructions for NEST 2.10 and earlier are provided 
-[below](#instructions-for-nest-2.10-and-earlier).
+[below](#instructions-for-nest-2-10-and-earlier).
 
 ## Introduction
 
 NEST compiles and runs on most Unix-like operating systems. 
 The installation instructions here should work on recent versions of Ubuntu or 
 Debian, while additional instructions for 
-[OS X/macOS are given below](#macos). 
+[OS X/macOS are given below](#mac-os-x). 
 For more generic installation instructions, see the `INSTALL` file in the top source
 directory. For using NEST on Microsoft Windows, see [below](#windows).
 

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -187,6 +187,11 @@ implementation that should work with [OpenMPI](http://www.openmpi.org/) library.
 
 ## Mac OS X
 
+On the Mac, you can install NEST either via Homebrew or manually. If you 
+want to use PyNEST, you need to have a version of Python with some science
+packages installed, see the [section Python on Mac](installation.md#python-on-mac) 
+for details. 
+
 ### Installation via Homebrew
 
 The easiest way to install NEST on a Mac is to install it via the Homebrew
@@ -253,6 +258,33 @@ and all other dependencies installed via [Homebrew](http://brew.sh).
 
 To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
 
+### Python on Mac
+
+The version of Python shipping with OSX/macOS is rather dated and does not
+include key packages such as NumPy. Therefore, you need to install Python via
+a channel that provides scientific packages.
+
+One well-tested source is the [Anaconda](https://www.continuum.io/anaconda-overview) 
+Python distribution for both Python 2 and 3. If you do not want to install the
+full Anaconda distribution, you can also install [Miniconda](http://conda.pydata.org/miniconda.html)
+and then install the packages needed by NEST by running
+
+    conda install numpy scipy matplotlib ipython cython nose
+
+Alternatively, you should be able to install the necessary Python packages via Homebrew, but
+this has not been tested.
+
+## Troubleshooting
+
+If your operating system does not find the `nest` executable or Python does not
+find the `nest` module, your path variables may not be set correctly. This may
+also be the case if Python cannot load the `nest` module due to missing or
+incompatible libraries. In this case, please run
+
+    source </path/to/nest_install_dir>/bin/nest_vars.sh
+
+to set the necessary environment variables. You may want to include this line
+in your `.bashrc` file, so that the environment variables are set automatically.
 
 ## Windows
 

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-These installation instructions are for NEST 2.12 and later as well as the most recent version obtained from [Github](https://github.com/nest/nest-simulator). 
+These installation instructions are for NEST 2.12 and later as well as the most recent version obtained from [GitHub](https://github.com/nest/nest-simulator). 
 
-Installation instructions for NEST 2.10 and earlier are provided [below](#instructions-for-nest-2-10-and-earlier).
+Installation instructions for NEST 2.10 and earlier are provided [below](#instructions-for-nest-210-and-earlier).
 
 ## Introduction
 

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -1,6 +1,292 @@
 # Installation
 
+These installation instructions are for NEST 2.12 and later as well as the
+most recent version obtained from [Github](https://github.com/nest/nest-simulator). 
+Installation instructions for NEST 2.10 and earlier are provided 
+[below](installation.md#instructions-for-nest-2.10-and-earlier).
+
 ## Introduction
+
+NEST compiles and runs on most Unix-like operating systems. 
+The installation instructions here should work on recent versions of Ubuntu or 
+Debian, while additional instructions for 
+[OSX/macOS are given below](installation.md#macos). 
+For more generic installation instructions, `INSTALL` file in the top source
+directory. For using NEST on Microsoft Windows, see [below](installation.md#windows).
+
+Following are the basic steps to compile and install NEST from source code:
+
+1.  [Download NEST](download.md)
+
+2.  Unpack the tarball: `tar -xzvf nest-x.y.z.tar.gz`
+
+3.  Create a build directory: `mkdir nest-x.y.z-build`
+
+4.  Change to the build directory: `cd nest-x.y.z-build`
+
+5.  Configure NEST: `cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> </path/to/NEST/src>` with
+additional `cmake` options as needed (see `INSTALL` file)
+
+6.  Compile by running `make `
+
+7.  Install by running `make install`
+
+8.  Run tests by running `make installcheck
+
+8.  See the [Getting started](getting-started.md) pages to
+    find out how to get going with NEST
+
+Please see the sections on [minimal](installation.md#minimal-configuration) and
+[standard configuration](installation.md#standard-configuration)
+below for details.
+
+## What gets installed where
+
+By default, everything will be installed to the subdirectories
+`$PREFIX/{bin,lib,share}`, where `$PREFIX` is the install path given to `cmake:
+
+Executables   
+`$PREFIX/bin`
+
+Dynamic libraries   
+`$PREFIX/lib/`
+
+SLI libraries   
+`$PREFIX/share/nest/sli`
+
+Documentation   
+`$PREFIX/share/doc/nest`
+
+Examples   
+`$PREFIX/share/doc/nest/examples`
+
+PyNEST   
+`$PREFIX/lib/pythonX.Y/site-packages/nest`
+
+PyNEST examples   
+`$PREFIX/share/doc/nest/examples/pynest`
+
+Extras   
+`$PREFIX/share/nest/extras/`
+
+If you want to run the `nest` executable or use the `nest` Python module without
+providing explicit paths, you have to add the installation directory to your
+search paths. For example, if you are using bash:
+
+    export PATH=$PATH:$PREFIX/bin
+    export PYTHONPATH=$PREFIX/lib/pythonX.Y/site-packages:$PYTHONPATH
+
+## Dependencies
+
+NEST needs a few third party tools and libraries to work. On many operating
+systems, these can be installed using a *package manager* such as `apt` or `brew` 
+(see [Standard configuration](installation.md#standard-configuration)).
+
+To build NEST, you need recent versions of [CMake](http://cmake.org) and
+[libtool](https://www.gnu.org/software/libtool/libtool.html); the latter
+should be available on most systems.
+
+The [GNU readline library](http://www.gnu.org/software/readline/) is recommended
+if you use NEST interactively without Python. Although most Linux distributions
+have GNU readline installed, you still need to install its development package
+if want to use GNU readline with NEST. GNU readline itself depends on
+[libncurses](http://www.gnu.org/software/ncurses/) (or libtermcap on older
+systems). Again, the development packages are needed to compile NEST.
+
+The [GNU Scientific Library](http://www.gnu.org/software/gsl/) is needed by
+several neuron models, in particular those with conductance based synapses. If
+you want these models, please install the GNU Scientific Library along with its
+development packages. 
+
+If you want to use PyNEST, we recommend to install the following along with
+their development packages:
+
+-   Python (<http://www.python.org/download>)
+-   NumPy (<http://www.scipy.org/Download>)
+-   SciPy (<http://www.scipy.org/Download>)
+-   matplotlib (<http://matplotlib.sourceforge.net/>)
+-   IPython (<http://ipython.scipy.org/moin/Download>)
+
+
+## Minimal configuration
+
+NEST can be compiled without any external packages; such configuration may be
+useful e.g. for initial porting to a new supercomputer. However, this implies
+several restrictions: First, some neuron and synapse models will not be
+available, as they depend on ODE solvers from the GNU scientific library.
+Second, the Python extension will not be available, and third, multi-threading
+and parallel computing facilities will be disabled.
+
+To compile NEST without external packages, use the following command line to
+configure it:
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+          -Dwith-python=OFF \
+          -Dwith-gsl=OFF \
+          -Dwith-readline=OFF \
+          -Dwith-ltdl=OFF \
+          -Dwith-openmp=OFF \
+          </path/to/nest/source>
+          
+## Standard configuration
+
+To install the packages required for the standard installation use the following
+command line:
+
+    sudo apt-get install -y build-essential cmake libltdl7-dev libreadline6-dev \
+    libncurses5-dev libgsl0-dev python-all-dev python-numpy python-scipy \ 
+    python-matplotlib ipython openmpi-bin libopenmpi-dev python-nose
+    
+Then configure NEST using:
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+          </path/to/nest/source>
+ 
+
+## Choice of compiler
+
+Most NEST developers use the GNU gcc/g++ compilers. We also regularly compile 
+NEST using the IBM xlc/xlC compilers. You can find the version of your compiler 
+by, e.g.,
+
+    g++ -v
+
+
+### Compiler-specific options
+
+NEST is pre-configured with a reasonable set of compiler options for the most 
+common compilers.
+
+When compiling with the Portland compiler, use the `-Kieee` flag to ensure that 
+computations obey the IEEE754 standard for floating point numerics.
+
+## Configuration options
+
+If you need special features, e.g., support for 
+[distributed computing](parallel-computing.md), please see the `INSTALL` file 
+in the main source code directory for available options.
+
+### Set up the integrated helpdesk
+
+The command `helpdesk` needs to know which browser to launch in order to display
+the help pages. The browser is set as an option of `helpdesk`. Please see the
+file `~/.nestrc` for an example setting `firefox` as browser. Please note that
+the command `helpdesk` does not work if you have compiled NEST with MPI support,
+but you have to enter the address of the helpdesk
+(`file://$PREFIX/share/doc/nest/index.html`) manually into the browser.
+Please replace `$PREFIX` with the prefix you chose during the configuration of
+NEST. If you did not explicitly specify one, it is most likely set to `/usr` or
+`/usr/local` depending on what system you are.
+
+### Tell NEST about your MPI setup
+
+If you compiled NEST with support for distributed computing via MPI, you have
+to tell it how your`mpirun`/`mpiexec` command works by defining the function
+mpirun in your `~/.nestrc` file. This file already contains an example
+implementation that should work with [OpenMPI](http://www.openmpi.org/) library.
+
+## Mac OS X
+
+### Installation via Homebrew
+
+The easiest way to install NEST on a Mac is to install it via the Homebrew
+package manager:
+
+1.  To install homebrew, follow the instructions at [brew.sh](http://brew.sh/)
+
+2.  Then, in a terminal
+
+    1.  Add the homebrew/science tap by running `brew tap homebrew/science`
+    
+    2.  For information on what options NEST has and what will be installed,
+        run `brew info nest`
+        
+    3.  To install nest, execute 'brew install nest'
+
+Options have to be appended, e.g. to install NEST with PyNEST run
+brew install nest --with-python`.
+
+
+### Manual installation
+
+The clang/clang++ compiler that ships with OSX/macOS does not support OpenMP
+threads and creates code that fails some tests. You therefore need to use GCC 
+to compile NEST under OSX/macOS.
+
+Installation instructions here have been tested under OSX 10.11 *El Capitan* 
+and macOS 10.12 *Sierra* with [Anaconda Python 2 and 3](https://www.continuum.io/anaconda-overview)
+and all other dependencies installed via [Homebrew](http://brew.sh).
+
+1.  Install Xcode from the AppStore.
+
+2.  Install the Xcode command line tools by executing the following line in the
+    Terminal and following the instructions in the windows that will pop up
+
+        xcode-select --install
+
+3.  Install dependencies via Homebrew
+
+    brew install gcc cmake gsl open-mpi libtool
+
+4.  Create a directory for building and installing NEST (you should always build
+    NEST outside the source code directory; installing NEST in a "place of its
+    own" makes it easy to remove NEST later).
+
+5.  Extract the NEST tarball as a subdirectory in that directory or clone NEST from Github into a subdirectory. 
+
+        mkdir NEST       # directory for all NEST stuff
+        cd NEST
+        tar zxf  nest-2.12.0.tar.gz
+        mkdir bld
+        cd bld
+
+6.  Configure and build NEST inside that directory:
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> \
+          -DCMAKE_C_COMPILER=gcc-6\
+          -DCMAKE_CXX_COMPILER=g++-6 \
+          </path/to/NEST/src>
+
+    make -j4         # -j4 builds in parallel using 4 processes
+    make install
+    make installcheck
+
+To compile NEST with MPI support, add `-Dwith-mpi=ON` as `cmake` option.
+
+
+## Windows
+
+Windows and Linux differ considerably. This is the reason why it is difficult
+to compile NEST natively under Windows. However, it is still possible to use
+NEST under Windows using one of the following methods:
+
+### Using the NEST LiveCD
+
+This is the easiest way to use NEST without having to install anything on your
+computer. The LiveCD can be used in almost any computer and boots directly into
+a complete Ubuntu system, which already has NEST, Python, and some analysis
+tools installed.
+The CD image is available on the [download page](download.md).
+
+### Virtual Machines
+
+A virtual machine is a software that lets you use Linux in parallel to Windows.
+We recommend to use VirtualBox, which is free software and can be downloaded
+from <http://www.virtualbox.org/>. Another popular virtual machine software is <http://www.vmware.com/>.
+The easiest way to get started is to download the NEST LiveCD from the [download page](download.md)
+and either just boot the CD image directly or install it into a virtual hard
+disk.
+
+### Cygwin
+
+Cywin is a software layer which emulates Unix system calls. NEST should compile
+and install under Cygwin with the generic installation instructions, but we have 
+not tested this for a long time and do not support NEST under Cygwin at present.
+Compilation under Cygwin is very slow, but the execution times are comparable
+to an equivalent Linux installation.
+
+
+## Instructions for NEST 2.10 and earlier
 
 NEST compiles and runs on most Unix-like operating systems including Linux and
 Mac OS X. For using NEST on Microsoft Windows, see [below](installation.md#windows).
@@ -32,41 +318,6 @@ Please see the sections on [minimal](installation.md#minimal-configuration) and
 [standard configuration](installation.md#standard-configuration)
 below for details.
 
-## What gets installed where
-
-By default, everything will be installed to the subdirectories
-`$PREFIX/{bin,lib,share}`, where `$PREFIX=$HOME/opt/nest`:
-
-Executables   
-`$PREFIX/bin`
-
-Extensions   
-`$PREFIX/lib/nest`
-
-SLI libraries   
-`$PREFIX/share/nest/sli`
-
-Documentation   
-`$PREFIX/share/doc/nest`
-
-Examples   
-`$PREFIX/share/doc/nest/examples`
-
-PyNEST   
-`$PREFIX/lib/pythonX.Y/site-packages/nest`
-
-PyNEST examples   
-`$PREFIX/share/doc/nest/examples/pynest`
-
-Extras   
-`$PREFIX/share/nest/extras/emacs/sli`
-
-You can supply a custom prefix using the `--prefix=$PREFIX` switch for
-`./configure`. In this case, you have to add the installation directory to your
-search paths. For example, if you are using bash:
-
-    export PATH=$PATH:$PREFIX/bin
-    export PYTHONPATH=$PREFIX/lib/pythonX.Y/site-packages:$PYTHONPATH
 
 ## Dependencies
 
@@ -150,24 +401,19 @@ Then configure NEST using:
 
 ## Choice of compiler
 
-**Caveat:** you should compile NEST with the same compiler and version as your
-Python. Strange crashes have been observed on importing NEST when compiling
-NEST with g++ 4.3 or later on OS X and importing it into Python compiled with
-the standard GCC 4.0 compiler. Most NEST developers use the GNU gcc/g++
-compilers. We also regularly compile NEST using the Intel icc/icpc compilers
-and the IBM xlc/xlC compilers. You can find the version of your compiler by,
-e.g.,
+Most NEST developers use the GNU gcc/g++ compilers. We also regularly compile 
+NEST using the IBM xlc/xlC compilers. You can find the version of your compiler 
+by, e.g.,
 
     g++ -v
 
-Python displays the compiler used to build it at startup.
 
 ### Compiler-specific options
 
 NEST is pre-configured with a reasonable set of compiler options for the most
 common compilers.
 
-When compiling with the Portland compiler, use the -Kieee flag to ensure that
+When compiling with the Portland compiler, use the `-Kieee` flag to ensure that
 computations obey the IEEE754 standard for floating point numerics.
 
 ## Configuration options
@@ -302,76 +548,6 @@ need to trick MacPorts into installing OpenMPI 1.6.4. Proceed as follows:
         make install
         make installcheck
 
-### Installation for Older OSX Versions
-
-#Outdated#
-
-Before you can build NEST under Mac OS X, you need to install Xcode from the
-Apple Developer tools installation DVD that came with your Mac (the packages are
-called Xcode and Optional on Mac OS X 10.6 Snow Leopard). If you are running
-Mac OS X 10.7 Lion or Mac OS X 10.8 Mountain Lion, you need to install Xcode
-from Mac App Store or download the DMG images from Apple Developer
-Connection and drag Xcode icon to the Applications folder. Proceed to the [ADC login page](http://connect.apple.com)
-and enter your ADC ID, then download Xcode 4.3.2 for Lion (or later) and
-Command Line Tools for Xcode - Late March 2012 (or later).
-
-#### From a tarball
-
-Decide whether you need GSL and SciPy / IPython, if yes, install them from [MacPorts](http://en.wikipedia.org/wiki/Macports)
-or [Fink](http://en.wikipedia.org/wiki/Fink) (command below is for MacPorts and
-assumes you are using Python 2.7; if using 2.6, replace `py27` with `py26`
-below):
-
-    sudo port install gsl py27-ipython py27-matplotlib py27-scipy
-
-You can save yourself some hassle by making this Python installation the
-default, otherwise you will have to specify the right Python to the configure
-command:
-
-    sudo port select --set python python27
-    sudo port select --set ipython ipython27
-
-Now follow the generic instructions above to install NEST.
-
-#### From Subversion checkout
-
-Install libtool from sources or a package manager, such as Fink or MacPorts,
-then run ./bootstrap.sh to bootstrap the build system (create the ./configure
-script) and proceed as above.
-
-#### Discussion
-
-To install NEST on Mac OS X you basically have three options:
-
-1.  Use only tools and libraries provided by Apple (compiler, system libraries,
-    OpenMPI, Python, NumPy)
-
-2.  Use mostly tools provided by Apple and build the rest from source
-    (Pythons etc.)
-
-3.  Use tools provided by third-party package archives (Fink or MacPorts)
-
-Only options (1) and (3) are recommended for non-expert users. Go for (3) if you
-are already using either of the package archives mentioned above or intending
-to use additional Pythons. Go for (1) if you want to get started immediately
-without any extra software (and compile NEST against system OpenMPI, Python &
-NumPy, although features requiring GSL / SciPy / matplotlib will not work unless
-you install them yourself).
-
-The most convenient source for GSL and NumPy / SciPy / matplotlib is MacPorts
-(Fink probably works as well, but we have not tested this). Another source for a
-complete Python distribution is the [Enthought Python Distribution](http://www.enthought.com),
-but we are not testing against it.
-
-**Note:** as of Mac OS X 10.6 Apple ships glibtool missing libltdl sources,
-which means that if you want to go for (1) and not use a tarball, but bootstrap
-the build system from e.g. an SVN checkout, you need to install libtool +
-libltdl from source (see `extras/install_autotools.sh`).
-
-**Note:** as of Mac OS X 10.7 Apple conveniently no longer provides support for
-OpenMPI in the default installation. Additionally, clang became the default
-compiler of choice, but it doesn't support OpenMP yet. Therefore, it makes most
-sense to install latest GCC, Python, OpenMPI and so on from MacPorts.
 
 ### Known problems
 


### PR DESCRIPTION
This PR updates  the installation documentation in the `INSTALL` and `installation.md` files to make them ready for NEST 2.12. Some of the material there was really very dated.

This documentation should be tested on Linux and OSX machines, and for website-compatibility, so I assign a range of reviewers.

@espenhgn, could you also take a look and maybe add some info on macports?