### PR TITLE
Added parenthesis in a python test to make it compatible with python 3

### DIFF
--- a/pynest/nest/tests/test_sp/test_issue_578_sp.py
+++ b/pynest/nest/tests/test_sp/test_issue_578_sp.py
@@ -82,7 +82,7 @@ class TestIssue578(unittest.TestCase):
         try:
             nest.Simulate(200 * 1000)
         except:
-            print sys.exc_info()[0]
+            print(sys.exc_info()[0])
             self.fail("Exception during simulation")
 
 


### PR DESCRIPTION
After pulling master the python tests did not run when calling installcheck with python 3. The problem was the lack of parenthesis with print in one of the tests, so this pull request add said parenthesis. 