### PR TITLE
Run tests in test_connect_all_patterns.py with mpirun

### DIFF
--- a/pynest/nest/tests/test_connect_all_patterns.py
+++ b/pynest/nest/tests/test_connect_all_patterns.py
@@ -39,21 +39,20 @@ class TestConnectAllPatterns(unittest.TestCase):
                    "test_connect_fixed_total_number.py",
                    "test_connect_pairwise_bernoulli.py"
                    ]
-        retcodes = []
+        failing_tests = []
         for script in scripts:
             test_script = os.path.join(directory, script)
             command = nest.sli_func("mpirun", 2, "nosetests",
                                     test_script)
-            print("Executing test with command: " + command)
             command = command.split()
-            retcodes.append(sp.call(command))
-        failed_tests = ''
-        for script, retcode in zip(scripts, retcodes):
+            process = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
+            stdout, stderr = process.communicate()
+            retcode = process.returncode
             if retcode != 0:
-                failed_tests += script + ' '
-        self.assertEqual(failed_tests, '',
-                         'Error using MPI with the following test(s): ' +
-                         failed_tests)
+                failing_tests.append(script)
+        self.assertTrue(not failing_tests, 'The following tests failed when ' +
+                        'executing with "mpirun -np 2 nosetests [script]": ' +
+                        ", ".join(failing_tests))
 
 
 if __name__ == '__main__':

--- a/pynest/nest/tests/test_connect_all_patterns.py
+++ b/pynest/nest/tests/test_connect_all_patterns.py
@@ -30,7 +30,6 @@ class TestConnectAllPatterns(unittest.TestCase):
     def testWithMPI(self):
         directory = os.path.dirname(os.path.realpath(__file__))
         scripts = ["test_connect_all_to_all.py",
-                   "test_connect_parameters.py",
                    "test_connect_one_to_one.py",
                    "test_connect_fixed_indegree.py",
                    "test_connect_fixed_outdegree.py",

--- a/pynest/nest/tests/test_connect_all_patterns.py
+++ b/pynest/nest/tests/test_connect_all_patterns.py
@@ -31,6 +31,11 @@ class TestConnectAllPatterns(unittest.TestCase):
 
     @unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
     def testWithMPI(self):
+        # Check that we can import mpi4py
+        try:
+            from mpi4py import MPI
+        except ImportError:
+            raise unittest.SkipTest("mpi4py required")
         directory = os.path.dirname(os.path.realpath(__file__))
         scripts = ["test_connect_all_to_all.py",
                    "test_connect_one_to_one.py",

--- a/pynest/nest/tests/test_connect_all_patterns.py
+++ b/pynest/nest/tests/test_connect_all_patterns.py
@@ -24,9 +24,12 @@ import subprocess as sp
 import unittest
 import nest
 
+HAVE_MPI = nest.sli_func("statusdict/have_mpi ::")
+
 
 class TestConnectAllPatterns(unittest.TestCase):
 
+    @unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
     def testWithMPI(self):
         directory = os.path.dirname(os.path.realpath(__file__))
         scripts = ["test_connect_all_to_all.py",

--- a/pynest/nest/tests/test_connect_all_patterns.py
+++ b/pynest/nest/tests/test_connect_all_patterns.py
@@ -41,7 +41,7 @@ class TestConnectAllPatterns(unittest.TestCase):
                    ]
         retcodes = []
         for script in scripts:
-            test_script = directory + "/" + script
+            test_script = os.path.join(directory, script)
             command = nest.sli_func("mpirun", 2, "nosetests",
                                     test_script)
             print("Executing test with command: " + command)

--- a/pynest/nest/tests/test_connect_one_to_one.py
+++ b/pynest/nest/tests/test_connect_one_to_one.py
@@ -55,9 +55,9 @@ class TestOneToOne(TestParams):
         M1 = hf.get_connectivity_matrix(self.pop1, self.pop2)
         M2 = hf.get_connectivity_matrix(self.pop2, self.pop1)
         # test that connections were created in both directions
-        hf.mpi_assert(M1, np.transpose(M2), self)
+        hf.mpi_assert(M1, np.transpose(hf.gather_data(M2)), self)
         # test that no other connections were created
-        hf.mpi_assert(M1-np.identity(self.N), np.zeros_like(M1), self)
+        hf.mpi_assert(M1, np.zeros_like(M1) + np.identity(self.N), self)
 
     def testInputArray(self):
         syn_params = {}


### PR DESCRIPTION
The test `test_connect_all_patterns.py` now uses `mpirun` to run the tests

- `test_connect_all_to_all.py`
- `test_connect_one_to_one.py`
- `test_connect_fixed_indegree.py`
- `test_connect_fixed_outdegree.py`
- `test_connect_fixed_total_number.py`
- `test_connect_pairwise_bernoulli.py`

This fixes #353.