### PR TITLE
Fix to issue #683.

### DIFF
--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -180,11 +180,21 @@ public:
   void set_model_defaults( Name name, DictionaryDatum params );
 
   /**
-   * Register a synape with default Connector and without any common properties.
+   * Register a synape model with default Connector and without any common
+   * properties. Convenience function that used the default Connector model
+   * GenericConnectorModel.
    * @param name The name under which the ConnectorModel will be registered.
-   * @return an ID for the synapse prototype.
    */
   template < class ConnectionT >
+  void register_connection_model( const std::string& name,
+    bool requires_symmetric = false );
+    
+  /**
+   * Register a synape model with a costom Connector model and without any
+   * common properties.
+   * @param name The name under which the ConnectorModel will be registered.
+   */
+  template < class ConnectionT, template<class> class ConnectorModelT >
   void register_connection_model( const std::string& name,
     bool requires_symmetric = false );
 

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -188,7 +188,7 @@ public:
   template < class ConnectionT >
   void register_connection_model( const std::string& name,
     bool requires_symmetric = false );
-    
+
   /**
    * Register a synape model with a costom Connector model and without any
    * common properties.

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -400,7 +400,9 @@ inline Model*
 ModelManager::get_model( index m ) const
 {
   if ( m >= models_.size() || models_[ m ] == 0 )
+  {
     throw UnknownModelID( m );
+  }
 
   return models_[ m ];
 }
@@ -476,7 +478,9 @@ inline void
 ModelManager::assert_valid_syn_id( synindex syn_id, thread t ) const
 {
   if ( syn_id >= prototypes_[ t ].size() || prototypes_[ t ][ syn_id ] == 0 )
+  {
     throw UnknownSynapseType( syn_id );
+  }
 }
 
 inline bool
@@ -493,12 +497,17 @@ ModelManager::delete_secondary_events_prototypes()
     if ( secondary_connector_models_[ i ] != NULL )
     {
       for ( size_t j = 0; j < secondary_events_prototypes_.size(); j++ )
+      {
         delete secondary_events_prototypes_[ j ][ i ];
+      }
     }
   }
 
   for ( size_t j = 0; j < secondary_events_prototypes_.size(); j++ )
+  {
     secondary_events_prototypes_[ j ].clear();
+  }
+
   secondary_events_prototypes_.clear();
 }
 

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -194,7 +194,7 @@ public:
    * common properties.
    * @param name The name under which the ConnectorModel will be registered.
    */
-  template < class ConnectionT, template<class> class ConnectorModelT >
+  template < class ConnectionT, template < class > class ConnectorModelT >
   void register_connection_model( const std::string& name,
     bool requires_symmetric = false );
 

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -185,20 +185,20 @@ public:
    * GenericConnectorModel.
    * @param name The name under which the ConnectorModel will be registered.
    */
-  template < class ConnectionT >
+  template < typename ConnectionT >
   void register_connection_model( const std::string& name,
     bool requires_symmetric = false );
 
   /**
-   * Register a synape model with a costom Connector model and without any
+   * Register a synape model with a custom Connector model and without any
    * common properties.
    * @param name The name under which the ConnectorModel will be registered.
    */
-  template < class ConnectionT, template < class > class ConnectorModelT >
+  template < typename ConnectionT, template < typename > class ConnectorModelT >
   void register_connection_model( const std::string& name,
     bool requires_symmetric = false );
 
-  template < class ConnectionT >
+  template < typename ConnectionT >
   void register_secondary_connection_model( const std::string& name,
     bool has_delay = true,
     bool requires_symmetric = false );

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -83,24 +83,32 @@ ModelManager::register_preconf_node_model( const Name& name,
   return register_node_model_( model, private_model );
 }
 
-template < class ConnectionT >
+template < class ConnectionT, template<class> class ConnectorModelT >
 void
 ModelManager::register_connection_model( const std::string& name,
   bool requires_symmetric )
 {
-  ConnectorModel* cf = new GenericConnectorModel< ConnectionT >(
+  ConnectorModel* cf = new ConnectorModelT< ConnectionT >(
     name, /*is_primary=*/true, /*has_delay=*/true, requires_symmetric );
   register_connection_model_( cf );
 
   if ( not ends_with( name, "_hpc" ) )
   {
-    cf = new GenericConnectorModel< ConnectionLabel< ConnectionT > >(
+    cf = new ConnectorModelT< ConnectionLabel< ConnectionT > >(
       name + "_lbl",
       /*is_primary=*/true,
       /*has_delay=*/true,
       requires_symmetric );
     register_connection_model_( cf );
   }
+}
+
+template < class ConnectionT >
+void
+ModelManager::register_connection_model( const std::string& name,
+  bool requires_symmetric )
+{
+  register_connection_model< ConnectionT, GenericConnectorModel >( name, requires_symmetric );
 }
 
 /**

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -83,7 +83,7 @@ ModelManager::register_preconf_node_model( const Name& name,
   return register_node_model_( model, private_model );
 }
 
-template < class ConnectionT, template<class> class ConnectorModelT >
+template < class ConnectionT, template < class > class ConnectorModelT >
 void
 ModelManager::register_connection_model( const std::string& name,
   bool requires_symmetric )
@@ -108,7 +108,8 @@ void
 ModelManager::register_connection_model( const std::string& name,
   bool requires_symmetric )
 {
-  register_connection_model< ConnectionT, GenericConnectorModel >( name, requires_symmetric );
+  register_connection_model< ConnectionT, GenericConnectorModel >(
+    name, requires_symmetric );
 }
 
 /**

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -94,8 +94,7 @@ ModelManager::register_connection_model( const std::string& name,
 
   if ( not ends_with( name, "_hpc" ) )
   {
-    cf = new ConnectorModelT< ConnectionLabel< ConnectionT > >(
-      name + "_lbl",
+    cf = new ConnectorModelT< ConnectionLabel< ConnectionT > >( name + "_lbl",
       /*is_primary=*/true,
       /*has_delay=*/true,
       requires_symmetric );

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -43,7 +43,7 @@ ModelManager::register_node_model( const Name& name,
   bool private_model,
   std::string deprecation_info )
 {
-  if ( !private_model && modeldict_->known( name ) )
+  if ( not private_model && modeldict_->known( name ) )
   {
     std::string msg = String::compose(
       "A model called '%1' already exists.\n"
@@ -64,7 +64,7 @@ ModelManager::register_preconf_node_model( const Name& name,
   bool private_model,
   std::string deprecation_info )
 {
-  if ( !private_model && modeldict_->known( name ) )
+  if ( not private_model && modeldict_->known( name ) )
   {
     std::string msg = String::compose(
       "A model called '%1' already exists.\n"
@@ -129,7 +129,9 @@ ModelManager::register_secondary_connection_model( const std::string& name,
   // otherwise when number of threads is increased no way to get further
   // elements
   if ( secondary_connector_models_.size() < synid + ( unsigned int ) 1 )
+  {
     secondary_connector_models_.resize( synid + 1, NULL );
+  }
 
   secondary_connector_models_[ synid ] = cm;
 
@@ -145,7 +147,9 @@ ModelManager::register_secondary_connection_model( const std::string& name,
   // otherwise when number of threads is increased no way to get further
   // elements
   if ( secondary_connector_models_.size() < synid + ( unsigned int ) 1 )
+  {
     secondary_connector_models_.resize( synid + 1, NULL );
+  }
 
   secondary_connector_models_[ synid ] = cm;
 

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -83,7 +83,7 @@ ModelManager::register_preconf_node_model( const Name& name,
   return register_node_model_( model, private_model );
 }
 
-template < class ConnectionT, template < class > class ConnectorModelT >
+template < typename ConnectionT, template < typename > class ConnectorModelT >
 void
 ModelManager::register_connection_model( const std::string& name,
   bool requires_symmetric )
@@ -102,7 +102,7 @@ ModelManager::register_connection_model( const std::string& name,
   }
 }
 
-template < class ConnectionT >
+template < typename ConnectionT >
 void
 ModelManager::register_connection_model( const std::string& name,
   bool requires_symmetric )
@@ -114,7 +114,7 @@ ModelManager::register_connection_model( const std::string& name,
 /**
  * Register a synape with default Connector and without any common properties.
  */
-template < class ConnectionT >
+template < typename ConnectionT >
 void
 ModelManager::register_secondary_connection_model( const std::string& name,
   bool has_delay,


### PR DESCRIPTION
- A second template argument to member function register_connection_model of the ModelManager has been added, which allows the user to specify the type of connector model.
- An overloaded function to register_connection_model has been added that uses the default connector model GenericConnectorModel.