### PR TITLE
Remove unnecessary `0 GetStatus` calls from hpc benchmark

### DIFF
--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -210,13 +210,13 @@ myrng rdevdict /normal get CreateRDV /normal_dv Set
   (Creating excitatory population.) message  % show message
   /iaf_psc_alpha [NE] LayoutNetwork /E_net Set  % subnet gets own gid
   /E_from E_net 1 add def                    % gid of first child
-  /E_to 0 GetStatus /network_size get 1 sub def % gid of last child
+  /E_to E_from NE add 1 sub def              % gid of last child
   
   M_INFO (BuildNetwork)
   (Creating inhibitory population.) message  % show message
   /iaf_psc_alpha [NI] LayoutNetwork /I_net Set  % subnet gets own gid
   /I_from I_net 1 add def                    % gid of first child
-  /I_to 0 GetStatus /network_size get 1 sub def % gid of last child
+  /I_to I_from NI add 1 sub def              % gid of last child
 
   randomize_Vm
   {


### PR DESCRIPTION
As discussed in #637 this PR removes two calls to `0 GetStatus` during network construction in the hpc benchmark, which cause communication of delay extrema and hence lead to misleading measurement results for a large number of MPI processes. They are replaced by a simple addition.
I suggest @jougs and @heplesser as reviewers.