### PR TITLE
Remove duplicate constructors for long & double from Time units

### DIFF
--- a/nestkernel/nest_time.h
+++ b/nestkernel/nest_time.h
@@ -264,10 +264,6 @@ public:
       : t( t )
     {
     }
-    explicit ms( long t )
-      : t( static_cast< double >( t ) )
-    {
-    }
 
     static double fromtoken( const Token& t );
     explicit ms( const Token& t )
@@ -279,10 +275,6 @@ public:
     double t;
     explicit ms_stamp( double t )
       : t( t )
-    {
-    }
-    explicit ms_stamp( long t )
-      : t( static_cast< double >( t ) )
     {
     }
   };

--- a/nestkernel/nest_time.h
+++ b/nestkernel/nest_time.h
@@ -259,7 +259,6 @@ public:
   struct ms
   {
     double t;
-
     explicit ms( double t )
       : t( t )
     {


### PR DESCRIPTION
Redundant constructors for both long & double types, which can only cause ambiguities since a long with a C++03 constructor is coerced automagically.
See #669 for example.