### PR TITLE
Properly set the environment variables for do_tests.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,22 +188,22 @@ file( MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/reports/ )
 
 if ( HAVE_PYTHON )
   add_custom_target( installcheck
-      #COMMAND ${CMAKE_MAKE_PROGRAM} install
-      COMMAND export PATH="${CMAKE_INSTALL_FULL_BINDIR}:$ENV{PATH}" &&
-      export PYTHON="${PYTHON}" &&
-      export PYTHONPATH="${CMAKE_INSTALL_PREFIX}/${PYEXECDIR}:$ENV{PYTHONPATH}" &&
+    COMMAND ${CMAKE_COMMAND} -E env
+      NEST_PATH="${CMAKE_INSTALL_FULL_BINDIR}"
+      PYTHON="${PYTHON}"
+      NEST_PYTHONPATH="${CMAKE_INSTALL_PREFIX}/${PYEXECDIR}"
       ${CMAKE_INSTALL_FULL_DATADIR}/extras/do_tests.sh --test-pynest --source-dir="${PROJECT_SOURCE_DIR}"
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
-      COMMENT "Execute NEST's testsuite...."
-      )
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+    COMMENT "Execute NEST's testsuite...."
+  )
 else ()
   add_custom_target( installcheck
-      #COMMAND ${CMAKE_MAKE_PROGRAM} install
-      COMMAND export PATH="${CMAKE_INSTALL_FULL_BINDIR}:$ENV{PATH}" &&
+    COMMAND ${CMAKE_COMMAND} -E env
+      NEST_PATH="${CMAKE_INSTALL_FULL_BINDIR}"
       ${CMAKE_INSTALL_FULL_DATADIR}/extras/do_tests.sh --source-dir="${PROJECT_SOURCE_DIR}"
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
-      COMMENT "Execute NEST's testsuite...."
-      )
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+    COMMENT "Execute NEST's testsuite...."
+  )
 endif ()
 
 add_custom_target( check

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -353,6 +353,12 @@ run_test ()
     rm -f "${TEST_OUTFILE}" "${TEST_RETFILE}"
 }
 
+# Set environment variables.
+# The NEST_ variants of the global variables were set by
+# cmake during configuration.
+export PYTHONPATH=$NEST_PYTHONPATH:$PYTHONPATH
+export PATH=$NEST_PATH:$PATH
+
 # Gather some information about the host
 INFO_ARCH="$(uname -m)"
 INFO_HOME="$(/bin/sh -c 'echo ~')"


### PR DESCRIPTION
This changes the custom build target `installcheck` to only set the configuration-specific part of the environment variables `PATH` and `PYTHONPATH`. The bash script `do_tests.sh` then concatenates these with the real environment variables.

The way it was done before did not actually work, but was setting the variables to the values at
*configure time*, instead of *build time*.

This fixes #817.