### PR TITLE
Fixes #720 Issues related to current recording from devices

### DIFF
--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -211,6 +211,8 @@ ac_generator::get_status( DictionaryDatum& d ) const
   P_.get( d );
   S_.get( d );
   device_.get_status( d );
+
+  ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }
 
 inline void

--- a/models/dc_generator.h
+++ b/models/dc_generator.h
@@ -204,6 +204,8 @@ dc_generator::get_status( DictionaryDatum& d ) const
 {
   P_.get( d );
   device_.get_status( d );
+
+  ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }
 
 inline void

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -345,7 +345,7 @@ nest::noise_generator::update( Time const& origin,
     {
       S_.I_avg_ += *it;
     }
-    S_.I_avg_ /= std::max( 1, int(B_.amps_.size()) );
+    S_.I_avg_ /= std::max( 1, int( B_.amps_.size() ) );
     B_.logger_.record_data( origin.get_steps() + offs );
 
     DSCurrentEvent ce;

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -339,16 +339,15 @@ nest::noise_generator::update( Time const& origin,
       // use now as reference, in case we woke up from inactive period
       B_.next_step_ = now + V_.dt_steps_;
     }
-    
+
     // record values
-    for ( AmpVec_::iterator it = B_.amps_.begin(); it != B_.amps_.end();
-          ++it )
+    for ( AmpVec_::iterator it = B_.amps_.begin(); it != B_.amps_.end(); ++it )
     {
       S_.I_avg_ += *it;
     }
     S_.I_avg_ /= B_.amps_.size();
     B_.logger_.record_data( origin.get_steps() + offs );
-    
+
     DSCurrentEvent ce;
     kernel().event_delivery_manager.send( *this, ce, offs );
   }

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -345,7 +345,7 @@ nest::noise_generator::update( Time const& origin,
     {
       S_.I_avg_ += *it;
     }
-    S_.I_avg_ /= B_.amps_.size();
+    S_.I_avg_ /= std::max( 1, int(B_.amps_.size()) );
     B_.logger_.record_data( origin.get_steps() + offs );
 
     DSCurrentEvent ce;

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -335,15 +335,20 @@ nest::noise_generator::update( Time const& origin,
         *it = P_.mean_
           + std::sqrt( P_.std_ * P_.std_ + S_.y_1_ * P_.std_mod_ * P_.std_mod_ )
             * V_.normal_dev_( kernel().rng_manager.get_rng( get_thread() ) );
-        S_.I_avg_ += *it;
       }
-      S_.I_avg_ /= B_.amps_.size();
-      B_.logger_.record_data( origin.get_steps() + offs );
-
       // use now as reference, in case we woke up from inactive period
       B_.next_step_ = now + V_.dt_steps_;
     }
-
+    
+    // record values
+    for ( AmpVec_::iterator it = B_.amps_.begin(); it != B_.amps_.end();
+          ++it )
+    {
+      S_.I_avg_ += *it;
+    }
+    S_.I_avg_ /= B_.amps_.size();
+    B_.logger_.record_data( origin.get_steps() + offs );
+    
     DSCurrentEvent ce;
     kernel().event_delivery_manager.send( *this, ce, offs );
   }

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -279,6 +279,8 @@ noise_generator::get_status( DictionaryDatum& d ) const
   P_.get( d );
   S_.get( d );
   device_.get_status( d );
+
+  ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }
 
 inline void

--- a/models/step_current_generator.h
+++ b/models/step_current_generator.h
@@ -203,6 +203,8 @@ step_current_generator::get_status( DictionaryDatum& d ) const
 {
   P_.get( d );
   device_.get_status( d );
+
+  ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }
 
 inline void

--- a/pynest/nest/tests/test_current_recording_generators.py
+++ b/pynest/nest/tests/test_current_recording_generators.py
@@ -88,33 +88,21 @@ class CurrentRecordingGeneratorTestCase(unittest.TestCase):
     def test_GetRecordables(self):
         """Check get recordables"""
 
-        try:
-            val = nest.GetDefaults('step_current_generator')['recordables'][0]
-            assert val == 'I', \
-                "Incorrect recordables ( %r ) for step current generator" % val
-        except:
-            raise
+        val = nest.GetDefaults('step_current_generator')['recordables'][0]            
+        self.assertEqual(val, 'I',
+                         'Incorrect recordables ({}) for step current generator'.format(val))
 
-        try:
-            val = nest.GetDefaults('ac_generator')['recordables'][0]
-            assert val == 'I', \
-                "Incorrect recordables ( %r ) for ac generator" % val
-        except:
-            raise
+        val = nest.GetDefaults('ac_generator')['recordables'][0]            
+        self.assertEqual(val, 'I',
+                         'Incorrect recordables ({}) for ac generator'.format(val))
 
-        try:
-            val = nest.GetDefaults('dc_generator')['recordables'][0]
-            assert val == 'I', \
-                "Incorrect recordables ( %r ) for dc generator" % val
-        except:
-            raise
+        val = nest.GetDefaults('dc_generator')['recordables'][0]            
+        self.assertEqual(val, 'I',
+                         'Incorrect recordables ({}) for dc generator'.format(val))
 
-        try:
-            val = nest.GetDefaults('noise_generator')['recordables'][0]
-            assert val == 'I', \
-                "Incorrect recordables ( %r ) for noise generator" % val
-        except:
-            raise
+        val = nest.GetDefaults('noise_generator')['recordables'][0]            
+        self.assertEqual(val, 'I',
+                         'Incorrect recordables ({}) for noise generator'.format(val))     
 
     def test_RecordedCurrentVectors(self):
         """Check the length and contents of recorded current vectors"""

--- a/pynest/nest/tests/test_current_recording_generators.py
+++ b/pynest/nest/tests/test_current_recording_generators.py
@@ -88,21 +88,21 @@ class CurrentRecordingGeneratorTestCase(unittest.TestCase):
     def test_GetRecordables(self):
         """Check get recordables"""
 
-        val = nest.GetDefaults('step_current_generator')['recordables'][0]            
-        self.assertEqual(val, 'I',
-                         'Incorrect recordables ({}) for step current generator'.format(val))
+        val = nest.GetDefaults('step_current_generator')['recordables'][0]
+        self.assertEqual(val, 'I', 'Incorrect recordables ({}) /'
+                         'for step current generator'.format(val))
 
-        val = nest.GetDefaults('ac_generator')['recordables'][0]            
-        self.assertEqual(val, 'I',
-                         'Incorrect recordables ({}) for ac generator'.format(val))
+        val = nest.GetDefaults('ac_generator')['recordables'][0]
+        self.assertEqual(val, 'I', 'Incorrect recordables ({}) /'
+                         'for ac generator'.format(val))
 
-        val = nest.GetDefaults('dc_generator')['recordables'][0]            
-        self.assertEqual(val, 'I',
-                         'Incorrect recordables ({}) for dc generator'.format(val))
+        val = nest.GetDefaults('dc_generator')['recordables'][0]
+        self.assertEqual(val, 'I', 'Incorrect recordables ({}) /'
+                         'for dc generator'.format(val))
 
-        val = nest.GetDefaults('noise_generator')['recordables'][0]            
-        self.assertEqual(val, 'I',
-                         'Incorrect recordables ({}) for noise generator'.format(val))     
+        val = nest.GetDefaults('noise_generator')['recordables'][0]
+        self.assertEqual(val, 'I', 'Incorrect recordables ({}) /'
+                         'for noise generator'.format(val))
 
     def test_RecordedCurrentVectors(self):
         """Check the length and contents of recorded current vectors"""

--- a/pynest/nest/tests/test_current_recording_generators.py
+++ b/pynest/nest/tests/test_current_recording_generators.py
@@ -85,6 +85,37 @@ class CurrentRecordingGeneratorTestCase(unittest.TestCase):
                                          'stop': self.t_stop})
         nest.Connect(self.noise, self.neuron)
 
+    def test_GetRecordables(self):
+        """Check get recordables"""
+
+        try:
+            val = nest.GetDefaults('step_current_generator')['recordables'][0]
+            assert val == 'I', \
+                "Incorrect recordables ( %r ) for step current generator" % val
+        except:
+            raise
+
+        try:
+            val = nest.GetDefaults('ac_generator')['recordables'][0]
+            assert val == 'I', \
+                "Incorrect recordables ( %r ) for ac generator" % val
+        except:
+            raise
+
+        try:
+            val = nest.GetDefaults('dc_generator')['recordables'][0]
+            assert val == 'I', \
+                "Incorrect recordables ( %r ) for dc generator" % val
+        except:
+            raise
+
+        try:
+            val = nest.GetDefaults('noise_generator')['recordables'][0]
+            assert val == 'I', \
+                "Incorrect recordables ( %r ) for noise generator" % val
+        except:
+            raise
+
     def test_RecordedCurrentVectors(self):
         """Check the length and contents of recorded current vectors"""
 


### PR DESCRIPTION
Implements the following (as discussed in #720 and #663 ):

- Setting the recordables: GetDefaults('..._generator')['recordables']
- Appropriate updates to unit test to include above
- For noise generator, set current = 0, when no target neuron connected
- For noise generator, keep the current value constant for the duration of noise_generator's dt
- (solutions for above discussed in #663)