### PR TITLE
Spin_detector precision and documentation fix

### DIFF
--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -185,8 +185,8 @@ nest::spin_detector::handle( SpikeEvent& e )
 
 
     // The following logic implements the decoding
-    // A single spike signals a transition to 0 state, two spikes in same time
-    // step signal the transition to 1 state.
+    // A single spike signals a transition to "0" state, two spikes at the
+    // same time step signal a transition to "1" state.
     //
     // Remember the global id of the sender of the last spike being received
     // this assumes that several spikes being sent by the same neuron in the

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -84,33 +84,33 @@ nest::spin_detector::calibrate()
 {
 
   if ( kernel().event_delivery_manager.get_off_grid_communication()
-  and not device_.is_precise_times_user_set() )
-{
-  device_.set_precise_times( true );
-  std::string msg = String::compose(
-    "Precise neuron models exist: the property precise_times "
-    "of the %1 with gid %2 has been set to true",
-    get_name(),
-    get_gid() );
-
-  if ( device_.is_precision_user_set() )
+    and not device_.is_precise_times_user_set() )
   {
-    // if user explicitly set the precision, there is no need to do anything.
-    msg += ".";
+    device_.set_precise_times( true );
+    std::string msg = String::compose(
+      "Precise neuron models exist: the property precise_times "
+      "of the %1 with gid %2 has been set to true",
+      get_name(),
+      get_gid() );
+
+    if ( device_.is_precision_user_set() )
+    {
+      // if user explicitly set the precision, there is no need to do anything.
+      msg += ".";
+    }
+
+    else
+    {
+      // it makes sense to increase the precision if precise models are used.
+      device_.set_precision( 15 );
+      msg += ", precision has been set to 15.";
+    }
+
+    LOG( M_INFO, "spin_detector::calibrate", msg );
   }
 
-  else
-  {
-    // it makes sense to increase the precision if precise models are used.
-    device_.set_precision( 15 );
-    msg += ", precision has been set to 15.";
-  }
 
-  LOG( M_INFO, "spin_detector::calibrate", msg );
-}
-
-
-device_.calibrate();
+  device_.calibrate();
 }
 
 void

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -46,7 +46,9 @@ By default, GID and time of each spike is recorded.
 
 The spike detector can also record spike times with full precision
 from neurons emitting precisely timed spikes. Set /precise_times to
-achieve this.
+achieve this. If there are precise models and /precise_times is not
+set, it will be set to True at the start of the simulation and
+/precision will be increased to 15 from its default value of 3.
 
 Any node from which spikes are to be recorded, must be connected to
 the spike detector using a normal connect command. Any connection weight
@@ -176,7 +178,6 @@ private:
   Buffers_ B_;
   index last_in_gid_;
   Time t_last_in_spike_;
-  bool user_set_precise_times_;
 };
 
 inline port

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -45,8 +45,9 @@ neurons at once. A single spike signals the 0 state, two spikes at the same time
 signal the 1 state. If a neuron is in the 0 or 1 state and emits the spiking
 activity corresponding to the same state, the same state is recorded again.
 Therefore, it is not only the transitions that are recorded. Data is recorded
-in memory or to file as for all RecordingDevices. By default, GID and time of
-each decoded state is recorded.
+in memory or to file as for all RecordingDevices. By default, GID, time, and
+binary state (0 or 1) for each decoded state is recorded. The state can be
+accessed from ['events']['weight'].
 
 The spin detector can also record binary state times with full precision
 from neurons emitting precisely timed spikes. Set /precise_times to
@@ -153,18 +154,18 @@ private:
   void update( Time const&, const long, const long );
 
   /**
-   * Buffer for incoming spikes.
+   * Buffer for binary states.
    *
-   * This data structure buffers all incoming spikes until they are
+   * This is a buffer for all binary states from decoded spikes until they are
    * passed to the RecordingDevice for storage or output during update().
    * update() always reads from spikes_[Network::get_network().read_toggle()]
    * and deletes all events that have been read.
    *
-   * Events arriving from locally sending nodes, i.e., devices without
+   * Decoded events arriving from locally sending nodes, i.e., devices without
    * proxies, are stored in spikes_[Network::get_network().write_toggle()], to
    * ensure order-independent results.
    *
-   * Events arriving from globally sending nodes are delivered from the
+   * Decoded events arriving from globally sending nodes are delivered from the
    * global event queue by Network::deliver_events() at the beginning
    * of the time slice. They are therefore written to
    * spikes_[Network::get_network().read_toggle()]

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -36,33 +36,37 @@
 
 /* BeginDocumentation
 
-Name: spin_detector - Device for detecting single spikes.
+Name: spin_detector - Device for detecting binary states in neurons.
 
 Description:
-The spin_detector device is a recording device. It is used to record
-spikes from a single neuron, or from multiple neurons at once. Data
-is recorded in memory or to file as for all RecordingDevices.
-By default, GID and time of each spike is recorded.
+The spin_detector device is a recording device. It is used to decode and record
+binary states from spiking activity from a single neuron, or from multiple
+neurons at once. A single spike signals the 0 state, two spikes at the same time
+signal the 1 state. If a neuron is in the 0 or 1 state and emits the spiking
+activity corresponding to the same state, the same state is recorded again.
+Therefore, it is not only the transitions that are recorded. Data is recorded
+in memory or to file as for all RecordingDevices. By default, GID and time of
+each decoded state is recorded.
 
-The spike detector can also record spike times with full precision
+The spin detector can also record binary state times with full precision
 from neurons emitting precisely timed spikes. Set /precise_times to
 achieve this. If there are precise models and /precise_times is not
 set, it will be set to True at the start of the simulation and
 /precision will be increased to 15 from its default value of 3.
 
-Any node from which spikes are to be recorded, must be connected to
-the spike detector using a normal connect command. Any connection weight
+Any node from which binary states are to be recorded, must be connected to
+the spin detector using a normal connect command. Any connection weight
 and delay will be ignored for that connection.
 
 Simulations progress in cycles defined by the minimum delay. During each
-cycle, the spike detector records (stores in memory or writes to screen/file)
-the spikes generated during the previous cycle. As a consequence, any
-spikes generated during the cycle immediately preceding the end of the
+cycle, the spin detector records (stores in memory or writes to screen/file)
+the states during the previous cycle. As a consequence, any state information
+that was decoded during the cycle immediately preceding the end of the
 simulation time will not be recorded. Setting the /stop parameter to at the
 latest one min_delay period before the end of the simulation time ensures that
-all spikes desired to be recorded, are recorded.
+all binary states desired to be recorded, are recorded.
 
-Spike are not necessarily written to file in chronological order.
+states are not necessarily written to file in chronological order.
 
 Receives: SpikeEvent
 
@@ -73,10 +77,10 @@ SeeAlso: spike_detector, Device, RecordingDevice
 namespace nest
 {
 /**
- * Spike detector class.
+ * Spin detector class.
  *
- * This class manages spike recording for normal and precise spikes. It
- * receives spikes via its handle(SpikeEvent&) method, buffers them, and
+ * This class decodes binary states based on incoming spikes. It receives
+ * spikes via its handle(SpikeEvent&) method, decodes the state, and
  * stores them via its RecordingDevice in the update() method.
  *
  * Spikes are buffered in a two-segment buffer. We need to distinguish between
@@ -90,8 +94,8 @@ namespace nest
  * - Spikes delivered locally may be delivered before or after
  *   spin_detector::update() is executed. These spikes are therefore buffered in
  *   the write_toggle() segment of the buffer and output during the next cycle.
- * - After all spikes are recorded, update() clears the read_toggle() segment
- *   of the buffer.
+ * - After all spikes are recieved and states are decoded, update()
+ *   clears the read_toggle() segment of the buffer.
  *
  * @ingroup Devices
  */
@@ -142,8 +146,7 @@ private:
    * Update detector by recording spikes.
    *
    * All spikes in the read_toggle() half of the spike buffer are
-   * recorded by passing them to the RecordingDevice, which then
-   * stores them in memory or outputs them as desired.
+   * used to detect binary states.
    *
    * @see RecordingDevice
    */

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -161,13 +161,14 @@ private:
    * update() always reads from spikes_[Network::get_network().read_toggle()]
    * and deletes all events that have been read.
    *
-   * Decoded events arriving from locally sending nodes, i.e., devices without
-   * proxies, are stored in spikes_[Network::get_network().write_toggle()], to
-   * ensure order-independent results.
+   * Events arriving from locally sending nodes, i.e., devices without
+   * proxies, are first decoded and then stored in
+   * spikes_[Network::get_network().write_toggle()], to ensure order-independent
+   * results.
    *
-   * Decoded events arriving from globally sending nodes are delivered from the
+   * Events arriving from globally sending nodes are delivered from the
    * global event queue by Network::deliver_events() at the beginning
-   * of the time slice. They are therefore written to
+   * of the time slice. They are therefore first decoded and then written to
    * spikes_[Network::get_network().read_toggle()]
    * so that they can be recorded by the subsequent call to update().
    * This does not violate order-independence, since all spikes are delivered

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -114,9 +114,9 @@ nest::RecordingDevice::Parameters_::get( const RecordingDevice& rd,
   ( *d )[ names::withrport ] = withrport_;
 
   ( *d )[ names::time_in_steps ] = time_in_steps_;
-  if ( rd.mode_ == RecordingDevice::WEIGHT_RECORDER or
-       rd.mode_ == RecordingDevice::SPIKE_DETECTOR or
-       rd.mode_ == RecordingDevice::SPIN_DETECTOR )
+  if ( rd.mode_ == RecordingDevice::WEIGHT_RECORDER
+    or rd.mode_ == RecordingDevice::SPIKE_DETECTOR
+    or rd.mode_ == RecordingDevice::SPIN_DETECTOR )
   {
     ( *d )[ names::precise_times ] = precise_times_;
   }
@@ -184,7 +184,7 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
   updateValue< bool >( d, names::withrport, withrport_ );
   updateValue< bool >( d, names::time_in_steps, time_in_steps_ );
   if ( rd.mode_ == RecordingDevice::SPIKE_DETECTOR
-    or rd.mode_ == RecordingDevice::WEIGHT_RECORDER 
+    or rd.mode_ == RecordingDevice::WEIGHT_RECORDER
     or rd.mode_ == RecordingDevice::SPIN_DETECTOR )
   {
     if ( d->known( names::precise_times ) )

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -114,11 +114,9 @@ nest::RecordingDevice::Parameters_::get( const RecordingDevice& rd,
   ( *d )[ names::withrport ] = withrport_;
 
   ( *d )[ names::time_in_steps ] = time_in_steps_;
-  if ( rd.mode_ == RecordingDevice::SPIKE_DETECTOR )
-  {
-    ( *d )[ names::precise_times ] = precise_times_;
-  }
-  if ( rd.mode_ == RecordingDevice::WEIGHT_RECORDER )
+  if ( rd.mode_ == RecordingDevice::WEIGHT_RECORDER or
+       rd.mode_ == RecordingDevice::SPIKE_DETECTOR or
+       rd.mode_ == RecordingDevice::SPIN_DETECTOR )
   {
     ( *d )[ names::precise_times ] = precise_times_;
   }
@@ -186,7 +184,8 @@ nest::RecordingDevice::Parameters_::set( const RecordingDevice& rd,
   updateValue< bool >( d, names::withrport, withrport_ );
   updateValue< bool >( d, names::time_in_steps, time_in_steps_ );
   if ( rd.mode_ == RecordingDevice::SPIKE_DETECTOR
-    or rd.mode_ == RecordingDevice::WEIGHT_RECORDER )
+    or rd.mode_ == RecordingDevice::WEIGHT_RECORDER 
+    or rd.mode_ == RecordingDevice::SPIN_DETECTOR )
   {
     if ( d->known( names::precise_times ) )
     {

--- a/testsuite/unittests/test_spin_detector.sli
+++ b/testsuite/unittests/test_spin_detector.sli
@@ -29,7 +29,12 @@
     Test, whether the communication mechanism for binary neurons
     works and whether the spin detector correctly decodes binary transitions.
 
-    Author:  March 2013, Helias
+    First Version: March 2013
+    Author: Mortiz Helias
+
+    Second Version: June 2017
+    Description: added more tests
+    Author: Sepehr Mahmoudian
 */
 
 (unittest) run
@@ -44,21 +49,21 @@
     ResetKernel
 
     0 <<
-	/local_num_threads 1 
+	/local_num_threads 1
 	/resolution h
     >> SetStatus
-    
+
     % check, if double spikes are correctly interpreted as up transition
     % and single spikes are interpreted as down transition
-    
+
     /sp /spin_detector Create def
 
     /sg /spike_generator Create def
 
-        
+
     sg << /spike_times [10. 10. 15.] >> SetStatus
 
-    sg sp 1. 1. Connect	
+    sg sp 1. 1. Connect
 
     20. Simulate
 
@@ -66,20 +71,95 @@
     sp /events get /weights get /w Set
     w 0 get 1.0 eq assert_or_die
     w 1 get 0.0 eq assert_or_die
-    
-    
+
+
     sp /events get /times get /times Set
     times cva
     [ 10. 15.] eq
     assert_or_die
-    
+
+    % test the setting of the /precision value absent precise models
+    % 1. checking the default value and changing it
+
+      ResetKernel
+      /spin_detector Create /sd Set
+
+      % is the default correctly set to 3?
+      sd GetStatus /precision get dup /p_val Set 3 eq assert_or_die
+
+      % is the precision still the same after simulating for some time?
+      100 Simulate
+      sd GetStatus /precision get p_val eq assert_or_die
+
+    % 2. setting Precision
+
+      ResetKernel
+      /spin_detector Create /sd Set
+
+      % can the precision be correctly set?
+      sd << /precision 15 >> SetStatus
+      sd GetStatus /precision get 15 eq assert_or_die
+
+      % is the precision the same after simulating?
+      100 Simulate
+      sd GetStatus /precision get 15 eq assert_or_die
+
+    % test the behavior of the /precise_times flag
+    % 3. if the user does not set it
+
+      ResetKernel
+      /spin_detector Create /sd Set
+
+      % is the default correctly set to false?
+      sd GetStatus /precise_times get dup /pt_flag Set false eq assert_or_die
+
+      % is the flag still the same after simulating for some time?
+      100 Simulate
+      sd GetStatus /precise_times get pt_flag eq assert_or_die
+
+      % is the flag still the same after the creation of a precise neuron?
+      /iaf_psc_exp_ps Create ;
+      sd GetStatus /precise_times get pt_flag eq assert_or_die
+
+      % does the flag change to true if simulating with a precise neuron around?
+      100 Simulate
+      sd GetStatus /precise_times get true eq assert_or_die
+
+      % check if precision correctly increased to 15.
+      sd GetStatus /precision get 15 eq assert_or_die
+
+    % 4.a if the user sets the flag to false
+
+      ResetKernel
+      /spin_detector Create /sd Set
+      sd << /precise_times false >> SetStatus
+      /iaf_psc_exp_ps Create ;
+      100 Simulate
+      sd GetStatus /precise_times get false eq assert_or_die
+
+    % 4.b if the user sets the flag to true
+
+      ResetKernel
+      /spin_detector Create /sd Set
+      sd << /precise_times true >> SetStatus
+      /iaf_psc_exp_ps Create ;
+      100 Simulate
+      sd GetStatus /precise_times get true eq assert_or_die
+
+    % 5. can precision be set correctly when precise models exist?
+
+      ResetKernel
+      /spin_detector Create /sd Set
+
+      % checking to see if precision gets set correctly.
+      /iaf_psc_exp_ps Create ;
+      sd << /precision 15 >> SetStatus
+      sd GetStatus /precision get 15 eq assert_or_die
+
+      % does it remain the same after simulation?
+      100 Simulate
+      sd GetStatus /precision get 15 eq assert_or_die
+
 } def
 
 run_test
-
-
-
-
-
-
-

--- a/testsuite/unittests/test_spin_detector.sli
+++ b/testsuite/unittests/test_spin_detector.sli
@@ -28,13 +28,10 @@
     Description:
     Test, whether the communication mechanism for binary neurons
     works and whether the spin detector correctly decodes binary transitions.
+    Finally, setting the precision is tested.
 
-    First Version: March 2013
-    Author: Mortiz Helias
-
-    Second Version: June 2017
-    Description: added more tests
-    Author: Sepehr Mahmoudian
+    FirstVersion: March 2013
+    Author: Mortiz Helias, Sepehr Mahmoudian
 */
 
 (unittest) run


### PR DESCRIPTION
Fix for the first issue of #698. Precision was already there for some current or future use so I made it compatible with #446. 

I'll fix the documentation of the spin_detector in a separate pull request. It got me thinking, maybe it could be made compatible with more than two states; a model I'm working on can have 4 states. 