### PR TITLE
using the minimal image of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
 # This is the Travis CI top-level script to setup and run the NEST build and test environment. 
 
 
-language: generic
+language: minimal
 
 # Required for Ubuntu Trusty (14.04 LTS).
 sudo: required


### PR DESCRIPTION
Using the minimal image of Ubuntu-Trusty to avoid the issue with python modules mentioned in #774