### PR TITLE
Change in GetStructrualPlasticityStatus format

### DIFF
--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -85,8 +85,6 @@ SPManager::get_status( DictionaryDatum& d )
 {
   DictionaryDatum sp_synapses = DictionaryDatum( new Dictionary() );
   DictionaryDatum sp_synapse;
-
-
   def< DictionaryDatum >(
     d, names::structural_plasticity_synapses, sp_synapses );
   for ( std::vector< SPBuilder* >::const_iterator i = sp_conn_builders_.begin();

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -234,9 +234,14 @@ def SetStructuralPlasticityStatus(params):
 
 
 @check_stack
-def GetStructuralPlasticityStatus(keys = None):
+def GetStructuralPlasticityStatus(keys=None):
     """Get the current structural plasticity parameters for the network
     simulation.
+    
+    Parameters
+    ---------
+    keys : str or list, optional
+        Keys indicating the values of interest to be retrieved by the get call
     """
 
     sps({})
@@ -246,8 +251,10 @@ def GetStructuralPlasticityStatus(keys = None):
         return d
     elif is_literal(keys):
         return d[keys]
+    elif is_iterable(keys):
+        return tuple(d[k] for k in keys)
     else:
-        raise TypeError("keys should be either empty or a string")
+        raise TypeError("keys must be either empty, a string or a list of strings")
 
 
 @check_stack

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -234,14 +234,20 @@ def SetStructuralPlasticityStatus(params):
 
 
 @check_stack
-def GetStructuralPlasticityStatus(params):
+def GetStructuralPlasticityStatus(keys = None):
     """Get the current structural plasticity parameters for the network
     simulation.
     """
 
-    sps(params)
+    sps({})
     sr('GetStructuralPlasticityStatus')
-    return spp()
+    d = spp()
+    if keys is None:
+        return d
+    elif is_literal(keys):
+        return d[keys]
+    else:
+        raise TypeError("keys should be either empty or a string")
 
 
 @check_stack

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -237,7 +237,7 @@ def SetStructuralPlasticityStatus(params):
 def GetStructuralPlasticityStatus(keys=None):
     """Get the current structural plasticity parameters for the network
     simulation.
-    
+
     Parameters
     ---------
     keys : str or list, optional
@@ -254,7 +254,7 @@ def GetStructuralPlasticityStatus(keys=None):
     elif is_iterable(keys):
         return tuple(d[k] for k in keys)
     else:
-        raise TypeError("keys must be either empty, a string or a list of strings")
+        raise TypeError("keys must be either empty, a string or a list")
 
 
 @check_stack

--- a/pynest/nest/tests/test_sp/test_all.py
+++ b/pynest/nest/tests/test_sp/test_all.py
@@ -29,6 +29,8 @@ from . import test_sp_manager
 from . import test_disconnect
 from . import test_disconnect_multiple
 from . import test_enable_multithread
+from . import test_get_sp_status
+
 HAVE_MPI = nest.sli_func("statusdict/have_mpi ::")
 if HAVE_MPI:
     print ("Testing with MPI")
@@ -60,9 +62,10 @@ def suite():
     test_suite.addTest(test_growth_curves.suite())
     test_suite.addTest(test_sp_manager.suite())
     test_suite.addTest(test_synaptic_elements.suite())
-    test_suite.addTest(test_disconnect.suite())
+    #test_suite.addTest(test_disconnect.suite())
     test_suite.addTest(test_disconnect_multiple.suite())
     test_suite.addTest(test_enable_multithread.suite())
+    test_suite.addTest(test_get_sp_status.suite())
 
     return test_suite
 

--- a/pynest/nest/tests/test_sp/test_all.py
+++ b/pynest/nest/tests/test_sp/test_all.py
@@ -62,7 +62,7 @@ def suite():
     test_suite.addTest(test_growth_curves.suite())
     test_suite.addTest(test_sp_manager.suite())
     test_suite.addTest(test_synaptic_elements.suite())
-    #test_suite.addTest(test_disconnect.suite())
+    test_suite.addTest(test_disconnect.suite())
     test_suite.addTest(test_disconnect_multiple.suite())
     test_suite.addTest(test_enable_multithread.suite())
     test_suite.addTest(test_get_sp_status.suite())

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -1,4 +1,4 @@
-#
+# -*- coding: utf-8 -*-
 # test_get_sp_status.py
 #
 # This file is part of NEST.

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -22,7 +22,7 @@
 """
 Structural Plasticity GetStatus Test
 -----------------------
-This test the functionality of the GetStructuralPlasticityStatus
+This tests the functionality of the GetStructuralPlasticityStatus
 function
 """
 

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # test_get_sp_status.py
 #
@@ -19,13 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-'''
+"""
 Structural Plasticity GetStatus Test
 -----------------------
 This test the functionality of the GetStructuralPlasticityStatus
 function
-'''
-
+"""
 
 import nest
 import unittest
@@ -34,17 +32,16 @@ __author__ = 'sdiaz'
 
 
 class TestGetStructuralPlasticityStatus(unittest.TestCase):
-
     neuron_model = 'iaf_psc_alpha'
     nest.CopyModel('static_synapse', 'synapse_ex')
     nest.SetDefaults('synapse_ex', {'weight': 1.0, 'delay': 1.0})
     nest.SetStructuralPlasticityStatus({
         'structural_plasticity_synapses': {
-        'synapse_ex': {
-            'model': 'synapse_ex',
-            'post_synaptic_element': 'Den_ex',
-            'pre_synaptic_element': 'Axon_ex',
-        },
+            'synapse_ex': {
+                'model': 'synapse_ex',
+                'post_synaptic_element': 'Den_ex',
+                'pre_synaptic_element': 'Axon_ex',
+            },
         }
     })
 
@@ -57,38 +54,47 @@ class TestGetStructuralPlasticityStatus(unittest.TestCase):
     }
 
     '''
-    Now we assign the growth curves to the corresponding synaptic elements
+    Now we assign the growth curves to the corresponding synaptic
+    elements
     '''
     synaptic_elements = {
         'Den_ex': growth_curve,
         'Den_in': growth_curve,
         'Axon_ex': growth_curve,
     }
-    nodes = nest.Create(neuron_model, 2, {'synaptic_elements': synaptic_elements})
-
+    nodes = nest.Create(neuron_model,
+                        2,
+                        {'synaptic_elements': synaptic_elements}
+                        )
     all = nest.GetStructuralPlasticityStatus()
     print (all)
-        assert('structural_plasticity_synapses' in all)
-        assert('syn1' in all['structural_plasticity_synapses'])
-        assert('structural_plasticity_update_interval' in all)
-    assert(all['structural_plasticity_update_interval'] == 1000)
+    assert ('structural_plasticity_synapses' in all)
+    assert ('syn1' in all['structural_plasticity_synapses'])
+    assert ('structural_plasticity_update_interval' in all)
+    assert (all['structural_plasticity_update_interval'] == 1000)
 
-    sp_synapses = nest.GetStructuralPlasticityStatus('structural_plasticity_synapses')
+    sp_synapses = nest.GetStructuralPlasticityStatus(
+        'structural_plasticity_synapses'
+    )
     print (sp_synapses)
-        syn = sp_synapses['syn1']
-        assert('pre_synaptic_element' in syn)
-        assert('post_synaptic_element' in syn)
-        assert(syn['pre_synaptic_element'] == 'Axon_ex')
-        assert(syn['post_synaptic_element'] == 'Den_ex')
+    syn = sp_synapses['syn1']
+    assert ('pre_synaptic_element' in syn)
+    assert ('post_synaptic_element' in syn)
+    assert (syn['pre_synaptic_element'] == 'Axon_ex')
+    assert (syn['post_synaptic_element'] == 'Den_ex')
 
     sp_interval = nest.GetStructuralPlasticityStatus(
-            'structural_plasticity_update_interval'
-        )
+        'structural_plasticity_update_interval'
+    )
     print (sp_interval)
-        assert(sp_interval == 1000)
+    assert (sp_interval == 1000)
+
 
 def suite():
-    test_suite = unittest.makeSuite(TestGetStructuralPlasticityStatus, 'test')
+    test_suite = unittest.makeSuite(
+        TestGetStructuralPlasticityStatus,
+        'test'
+    )
     return test_suite
 
 

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+#
 # test_get_sp_status.py
 #
 # This file is part of NEST.

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -35,56 +35,56 @@ __author__ = 'sdiaz'
 
 class TestGetStructuralPlasticityStatus(unittest.TestCase):
 
-	neuron_model = 'iaf_psc_alpha'
-	nest.CopyModel('static_synapse', 'synapse_ex')
-	nest.SetDefaults('synapse_ex', {'weight': 1.0, 'delay': 1.0})
-	nest.SetStructuralPlasticityStatus({
-	    'structural_plasticity_synapses': {
-		'synapse_ex': {
-		    'model': 'synapse_ex',
-		    'post_synaptic_element': 'Den_ex',
-		    'pre_synaptic_element': 'Axon_ex',
-		},
-	    }
-	})
+    neuron_model = 'iaf_psc_alpha'
+    nest.CopyModel('static_synapse', 'synapse_ex')
+    nest.SetDefaults('synapse_ex', {'weight': 1.0, 'delay': 1.0})
+    nest.SetStructuralPlasticityStatus({
+        'structural_plasticity_synapses': {
+        'synapse_ex': {
+            'model': 'synapse_ex',
+            'post_synaptic_element': 'Den_ex',
+            'pre_synaptic_element': 'Axon_ex',
+        },
+        }
+    })
 
-	growth_curve = {
-	    'growth_curve': "gaussian",
-	    'growth_rate': 0.0001,  # (elements/ms)
-	    'continuous': False,
-	    'eta': 0.0,  # Ca2+
-	    'eps': 0.05
-	}
+    growth_curve = {
+        'growth_curve': "gaussian",
+        'growth_rate': 0.0001,  # (elements/ms)
+        'continuous': False,
+        'eta': 0.0,  # Ca2+
+        'eps': 0.05
+    }
 
-	'''
-	Now we assign the growth curves to the corresponding synaptic elements
-	'''
-	synaptic_elements = {
-	    'Den_ex': growth_curve,
-	    'Den_in': growth_curve,
-	    'Axon_ex': growth_curve,
-	}
-	nodes = nest.Create(neuron_model,
-			           2,
-			           {'synaptic_elements': synaptic_elements})
+    '''
+    Now we assign the growth curves to the corresponding synaptic elements
+    '''
+    synaptic_elements = {
+        'Den_ex': growth_curve,
+        'Den_in': growth_curve,
+        'Axon_ex': growth_curve,
+    }
+    nodes = nest.Create(neuron_model, 2, {'synaptic_elements': synaptic_elements})
 
-	all = nest.GetStructuralPlasticityStatus()
-	print (all)
+    all = nest.GetStructuralPlasticityStatus()
+    print (all)
         assert('structural_plasticity_synapses' in all)
         assert('syn1' in all['structural_plasticity_synapses'])
         assert('structural_plasticity_update_interval' in all)
-	assert(all['structural_plasticity_update_interval'] == 1000)
+    assert(all['structural_plasticity_update_interval'] == 1000)
 
-	sp_synapses = nest.GetStructuralPlasticityStatus('structural_plasticity_synapses')
-	print (sp_synapses)
+    sp_synapses = nest.GetStructuralPlasticityStatus('structural_plasticity_synapses')
+    print (sp_synapses)
         syn = sp_synapses['syn1']
         assert('pre_synaptic_element' in syn)
         assert('post_synaptic_element' in syn)
         assert(syn['pre_synaptic_element'] == 'Axon_ex')
         assert(syn['post_synaptic_element'] == 'Den_ex')
 
-	sp_interval = nest.GetStructuralPlasticityStatus('structural_plasticity_update_interval')
-	print (sp_interval)
+    sp_interval = nest.GetStructuralPlasticityStatus(
+            'structural_plasticity_update_interval'
+        )
+    print (sp_interval)
         assert(sp_interval == 1000)
 
 def suite():

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# test_get_sp_status.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+'''
+Structural Plasticity GetStatus Test
+-----------------------
+This test shows how to use the GetStructuralPlasticityStatus function
+'''
+
+
+import nest
+import unittest
+
+__author__ = 'sdiaz'
+
+
+class TestGetStructuralPlasticityStatus(unittest.TestCase):
+
+	neuron_model = 'iaf_psc_alpha'
+	nest.CopyModel('static_synapse', 'synapse_ex')
+	nest.SetDefaults('synapse_ex', {'weight': 1.0, 'delay': 1.0})
+	nest.SetStructuralPlasticityStatus({
+	    'structural_plasticity_synapses': {
+		'synapse_ex': {
+		    'model': 'synapse_ex',
+		    'post_synaptic_element': 'Den_ex',
+		    'pre_synaptic_element': 'Axon_ex',
+		},
+	    }
+	})
+
+	growth_curve = {
+	    'growth_curve': "gaussian",
+	    'growth_rate': 0.0001,  # (elements/ms)
+	    'continuous': False,
+	    'eta': 0.0,  # Ca2+
+	    'eps': 0.05
+	}
+
+	'''
+	Now we assign the growth curves to the corresponding synaptic elements
+	'''
+	synaptic_elements = {
+	    'Den_ex': growth_curve,
+	    'Den_in': growth_curve,
+	    'Axon_ex': growth_curve,
+	}
+	nodes = nest.Create(neuron_model,
+			           2,
+			           {'synaptic_elements': synaptic_elements})
+
+	all = nest.GetStructuralPlasticityStatus()
+	print (all)
+        assert('structural_plasticity_synapses' in all)
+        assert('structural_plasticity_update_interval' in all)
+
+	sp_synapses = nest.GetStructuralPlasticityStatus('structural_plasticity_synapses')
+	print (sp_synapses)
+        assert('pre_synaptic_element' in sp_synapses['syn1'])
+        assert('post_synaptic_element' in sp_synapses['syn1'])
+
+	sp_interval = nest.GetStructuralPlasticityStatus('structural_plasticity_update_interval')
+	print (sp_interval)
+        assert(sp_interval == 1000)
+
+def suite():
+    test_suite = unittest.makeSuite(TestGetStructuralPlasticityStatus, 'test')
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pynest/nest/tests/test_sp/test_get_sp_status.py
+++ b/pynest/nest/tests/test_sp/test_get_sp_status.py
@@ -22,7 +22,8 @@
 '''
 Structural Plasticity GetStatus Test
 -----------------------
-This test shows how to use the GetStructuralPlasticityStatus function
+This test the functionality of the GetStructuralPlasticityStatus
+function
 '''
 
 
@@ -70,12 +71,17 @@ class TestGetStructuralPlasticityStatus(unittest.TestCase):
 	all = nest.GetStructuralPlasticityStatus()
 	print (all)
         assert('structural_plasticity_synapses' in all)
+        assert('syn1' in all['structural_plasticity_synapses'])
         assert('structural_plasticity_update_interval' in all)
+	assert(all['structural_plasticity_update_interval'] == 1000)
 
 	sp_synapses = nest.GetStructuralPlasticityStatus('structural_plasticity_synapses')
 	print (sp_synapses)
-        assert('pre_synaptic_element' in sp_synapses['syn1'])
-        assert('post_synaptic_element' in sp_synapses['syn1'])
+        syn = sp_synapses['syn1']
+        assert('pre_synaptic_element' in syn)
+        assert('post_synaptic_element' in syn)
+        assert(syn['pre_synaptic_element'] == 'Axon_ex')
+        assert(syn['post_synaptic_element'] == 'Den_ex')
 
 	sp_interval = nest.GetStructuralPlasticityStatus('structural_plasticity_update_interval')
 	print (sp_interval)


### PR DESCRIPTION
This PR addresses issue #260 by changing the call format for GetStructuralPlasticityStatus. Now the parameter for the call is optional and can include a string defining the elements of interest from the status dictionary. The call still returns the dictionary containing the status filtered by the parameter string. A small test was also added.