### PR TITLE
Allow negative exponential distributions (fixes #835)

### DIFF
--- a/librandom/exp_randomdev.cpp
+++ b/librandom/exp_randomdev.cpp
@@ -33,9 +33,9 @@ librandom::ExpRandomDev::set_status( const DictionaryDatum& d )
 
   updateValue< double >( d, names::lambda, new_lambda );
 
-  if ( new_lambda <= 0. )
+  if ( new_lambda == 0. )
   {
-    throw BadParameterValue( "Exponential RDV: lambda > 0 required." );
+    throw BadParameterValue( "Exponential RDV: lambda != 0 required." );
   }
 
   lambda_ = new_lambda;

--- a/librandom/exp_randomdev.h
+++ b/librandom/exp_randomdev.h
@@ -40,7 +40,9 @@ namespace librandom
 Name: rdevdict::exponential - exponential random deviate generator
 Description: Generates exponentially distributed random numbers.
 
-  p(x) = lambda exp(-lambda*x), x >= 0.
+  p(x) =  lambda exp(-lambda*x), x >= 0 if lambda > 0
+  p(x) = -lambda exp(-lambda*x), x <= 0 if lambda < 0
+
 
 Parameters:
  lambda - rate parameter (default: 1.0)

--- a/librandom/exp_randomdev.h
+++ b/librandom/exp_randomdev.h
@@ -39,10 +39,15 @@ namespace librandom
 /*BeginDocumentation
 Name: rdevdict::exponential - exponential random deviate generator
 Description: Generates exponentially distributed random numbers.
+Negative values of lambda are allowed and generate a distribution of negative numbers.
 
-  p(x) =  lambda exp(-lambda*x), x >= 0 if lambda > 0
-  p(x) = -lambda exp(-lambda*x), x <= 0 if lambda < 0
+For lambda > 0:
+  p(x) = lambda exp(-lambda*x), for x >= 0
+  p(x) = 0, for x < 0
 
+For lambda < 0:
+  p(x) = 0, for x > 0
+  p(x) = |lambda| exp ( -|lambda| |x| ), for x <= 0
 
 Parameters:
  lambda - rate parameter (default: 1.0)

--- a/librandom/exp_randomdev.h
+++ b/librandom/exp_randomdev.h
@@ -39,7 +39,8 @@ namespace librandom
 /*BeginDocumentation
 Name: rdevdict::exponential - exponential random deviate generator
 Description: Generates exponentially distributed random numbers.
-Negative values of lambda are allowed and generate a distribution of negative numbers.
+Negative values of lambda are allowed and generate a distribution
+of negative numbers.
 
 For lambda > 0:
   p(x) = lambda exp(-lambda*x), for x >= 0

--- a/testsuite/unittests/test_rdv_param_setting.sli
+++ b/testsuite/unittests/test_rdv_param_setting.sli
@@ -109,7 +109,7 @@ FirstVersion: 20140402
 
 {
   /MT19937 /exponential << /lambda -1. >> run_test
-} fail_or_die
+} assert_or_die
 
 {
   /MT19937 /exponential_clipped << /min 0. /max -1. >> run_test


### PR DESCRIPTION
Some models rely on the synaptic weight being negative in order to consider the synapse inhibitory.
However the exponential distribution wasn't allowing a negative lambda value.
With this change we can generate exponential distributions of inhibitory synaptic weights.

Note that the implementation in librandom/exp_randomdev.h already works for negative lambda values, this is just removing the check for negative parameter values.