### PR TITLE
Fix #762: PyNEST test result parsing confused by NEST output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,7 @@ before_install:
   # (Please note that the nose-capturestderr plugin is needed to suppress NEST output to stderr which may interfere 
   #  with the nosetests output hindering correct log-parsing. stdout it captured by default.)
   - sudo apt-get install -y python-nose
-  - git clone https://github.com/sio2project/nose-capturestderr.git capturestderr
-  - cd capturestderr
-  - sudo python setup.py install
+  - sudo pip install "nose-capturestderr==1.2"
 
   # Install VERA++ and pep8 for static code analysis.
   - sudo apt-get install -y vera++ pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,12 @@ before_install:
   - sudo apt-get install -y openmpi-bin libopenmpi-dev
 
   # Install nose framework for the Python testsuite.
+  # (Please note that the nose-capturestderr plugin is needed to suppress NEST output to stderr which may interfere 
+  #  with the nosetests output hindering correct log-parsing. stdout it captured by default.)
   - sudo apt-get install -y python-nose
+  - git clone https://github.com/sio2project/nose-capturestderr.git capturestderr
+  - cd capturestderr
+  - sudo python setup.py install
 
   # Install VERA++ and pep8 for static code analysis.
   - sudo apt-get install -y vera++ pep8
@@ -110,6 +115,9 @@ install:
   - which python
   - python --version
   - which pip
+  - which nosetests
+  - nosetests --version
+  - nosetests --plugins
   - which cmake
   - cmake --version
 

--- a/pynest/nest/tests/test_aeif_lsodar.py
+++ b/pynest/nest/tests/test_aeif_lsodar.py
@@ -249,10 +249,10 @@ class AEIFTestCase(unittest.TestCase):
                                     model, var, diff, di_tol[model][var]))
 
     @unittest.skipIf(not HAVE_GSL, 'GSL is not available')
-    def test_closeness_nest_lsodar(self):
-        '''
-        Compare models to the LSODAR implementation.
-        '''
+    def testClosenessNestLSODAR(self):
+
+        # Compare models to the LSODAR implementation.
+
         simtime = 100.
 
         # get lsodar reference
@@ -281,11 +281,11 @@ class AEIFTestCase(unittest.TestCase):
         self.assert_pass_tolerance(rel_diff, di_tolerances_lsodar)
 
     @unittest.skipIf(not HAVE_GSL, 'GSL is not available')
-    def test_iaf_behaviour(self):
-        '''
-        The models should behave as iaf_cond_* if a == 0., b == 0. and
-        Delta_T == 0.
-        '''
+    def testIafBehaviour(self):
+
+        # The models should behave as iaf_cond_* if a == 0., b == 0. and
+        # Delta_T == 0.
+
         simtime = 200.
         # create the neurons and devices
         refs = {syn_type: nest.Create("iaf_" + syn_type,


### PR DESCRIPTION
This PR installs the nosetests capturestderr plugin and corrcets some of the nosetests log messages. For more details please see issue #762.