### PR TITLE
Ensure number of vacant synaptic elements is always >= 0

### DIFF
--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -172,7 +172,7 @@ public:
   int
   get_z_vacant() const
   {
-    return std::floor( z_ ) - z_connected_;
+    return std::max( std::floor( z_ ) - z_connected_, 0. );
   }
   /*
    * Retrieves the current number of synaptic elements bound to a synapse


### PR DESCRIPTION
Minor check to ensure that the number of vacant synaptic elements is
always >= 0. When synaptic elements are to be deleted, z_ <
z_connected_, and in this scenario, this method may return a negative -
which when passed to the `decay_synaptic_elements` method unexpectedly
adds to the z_ value instead of having no effect (there are no
vacant elements to decay).

The decay method is only called after connectivity updates have been
made in the current source, so this issue doesn not arise. However, as
we're thinking of moving towards decoupling the structural plasticity
updates in the future, this general check is worth adding.

(Discussed this with @sdiazpier over slack and we thought it'd be better to have the check in now than diagnose unexpected behaviours later.)