### PR TITLE
Prohibit DataConnect in multithreaded mode.

### DIFF
--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -866,8 +866,7 @@ NestModule::DataConnect_i_D_sFunction::execute( SLIInterpreter* i ) const
 
   if ( kernel().vp_manager.get_num_threads() > 1 )
   {
-    throw KernelException(
-      "DataConnect can not be used with multiple threads" );
+    throw KernelException( "DataConnect cannot be used with multiple threads" );
   }
 
   const index source = getValue< long >( i->OStack.pick( 2 ) );
@@ -931,8 +930,7 @@ NestModule::DataConnect_aFunction::execute( SLIInterpreter* i ) const
 
   if ( kernel().vp_manager.get_num_threads() > 1 )
   {
-    throw KernelException(
-      "DataConnect can not be used with multiple threads" );
+    throw KernelException( "DataConnect cannot be used with multiple threads" );
   }
 
   const ArrayDatum connectome = getValue< ArrayDatum >( i->OStack.top() );

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -864,6 +864,12 @@ NestModule::DataConnect_i_D_sFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 3 );
 
+  if ( kernel().vp_manager.get_num_threads() > 1 )
+  {
+    throw KernelException(
+      "DataConnect can not be used with multiple threads" );
+  }
+
   const index source = getValue< long >( i->OStack.pick( 2 ) );
   DictionaryDatum params = getValue< DictionaryDatum >( i->OStack.pick( 1 ) );
   const Name synmodel_name = getValue< std::string >( i->OStack.pick( 0 ) );
@@ -922,6 +928,13 @@ void
 NestModule::DataConnect_aFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 1 );
+
+  if ( kernel().vp_manager.get_num_threads() > 1 )
+  {
+    throw KernelException(
+      "DataConnect can not be used with multiple threads" );
+  }
+
   const ArrayDatum connectome = getValue< ArrayDatum >( i->OStack.top() );
 
   kernel().connection_manager.data_connect_connectome( connectome );

--- a/testsuite/regressiontests/issue-527.sli
+++ b/testsuite/regressiontests/issue-527.sli
@@ -1,0 +1,74 @@
+/*
+ *  issue-527.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /* BeginDocumentation
+  Name: testsuite::issue-527
+  
+  Synopsis: (issue-527) run -> NEST exits if test fails
+  
+  Description:
+  This test ensures that NEST raises an error if the user tries to use 
+  DataConnect in multithreaded mode.
+  
+  Author: Stine B. Vennemo
+  FirstVersion: July 2017
+  SeeAlso:
+*/
+
+(unittest) run
+/unittest using
+
+skip_if_not_threaded
+
+/test_threaded_DataConnect
+{
+  dup /threads Set
+  ResetKernel
+  0 << /local_num_threads threads /total_num_virtual_procs threads >> SetStatus
+  
+  % Create set of neurons
+  /A /iaf_psc_alpha 1 Create def
+  /B /iaf_psc_alpha 1000 Create def
+  
+  % Make target array
+  /t [A 1 add 1.0 mul B 1.0 mul] Range def
+  
+  % Make weight array
+  /w [1000] 1.0 LayoutArray def
+  
+  % Make delay array
+  /d [1000] 1.0 LayoutArray def
+  
+  % Connect using DataConnect
+  A << /target t /weight w /delay d >> /static_synapse DataConnect
+
+} def
+
+/* test runs with different number of threads */
+[2 16 2] Range
+{
+  { test_threaded_DataConnect } fail_or_die
+}
+forall
+
+endusing

--- a/testsuite/regressiontests/issue-527.sli
+++ b/testsuite/regressiontests/issue-527.sli
@@ -44,7 +44,7 @@ skip_if_not_threaded
 {
   dup /threads Set
   ResetKernel
-  0 << /local_num_threads threads /total_num_virtual_procs threads >> SetStatus
+  0 << /local_num_threads threads >> SetStatus
   
   % Create set of neurons
   /A /iaf_psc_alpha 1 Create def


### PR DESCRIPTION
This PR fixes #527. I have added a check to see if we have more than one thread when using `DataConnect`, in which case an exception is thrown. I have also added a simple regressiontest. 