### PR TITLE
fixing various typos in pynest docs

### DIFF
--- a/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
+++ b/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
@@ -73,9 +73,9 @@ for.
 
 One such command is `nest.Models?`, which will return a list of all the
 available models you can use. If you want to obtain more information about a
-particular command, you may use iPython’s standard help system.
+particular command, you may use IPython’s standard help system.
 
-    nest.Models? 
+    nest.Models?
 
 This will return the help text (docstring) explaining the use of this particular
 function. There is a help system within NEST as well. You can open the help

--- a/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
+++ b/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
@@ -71,11 +71,11 @@ for.
 
     dir(nest)
 
-One such command is `nest.Models()`, which will return a list of all the
+One such command is `nest.Models?`, which will return a list of all the
 available models you can use. If you want to obtain more information about a
-particular command, you may use Python’s standard help system.
+particular command, you may use iPython’s standard help system.
 
-    nest.Models() 
+    nest.Models? 
 
 This will return the help text (docstring) explaining the use of this particular
 function. There is a help system within NEST as well. You can open the help

--- a/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
+++ b/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
@@ -75,7 +75,7 @@ One such command is `nest.Models()`, which will return a list of all the
 available models you can use. If you want to obtain more information about a
 particular command, you may use Python’s standard help system.
 
-    nest.Models?
+    nest.Models() 
 
 This will return the help text (docstring) explaining the use of this particular
 function. There is a help system within NEST as well. You can open the help
@@ -377,7 +377,7 @@ current, and add a second neuron.
     nest.SetStatus(neuron1, {"I_e": 376.0})
     neuron2 = nest.Create("iaf_psc_alpha")
     multimeter = nest.Create("multimeter")
-    nest.SetStatus(multimeter, {"withtime":True, "record_from":["V_m"]}
+    nest.SetStatus(multimeter, {"withtime":True, "record_from":["V_m"]})
 
 We now connect `neuron1` to `neuron2`, and record the membrane potential from
 `neuron2` so we can observe the postsynaptic potentials caused by the spikes of

--- a/extras/userdoc/md/documentation/part-2-populations-of-neurons.md
+++ b/extras/userdoc/md/documentation/part-2-populations-of-neurons.md
@@ -112,7 +112,7 @@ each of them, which is more efficient, and thus to be preferred. One way to do
 it is to give a list of dictionaries which is the same length as the number of
 nodes to be parameterised, for example using a list comprehension:
 
-    dVms =  [{"V_m": Vrest+(Vth-Vrest)\*numpy.random.rand()} for x in epop1]
+    dVms =  [{"V_m": Vrest+(Vth-Vrest)*numpy.random.rand()} for x in epop1]
     nest.SetStatus(epop1, dVms)
 
 If we only need to randomise one parameter then there is a more concise way by
@@ -120,7 +120,7 @@ passing in the name of the parameter and a list of its desired values. Once
 again, the list must be the same size as the number of nodes to be
 parameterised:
 
-    Vms = Vrest+(Vth-Vrest)\*numpy.random.rand(len(epop1))
+    Vms = Vrest+(Vth-Vrest)*numpy.random.rand(len(epop1))
     nest.SetStatus(epop1, "V_m", Vms)
 
 Note that we are being rather lax with random numbers here. Really we have to

--- a/extras/userdoc/md/documentation/part-3-connecting-networks-with-synapses.md
+++ b/extras/userdoc/md/documentation/part-3-connecting-networks-with-synapses.md
@@ -25,7 +25,7 @@ subdirectory: `pynest/examples/`.
 ## Parameterising synapse models
 
 NEST provides a variety of different synapse models. You can see the available
-models by using the command `Models(synapses)`, which picks only the synapse
+models by using the command `nest.Models(mtype='synapses')`, which picks only the synapse
 models out of the list of all available models.
 
 Synapse models can be parameterised analogously to neuron models. You can


### PR DESCRIPTION
Some minor corrections to the pynest documentation brought to my attention a couple of weeks ago.  