### PR TITLE
Point out in documentation that install path should be absolute, fixes #561 [ci skip]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,9 +11,9 @@ NEST is installed with `cmake` (at least v2.8.12). In the simplest case, the com
     make
     make install
 
-should build and install NEST to <install-path>. Detailed installation 
-instructions can be found below, including instructions for macOS, BlueGene/Q
-and Fujitsu Sparc64 systems.
+should build and install NEST to `/install/path`, which should be an absolute
+path. Detailed installation  instructions can be found below, including 
+instructions for macOS, BlueGene/Q and Fujitsu Sparc64 systems.
 
 Choice of CMake Version
 =======================

--- a/extras/userdoc/md/documentation/installation.md
+++ b/extras/userdoc/md/documentation/installation.md
@@ -17,7 +17,8 @@ Following are the basic steps to compile and install NEST from source code:
 1.  Create a build directory: `mkdir nest-x.y.z-build`
 1.  Change to the build directory: `cd nest-x.y.z-build`
 1.  Configure NEST: `cmake -DCMAKE_INSTALL_PREFIX:PATH=</install/path> </path/to/NEST/src>` with
-additional `cmake` options as needed (see `INSTALL` file)
+additional `cmake` options as needed (see `INSTALL` file; `/install/path` should be an
+absolute path)
 1.  Compile by running `make`
 1.  Install by running `make install`
 1.  Run tests by running `make installcheck`


### PR DESCRIPTION
#561 reported some mix-up when passing relative path as install prefix. From Cmake docs, relative paths should be converted to absolute automatically, but to be safe I added explicit remarks to the installation instructions.

As single reviewer should suffice on this one.