### PR TITLE
Fix #748: For nest.helpdesk() Python 2.7.8 and later is needed

### DIFF
--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -32,6 +32,7 @@ import textwrap
 import subprocess
 import os
 import re
+import sys
 
 from string import Template
 
@@ -458,6 +459,10 @@ def show_help_with_pager(hlpobj, pager):
     pager: str, optional
         pager to use, NO if you explicity do not want to use a pager
     """
+    if sys.version_info < (2, 7, 8):
+        print("NEST help is only available with Python 2.7.8 or later. \n")
+        return
+
     if 'NEST_INSTALL_DIR' not in os.environ:
         print(
             'NEST help needs to know where NEST is installed.'

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -64,7 +64,8 @@ def helpdesk():
     Use the system default browser.
     """
     if sys.version_info < (2, 7, 8):
-        print("The NEST Helpdesk is only available with Python 2.7.8 or later.")
+        print("The NEST Helpdesk is only available with Python 2.7.8 or "
+              "later. \n")
         return
 
     if 'NEST_DOC_DIR' not in os.environ:

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -64,7 +64,7 @@ def helpdesk():
     Use the system default browser.
     """
     if sys.version_info < (2, 7, 8):
-        print("You need python 2.7.8 or later to run this script.\n")
+        print("The NEST Helpdesk is only available with Python 2.7.8 or later.")
         return
 
     if 'NEST_DOC_DIR' not in os.environ:

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -63,6 +63,10 @@ def helpdesk():
 
     Use the system default browser.
     """
+    if sys.version_info < (2, 7, 8):
+        print("You need python 2.7.8 or later to run this scrip.\n")
+        return
+
     if 'NEST_DOC_DIR' not in os.environ:
         print(
             'NEST help needs to know where NEST is installed.'

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -64,7 +64,7 @@ def helpdesk():
     Use the system default browser.
     """
     if sys.version_info < (2, 7, 8):
-        print("You need python 2.7.8 or later to run this scrip.\n")
+        print("You need python 2.7.8 or later to run this script.\n")
         return
 
     if 'NEST_DOC_DIR' not in os.environ:


### PR DESCRIPTION
This fix for #748 checks for the right Python version ( >= 2.7.8) when nest.helpdesk() is called.


