### PR TITLE
Throw exception when connecting fails

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -413,7 +413,8 @@ nest::ConnectionManager::connect( index sgid,
     // we do not allow to connect a device to a global receiver at the moment
     if ( not source->has_proxies() )
     {
-      return;
+      throw IllegalConnection( "The models " + target->get_name() + " and "
+        + source->get_name() + " cannot be connected." );
     }
     connect_( *source, *target, sgid, tid, syn, d, w );
   }
@@ -474,7 +475,8 @@ nest::ConnectionManager::connect( index sgid,
     // we do not allow to connect a device to a global receiver at the moment
     if ( not source->has_proxies() )
     {
-      return;
+      throw IllegalConnection( "The models " + target->get_name() + " and "
+        + source->get_name() + " cannot be connected." );
     }
     connect_( *source, *target, sgid, tid, syn, params, d, w );
   }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -543,7 +543,8 @@ nest::ConnectionManager::connect( index sgid,
     // we do not allow to connect a device to a global receiver at the moment
     if ( not source->has_proxies() )
     {
-      return false;
+      throw IllegalConnection( "The models " + target->get_name() + " and "
+        + source->get_name() + " cannot be connected." );
     }
     connect_( *source, *target, sgid, tid, syn, params );
   }

--- a/testsuite/regressiontests/issue-211.sli
+++ b/testsuite/regressiontests/issue-211.sli
@@ -68,8 +68,8 @@ n2 d4 << /weight 1. >> Connect
 [g5 g5] [n1] Connect
 g5 n3 << /weight 1. >> Connect
 
-% device-device; but g5g5 should be ignored
-[g5 g5] [d4 g5] /one_to_one Connect
+% device-device
+[g5] [d4] /one_to_one Connect
 [g5 g5] [d4] Connect
 g5 d4 << /weight 1. >> Connect
 
@@ -78,7 +78,6 @@ n1 v6 Connect
 n2 v6 Connect
 
 /conn << >> GetConnections def
-
 % expected connections with expected threads
 /target_conn <[1 3 1] [2 3 1] [2 1 1] [3 1 1] [2 1 1] % neuron-neuron
               [1 4 1] [1 3 1] [2 4 0] [3 4 1] [2 4 0] % neuron-device

--- a/testsuite/regressiontests/issue-211.sli
+++ b/testsuite/regressiontests/issue-211.sli
@@ -68,21 +68,16 @@ n2 d4 << /weight 1. >> Connect
 [g5 g5] [n1] Connect
 g5 n3 << /weight 1. >> Connect
 
-% device-device
-[g5] [d4] /one_to_one Connect
-[g5 g5] [d4] Connect
-g5 d4 << /weight 1. >> Connect
-
 % neuron-globally receiving device (volume transmitter)
 n1 v6 Connect
 n2 v6 Connect
 
 /conn << >> GetConnections def
+
 % expected connections with expected threads
 /target_conn <[1 3 1] [2 3 1] [2 1 1] [3 1 1] [2 1 1] % neuron-neuron
               [1 4 1] [1 3 1] [2 4 0] [3 4 1] [2 4 0] % neuron-device
               [5 2 0] [5 3 1] [5 1 1] [5 1 1] [5 3 1] % device-neuron
-              [5 4 0] [5 4 0] [5 4 0] [5 4 0]         % device-device
               [1 6 0] [1 6 1] [2 6 0] [2 6 1]> def    % neuron-globally receiving device
 
 conn {

--- a/testsuite/regressiontests/issue-211.sli
+++ b/testsuite/regressiontests/issue-211.sli
@@ -68,6 +68,10 @@ n2 d4 << /weight 1. >> Connect
 [g5 g5] [n1] Connect
 g5 n3 << /weight 1. >> Connect
 
+% device-device
+[g5 g5] [d4] Connect
+g5 d4 << /weight 1. >> Connect
+
 % neuron-globally receiving device (volume transmitter)
 n1 v6 Connect
 n2 v6 Connect
@@ -78,6 +82,7 @@ n2 v6 Connect
 /target_conn <[1 3 1] [2 3 1] [2 1 1] [3 1 1] [2 1 1] % neuron-neuron
               [1 4 1] [1 3 1] [2 4 0] [3 4 1] [2 4 0] % neuron-device
               [5 2 0] [5 3 1] [5 1 1] [5 1 1] [5 3 1] % device-neuron
+              [5 4 0] [5 4 0] [5 4 0]                 % device-device
               [1 6 0] [1 6 1] [2 6 0] [2 6 1]> def    % neuron-globally receiving device
 
 conn {

--- a/testsuite/unittests/test_connect.sli
+++ b/testsuite/unittests/test_connect.sli
@@ -180,49 +180,38 @@ ResetKernel
 
 (Running Connect tests with illegal combinations) =
 ResetKernel
-/generator /poisson_generator Create def
-/multimeter /multimeter Create def
-/recordable /iaf_psc_alpha Create def
 
+/n_connections 0 def
+modeldict
 {
-  generator generator Connect
-} fail_or_die
+  pop  % remove model id
+  /model_a Set
+  /type_a model_a GetDefaults /element_type get def 
+  /m_a model_a Create def
+  modeldict
+  {
+    pop  % remove model id
+    /model_b Set
+    /type_b model_b GetDefaults /element_type get def 
+    /m_b model_b Create def
 
-% removing items on stack
-pop pop pop pop
+    % try to connect model_a and model_b
+    {
+      m_a m_b Connect
+    } stopped not
+    {  % if there is no error, check that a connection has been made
+      {
+        n_connections 1 add 
+        0 GetStatus /num_connections get 
+        eq
+      } assert_or_die
+      /n_connections n_connections 1 add def
+    }
+    {
+      5 npop 
+    } ifelse
+  } forall
 
-{
-  generator multimeter Connect
-} fail_or_die
+} forall
+(All illegal connections throw an error) =
 
-% removing items on stack
-pop pop pop pop
-
-{
-  % recordable -> multimeter 
-  recordable multimeter Connect
-} fail_or_die
-
-% removing items on stack
-pop pop pop pop
-
-{
-  recordable generator Connect
-} fail_or_die
-
-% removing items on stack
-pop pop pop pop
-
-{
-  multimeter multimeter Connect
-} fail_or_die
-
-% removing items on stack
-pop pop pop pop
-
-{
-  multimeter generator Connect
-} fail_or_die
-
-% removing items on stack
-pop pop pop pop

--- a/testsuite/unittests/test_connect.sli
+++ b/testsuite/unittests/test_connect.sli
@@ -177,3 +177,52 @@ ResetKernel
   Last /target get 6 eq assert_or_die
 
 } forall
+
+(Running Connect tests with illegal combinations) =
+ResetKernel
+/generator /poisson_generator Create def
+/multimeter /multimeter Create def
+/recordable /iaf_psc_alpha Create def
+
+{
+  generator generator Connect
+} fail_or_die
+
+% removing items on stack
+pop pop pop pop
+
+{
+  generator multimeter Connect
+} fail_or_die
+
+% removing items on stack
+pop pop pop pop
+
+{
+  % recordable -> multimeter 
+  recordable multimeter Connect
+} fail_or_die
+
+% removing items on stack
+pop pop pop pop
+
+{
+  recordable generator Connect
+} fail_or_die
+
+% removing items on stack
+pop pop pop pop
+
+{
+  multimeter multimeter Connect
+} fail_or_die
+
+% removing items on stack
+pop pop pop pop
+
+{
+  multimeter generator Connect
+} fail_or_die
+
+% removing items on stack
+pop pop pop pop

--- a/testsuite/unittests/test_connect.sli
+++ b/testsuite/unittests/test_connect.sli
@@ -184,20 +184,14 @@ ResetKernel
 /n_connections 0 def
 modeldict
 {
-  pop  % remove model id
-  /model_a Set
-  /type_a model_a GetDefaults /element_type get def 
-  /m_a model_a Create def
+  pop Create /node_a Set
   modeldict
   {
-    pop  % remove model id
-    /model_b Set
-    /type_b model_b GetDefaults /element_type get def 
-    /m_b model_b Create def
+    pop Create /node_b Set
 
-    % try to connect model_a and model_b
+    % try to connect node_a and node_b
     {
-      m_a m_b Connect
+      node_a node_b Connect
     } stopped not
     {  % if there is no error, check that a connection has been made
       {
@@ -213,5 +207,4 @@ modeldict
   } forall
 
 } forall
-(All illegal connections throw an error) =
 


### PR DESCRIPTION
This PR fixes an issue where in some cases an attempt to create a connection fails silently, such as when trying to connect a multimeter to a generator. NEST will now throw an exception in these cases. 

Additionally, a part of the regressiontest issue-211 that now throws an exception has been removed, and tests to make sure that NEST throws an exception to avoid silent failure has been added.

This fixes #578. 