### PR TITLE
Correction in the test of synapse disconnection with mpi

### DIFF
--- a/pynest/nest/tests/test_sp/test_disconnect.py
+++ b/pynest/nest/tests/test_sp/test_disconnect.py
@@ -19,10 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-__author__ = 'naveau'
-
 import nest
 import unittest
+import numpy as np
+
+__author__ = 'naveau'
 
 try:
     from mpi4py import MPI
@@ -32,6 +33,7 @@ except ImportError:
 else:
     # Test with MPI
     mpi_test = 1
+mpi_test = nest.sli_func("statusdict/have_mpi ::") & mpi_test
 
 
 class TestDisconnectSingle(unittest.TestCase):
@@ -52,12 +54,6 @@ class TestDisconnectSingle(unittest.TestCase):
             'stdp_dopamine_synapse_hpc_lbl',
             'gap_junction',
             'gap_junction_lbl',
-            'diffusion_connection',
-            'diffusion_connection_lbl',
-            'rate_connection_instantaneous',
-            'rate_connection_instantaneous_lbl',
-            'rate_connection_delayed',
-            'rate_connection_delayed_lbl'
         ]
 
     def test_synapse_deletion_one_to_one_no_sp(self):
@@ -82,14 +78,14 @@ class TestDisconnectSingle(unittest.TestCase):
                     [neurons[0]], [neurons[2]], syn_model)
                 if mpi_test:
                     conns = self.comm.allgather(conns)
-                    conns = filter(None, conns)
+                    conns = list(filter(None, conns))
                 assert len(conns) == 1
                 nest.DisconnectOneToOne(neurons[0], neurons[2], syn_dict)
                 conns = nest.GetConnections(
                     [neurons[0]], [neurons[2]], syn_model)
                 if mpi_test:
                     conns = self.comm.allgather(conns)
-                    conns = filter(None, conns)
+                    conns = list(filter(None, conns))
                 assert len(conns) == 0
 
                 # Assert that one can not delete a non existent connection
@@ -97,7 +93,7 @@ class TestDisconnectSingle(unittest.TestCase):
                     [neurons[0]], [neurons[1]], syn_model)
                 if mpi_test:
                     conns1 = self.comm.allgather(conns1)
-                    conns1 = filter(None, conns1)
+                    conns1 = list(filter(None, conns1))
                 assert len(conns1) == 0
                 try:
                     nest.DisconnectOneToOne(neurons[0], neurons[1], syn_dict)


### PR DESCRIPTION
This PR solves an issue with the test of synapse deletion using mpi and pynest. Thanks to @lekshmideepu who implemented the solution in PR #789 but we have decided to split this change as this problem is not directly related to the issue in that PR. 