### PR TITLE
Fix #74 osx clang problems

### DIFF
--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -174,7 +174,7 @@ nest::RecordingDevice::Parameters_::get( const RecordingDevice& rd,
 
 void
 nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
-  const Buffers_&,
+  const Buffers_& B,
   const DictionaryDatum& d )
 {
   updateValue< std::string >( d, names::label, label_ );
@@ -207,15 +207,15 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
   long fbuffer_size;
   if ( updateValue< long >( d, names::fbuffer_size, fbuffer_size ) )
   {
+    if ( B.fs_.is_open() )
+    {
+      throw BadProperty( "fbuffer_size cannot be set on open files." );
+    }
     if ( fbuffer_size < 0 )
     {
-      throw BadProperty( "/fbuffer_size must be <= 0" );
+      throw BadProperty( "fbuffer_size must be >= 0" );
     }
-    else
-    {
-      fbuffer_size_old_ = fbuffer_size_;
-      fbuffer_size_ = fbuffer_size;
-    }
+    fbuffer_size_ = fbuffer_size;
   }
 
   updateValue< bool >( d, names::close_after_simulate, close_after_simulate_ );
@@ -445,8 +445,24 @@ nest::RecordingDevice::State_::set( const DictionaryDatum& d )
   }
 }
 
+nest::RecordingDevice::Buffers_::Buffers_()
+  : fs_()
+  , fbuffer_( 0 )
+  , fbuffer_size_( 0 )
+{
+}
+
+nest::RecordingDevice::Buffers_::~Buffers_()
+{
+  if ( fbuffer_ )
+  {
+    delete[] fbuffer_;
+  }
+}
+
+
 /* ----------------------------------------------------------------
- * Default and copy constructor for device
+ * Default and copy constructor and destructor for device
  * ---------------------------------------------------------------- */
 
 nest::RecordingDevice::RecordingDevice( const Node& n,
@@ -469,6 +485,7 @@ nest::RecordingDevice::RecordingDevice( const Node& n,
       withport,
       withrport )
   , S_()
+  , B_()
 {
 }
 
@@ -479,9 +496,9 @@ nest::RecordingDevice::RecordingDevice( const Node& n,
   , mode_( d.mode_ )
   , P_( d.P_ )
   , S_( d.S_ )
+  , B_() // no not copy
 {
 }
-
 
 /* ----------------------------------------------------------------
  * Device initialization functions
@@ -509,6 +526,8 @@ nest::RecordingDevice::init_buffers()
   Device::init_buffers();
 
   // we only close files here, opening is left to calibrate()
+  // we must not touch B_.fbuffer_ here, as it will be used
+  // as long as B_.fs_ exists.
   if ( P_.close_on_reset_ && B_.fs_.is_open() )
   {
     B_.fs_.close();
@@ -550,6 +569,34 @@ nest::RecordingDevice::calibrate()
     {
       assert( not B_.fs_.is_open() );
 
+      // fbuffer should be set before opening file
+      if (
+        // still using default buffer, changing to non-default size
+        ( B_.fbuffer_ == 0 and P_.fbuffer_size_ != BUFSIZ )
+        // manual buffer, changing size
+        or ( B_.fbuffer_ != 0 and P_.fbuffer_size_ != B_.fbuffer_size_ ) )
+      {
+        if ( B_.fbuffer_ )
+        {
+          delete[] B_.fbuffer_;
+          B_.fbuffer_ = 0;
+        }
+        if ( P_.fbuffer_size_ > 0 )
+        {
+          B_.fbuffer_ = new char[ P_.fbuffer_size_ ];
+        }
+        B_.fbuffer_size_ = P_.fbuffer_size_;
+        std::basic_streambuf< char >* res =
+          B_.fs_.rdbuf()->pubsetbuf( B_.fbuffer_, B_.fbuffer_size_ );
+        if ( res == 0 )
+        {
+          LOG( M_ERROR,
+            "RecordingDevice::calibrate()",
+            "Failed to set file buffer." );
+          throw IOError();
+        }
+      }
+
       if ( kernel().io_manager.overwrite_files() )
       {
         if ( P_.binary_ )
@@ -590,23 +637,6 @@ nest::RecordingDevice::calibrate()
           B_.fs_.open( P_.filename_.c_str() );
         }
       }
-
-      if ( P_.fbuffer_size_ != P_.fbuffer_size_old_ )
-      {
-        if ( P_.fbuffer_size_ == 0 )
-        {
-          B_.fs_.rdbuf()->pubsetbuf( 0, 0 );
-        }
-        else
-        {
-          std::vector< char >* buffer =
-            new std::vector< char >( P_.fbuffer_size_ );
-          B_.fs_.rdbuf()->pubsetbuf(
-            reinterpret_cast< char* >( &buffer[ 0 ] ), P_.fbuffer_size_ );
-        }
-
-        P_.fbuffer_size_old_ = P_.fbuffer_size_;
-      }
     }
 
     if ( not B_.fs_.good() )
@@ -641,17 +671,6 @@ nest::RecordingDevice::calibrate()
     }
 
     B_.fs_ << std::setprecision( P_.precision_ );
-
-    if ( P_.fbuffer_size_ != P_.fbuffer_size_old_ )
-    {
-      std::string msg = String::compose(
-        "Cannot set file buffer size, as the file is already "
-        "openeded with a buffer size of %1. Please close the "
-        "file first.",
-        P_.fbuffer_size_old_ );
-      LOG( M_ERROR, "RecordingDevice::calibrate()", msg );
-      throw IOError();
-    }
   }
 }
 
@@ -661,9 +680,11 @@ nest::RecordingDevice::post_run_cleanup()
   if ( B_.fs_.is_open() )
   {
     if ( P_.flush_after_simulate_ )
+    {
       B_.fs_.flush();
+    }
 
-    if ( !B_.fs_.good() )
+    if ( not B_.fs_.good() )
     {
       std::string msg =
         String::compose( "I/O error while opening file '%1'", P_.filename_ );

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -496,7 +496,7 @@ nest::RecordingDevice::RecordingDevice( const Node& n,
   , mode_( d.mode_ )
   , P_( d.P_ )
   , S_( d.S_ )
-  , B_() // no not copy
+  , B_() // do not copy
 {
 }
 

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -214,7 +214,7 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
 
     // prohibit negative sizes but allow Create_l_i_D to reset -1 on prototype
     if ( fbuffer_size < 0
-    	 and not ( rd.node_.get_vp() == -1 and fbuffer_size == -1 ) )
+      and not( rd.node_.get_vp() == -1 and fbuffer_size == -1 ) )
     {
       throw BadProperty( "fbuffer_size must be >= 0." );
     }
@@ -600,7 +600,8 @@ nest::RecordingDevice::calibrate()
         if ( res == 0 )
         {
           LOG( M_ERROR,
-            "RecordingDevice::calibrate()", "Failed to set file buffer." );
+            "RecordingDevice::calibrate()",
+            "Failed to set file buffer." );
           throw IOError();
         }
       }

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -472,6 +472,18 @@ private:
   struct Buffers_
   {
     std::ofstream fs_; //!< the file to write the recorded data to
+
+    /**
+     * Manually managed output buffer.
+     *
+     * This pointer is zero unless the user explicitly sets fbuffer_size
+     * to a value greater than zero.
+     */
+    char* fbuffer_;
+    size_t fbuffer_size_; //!< size of fbuffer_
+
+    Buffers_();
+    ~Buffers_();
   };
 
   // ------------------------------------------------------------------
@@ -499,9 +511,7 @@ private:
     bool user_set_precision_;     //!< true if user set precision
 
     bool binary_; //!< true if to write files in binary mode instead of ASCII
-    long fbuffer_size_;     //!< the buffer size to use when writing to file
-    long fbuffer_size_old_; //!< the buffer size to use when writing
-                            //!< to file (old)
+    size_t fbuffer_size_; //!< the buffer size to use when writing to file
 
     std::string label_;    //!< a user-defined label for symbolic device names.
     std::string file_ext_; //!< the file name extension to use, without .
@@ -559,7 +569,6 @@ private:
   Parameters_ P_;
   State_ S_;
   Buffers_ B_;
-  Buffers_ V_;
 };
 
 inline bool

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -174,10 +174,12 @@ namespace nest
   /binary        - if set to true, data is written in binary mode to files
                    instead of ASCII. This setting affects file output only, not
                    screen output (default: false)
-  /fbuffer_size  - the size of the buffer to use for writing to files. The
-                   default size is determined by the implementation of the C++
-                   standard library. To obtain an unbuffered file stream, use a
-                   buffer size of 0.
+  /fbuffer_size  - the size of the buffer to use for writing to files. Setting
+                   this value to 0 will reduce buffering to a system-dependent
+                   minimum. Set /flush_after_simulate to true to ensure that all
+                   pending data is written to file before Simulate returns. A
+                   value of -1 shows that the system default is in use. This
+                   value can only be changed before Simulate is called.
 
   Data recorded in memory is available through the following parameter:
   /n_events      - Number of events collected or sampled. n_events can be set to
@@ -476,11 +478,11 @@ private:
     /**
      * Manually managed output buffer.
      *
-     * This pointer is zero unless the user explicitly sets fbuffer_size
+     * This pointer is zero unless the user explicitly sets fbuffer_size_
      * to a value greater than zero.
      */
     char* fbuffer_;
-    size_t fbuffer_size_; //!< size of fbuffer_
+    long fbuffer_size_; //!< size of fbuffer_; -1: not yet set
 
     Buffers_();
     ~Buffers_();
@@ -511,7 +513,7 @@ private:
     bool user_set_precision_;     //!< true if user set precision
 
     bool binary_; //!< true if to write files in binary mode instead of ASCII
-    size_t fbuffer_size_; //!< the buffer size to use when writing to file
+    long fbuffer_size_; //!< output buffer size; -1 until set by user
 
     std::string label_;    //!< a user-defined label for symbolic device names.
     std::string file_ext_; //!< the file name extension to use, without .

--- a/pynest/pynestkernel.pxd
+++ b/pynest/pynestkernel.pxd
@@ -63,11 +63,11 @@ cdef extern from "stringdatum.h":
     cppclass StringDatum:
         StringDatum(const string&) except +
 
-cdef extern from "mask.h" namespace "nest":
+cdef extern from "topologymodule.h" namespace "nest":
     cppclass MaskDatum:
         MaskDatum(const MaskDatum&)
 
-cdef extern from "topology_parameter.h" namespace "nest":
+cdef extern from "topologymodule.h" namespace "nest":
     cppclass ParameterDatum:
         ParameterDatum(const ParameterDatum&)
 

--- a/pynest/pynestkernel.pxd
+++ b/pynest/pynestkernel.pxd
@@ -63,11 +63,11 @@ cdef extern from "stringdatum.h":
     cppclass StringDatum:
         StringDatum(const string&) except +
 
-cdef extern from "topologymodule.h" namespace "nest":
+cdef extern from "mask.h" namespace "nest":
     cppclass MaskDatum:
         MaskDatum(const MaskDatum&)
 
-cdef extern from "topologymodule.h" namespace "nest":
+cdef extern from "topology_parameter.h" namespace "nest":
     cppclass ParameterDatum:
         ParameterDatum(const ParameterDatum&)
 

--- a/sli/processes.cc
+++ b/sli/processes.cc
@@ -940,8 +940,12 @@ Processes::SetNonblockFunction::execute( SLIInterpreter* i ) const
 void
 Processes::CtermidFunction::execute( SLIInterpreter* i ) const
 {
-  char term[] = "\0";
-  std::string termid = ctermid( term );
+  // ensure term buffer is sufficiently large and safely initialized
+  assert( L_ctermid > 0 );
+  char term[ L_ctermid ];
+  term[ 0 ] = '\0';
+
+  const std::string termid = ctermid( term );
 
   i->OStack.push( Token( termid ) );
   i->EStack.pop();

--- a/topology/CMakeLists.txt
+++ b/topology/CMakeLists.txt
@@ -34,6 +34,7 @@ set( topo_sources
     grid_layer.h
     mask.h
     mask_impl.h
+    mask.cpp
     grid_mask.h
     ntree.h
     ntree_impl.h

--- a/topology/mask.cpp
+++ b/topology/mask.cpp
@@ -1,0 +1,32 @@
+/*
+ *  mask.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "mask.h"
+
+// includes from sli
+#include "lockptrdatum_impl.h"
+
+// Explicit definition required to ensure visibility when compiling with
+// clang under OSX. This must be outside namespace NEST, since the template
+// is defined in the global namespace.
+template class lockPTRDatum< nest::AbstractMask,
+  &nest::TopologyModule::MaskType >;

--- a/topology/mask.h
+++ b/topology/mask.h
@@ -41,6 +41,11 @@
 
 namespace nest
 {
+class AbstractMask;
+
+typedef lockPTRDatum< AbstractMask, &TopologyModule::MaskType > MaskDatum;
+
+
 /**
  * Abstract base class for masks with unspecified dimension.
  */

--- a/topology/mask.h
+++ b/topology/mask.h
@@ -41,8 +41,6 @@
 
 namespace nest
 {
-class TopologyModule;
-
 /**
  * Abstract base class for masks with unspecified dimension.
  */
@@ -91,8 +89,6 @@ public:
    */
   virtual AbstractMask* minus_mask( const AbstractMask& other ) const = 0;
 };
-
-typedef lockPTRDatum< AbstractMask, &TopologyModule::MaskType > MaskDatum;
 
 /**
  * Abstract base class for masks with given dimension.

--- a/topology/topology_names.cpp
+++ b/topology/topology_names.cpp
@@ -67,7 +67,6 @@ const Name mean_x( "mean_x" );
 const Name mean_y( "mean_y" );
 const Name min( "min" );
 const Name minor_axis( "minor_axis" );
-const Name mu( "mu" );
 const Name number_of_connections( "number_of_connections" );
 const Name outer_radius( "outer_radius" );
 const Name p_center( "p_center" );
@@ -85,11 +84,8 @@ const Name sigma_x( "sigma_x" );
 const Name sigma_y( "sigma_y" );
 const Name sources( "sources" );
 const Name spherical( "spherical" );
-const Name tau( "tau" );
 const Name topology( "topology" );
 const Name upper_right( "upper_right" );
 const Name volume( "volume" );
-// const Name x("x");
-const Name y( "y" );
 }
 }

--- a/topology/topology_names.h
+++ b/topology/topology_names.h
@@ -76,7 +76,6 @@ extern const Name mean_x;
 extern const Name mean_y;
 extern const Name min;
 extern const Name minor_axis;
-extern const Name mu;
 extern const Name number_of_connections;
 extern const Name outer_radius;
 extern const Name p_center;
@@ -94,12 +93,9 @@ extern const Name sigma_x;
 extern const Name sigma_y;
 extern const Name sources;
 extern const Name spherical;
-extern const Name tau;
 extern const Name topology;
 extern const Name upper_right;
 extern const Name volume;
-// extern const Name x; // this name is already defined in nest_names
-extern const Name y;
 }
 }
 

--- a/topology/topology_parameter.cpp
+++ b/topology/topology_parameter.cpp
@@ -22,6 +22,15 @@
 
 #include "topology_parameter.h"
 
+// includes from sli
+#include "lockptrdatum_impl.h"
+
+// Explicit definition required to ensure visibility when compiling with
+// clang under OSX. This must be outside namespace NEST, since the template
+// is defined in the global namespace.
+template class lockPTRDatum< nest::TopologyParameter,
+  &nest::TopologyModule::ParameterType >;
+
 namespace nest
 {
 

--- a/topology/topology_parameter.h
+++ b/topology/topology_parameter.h
@@ -45,6 +45,10 @@
 
 namespace nest
 {
+class TopologyParameter;
+typedef lockPTRDatum< TopologyParameter, &TopologyModule::ParameterType >
+  ParameterDatum;
+
 /**
  * Abstract base class for parameters
  */

--- a/topology/topology_parameter.h
+++ b/topology/topology_parameter.h
@@ -45,8 +45,6 @@
 
 namespace nest
 {
-class TopologyModule;
-
 /**
  * Abstract base class for parameters
  */
@@ -182,9 +180,6 @@ public:
 private:
   double cutoff_;
 };
-
-typedef lockPTRDatum< TopologyParameter, &TopologyModule::ParameterType >
-  ParameterDatum;
 
 /**
  * Parameter with constant value.

--- a/topology/topologymodule.cpp
+++ b/topology/topologymodule.cpp
@@ -57,9 +57,9 @@
 // clang under OSX. This must be outside namespace NEST, since the template
 // is defined in the global namespace.
 template class lockPTRDatum< nest::TopologyParameter,
-                             &nest::TopologyModule::ParameterType >;
+  &nest::TopologyModule::ParameterType >;
 template class lockPTRDatum< nest::AbstractMask,
-                             &nest::TopologyModule::MaskType >;
+  &nest::TopologyModule::MaskType >;
 
 namespace nest
 {

--- a/topology/topologymodule.cpp
+++ b/topology/topologymodule.cpp
@@ -39,7 +39,6 @@
 #include "doubledatum.h"
 #include "integerdatum.h"
 #include "iostreamdatum.h"
-#include "lockptrdatum_impl.h"
 
 // Includes from topology:
 #include "connection_creator_impl.h"
@@ -53,13 +52,6 @@
 #include "topology.h"
 #include "topology_parameter.h"
 
-// Explicit definition required to ensure visibility when compiling with
-// clang under OSX. This must be outside namespace NEST, since the template
-// is defined in the global namespace.
-template class lockPTRDatum< nest::TopologyParameter,
-  &nest::TopologyModule::ParameterType >;
-template class lockPTRDatum< nest::AbstractMask,
-  &nest::TopologyModule::MaskType >;
 
 namespace nest
 {

--- a/topology/topologymodule.cpp
+++ b/topology/topologymodule.cpp
@@ -53,6 +53,14 @@
 #include "topology.h"
 #include "topology_parameter.h"
 
+// Explicit definition required to ensure visibility when compiling with
+// clang under OSX. This must be outside namespace NEST, since the template
+// is defined in the global namespace.
+template class lockPTRDatum< nest::TopologyParameter,
+                             &nest::TopologyModule::ParameterType >;
+template class lockPTRDatum< nest::AbstractMask,
+                             &nest::TopologyModule::MaskType >;
+
 namespace nest
 {
 SLIType TopologyModule::MaskType;

--- a/topology/topologymodule.h
+++ b/topology/topologymodule.h
@@ -27,6 +27,7 @@
 #include "exceptions.h"
 
 // Includes from sli:
+#include "lockptr.h"
 #include "slimodule.h"
 
 // Includes from topology:
@@ -36,9 +37,9 @@
 
 namespace nest
 {
-class TopologyParameter;
-class AbstractMask;
 class AbstractLayer;
+class AbstractMask;
+class TopologyParameter;
 
 template < int D >
 class Layer;
@@ -314,6 +315,10 @@ private:
    */
   static ParameterFactory& parameter_factory_();
 };
+
+typedef lockPTRDatum< AbstractMask, &TopologyModule::MaskType > MaskDatum;
+typedef lockPTRDatum< TopologyParameter, &TopologyModule::ParameterType >
+          ParameterDatum;
 
 /**
  * Exception to be thrown if the wrong argument type

--- a/topology/topologymodule.h
+++ b/topology/topologymodule.h
@@ -316,9 +316,6 @@ private:
   static ParameterFactory& parameter_factory_();
 };
 
-typedef lockPTRDatum< AbstractMask, &TopologyModule::MaskType > MaskDatum;
-typedef lockPTRDatum< TopologyParameter, &TopologyModule::ParameterType >
-  ParameterDatum;
 
 /**
  * Exception to be thrown if the wrong argument type

--- a/topology/topologymodule.h
+++ b/topology/topologymodule.h
@@ -318,7 +318,7 @@ private:
 
 typedef lockPTRDatum< AbstractMask, &TopologyModule::MaskType > MaskDatum;
 typedef lockPTRDatum< TopologyParameter, &TopologyModule::ParameterType >
-          ParameterDatum;
+  ParameterDatum;
 
 /**
  * Exception to be thrown if the wrong argument type


### PR DESCRIPTION
This PR fixes problems that made NEST fails when built with Clang under OSX. I have tested with everything (except MPI) enabled under OSX 10.12.5 with Clang 4.0.0 from brew [as described here (but with Python)](https://github.com/nest/nest-simulator/issues/74#issuecomment-296107035).

Problems where of several kinds:
- When building static libraries, duplicate definitions of `Name` objects in nestkernel and topology prevented linking; the duplicates are removed from `topology_names.*`.
- The `ctermid()` system function call from `sli/processes.cc` was called with an incorrectly sized output buffer.
- Output file buffers in `recording_device.*` were not set up properly.
- Explicit template instantiations of `lockPTRDatum` types are required to make these Datum types visible to PyNEST; clang and gcc seem to have different rules on symbol visibility.

I have tested with clang and gcc 7.1.0.