### PR TITLE
Remove `doc/help` directory in the source tree after installation

### DIFF
--- a/extras/help_generator/parse_help.py
+++ b/extras/help_generator/parse_help.py
@@ -135,3 +135,4 @@ write_helpindex(helpdir)
 
 shutil.rmtree(install_dir, ignore_errors=True)
 shutil.copytree(helpdir, install_dir)
+shutil.rmtree(helpdir, ignore_errors=True)

--- a/extras/help_generator/parse_help.py
+++ b/extras/help_generator/parse_help.py
@@ -134,5 +134,4 @@ for fname in allfiles:
 write_helpindex(helpdir)
 
 shutil.rmtree(install_dir, ignore_errors=True)
-shutil.copytree(helpdir, install_dir)
-shutil.rmtree(helpdir, ignore_errors=True)
+shutil.move(helpdir, install_dir)


### PR DESCRIPTION
Fix for #574. 
