### PR TITLE
Fix #644: bad_alloc exception

### DIFF
--- a/nestkernel/nest_time.h
+++ b/nestkernel/nest_time.h
@@ -144,6 +144,8 @@ class Time
   // delay: steps, signed long
   // double: milliseconds (double!)
 
+  friend class TimeConverter;
+
   /////////////////////////////////////////////////////////////
   // Range: Limits & conversion factors for different types
   /////////////////////////////////////////////////////////////

--- a/nestkernel/nest_timeconverter.cpp
+++ b/nestkernel/nest_timeconverter.cpp
@@ -37,6 +37,10 @@ TimeConverter::TimeConverter()
 Time
 TimeConverter::from_old_steps( long s_old ) const
 {
+  if ( s_old == Time::LIM_NEG_INF.steps || s_old == Time::LIM_POS_INF.steps )
+  {
+    return Time( Time::step( s_old ) );
+  }
   double ms = s_old * OLD_TICS_PER_STEP / OLD_TICS_PER_MS;
   return Time::ms( ms );
 }
@@ -44,6 +48,10 @@ TimeConverter::from_old_steps( long s_old ) const
 Time
 TimeConverter::from_old_tics( tic_t t_old ) const
 {
+  if ( t_old == Time::LIM_NEG_INF.tics || t_old == Time::LIM_POS_INF.tics )
+  {
+    return Time( Time::tic( t_old ) );
+  }
   double ms = t_old / OLD_TICS_PER_MS;
   return Time::ms( ms );
 }

--- a/nestkernel/nest_timeconverter.h
+++ b/nestkernel/nest_timeconverter.h
@@ -37,7 +37,7 @@ namespace nest
 class Time;
 /**
  * Class to convert times from one representation to another.
- * Createing an object of TimeCOnverter at a current time representation
+ * Creating an object of TimeConverter at a current time representation
  * saves the current values of TICS_PER_MS and TICS_PER_STEP.
  * After having changed the time representation,
  * the members from_old_steps and from_old_tics can be used


### PR DESCRIPTION
This PR fixes a bad_alloc exception caused by an incorrect or missing, respectively,  infinity handling in the TimeConverter class. For a detailed description please see #644.