### PR TITLE
Exclude files starting with ".#" from help generation

### DIFF
--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -51,7 +51,8 @@ for dirpath, dirnames, files in os.walk(source_dir):
         continue
 
     for f in files:
-        if f.endswith((".sli", ".cpp", ".cc", ".h", ".py")):
+        if f.endswith((".sli", ".cpp", ".cc", ".h", ".py")) and \
+           not f.startswith(".#"):
             allfiles.append(os.path.join(dirpath, f))
 
 num = 0


### PR DESCRIPTION
If these files exist and are not excluded, the help generation fails:

```bash
Traceback (most recent call last):                                                                                                              
  File "generate_help.py", line 95, in <module>                                                                                        
    f = open(fname, 'r')                                                                        
FileNotFoundError: [Errno 2] No such file or directory: '/home/jordan/opt/nest-private/nestkernel/.#kernel_manager.cpp'
doc/CMakeFiles/generate_help.dir/build.make:57: recipe for target 'generate_help' failed                                  
make[2]: *** [generate_help] Error 1                                                                                     
CMakeFiles/Makefile2:247: recipe for target 'doc/CMakeFiles/generate_help.dir/all' failed    
make[1]: *** [doc/CMakeFiles/generate_help.dir/all] Error 2                                                                                                                                                                                                                                
make[1]: *** Waiting for unfinished jobs....
```

This PR fixes this.