### PR TITLE
Circumvent negative max_width in Travis log parser

### DIFF
--- a/extras/parse_travis_log.py
+++ b/extras/parse_travis_log.py
@@ -830,6 +830,14 @@ def printable_summary(list_of_changed_files,
     table = AsciiTable(summary_table)
     table.inner_row_border = True
     max_width = table.column_max_width(1)
+
+    # Bypass Travis issue:  ValueError: invalid width -29 (must be > 0)
+    #                       (in the wrap() below max_width must be > 0)
+    # The calculation of column_max_width is based on the returned terminal
+    # width which sometimes seems to be zero resulting in a negative value.
+    if max_width < 0:
+        max_width = 70
+
     table.table_data[1][1] = '\n'.join(wrap(', '.join(list_of_changed_files),
                                             max_width))
 


### PR DESCRIPTION
Bypass Travis issue: ValueError: invalid width -29 (must be > 0)

On Travis column_max_width sometimes returns a negative value causing the parser script to abend. The calculation is based on the terminal width which seems to be zero in that case. This pull requests adds two lines to set the value to 70 if it is negative.   