### PR TITLE
Added check on threading in two python tests which require it.

### DIFF
--- a/pynest/nest/tests/test_sp/test_enable_multithread.py
+++ b/pynest/nest/tests/test_sp/test_enable_multithread.py
@@ -29,7 +29,10 @@ __author__ = 'sdiaz'
 # and multiple threads are set, or if multiple threads are set and
 # the enable_structural_plasticity function is called.
 
+HAVE_OPENMP = nest.sli_func("statusdict/threading ::")
 
+
+@unittest.skipIf(HAVE_OPENMP == 'no', 'OpenMP is not available')
 class TestEnableMultithread(unittest.TestCase):
 
     def setUp(self):

--- a/pynest/nest/tests/test_sp/test_enable_multithread.py
+++ b/pynest/nest/tests/test_sp/test_enable_multithread.py
@@ -29,10 +29,10 @@ __author__ = 'sdiaz'
 # and multiple threads are set, or if multiple threads are set and
 # the enable_structural_plasticity function is called.
 
-HAVE_OPENMP = nest.sli_func("statusdict/threading ::")
+HAVE_OPENMP = nest.sli_func("is_threaded")
 
 
-@unittest.skipIf(HAVE_OPENMP == 'no', 'OpenMP is not available')
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 class TestEnableMultithread(unittest.TestCase):
 
     def setUp(self):

--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -28,7 +28,7 @@ import unittest
 import nest
 from nest import raster_plot
 import time
-HAVE_OPENMP = nest.sli_func("statusdict/threading ::")
+HAVE_OPENMP = nest.sli_func("is_threaded")
 
 
 class SynapticElementIntegrator(object):
@@ -217,7 +217,7 @@ class GaussianNumericSEI(SynapticElementIntegrator):
         )
 
 
-@unittest.skipIf(HAVE_OPENMP == 'no', 'OpenMP is not available')
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 class TestGrowthCurve(unittest.TestCase):
     """
     Unittest class to test the GrowthCurve used with nest

--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -28,6 +28,7 @@ import unittest
 import nest
 from nest import raster_plot
 import time
+HAVE_OPENMP = nest.sli_func("statusdict/threading ::")
 
 
 class SynapticElementIntegrator(object):
@@ -216,6 +217,7 @@ class GaussianNumericSEI(SynapticElementIntegrator):
         )
 
 
+@unittest.skipIf(HAVE_OPENMP == 'no', 'OpenMP is not available')
 class TestGrowthCurve(unittest.TestCase):
     """
     Unittest class to test the GrowthCurve used with nest


### PR DESCRIPTION
This PR solves a problem with two python tests which require threading but were not being skipped if threading was not enabled.