### PR TITLE
Fix ac_generator when used with start/stop (addresses #720)

### DIFF
--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -215,15 +215,16 @@ nest::ac_generator::update( Time const& origin, const long from, const long to )
   CurrentEvent ce;
   for ( long lag = from; lag < to; ++lag )
   {
-    S_.I_ = 0.0;
+    // We need to iterate the oscillator throughout all steps, even when the
+    // device is not active, since inactivity only windows the oscillator.
+    const double y_0 = S_.y_0_;
+    S_.y_0_ = V_.A_00_ * y_0 + V_.A_01_ * S_.y_1_;
+    S_.y_1_ = V_.A_10_ * y_0 + V_.A_11_ * S_.y_1_;
 
+    S_.I_ = 0.0;
     if ( device_.is_active( Time::step( start + lag ) ) )
     {
-      const double y_0 = S_.y_0_;
-      S_.y_0_ = V_.A_00_ * y_0 + V_.A_01_ * S_.y_1_;
-      S_.y_1_ = V_.A_10_ * y_0 + V_.A_11_ * S_.y_1_;
       S_.I_ = S_.y_1_ + P_.offset_;
-
       ce.set_current( S_.I_ );
       kernel().event_delivery_manager.send( *this, ce, lag );
     }

--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -37,16 +37,25 @@
    Name: ac_generator - provides AC input current
    Description:
 
-   This device produce an ac-current which are sent by a current event.
+   This device produce an ac-current which are sent by a CurrentEvent. The
+   current is given by
+
+           I(t) = offset + amplitude * sin ( om * t + phi )
+
+   where
+
+       om  = 2 * pi * frequency
+       phi = phase / 180 * pi
+
    The parameters are
+
    amplitude   double -  Amplitude of sine current in pA
    offset      double -  Constant amplitude offset in pA
-   phase       double -  Phase of sine current (0-360 deg)
    frequency   double -  Frequency in Hz
-   4) The
+   phase       double -  Phase of sine current (0-360 deg)
 
-   The currents are updated every time step by exact integration schemes from
-   [1]
+   Setting start and stop (see StimulatingDevice) only windows the current
+   as defined above. It does not shift the time axis.
 
    References:
    [1] S. Rotter and M. Diesmann, Exact digital simulation of time-
@@ -57,7 +66,7 @@
 
    Author: Johan Hake, Spring 2003
 
-   SeeAlso: Device, StimulatingDevice, dc_generator
+   SeeAlso: Device, StimulatingDevice, dc_generator, step_current_generator
 */
 
 namespace nest

--- a/testsuite/unittests/test_ac_generator.sli
+++ b/testsuite/unittests/test_ac_generator.sli
@@ -1,0 +1,108 @@
+/*
+ *  test_ac_generator.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* BeginDocumentation
+   Name: testsuite::test_ac_generator - test that ac_generator provides correct current
+
+   Synopsis: (test_ac_generator) run
+
+   Description:
+   This testscript checks tests that the ac_generator provides the correct
+   current by comparing with a neuron driven by a step-current input 
+   corresponding to the current expected from the ac_generator.
+
+   FirstVersion: May 2017
+   Author: Hans Ekkehard Plesser
+ */
+
+M_ERROR setverbosity
+
+(unittest) run
+/unittest using
+
+{
+  /dc   1000.0 def
+  /ac    550.0 def
+  /freq  100.0 def
+  /phi     0.0 def
+  /start   5.0 def
+  /stop    6.0 def
+  /dt      0.1 def
+
+  /om freq 1000.0 div 2 mul Pi mul def   % in radians per ms
+  
+  /sc_times [ start stop dt ] { } Table def
+  /sc_amps sc_times { om mul phi add sin ac mul dc add } Map def
+
+  ResetKernel
+  0 << /resolution dt >> SetStatus
+  /n_ac /iaf_psc_alpha Create def
+  /n_sc /iaf_psc_alpha Create def
+  
+  /g_ac /ac_generator 
+        << /amplitude ac /offset dc /frequency freq /phase phi
+           /start start /stop stop >>
+        Create def
+  /g_sc /step_current_generator 
+        << /amplitude_times sc_times /amplitude_values sc_amps 
+           /start start /stop stop >>
+        Create def
+  
+  /vm_ac /voltmeter 
+         << /interval 0.1 >> 
+         Create def
+  /vm_sc /voltmeter 
+         << /interval 0.1 >> 
+         Create def
+         
+  /I_ac /multimeter 
+         << /record_from [ /I ] /interval 0.1 >> 
+         Create def
+  /I_sc /multimeter 
+         << /record_from [ /I ] /interval 0.1 >> 
+         Create def
+        
+  g_ac n_ac Connect
+  vm_ac n_ac Connect
+  I_ac g_ac Connect
+  
+  g_sc n_sc Connect
+  vm_sc n_sc Connect
+  I_sc g_sc Connect
+  
+  10 Simulate
+  
+  vm_ac [/events /V_m] get
+  vm_sc [/events /V_m] get
+  sub cva { abs } Map Max 1e-10 lt
+
+  I_ac [/events /I] get
+  I_sc [/events /I] get
+  sub cva { abs } Map Max 1e-10 lt
+
+  and
+}
+assert_or_die      
+        
+endusing
+
+

--- a/testsuite/unittests/test_step_current_generator.sli
+++ b/testsuite/unittests/test_step_current_generator.sli
@@ -22,7 +22,7 @@
 
 
  /* BeginDocumentation
-Name: testsuite::test_step_current_generator - minimal test of noise_generator
+Name: testsuite::test_step_current_generator - minimal test of step_current_generator
 
 Synopsis: (test_step_current_generator) run -> dies if assertion fails
 


### PR DESCRIPTION
Corrected ac_generator when used with start/stop, improved documentation and added test.

This addresses #720, although with a slightly different logic than apparently assumed by PyNN: In NEST, `start` and `stop` strictly do windowing and `origin` strictly moves this window. Thus, time is always counted from 0 when computing the sinusoid. This was incorrectly implemented until now and is now fixed.

Furthermore, for the parameters given in #720, the `ac_generator` now provides I=1000 pA at t=5 ms as expected. 

@appukuttan-shailesh Would you be willing to review this PR? Please use the "Start a review" feature and the "Review changes" button to submit your comments and verdict. I cannot add you to the "Reviewers" since you currently are not a member of NEST on Github.