### PR TITLE
Fix for usage of gap junctions without wfr (issue #655)

### DIFF
--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -849,12 +849,10 @@ void
 NodeManager::check_wfr_use()
 {
   wfr_is_used_ = kernel().mpi_manager.any_true( wfr_is_used_ );
-  if ( wfr_is_used_ )
-  {
-    GapJunctionEvent::set_coeff_length(
-      kernel().connection_manager.get_min_delay()
-      * ( kernel().simulation_manager.get_wfr_interpolation_order() + 1 ) );
-  }
+
+  GapJunctionEvent::set_coeff_length(
+    kernel().connection_manager.get_min_delay()
+    * ( kernel().simulation_manager.get_wfr_interpolation_order() + 1 ) );
 }
 
 void


### PR DESCRIPTION
This PR fixes issue #655 by setting the coeff_length parameter of the `GapJunctionEvent` regardless of the use of the waveform relaxation method.