### PR TITLE
Small fixes for compiler warnings and spelling

### DIFF
--- a/extras/static_code_analysis.sh
+++ b/extras/static_code_analysis.sh
@@ -252,7 +252,7 @@ if [ "x$c_files_with_errors" != "x" ] || [ "x$python_files_with_errors" != "x" ]
 else
   print_msg "" ""
   print_msg "MSGBLD0220: " "+ + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +"
-  print_msg "MSGBLD0220: " "+               STATIC CODE ANALYSIS TERMINATED SUCESSFULLY !                 +"
+  print_msg "MSGBLD0220: " "+               STATIC CODE ANALYSIS TERMINATED SUCCESSFULLY !                +"
   print_msg "MSGBLD0220: " "+ + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +"
   print_msg "" ""  
 fi

--- a/lib/sli/processes.sli
+++ b/lib/sli/processes.sli
@@ -703,7 +703,7 @@ Bugs: No error message is raised, if Flag=1 or Flag=2 and the given
       but it is raised in a child process of SLI, and -after- standard
       output has been redirected. The error message can be read from
       the "mouth"-pipe!
-       "spawn" always returns sucessful if Flag=1 or Flag=2. However,
+      "spawn" always returns successful if Flag=1 or Flag=2. However,
       excution of the UNIX command may have failed in the child process.
       This may be a bug or a feature, whatever you like best ;->
 

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -44,17 +44,17 @@ namespace nest
    with exponential shaped postsynaptic currents (PSCs) according to [1].
    The postsynaptic currents have an infinitely short rise time.
    In particular, this model allows setting an absolute and relative
-   refractory time separately, as requied by [1].
+   refractory time separately, as required by [1].
 
    The threshold crossing is followed by an absolute refractory period (tau_abs)
    during which the membrane potential is clamped to the resting potential.
    During the total refractory period, the membrane potential evolves,
    but the neuron will not emit a spike, even if the membrane potential
-   reaches threshold. The total refratory time must be larger or equal to
+   reaches threshold. The total refractory time must be larger or equal to
    the absolute refractory time. If equal, the refractoriness of the model
    if equivalent to the other models of NEST.
 
-   The linear subthresold dynamics is integrated by the Exact
+   The linear subthreshold dynamics is integrated by the Exact
    Integration scheme [2]. The neuron dynamics is solved on the time
    grid given by the computation step size. Incoming as well as emitted
    spikes are forced to that grid.

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -254,12 +254,13 @@ private:
 
   // ------------------------------------------------------------
 
-  StimulatingDevice< CurrentEvent > device_;
   static RecordablesMap< noise_generator > recordablesMap_;
+
+  StimulatingDevice< CurrentEvent > device_;
   Parameters_ P_;
+  State_ S_;
   Variables_ V_;
   Buffers_ B_;
-  State_ S_;
 };
 
 inline port

--- a/nest/sli_neuron.cpp
+++ b/nest/sli_neuron.cpp
@@ -125,8 +125,6 @@ nest::sli_neuron::calibrate()
 {
   B_.logger_.init();
 
-  bool terminate = false;
-
   if ( not state_->known( names::calibrate ) )
   {
     std::string msg = String::compose(


### PR DESCRIPTION
This PR fixes two minor details in C++-code eliciting compiler warnings at least with clang and fixes a few spelling errors in messages and documentation.