### PR TITLE
Fixed bug in delivery of secondary events

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -1212,13 +1212,12 @@ public:
     const std::vector< ConnectorModel* >& cm )
   {
     // for all secondary connections delegate send to the matching homogeneous
-    // connector only
+    // connectors only
     for ( size_t i = primary_end_; i < size(); i++ )
     {
       if ( e.supports_syn_id( at( i )->get_syn_id() ) )
       {
         at( i )->send( e, t, cm );
-        break;
       }
     }
   }

--- a/testsuite/regressiontests/issue-708.sli
+++ b/testsuite/regressiontests/issue-708.sli
@@ -1,0 +1,94 @@
+/*
+ *  issue-708.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /* BeginDocumentation
+Name: testsuite::issue-708
+
+Synopsis: (issue-708) run -> NEST exits if test fails
+
+Description:
+This test ensures that CopyModel works with connection
+types which use secondary events.
+
+Author: Jan Hahne
+FirstVersion: April 2017
+SeeAlso:
+*/
+
+(unittest) run
+/unittest using
+
+% The following test needs the model hh_psc_alpha_gap, so
+% this test should only run if we have GSL
+statusdict/have_gsl :: not
+{
+  exit_test_gracefully
+}
+if
+
+{
+  ResetKernel
+
+  /hh_psc_alpha_gap Create /neuron_in Set
+  /hh_psc_alpha_gap Create /neuron_out1 Set
+  /hh_psc_alpha_gap Create /neuron_out2 Set
+  /voltmeter Create /vm1 Set
+  /voltmeter Create /vm2 Set
+
+  /gap_junction /syn0 CopyModel
+  /gap_junction /syn1 CopyModel
+
+  neuron_in << /I_e 200.0 >> SetStatus
+  vm1 << /interval 1.0 >> SetStatus
+  vm2 << /interval 1.0 >> SetStatus
+
+  [neuron_in] [neuron_out1]
+  << /rule /one_to_one /make_symmetric true >>
+  << /model /syn0 /weight 10.0 >>
+  Connect
+
+  [neuron_in] [neuron_out2]
+  << /rule /one_to_one /make_symmetric true >>
+  << /model /syn1 /weight 10.0 >>
+  Connect
+
+  vm1 neuron_out1 Connect
+  vm2 neuron_out2 Connect
+
+  10 Simulate
+
+  % check that neuron_out1 received the input
+  % -6.960401e+01 is the resting potential
+  vm1 GetStatus /events get /V_m get 8 get
+  -6.960401e+01 gt
+
+  % check that neuron_out2 received the input
+  % -6.960401e+01 is the resting potential
+  vm2 GetStatus /events get /V_m get 8 get
+  -6.960401e+01 gt
+
+  and
+}
+assert_or_die
+
+endusing


### PR DESCRIPTION
This fixes #708. The `break` statement was accidentally not removed with the original PR #175 which should already have fixed this issue.

Originally there was a one-to-one mapping between `syn_id` and `SecondaryEvent` classes. Meaning only `gap_junction`s used `GapJunctionEvent`s. The property `get_syn_id()` was replaced by `supports_syn_id` with #175 to allow the use of `CopyModel` and due to the introduction of labeled synapses, as both `gap_junction` and `gap_junction_lbl` of course use the `GapJunctionEvent`. 

The here removed `break` statement was (in the days of the one-to-one mapping) used to improve the performance and then by mistake not removed when #175 was introduced.

@heplesser Do you remember the original PR? If yes, could you have a quick look?