### PR TITLE
Remove const qualifier so it can be built with FCC

### DIFF
--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -174,7 +174,7 @@ nest::RecordingDevice::Parameters_::get( const RecordingDevice& rd,
 
 void
 nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
-  const Buffers_& B,
+  Buffers_& B,
   const DictionaryDatum& d )
 {
   updateValue< std::string >( d, names::label, label_ );

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -538,7 +538,7 @@ private:
     //! Store current values in dictionary
     void get( const RecordingDevice&, DictionaryDatum& ) const;
     //! Set values from dictionary
-    void set( const RecordingDevice&, const Buffers_&, const DictionaryDatum& );
+    void set( const RecordingDevice&, Buffers_&, const DictionaryDatum& );
   };
 
   // ------------------------------------------------------------------

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -537,7 +537,13 @@ private:
 
     //! Store current values in dictionary
     void get( const RecordingDevice&, DictionaryDatum& ) const;
-    //! Set values from dictionary
+
+    /**
+     * Set values from dictionary.
+     *
+     * @note `Buffers_&` cannot be `const` because `basic_ofstream::is_open()`
+     * is not `const` in C++98  (cf C++ Standard §27.8.1.10).
+     */
     void set( const RecordingDevice&, Buffers_&, const DictionaryDatum& );
   };
 


### PR DESCRIPTION
As of today the HEAD can not be built with FCC on the frontend for K computer. Please review and pull the patch into master.