### PR TITLE
Ensure that ResetKernel resets off_grid_spiking_

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -69,6 +69,8 @@ EventDeliveryManager::~EventDeliveryManager()
 void
 EventDeliveryManager::initialize()
 {
+  off_grid_spiking_ =
+    false; // ensures that ResetKernel resets off_grid_spiking_
   init_moduli();
   reset_timers_counters();
 }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -69,8 +69,8 @@ EventDeliveryManager::~EventDeliveryManager()
 void
 EventDeliveryManager::initialize()
 {
-  off_grid_spiking_ =
-    false; // ensures that ResetKernel resets off_grid_spiking_
+  // ensures that ResetKernel resets off_grid_spiking_
+  off_grid_spiking_ = false;
   init_moduli();
   reset_timers_counters();
 }

--- a/testsuite/unittests/test_spike_generator.sli
+++ b/testsuite/unittests/test_spike_generator.sli
@@ -347,7 +347,7 @@ assert_or_die
   >> SetStatus
   
   /spike_detector Create /sd Set
-  sd << /withtime true /to_memory true /withgid true /time_in_steps true >> SetStatus
+  sd << /precise_times true /withtime true /to_memory true /withgid true /time_in_steps true >> SetStatus
   sg sd 1.0 1.0 Connect
 
   10.0 Simulate
@@ -383,7 +383,7 @@ assert_or_die
   >> SetStatus
   
   /spike_detector Create /sd Set
-  sd << /withtime true /to_memory true /withgid true /time_in_steps true >> SetStatus
+  sd << /precise_times true /withtime true /to_memory true /withgid true /time_in_steps true >> SetStatus
   sg sd 1.0 1.0 Connect
 
   10.0 Simulate


### PR DESCRIPTION
The default of the kernel parameter `off_grid_spiking_` is `false`. The parameter can be altered by the user and it is automatically set to `true` if a precise neuron model is created.

So far, `ResetKernel` did not result in a reset of `off_grid_spiking_` to `false`, which I find counterintuitive.