### PR TITLE
Fix778: Remove assertion that prohibits simulation for 0 ms

### DIFF
--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -489,7 +489,11 @@ nest::SimulationManager::run( Time const& t )
 
   to_do_ += t.get_steps();
   to_do_total_ = to_do_;
-  assert( to_do_ != 0 );
+
+  if ( to_do_ == 0 )
+  {
+    return;
+  }
 
   // Reset profiling timers and counters within event_delivery_manager
   kernel().event_delivery_manager.reset_timers_counters();


### PR DESCRIPTION
This pull request fixes issue #778.

`0 Simulate` should not raise an assertion.