### PR TITLE
Adjust examples to NEST 2.12 (fixes #645)

### DIFF
--- a/examples/nest/ArtificialSynchrony.sli
+++ b/examples/nest/ArtificialSynchrony.sli
@@ -67,7 +67,9 @@ AH 09) =
 %%%%%%%%%%%%%%%%% Simulation parameter  %%%%%%%%%%%%%%%%%%%%%%%%%
 (Set Simulation Parameters ) =only
 /nr 128 def                     % number of neurons in the network
-/h 0.03125 def                  % simulation resolution h=2^-5
+
+/h 2. -5 pow def                % simulation resolution h=2^-5
+/tics_per_ms 2 5 pow def        % low-level time resolution in tics
 
 /C_m 250.0 def                  % membrane capacitance
 /E_L 0.0 def                    % leaky potential
@@ -77,9 +79,7 @@ AH 09) =
 /V_th  20.0 def                 % threshold potential
 /t_refra 0.25 def               % refractory time
 /tau_syn_ex 1.648 def           % syn. time constant 3/2ln3
-%/tau_syn_in 1.648 def
 /INTERPOL 3 def                 % cubic interpolation (canonical model)
-
 
 /gamma 0.5 def                  % parameter determining the degree of synchrony at the beginning
 
@@ -155,6 +155,7 @@ modeldict begin
        0
        <<
          /resolution h                  % time steps in ms
+         /tics_per_ms tics_per_ms       % low-level time resolution
          /off_grid_spiking true         % precise neuron model
          /rngs [myrng]                  % set rnd seed
          /overwrite_files true          % overwrite previous output

--- a/examples/nest/balancedneuron-2.sli
+++ b/examples/nest/balancedneuron-2.sli
@@ -60,7 +60,8 @@ ResetKernel
 
  neuron
  <<
-    /tau_syn 1.0
+    /tau_syn_ex 1.0
+    /tau_syn_in 1.0
     /V_th -55.0
  >> SetStatus
 

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -92,7 +92,8 @@ def
   
 } def
 
-% Inverting this equation numerically leads to tau_syn = 0.32582722403722841 ms, as specified in model_params below.
+% Inverting this equation numerically leads to tau_syn = 0.32582722403722841 ms,
+% as specified in model_params below.
 
 % -------------------------------------------------------------------------------------
 
@@ -104,6 +105,9 @@ def
   % number of neurons to record spikes from
   /Nrec 1000
 
+  % synaptic time constant
+  /tau_syn 0.32582722403722841 def   % ms
+  
   /model_params
   <<
     % Set variables for iaf_psc_alpha
@@ -113,7 +117,8 @@ def
     /t_ref 0.5  ms  % duration of refractory period (ms)
     /V_th   20.0  mV  % Threshold (mV)
     /V_reset 0.0  mV  % Reset Potential (mV)
-    /tau_syn  0.32582722403722841 ms  % time const. postsynaptic excitatory currents (ms)
+    /tau_syn_ex tau_syn
+    /tau_syn_in tau_syn
     /tau_minus 30.0 ms %time constant for STDP (depression)
     % V can be randomly initialized see below
     /V_m 5.7 mV % mean value of membrane potential

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -30,9 +30,38 @@
    and independent of network size (indegree=11250).
 
    This is the standard network investigated in:
-   Morrison et al (2007). Spike-timing-dependent plasticity in balanced random networks Neural Comput 19(6):1437-67
-   Helias et al (2012). Supercomputers ready for use as discovery machines for neuroscience Front. Neuroinform. 6:26,
-   Kunkel et al (2014). Spiking network simulation code for petascale computers. Front. Neuroinform. 8:78
+   Morrison et al (2007). Spike-timing-dependent plasticity in balanced random
+     networks. Neural Comput 19(6):1437-67
+   Helias et al (2012). Supercomputers ready for use as discovery machines for
+     neuroscience. Front. Neuroinform. 6:26
+   Kunkel et al (2014). Spiking network simulation code for petascale 
+     computers. Front. Neuroinform. 8:78
+     
+   A note on scaling
+   -----------------
+   
+   This benchmark was originally developed for very large-scale benchmarks on
+   supercomputers with more than 1 million neurons in the network and 
+   11.250 incoming synapses per neuron. For such large networks, input to a
+   single neuron will be little correlated and network activity will remain
+   stable for long periods of time. 
+   
+   That original network size corresponds to a scale parameter of 100 or more.
+   In order to make it possible to test this benchmark script on desktop
+   computers, the scale parameter is set to 1 below, while the number of
+   11.250 incoming synapses per neuron is retained. In this limit, correlations
+   in input to neurons are large and will lead to increasing synaptic weights.
+   Over time, network dynamics will therefore become unstable and all neurons
+   in the network will fire in synchrony, leading to extremely slow simulation
+   speeds.
+   
+   Therefore, the presimulation time is reduced to 50 ms below and the
+   simulation time to 250 ms, while we usually use 100 ms presimulation and
+   1000 ms simulation time.
+   
+   For meaningful use of this benchmark, you should use a scale > 10 and check
+   that the firing rate reported at the end of the benchmark is below 10 spikes
+   per second. 
 */
   
 %%% PARAMETER SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -41,9 +70,10 @@
 % all data is placed in the userdict dictionary
 
 /nvp 1 def              % total number of virtual processes
-/scale 2 def            % scaling factor of the network size, total network size = scale*11250 neurons
-/simtime 1000. def      % total simulation time in ms
-/presimtime 100. ms def % simulation time until reaching equilibrium
+/scale 1.0 def          % scaling factor of the network size, 
+                        % total network size = scale*11250 neurons
+/simtime 250. def       % total simulation time in ms
+/presimtime 50. ms def % simulation time until reaching equilibrium
 /dt 0.1 ms def          % simulation step
 /record_spikes true def % switch to record spikes of excitatory neurons to file
 /path_name (.) def      % path where all files will have to be written

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -125,6 +125,8 @@ def
 % Inverting this equation numerically leads to tau_syn = 0.32582722403722841 ms,
 % as specified in model_params below.
 
+/tau_syn 0.32582722403722841 ms def
+
 % -------------------------------------------------------------------------------------
 
 /brunel_params
@@ -135,9 +137,6 @@ def
   % number of neurons to record spikes from
   /Nrec 1000
 
-  % synaptic time constant
-  /tau_syn 0.32582722403722841 def   % ms
-  
   /model_params
   <<
     % Set variables for iaf_psc_alpha
@@ -147,8 +146,8 @@ def
     /t_ref 0.5  ms  % duration of refractory period (ms)
     /V_th   20.0  mV  % Threshold (mV)
     /V_reset 0.0  mV  % Reset Potential (mV)
-    /tau_syn_ex tau_syn
-    /tau_syn_in tau_syn
+    /tau_syn_ex   tau_syn % time const. postsynaptic excitatory currents (ms)
+    /tau_syn_in   tau_syn % time const. postsynaptic inhibitory currents (ms)
     /tau_minus 30.0 ms %time constant for STDP (depression)
     % V can be randomly initialized see below
     /V_m 5.7 mV % mean value of membrane potential

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -40,13 +40,13 @@
    A note on scaling
    -----------------
    
-   This benchmark was originally developed for very large-scale benchmarks on
+   This benchmark was originally developed for very large-scale simulations on
    supercomputers with more than 1 million neurons in the network and 
    11.250 incoming synapses per neuron. For such large networks, input to a
    single neuron will be little correlated and network activity will remain
    stable for long periods of time. 
    
-   That original network size corresponds to a scale parameter of 100 or more.
+   The original network size corresponds to a scale parameter of 100 or more.
    In order to make it possible to test this benchmark script on desktop
    computers, the scale parameter is set to 1 below, while the number of
    11.250 incoming synapses per neuron is retained. In this limit, correlations

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -70,15 +70,15 @@ for i in $EXAMPLES ; do
         runner=python
     fi
 
-    echo ">>> RUNNING: $workdir$example"
+    echo ">>> RUNNING: $workdir/$example"
 
     set +e
     $runner $example
 
     if [ $? != 0 ] ; then
-        echo ">>> FAILURE: $workdir$example"
+        echo ">>> FAILURE: $workdir/$example"
         FAILURES=$(( $FAILURES + 1 ))
-        OUTPUT=$(printf "        %s\n        %s\n" "$OUTPUT" "$workdir$example")
+        OUTPUT=$(printf "        %s\n        %s\n" "$OUTPUT" "$workdir/$example")
     else
         echo ">>> SUCCESS: $example"
     fi


### PR DESCRIPTION
This PR makes minor corrections to three examples that did not execute due to changes in NEST 2.12.
`hpc_benchmark.sli` now works, but generates very high firing rates.

This addresses #645.