### PR TITLE
Prohibit module installation after CopyModel (fixes #746)

### DIFF
--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -155,6 +155,13 @@ DynamicLoaderModule::LoadModuleFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 1 );
 
+  if ( kernel().model_manager.has_user_models()
+    or kernel().model_manager.has_user_prototypes() )
+  {
+    throw DynamicModuleManagementError(
+      "Modules cannot be installed after CopyModel has been called" );
+  }
+
   sDynModule new_module;
 
   new_module.name = getValue< std::string >( i->OStack.top() );

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -621,8 +621,8 @@ ModelManager::register_connection_model_( ConnectorModel* cf )
 
   pristine_prototypes_.push_back( cf );
 
-  const synindex syn_id = prototypes_[ 0 ].size();
-  pristine_prototypes_[ syn_id ]->set_syn_id( syn_id );
+  const synindex syn_id = prototypes_.at( 0 ).size();
+  pristine_prototypes_.at( syn_id )->set_syn_id( syn_id );
 
   for ( thread t = 0;
         t < static_cast< thread >( kernel().vp_manager.get_num_threads() );


### PR DESCRIPTION
This PR fixes #746. It does not contain a regression test, since that would require building `MyModule`, which is currently not supported by our test harness. I will create a separate issue for that.