### PR TITLE
Add Allreduce_min and Allreduce_max functions, use them to determine delay extrema

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -344,19 +344,19 @@ nest::ConnectionManager::update_delay_extrema_()
 
   if ( kernel().mpi_manager.get_num_processes() > 1 )
   {
-    std::vector< delay > min_delays( kernel().mpi_manager.get_num_processes() );
-    min_delays[ kernel().mpi_manager.get_rank() ] = min_delay_;
-    kernel().mpi_manager.communicate( min_delays );
-    min_delay_ = *std::min_element( min_delays.begin(), min_delays.end() );
+    std::vector< delay > min_delay( 1, min_delay_ );
+    kernel().mpi_manager.communicate_Allreduce_min_in_place( min_delay );
+    min_delay_ = min_delay[ 0 ];
 
-    std::vector< delay > max_delays( kernel().mpi_manager.get_num_processes() );
-    max_delays[ kernel().mpi_manager.get_rank() ] = max_delay_;
-    kernel().mpi_manager.communicate( max_delays );
-    max_delay_ = *std::max_element( max_delays.begin(), max_delays.end() );
+    std::vector< delay > max_delay( 1, max_delay_ );
+    kernel().mpi_manager.communicate_Allreduce_max_in_place( max_delay );
+    max_delay_ = max_delay[ 0 ];
   }
 
   if ( min_delay_ == Time::pos_inf().get_steps() )
+  {
     min_delay_ = Time::get_resolution().get_steps();
+  }
 }
 
 // gid node thread syn delay weight

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -639,6 +639,20 @@ nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer,
 }
 
 void
+nest::MPIManager::communicate_Allreduce_min_in_place(
+  std::vector< long >& buffer )
+{
+  MPI_Allreduce( MPI_IN_PLACE, &buffer[ 0 ], 1, MPI_LONG, MPI_MIN, comm );
+}
+
+void
+nest::MPIManager::communicate_Allreduce_max_in_place(
+  std::vector< long >& buffer )
+{
+  MPI_Allreduce( MPI_IN_PLACE, &buffer[ 0 ], 1, MPI_LONG, MPI_MAX, comm );
+}
+
+void
 nest::MPIManager::communicate_Allgather( std::vector< long >& buffer )
 {
   // avoid aliasing, see http://www.mpi-forum.org/docs/mpi-11-html/node10.html
@@ -1063,6 +1077,19 @@ nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer,
   std::vector< double >& recv_buffer )
 {
   recv_buffer.swap( send_buffer );
+}
+
+
+void
+nest::MPIManager::communicate_Allreduce_min_in_place(
+  std::vector< long >& buffer )
+{
+}
+
+void
+nest::MPIManager::communicate_Allreduce_max_in_place(
+  std::vector< long >& buffer )
+{
 }
 
 #endif /* #ifdef HAVE_MPI */

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -167,6 +167,16 @@ public:
     std::vector< double >& recv_buffer );
 
   /**
+   * Determines minimum across all ranks.
+   */
+  void communicate_Allreduce_min_in_place( std::vector< long >& buffer );
+
+  /**
+   * Determines maximum across all ranks.
+   */
+  void communicate_Allreduce_max_in_place( std::vector< long >& buffer );
+
+  /**
    * Collect GIDs for all nodes in a given node list across processes.
    * The NodeListType should be one of LocalNodeList, LocalLeafList,
    * LocalChildList.


### PR DESCRIPTION
This PR replaces MPI::Allgather and subsequent std::min/max_element with a single call to MPI::Allreduce with the min/max operations to reduce overhead for a large number of MPI processes. Some timing measurements will follow, but someone with experience in the min delay intricacies could already comment on whether this change is appropiate.
I suggest @heplesser @jougs @suku248 as reviewers.