### PR TITLE
Fix issue #678  - Skip help generation without python or python older than 2.7.8

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,8 +20,15 @@
 if ( NOT CMAKE_CROSSCOMPILING )
   add_custom_target( generate_help ALL )
 
+    # Python is needed to generate the help. If Python does not exist, there are
+    # problems with the following.
+    # See https://github.com/nest/nest-simulator/issues/678.
     find_package( PythonInterp )
     if ( PYTHONINTERP_FOUND )
+
+      # Because of problems of help generation with the implementation of 're'
+      # in Python older than 2.7.8, the production of the help is skipped
+      # completely for these versions.
       if(${PYTHON_VERSION_STRING} VERSION_GREATER "2.7.7")
           # Extract help from all source files in the source code, put them in
           # doc/help and generate a local help index in the build directory containing
@@ -47,6 +54,7 @@ if ( NOT CMAKE_CROSSCOMPILING )
             )"
             )
       endif ()
+
     endif ()
 
 endif ()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -19,28 +19,36 @@
 
 if ( NOT CMAKE_CROSSCOMPILING )
   add_custom_target( generate_help ALL )
-  # Extract help from all source files in the source code, put them in
-  # doc/help and generate a local help index in the build directory containing 
-  # links to the help files.
-  add_custom_command( TARGET generate_help POST_BUILD
-    COMMAND python -B generate_help.py "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}"
-    COMMAND python -B generate_helpindex.py "${PROJECT_BINARY_DIR}/doc"
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/extras/help_generator"
-    COMMENT "Extracting help information; this may take a litte while."
-    )
-  # Copy the local doc/help directory to the global installation
-  # directory for documentation.
-  install( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/help"
-    DESTINATION "${CMAKE_INSTALL_DOCDIR}"
-    )
-  # Update the global help index to contain all help files that are
-  # located in the global installation directory for documentation.
-  install( CODE
-    "execute_process(
-      COMMAND python -B generate_helpindex.py \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}\"
-      WORKING_DIRECTORY \"${PROJECT_SOURCE_DIR}/extras/help_generator\"
-    )"
-    )
+
+    find_package( PythonInterp )
+    if ( PYTHONINTERP_FOUND )
+      if(${PYTHON_VERSION_STRING} VERSION_GREATER "2.7.7")
+          # Extract help from all source files in the source code, put them in
+          # doc/help and generate a local help index in the build directory containing
+          # links to the help files.
+          add_custom_command( TARGET generate_help POST_BUILD
+            COMMAND ${PYTHON_EXECUTABLE} -B generate_help.py "${PROJECT_SOURCE_DIR}"
+            "${PROJECT_BINARY_DIR}"
+            COMMAND ${PYTHON_EXECUTABLE} -B generate_helpindex.py "${PROJECT_BINARY_DIR}/doc"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/extras/help_generator"
+            COMMENT "Extracting help information; this may take a litte while."
+            )
+          # Copy the local doc/help directory to the global installation
+          # directory for documentation.
+          install( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/help"
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+            )
+          # Update the global help index to contain all help files that are
+          # located in the global installation directory for documentation.
+          install( CODE
+            "execute_process(
+              COMMAND ${PYTHON_EXECUTABLE} -B generate_helpindex.py \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}\"
+              WORKING_DIRECTORY \"${PROJECT_SOURCE_DIR}/extras/help_generator\"
+            )"
+            )
+      endif ()
+    endif ()
+
 endif ()
 
 install( DIRECTORY conngen model_details


### PR DESCRIPTION
Getting python from CMake variables and using this instead of the hard coded python. Skipping help generation if no python is found or the version is older than 2.7.8.

This is a fix for issue #678 and #712