### PR TITLE
Moved vacant sp elements sanity check to decay function

### DIFF
--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -172,7 +172,7 @@ public:
   int
   get_z_vacant() const
   {
-    return std::max( std::floor( z_ ) - z_connected_, 0. );
+    return std::floor( z_ ) - z_connected_;
   }
   /*
    * Retrieves the current number of synaptic elements bound to a synapse
@@ -243,7 +243,9 @@ public:
   void
   decay_z_vacant()
   {
-    z_ -= get_z_vacant() * tau_vacant_;
+    if(get_z_vacant() > 0){
+      z_ -= get_z_vacant() * tau_vacant_;
+    }
   }
 
   bool

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -243,7 +243,7 @@ public:
   void
   decay_z_vacant()
   {
-    if( get_z_vacant() > 0 )
+    if ( get_z_vacant() > 0 )
     {
       z_ -= get_z_vacant() * tau_vacant_;
     }

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -243,7 +243,8 @@ public:
   void
   decay_z_vacant()
   {
-    if(get_z_vacant() > 0){
+    if( get_z_vacant() > 0 )
+    {
       z_ -= get_z_vacant() * tau_vacant_;
     }
   }


### PR DESCRIPTION
This PR follows up on #818. The check on the vacant synaptic elements is moved to the decay function of the synaptic elements to ensure that the deletion of elements still takes place correctly by the sp_manager. 

I suggest @sanjayankur31  as reviewer for this. 