### PR TITLE
Update setting of dlopenflags() to current Python standards (fixes #632)

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -39,20 +39,20 @@ try:
 except:
     pass
 
-# This is a workaround to make MPI-enabled NEST import properly. The
-# underlying problem is that the shared object pynestkernel
-# dynamically opens other libraries that open other libraries...
+# Make MPI-enabled NEST import properly. The underlying problem is that the
+# shared object pynestkernel dynamically opens other libraries that open
+# yet other libraries.
 try:
-    try:
-        import dl
-    except:
-        import DLFCN as dl
-    sys.setdlopenflags(dl.RTLD_NOW | dl.RTLD_GLOBAL)
+    # Python 3.3 and later has flags in os
+    sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
 except:
-    # this is a hack for Python 2.6 on Mac, where RTDL_NOW is nowhere
-    # to be found. See trac ticket #397
+    # Python 2.6 and later have flags in ctypes, RTLD_NOW may be missing
     import ctypes
-    sys.setdlopenflags(ctypes.RTLD_GLOBAL)
+    try:
+        sys.setdlopenflags(ctypes.RTLD_GLOBAL | ctypes.RTLD_NOW)
+    except:
+        # RTLD_NOW missing from ctypes eg on OSX
+        sys.setdlopenflags(ctypes.RTLD_GLOBAL)
 
 from . import pynestkernel as _kernel      # noqa
 from .lib import hl_api_helper as hl_api   # noqa
@@ -81,7 +81,7 @@ def catching_sli_run(cmd):
         SLI errors are bubbled to the Python API as NESTErrors.
     """
 
-    if sys.version_info >= (3,):
+    if sys.version_info >= (3, ):
         def encode(s):
             return s
 
@@ -159,7 +159,6 @@ def sli_func(s, *args, **kwargs):
 
     if len(r) != 0:
         return r
-
 
 hl_api.sli_func = sli_func
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -47,18 +47,18 @@ try:
     sys.setdlopenflags(os.RTLD_NOW | os.RTLD_GLOBAL)
 except AttributeError:
     # Python 2.6 and 2.7 have flags in ctypes, but RTLD_NOW may only
-    # be available in dl or DLFCN and is required at least under 
+    # be available in dl or DLFCN and is required at least under
     # Ubuntu 14.04. The latter two are not available under OSX,
     # but OSX does not have and does not need RTLD_NOW. We therefore
     # first try dl and DLFCN, then ctypes just for OSX.
     try:
         import dl
         sys.setdlopenflags(dl.RTLD_GLOBAL | dl.RTLD_NOW)
-    except ImportError, AttributeError:
+    except (ImportError, AttributeError):
         try:
             import DLFCN
             sys.setdlopenflags(DLFCN.RTLD_GLOBAL | DLFCN.RTLD_NOW)
-        except ImportError, AttributeError:
+        except (ImportError, AttributeError):
             import ctypes
             try:
                 sys.setdlopenflags(ctypes.RTLD_GLOBAL | ctypes.RTLD_NOW)


### PR DESCRIPTION
This solves Python 3.6 compatibility problems (#632) and removes code deprecated since Python 2.6.