### PR TITLE
Fix quantal stdp test for numpy

### DIFF
--- a/pynest/nest/tests/test_quantal_stp_synapse.py
+++ b/pynest/nest/tests/test_quantal_stp_synapse.py
@@ -101,15 +101,16 @@ class QuantalSTPSynapseTestCase(unittest.TestCase):
         vm_reference = numpy.array(nest.GetStatus(
             [voltmeter[0]], 'events')[0]['V_m'])
 
-        vm.shape = (n_trials, t_tot)
-        vm_reference.shape = (n_trials, t_tot)
+        assert(len(vm) % n_trials == 0)
+        n_steps = int(len(vm) / n_trials)
+        vm.shape = (n_trials, n_steps)
+        vm_reference.shape = (n_trials, n_steps)
 
-        vm_mean = numpy.array([numpy.mean(vm[:, i])
-                               for i in range(int(t_tot))])
-        vm_ref_mean = numpy.array(
-            [numpy.mean(vm_reference[:, i]) for i in range(int(t_tot))])
+        vm_mean = numpy.mean(vm, axis=0)
+        vm_ref_mean = numpy.mean(vm_reference, axis=0)
 
-        error = numpy.sqrt((vm_ref_mean[:t_plot] - vm_mean[:t_plot])**2)
+        error = numpy.sqrt((vm_ref_mean[:int(t_plot)] -
+                            vm_mean[:int(t_plot)])**2)
         self.assertTrue(numpy.max(error) < 4.0e-4)
 
 

--- a/pynest/nest/tests/test_quantal_stp_synapse.py
+++ b/pynest/nest/tests/test_quantal_stp_synapse.py
@@ -40,10 +40,6 @@ class QuantalSTPSynapseTestCase(unittest.TestCase):
         # parameter set for facilitation
         fac_params = {"U": 0.03, "u": 0.03,
                       "tau_fac": 500., "tau_rec": 200., "weight": 1.}
-        dep_params = {"U": 0.5, "u": 0.5,  "tau_fac": 15.,
-                      "tau_rec": 670., "weight": 1.}
-        lin_params = {"U": 0.3, "u": 0.3,  "tau_fac": 330.,
-                      "tau_rec": 330., "weight": 1.}
 
         # Here we assign the parameter set to the synapse models
         t1_params = fac_params       # for tsodyks2_synapse
@@ -78,7 +74,6 @@ class QuantalSTPSynapseTestCase(unittest.TestCase):
 
         voltmeter = nest.Create("voltmeter", 2)
         nest.SetStatus(voltmeter, {"withgid": False, "withtime": True})
-        t_plot = 1000.
         t_tot = 1500.
 
         # the following is a dry run trial so that the synapse dynamics is
@@ -109,8 +104,7 @@ class QuantalSTPSynapseTestCase(unittest.TestCase):
         vm_mean = numpy.mean(vm, axis=0)
         vm_ref_mean = numpy.mean(vm_reference, axis=0)
 
-        error = numpy.sqrt((vm_ref_mean[:int(t_plot)] -
-                            vm_mean[:int(t_plot)])**2)
+        error = numpy.sqrt((vm_ref_mean - vm_mean)**2)
         self.assertTrue(numpy.max(error) < 4.0e-4)
 
 


### PR DESCRIPTION
This pull request addresses #680  and contains the following changes:

- Convert the float variables in the test to integers when they are used as indices to numpy arrays. I decided to do this rather then defining them as integers in the first place because a) defining times as floats seems plausible to me and b) the conversion of `t_tot` had been implemented in this test at a different location earlier.
- Remove two parameter dictionaries that were not used in the script.
- Make travis download the latest release of numpy via pip.