### PR TITLE
Enable users to remove gid from filename in recording devices

### DIFF
--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -484,7 +484,7 @@ const Name U_std( "U_std" );
 const Name U_upper( "U_upper" );
 const Name update( "update" );
 const Name update_node( "update_node" );
-const Name use_gid( "use_gid" );
+const Name use_gid( "use_gid_in_filename" );
 const Name use_wfr( "use_wfr" );
 
 const Name V_act_NMDA( "V_act_NMDA" );

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -484,6 +484,7 @@ const Name U_std( "U_std" );
 const Name U_upper( "U_upper" );
 const Name update( "update" );
 const Name update_node( "update_node" );
+const Name use_gid( "use_gid" );
 const Name use_wfr( "use_wfr" );
 
 const Name V_act_NMDA( "V_act_NMDA" );

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -484,7 +484,7 @@ const Name U_std( "U_std" );
 const Name U_upper( "U_upper" );
 const Name update( "update" );
 const Name update_node( "update_node" );
-const Name use_gid( "use_gid_in_filename" );
+const Name use_gid_in_filename( "use_gid_in_filename" );
 const Name use_wfr( "use_wfr" );
 
 const Name V_act_NMDA( "V_act_NMDA" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -39,23 +39,23 @@ namespace nest
 namespace names
 {
 extern const Name a; //!< Specific to Brette & Gerstner 2005 (aeif_cond-*)
-extern const Name a_acausal;          //!< Used by stdp_connection_facetshw_hom
-extern const Name a_causal;           //!< Used by stdp_connection_facetshw_hom
+extern const Name a_acausal; //!< Used by stdp_connection_facetshw_hom
+extern const Name a_causal;  //!< Used by stdp_connection_facetshw_hom
 extern const Name A_lower;
 extern const Name A_mean;
 extern const Name A_minus; //!< Used by stdp_dopa_connection
 extern const Name A_plus;  //!< Used by stdp_dopa_connection
 extern const Name A_std;
-extern const Name a_thresh_th;        //!< Used by stdp_connection_facetshw_hom
-extern const Name a_thresh_tl;        //!< Used by stdp_connection_facetshw_hom
+extern const Name a_thresh_th; //!< Used by stdp_connection_facetshw_hom
+extern const Name a_thresh_tl; //!< Used by stdp_connection_facetshw_hom
 extern const Name A_upper;
-extern const Name acceptable_latency; //!< Used in music_message_in_proxy
-extern const Name accumulator;        //!< Recorder parameter
-extern const Name Act_h;              //!< Specific to Hodgkin Huxley models
-extern const Name Act_m;              //!< Specific to Hodgkin Huxley models
-extern const Name activity;           //!< Used in pulsepacket_generator
-extern const Name address;            //!< Node parameter
-extern const Name ahp_bug;            //!< Used in iaf_chxk_2008
+extern const Name acceptable_latency;   //!< Used in music_message_in_proxy
+extern const Name accumulator;          //!< Recorder parameter
+extern const Name Act_h;                //!< Specific to Hodgkin Huxley models
+extern const Name Act_m;                //!< Specific to Hodgkin Huxley models
+extern const Name activity;             //!< Used in pulsepacket_generator
+extern const Name address;              //!< Node parameter
+extern const Name ahp_bug;              //!< Used in iaf_chxk_2008
 extern const Name allow_offgrid_spikes; //!< Used in spike_generator
 extern const Name alpha;                //!< stdp_synapse parameter
 extern const Name alpha_1; //!< Specific to Kobayashi, Tsubo, Shinomoto 2009
@@ -549,6 +549,7 @@ extern const Name U_std;
 extern const Name U_upper;
 extern const Name update;      //!< Command to execute the neuron (sli_neuron)
 extern const Name update_node; //!< Command to execute the neuron (sli_neuron)
+extern const Name use_gid;     //!< use gid in the filename
 extern const Name use_wfr;     //!< Simulation-related
 
 extern const Name V_act_NMDA; //!< specific to Hill & Tononi 2005

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -549,8 +549,8 @@ extern const Name U_std;
 extern const Name U_upper;
 extern const Name update;      //!< Command to execute the neuron (sli_neuron)
 extern const Name update_node; //!< Command to execute the neuron (sli_neuron)
-extern const Name use_gid;     //!< use gid in the filename
-extern const Name use_wfr;     //!< Simulation-related
+extern const Name use_gid_in_filename; //!< use gid in the filename
+extern const Name use_wfr;             //!< Simulation-related
 
 extern const Name V_act_NMDA; //!< specific to Hill & Tononi 2005
 extern const Name V_epsp;     //!< Specific to iaf_chs_2008 neuron

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -81,6 +81,7 @@ nest::RecordingDevice::Parameters_::Parameters_( const std::string& file_ext,
   , flush_after_simulate_( true )
   , flush_records_( false )
   , close_on_reset_( true )
+  , use_gid_( true )
 {
 }
 
@@ -165,6 +166,8 @@ nest::RecordingDevice::Parameters_::get( const RecordingDevice& rd,
   ( *d )[ names::flush_records ] = flush_records_;
   ( *d )[ names::close_on_reset ] = close_on_reset_;
 
+  ( *d )[ names::use_gid ] = use_gid_;
+
   if ( to_file_ && not filename_.empty() )
   {
     initialize_property_array( d, names::filenames );
@@ -225,6 +228,8 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
   updateValue< bool >( d, names::flush_after_simulate, flush_after_simulate_ );
   updateValue< bool >( d, names::flush_records, flush_records_ );
   updateValue< bool >( d, names::close_on_reset, close_on_reset_ );
+
+  updateValue< bool >( d, names::use_gid, use_gid_ );
 
   // In Pynest we cannot use /record_to, because we have no way to pass
   // values as LiteralDatum. Thus, we must keep the boolean flags.
@@ -984,9 +989,17 @@ nest::RecordingDevice::build_filename_() const
     basename << node_.get_name();
   }
 
-  basename << "-" << std::setfill( '0' ) << std::setw( gidigits )
-           << node_.get_gid() << "-" << std::setfill( '0' )
-           << std::setw( vpdigits ) << node_.get_vp();
+  if ( P_.use_gid_ and not P_.label_.empty() )
+  {
+    basename << "-" << std::setfill( '0' ) << std::setw( gidigits )
+             << node_.get_gid() << "-" << std::setfill( '0' )
+             << std::setw( vpdigits ) << node_.get_vp();
+  }
+  else
+  {
+    basename << "-" << std::setfill( '0' ) << std::setw( vpdigits )
+             << node_.get_vp();
+  }
   return basename.str() + '.' + P_.file_ext_;
 }
 

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -989,16 +989,16 @@ nest::RecordingDevice::build_filename_() const
     basename << node_.get_name();
   }
 
-  if ( P_.use_gid_ and not P_.label_.empty() )
+  if ( not P_.use_gid_ and not P_.label_.empty() )
+  {
+    basename << "-" << std::setfill( '0' ) << std::setw( vpdigits )
+             << node_.get_vp();
+  }
+  else
   {
     basename << "-" << std::setfill( '0' ) << std::setw( gidigits )
              << node_.get_gid() << "-" << std::setfill( '0' )
              << std::setw( vpdigits ) << node_.get_vp();
-  }
-  else
-  {
-    basename << "-" << std::setfill( '0' ) << std::setw( vpdigits )
-             << node_.get_vp();
   }
   return basename.str() + '.' + P_.file_ext_;
 }

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -81,7 +81,7 @@ nest::RecordingDevice::Parameters_::Parameters_( const std::string& file_ext,
   , flush_after_simulate_( true )
   , flush_records_( false )
   , close_on_reset_( true )
-  , use_gid_( true )
+  , use_gid_in_filename_( true )
 {
 }
 
@@ -166,7 +166,7 @@ nest::RecordingDevice::Parameters_::get( const RecordingDevice& rd,
   ( *d )[ names::flush_records ] = flush_records_;
   ( *d )[ names::close_on_reset ] = close_on_reset_;
 
-  ( *d )[ names::use_gid ] = use_gid_;
+  ( *d )[ names::use_gid_in_filename ] = use_gid_in_filename_;
 
   if ( to_file_ && not filename_.empty() )
   {
@@ -229,8 +229,8 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
   updateValue< bool >( d, names::flush_records, flush_records_ );
   updateValue< bool >( d, names::close_on_reset, close_on_reset_ );
 
-  bool tmp_use_gid = true;
-  updateValue< bool >( d, names::use_gid, tmp_use_gid );
+  bool tmp_use_gid_in_filename = true;
+  updateValue< bool >( d, names::use_gid_in_filename, tmp_use_gid_in_filename );
 
   // In Pynest we cannot use /record_to, because we have no way to pass
   // values as LiteralDatum. Thus, we must keep the boolean flags.
@@ -315,14 +315,14 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
       "have been set to false." );
   }
 
-  if ( not tmp_use_gid and label_.empty() )
+  if ( not tmp_use_gid_in_filename and label_.empty() )
   {
     throw BadProperty(
       "If /use_gid_in_filename is false, /label must be specified." );
   }
   else
   {
-    use_gid_ = tmp_use_gid;
+    use_gid_in_filename_ = tmp_use_gid_in_filename;
   }
 }
 
@@ -1000,7 +1000,7 @@ nest::RecordingDevice::build_filename_() const
     basename << node_.get_name();
   }
 
-  if ( not P_.use_gid_ and not P_.label_.empty() )
+  if ( not P_.use_gid_in_filename_ and not P_.label_.empty() )
   {
     basename << "-" << std::setfill( '0' ) << std::setw( vpdigits )
              << node_.get_vp();

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -229,7 +229,8 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
   updateValue< bool >( d, names::flush_records, flush_records_ );
   updateValue< bool >( d, names::close_on_reset, close_on_reset_ );
 
-  updateValue< bool >( d, names::use_gid, use_gid_ );
+  bool tmp_use_gid = true;
+  updateValue< bool >( d, names::use_gid, tmp_use_gid );
 
   // In Pynest we cannot use /record_to, because we have no way to pass
   // values as LiteralDatum. Thus, we must keep the boolean flags.
@@ -312,6 +313,16 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
       "Accumulator mode selected. All incompatible properties "
       "(to_file, to_screen, to_memory, withgid, withweight) "
       "have been set to false." );
+  }
+
+  if ( not tmp_use_gid and label_.empty() )
+  {
+    throw BadProperty(
+      "If /use_gid_in_filename is false, /label must be specified." );
+  }
+  else
+  {
+    use_gid_ = tmp_use_gid;
   }
 }
 

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -525,7 +525,7 @@ private:
     bool flush_records_;        //!< if true, flush stream after each output
     bool close_on_reset_;       //!< if true, close stream in init_buffers()
 
-    bool use_gid_;
+    bool use_gid_in_filename_;
 
     /**
      * Set default parameter values.

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -523,6 +523,8 @@ private:
     bool flush_records_;        //!< if true, flush stream after each output
     bool close_on_reset_;       //!< if true, close stream in init_buffers()
 
+    bool use_gid_;
+
     /**
      * Set default parameter values.
      * @param Default file name extension, excluding ".".

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -147,6 +147,8 @@ namespace nest
                     contents. If set to false, the file will remain open after
                     ResetNetwork, so you can record continuously. NB:
                     the file is always closed upon ResetKernel. (Default: true).
+  /use_gid_in_filename - Determines if the GID is used in the file name of the
+  recording device. Setting this to false can lead to conflicting file names.
 
   The following parameters control how output is formatted:
   /withtime      - boolean value which specifies whether the network time should

--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -49,6 +49,7 @@ from . import test_parrot_neuron
 from . import test_stdp_triplet_synapse
 from . import test_weight_recorder
 from . import test_aeif_lsodar
+from . import test_use_gid_in_filename
 
 
 def suite():
@@ -80,6 +81,7 @@ def suite():
     suite.addTest(test_stdp_triplet_synapse.suite())
     suite.addTest(test_weight_recorder.suite())
     suite.addTest(test_aeif_lsodar.suite())
+    suite.addTest(test_use_gid_in_filename.suite())
 
     return suite
 

--- a/pynest/nest/tests/test_use_gid_in_filename.py
+++ b/pynest/nest/tests/test_use_gid_in_filename.py
@@ -37,12 +37,14 @@ class UseGidInFilenameTestCase(unittest.TestCase):
 
         nest.ResetKernel()
         sg = nest.Create("poisson_generator", 1, {"rate": 100.})
-        sd = nest.Create("spike_detector", 1, {"to_file": True, "label": "sd", "use_gid_in_filename": True})
+        sd = nest.Create("spike_detector", 1, {"to_file": True,
+                         "label": "sd", "use_gid_in_filename": True})
         nest.Connect(sg, sd)
 
         nest.Simulate(100)
 
-        self.assertTrue(os.path.exists(os.environ["NEST_DATA_PATH"] + "/sd-2-0.gdf"))
+        self.assertTrue(os.path.exists(os.environ["NEST_DATA_PATH"] +
+                                       "/sd-2-0.gdf"))
 
     def test_NoGid(self):
         """Without GID"""
@@ -50,12 +52,14 @@ class UseGidInFilenameTestCase(unittest.TestCase):
         nest.ResetKernel()
 
         sg = nest.Create("poisson_generator", 1, {"rate": 100.})
-        sd = nest.Create("spike_detector", 1, {"to_file": True, "label": "sd", "use_gid_in_filename": False})
+        sd = nest.Create("spike_detector", 1, {"to_file": True,
+                         "label": "sd", "use_gid_in_filename": False})
         nest.Connect(sg, sd)
 
         nest.Simulate(100)
 
-        self.assertTrue(os.path.exists(os.environ["NEST_DATA_PATH"] + "/sd-0.gdf"))
+        self.assertTrue(os.path.exists(os.environ["NEST_DATA_PATH"] +
+                                       "/sd-0.gdf"))
 
 
 def suite():

--- a/pynest/nest/tests/test_use_gid_in_filename.py
+++ b/pynest/nest/tests/test_use_gid_in_filename.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# test_use_gid_in_filename.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test if use_gid_in_filename works properly as a parameter of recording devices
+"""
+
+import unittest
+import nest
+import os
+
+
+@nest.check_stack
+class UseGidInFilenameTestCase(unittest.TestCase):
+    """Tests of use_gid_in_filename"""
+
+    def test_WithGid(self):
+        """With GID"""
+
+        nest.ResetKernel()
+        sg = nest.Create("poisson_generator", 1, {"rate": 100.})
+        sd = nest.Create("spike_detector", 1, {"to_file": True, "label": "sd", "use_gid_in_filename": True})
+        nest.Connect(sg, sd)
+
+        nest.Simulate(100)
+
+        self.assertTrue(os.path.exists(os.environ["NEST_DATA_PATH"] + "/sd-2-0.gdf"))
+
+    def test_NoGid(self):
+        """Without GID"""
+
+        nest.ResetKernel()
+
+        sg = nest.Create("poisson_generator", 1, {"rate": 100.})
+        sd = nest.Create("spike_detector", 1, {"to_file": True, "label": "sd", "use_gid_in_filename": False})
+        nest.Connect(sg, sd)
+
+        nest.Simulate(100)
+
+        self.assertTrue(os.path.exists(os.environ["NEST_DATA_PATH"] + "/sd-0.gdf"))
+
+
+def suite():
+    suite = unittest.makeSuite(UseGidInFilenameTestCase, 'test')
+    return suite
+
+
+def run():
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Hi,

with this PR I'd like to give the user more power over the filename of `recording_devices`. So far, the `GID` of the device is a obligatory part of the filename. This can be annoying during the development of network models as the GID might change quite often.

I introduced a field called `use_gid` as a parameter of the `recording_device` which, if turned off, makes the `recording_device` neglect its GID in the filename. As this can lead to more collisions of filenames, this mechanism only works if the user has set a `prefix` for the filename.