### PR TITLE
Adding the recommended group option due to the trusty update from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ language: generic
 # Required for Ubuntu Trusty (14.04 LTS).
 sudo: required
 dist: trusty
-
+#https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2
+group: edge
 env:
   matrix:
     # We don't have to run a full matrix here, because most of the options are


### PR DESCRIPTION
Due to the update (https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2) of trusty images from Travis, we need to update our .yaml file.