### PR TITLE
Allow rectangular and box masks to be rotated

### DIFF
--- a/topology/mask.h
+++ b/topology/mask.h
@@ -219,8 +219,8 @@ public:
 
   BoxMask( const Position< D >& lower_left,
     const Position< D >& upper_right,
-    double azimuth_angle = 0.0,
-    double polar_angle = 0.0 );
+    const double azimuth_angle = 0.0,
+    const double polar_angle = 0.0 );
 
   ~BoxMask()
   {
@@ -759,8 +759,8 @@ BoxMask< D >::BoxMask( const DictionaryDatum& d )
 template < int D >
 inline BoxMask< D >::BoxMask( const Position< D >& lower_left,
   const Position< D >& upper_right,
-  double azimuth_angle,
-  double polar_angle )
+  const double azimuth_angle,
+  const double polar_angle )
   : lower_left_( lower_left )
   , upper_right_( upper_right )
   , azimuth_angle_( azimuth_angle )

--- a/topology/mask.h
+++ b/topology/mask.h
@@ -217,7 +217,10 @@ public:
    */
   BoxMask( const DictionaryDatum& );
 
-  BoxMask( const Position< D >& lower_left, const Position< D >& upper_right, double azimuth_angle = 0.0, double polar_angle = 0.0 );
+  BoxMask( const Position< D >& lower_left,
+    const Position< D >& upper_right,
+    double azimuth_angle = 0.0,
+    double polar_angle = 0.0 );
 
   ~BoxMask()
   {
@@ -751,11 +754,13 @@ BoxMask< D >::BoxMask( const DictionaryDatum& d )
 
 template < int D >
 inline BoxMask< D >::BoxMask( const Position< D >& lower_left,
-  const Position< D >& upper_right, double azimuth_angle, double polar_angle )
+  const Position< D >& upper_right,
+  double azimuth_angle,
+  double polar_angle )
   : lower_left_( lower_left )
   , upper_right_( upper_right )
-  , azimuth_angle_ ( azimuth_angle )
-  , polar_angle_ ( polar_angle )
+  , azimuth_angle_( azimuth_angle )
+  , polar_angle_( polar_angle )
   , azimuth_cos_( std::cos( azimuth_angle_ * numerics::pi / 180. ) )
   , azimuth_sin_( std::sin( azimuth_angle_ * numerics::pi / 180. ) )
   , polar_cos_( std::cos( polar_angle_ * numerics::pi / 180. ) )

--- a/topology/mask.h
+++ b/topology/mask.h
@@ -258,7 +258,7 @@ protected:
   /**
    *  Calculate the min/max x, y, z values in case of a rotated box.
    */
-  void create_min_max_values_();
+  void calculate_min_max_values_();
 
   Position< D > lower_left_;
   Position< D > upper_right_;
@@ -753,7 +753,7 @@ BoxMask< D >::BoxMask( const DictionaryDatum& d )
 
   is_rotated_ = azimuth_angle_ or polar_angle_;
 
-  create_min_max_values_();
+  calculate_min_max_values_();
 }
 
 template < int D >
@@ -779,7 +779,7 @@ inline BoxMask< D >::BoxMask( const Position< D >& lower_left,
 
   is_rotated_ = azimuth_angle_ or polar_angle_;
 
-  create_min_max_values_();
+  calculate_min_max_values_();
 }
 
 template <>

--- a/topology/mask.h
+++ b/topology/mask.h
@@ -272,6 +272,8 @@ protected:
   double azimuth_sin_;
   double polar_cos_;
   double polar_sin_;
+
+  bool is_rotated_;
 };
 
 /**
@@ -749,6 +751,8 @@ BoxMask< D >::BoxMask( const DictionaryDatum& d )
   polar_cos_ = std::cos( polar_angle_ * numerics::pi / 180. );
   polar_sin_ = std::sin( polar_angle_ * numerics::pi / 180. );
 
+  is_rotated_ = azimuth_angle_ or polar_angle_;
+
   create_min_max_values_();
 }
 
@@ -772,6 +776,8 @@ inline BoxMask< D >::BoxMask( const Position< D >& lower_left,
       "topology::BoxMask<D>: "
       "polar_angle not defined in 2D." );
   }
+
+  is_rotated_ = azimuth_angle_ or polar_angle_;
 
   create_min_max_values_();
 }

--- a/topology/mask_impl.h
+++ b/topology/mask_impl.h
@@ -87,43 +87,32 @@ Mask< D >::outside( const Box< D >& b ) const
   return false;
 }
 
-/*template < int D >
-bool
-BoxMask< D >::inside( const Position< D >& p ) const
-{
-  const double new_x = p[ 0 ] * azimuth_cos_ + p[ 1 ] * azimuth_sin_;
-  const double new_y = - p[ 0 ] * azimuth_sin_ + p[ 1 ] * azimuth_cos_;
-
-  Position< D > new_p;
-  new_p[ 0 ] = new_x;
-  new_p[ 1 ] = new_y;
-
-  if ( D == 3 )
-  {
-    new_p[ 2 ] = p[ 2 ];
-  }
-
-  return ( new_p >= lower_left_ ) && ( new_p <= upper_right_ );
-}*/
-
 template <>
 bool
 BoxMask< 2 >::inside( const Position< 2 >& p ) const
 {
+  // We rotate the point down to the unrotated box, and check if it is inside
+  // said unrotated box.
+
+  // The new x, y values are calculated using a rotation matrix:
+  // [new_x, new_y] = R(-azimuth)*[x - x_c, y - y_c]
+  // where R(-t) = [cos(t) sin(t); -sin(t) cos(t)]
+
+  // See https://en.wikipedia.org/wiki/Rotation_matrix for more.
+
   const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
   const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
 
-  const double new_x = ( p[ 0 ] - cntr_x ) * azimuth_cos_ + ( p[ 1 ] - cntr_y ) * azimuth_sin_ + cntr_x;
-  const double new_y = - ( p[ 0 ] - cntr_x ) * azimuth_sin_ + ( p[ 1 ] - cntr_y ) * azimuth_cos_ + cntr_y;
+  const double new_x = ( p[ 0 ] - cntr_x ) * azimuth_cos_
+    + ( p[ 1 ] - cntr_y ) * azimuth_sin_ + cntr_x;
+  const double new_y = -( p[ 0 ] - cntr_x ) * azimuth_sin_
+    + ( p[ 1 ] - cntr_y ) * azimuth_cos_ + cntr_y;
+  const Position< 2 > new_p( new_x, new_y );
 
-  //const double new_x = ( p[ 0 ] ) * azimuth_cos_ + ( p[ 1 ] ) * azimuth_sin_;
-  //const double new_y = - ( p[ 0 ] ) * azimuth_sin_ + ( p[ 1 ] ) * azimuth_cos_;
-
-  Position< 2 > new_p( new_x, new_y );
-
+  // We need to add a small epsilon in case of rounding errors.
   const double x_length = upper_right_[ 0 ] - lower_left_[ 0 ];
   const double y_length = upper_right_[ 1 ] - lower_left_[ 1 ];
-  Position< 2 > eps( x_length / 100, y_length / 100 );
+  const Position< 2 > eps( x_length / 1000000, y_length / 1000000 );
 
   return ( lower_left_ - eps <= new_p ) && ( new_p <= upper_right_ + eps );
 }
@@ -132,24 +121,46 @@ template <>
 bool
 BoxMask< 3 >::inside( const Position< 3 >& p ) const
 {
+  // We rotate the point down to the unrotated box, and check if it is inside
+  // said unrotated box.
+
+  // The new x, y, z values are calculated using rotation matrices:
+  // [new_x, new_y, new_z] =
+  //       R_y(-polar)*R_z(-azimuth)*[x - x_c, y - y_c, z - z_c]
+  // where R_z(-t) = [cos(t) sin(t) 0; -sin(t) cos(t) 0; 0 0 1] and
+  //       R_y(-t) = [cos(t) 0 -sin(t); 0 1 0; sin(t) 0 cos(t)]
+
+  // See https://en.wikipedia.org/wiki/Rotation_matrix for more.
+
   const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
   const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
   const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) / 2;
 
-  const double new_x = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_ + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_cos_ - ( ( p[ 2 ] - cntr_z ) * polar_sin_ ) + cntr_x;
-  const double new_y = - ( p[ 0 ] - cntr_x ) * azimuth_sin_ + ( p[ 1 ] - cntr_y ) * azimuth_cos_ + cntr_y;
-  const double new_z = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_ + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_sin_ + ( ( p[ 2 ] - cntr_z ) * polar_cos_ ) + cntr_z;
+  const double new_x = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_
+                         + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_cos_
+    - ( ( p[ 2 ] - cntr_z ) * polar_sin_ ) + cntr_x;
+  const double new_y = -( p[ 0 ] - cntr_x ) * azimuth_sin_
+    + ( p[ 1 ] - cntr_y ) * azimuth_cos_ + cntr_y;
+  const double new_z = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_
+                         + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_sin_
+    + ( ( p[ 2 ] - cntr_z ) * polar_cos_ ) + cntr_z;
 
-  Position< 3 > new_p(new_x, new_y, new_z);
+  const Position< 3 > new_p( new_x, new_y, new_z );
 
-  return ( new_p >= lower_left_ ) && ( new_p <= upper_right_ );
+  // We need to add a small epsilon in case of rounding errors.
+  const double x_length = upper_right_[ 0 ] - lower_left_[ 0 ];
+  const double y_length = upper_right_[ 1 ] - lower_left_[ 1 ];
+  const double z_length = upper_right_[ 2 ] - lower_left_[ 2 ];
+  const Position< 3 > eps( x_length / 1000000, y_length / 1000000,
+    z_length / 1000000 );
+
+  return ( lower_left_ - eps <= new_p ) && ( new_p <= upper_right_ + eps );
 }
 
 template < int D >
 bool
 BoxMask< D >::inside( const Box< D >& b ) const
 {
-  //return ( b.lower_left >= lower_left_ ) && ( b.upper_right <= upper_right_ );
   return ( inside( b.lower_left ) and inside( b.upper_right ) );
 }
 
@@ -159,11 +170,6 @@ BoxMask< D >::outside( const Box< D >& b ) const
 {
   for ( int i = 0; i < D; ++i )
   {
-    /*if ( ( b.upper_right[ i ] < lower_left_[ i ] )
-      || ( b.lower_left[ i ] > upper_right_[ i ] ) )
-    {
-      return true;
-    }*/
     if ( ( b.upper_right[ i ] < min_values_[ i ] )
       || ( b.lower_left[ i ] > max_values_[ i ] ) )
     {
@@ -177,34 +183,17 @@ template <>
 void
 BoxMask< 2 >::create_min_max_values_()
 {
+  // Rotate the corners of the box to find the new minimum and maximum x and y
+  // values to define the bounding box of the rotated box.
+
   const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
   const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
-
-  Position<2> cntr( cntr_x, cntr_y );
-
+  const Position< 2 > cntr( cntr_x, cntr_y );
 
   Position< 2 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
   Position< 2 > lower_left_sin = ( lower_left_ - cntr ) * azimuth_sin_;
   Position< 2 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
   Position< 2 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
-
-/*  Position< 2 > lower_left_cos = ( lower_left_ ) * azimuth_cos_;
-  Position< 2 > lower_left_sin = ( lower_left_ ) * azimuth_sin_;
-  Position< 2 > upper_right_cos = ( upper_right_ ) * azimuth_cos_;
-  Position< 2 > upper_right_sin = ( upper_right_ ) * azimuth_sin_;*/
-
-
-  /*double rotatedLLx = lower_left_cos[ 0 ] - lower_left_sin[ 1 ];
-  double rotatedLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ];
-
-  double rotatedLRx = upper_right_cos[ 0 ] - lower_left_sin[ 1 ];
-  double rotatedLRy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ];
-
-  double rotatedURx = upper_right_cos[ 0 ] - upper_right_sin[ 1 ];
-  double rotatedURy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ];
-
-  double rotatedULx = lower_left_cos[ 0 ] - upper_right_sin[ 1 ];
-  double rotatedULy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ];*/
 
   double rotatedLLx = lower_left_cos[ 0 ] - lower_left_sin[ 1 ] + cntr_x;
   double rotatedLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
@@ -218,13 +207,14 @@ BoxMask< 2 >::create_min_max_values_()
   double rotatedULx = lower_left_cos[ 0 ] - upper_right_sin[ 1 ] + cntr_x;
   double rotatedULy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
 
-  min_values_[ 0 ] = std::min( rotatedLLx, std::min( rotatedLRx, std::min( rotatedURx, rotatedULx ) ) );
-  min_values_[ 1 ] = std::min( rotatedLLy, std::min( rotatedLRy, std::min( rotatedURy, rotatedULy ) ) );
-  max_values_[ 0 ] = std::max( rotatedLLx, std::max( rotatedLRx, std::max( rotatedURx, rotatedULx ) ) );
-  max_values_[ 1 ] = std::max( rotatedLLy, std::max( rotatedLRy, std::max( rotatedURy, rotatedULy ) ) );
-
-  //min_values_ = lower_left_;
-  //max_values_ = upper_right_;
+  min_values_[ 0 ] = std::min(
+    rotatedLLx, std::min( rotatedLRx, std::min( rotatedURx, rotatedULx ) ) );
+  min_values_[ 1 ] = std::min(
+    rotatedLLy, std::min( rotatedLRy, std::min( rotatedURy, rotatedULy ) ) );
+  max_values_[ 0 ] = std::max(
+    rotatedLLx, std::max( rotatedLRx, std::max( rotatedURx, rotatedULx ) ) );
+  max_values_[ 1 ] = std::max(
+    rotatedLLy, std::max( rotatedLRy, std::max( rotatedURy, rotatedULy ) ) );
 }
 
 template <>
@@ -244,50 +234,133 @@ BoxMask< 3 >::create_min_max_values_()
    *
    */
 
-  Position< 3 > lower_left_cos = lower_left_ * azimuth_cos_;
-  Position< 3 > lower_left_sin = lower_left_ * azimuth_sin_;
-  Position< 3 > upper_right_cos = upper_right_ * azimuth_cos_;
-  Position< 3 > upper_right_sin = upper_right_ * azimuth_sin_;
+  // Rotate the corners of the box to find the new minimum and maximum x, y and
+  // z values to define the bounding box of the rotated box. We need to rotate
+  // all eight corners.
 
-  // Need to rotate 8 corners in 3D
-  double rotatedLLLx = ( lower_left_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_cos_ - lower_left_[ 2 ] * polar_sin_;
-  double rotatedLLLy = -lower_left_sin[ 0 ] + lower_left_cos[ 1 ];
-  double rotatedLLLz = ( lower_left_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_sin_ + lower_left_[ 2 ] * polar_cos_;
+  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
+  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
+  const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) / 2;
 
-  double rotatedLLHx = ( lower_left_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_cos_ - upper_right_[ 2 ] * polar_sin_;
-  double rotatedLLHy = -lower_left_sin[ 0 ] + lower_left_cos[ 1 ];
-  double rotatedLLHz = ( lower_left_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_sin_ + upper_right_[ 2 ] * polar_cos_;
+  Position< 3 > cntr( cntr_x, cntr_y, cntr_z );
 
-  double rotatedHLLx = ( upper_right_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_cos_ - lower_left_[ 2 ] * polar_sin_;
-  double rotatedHLLy = -upper_right_sin[ 0 ] + lower_left_cos[ 1 ];
-  double rotatedHLLz = ( upper_right_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_sin_ + lower_left_[ 2 ] * polar_cos_;
+  Position< 3 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
+  Position< 3 > lower_left_sin = ( lower_left_ - cntr ) * azimuth_sin_;
+  Position< 3 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
+  Position< 3 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
 
-  double rotatedHLHx = ( upper_right_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_cos_ - upper_right_[ 2 ] * polar_sin_;
-  double rotatedHLHy = -upper_right_sin[ 0 ] + lower_left_cos[ 1 ];
-  double rotatedHLHz = ( upper_right_cos[ 0 ] + lower_left_sin[ 1 ] ) * polar_sin_ + upper_right_[ 2 ] * polar_cos_;
+  double rotatedLLLx =
+    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedLLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+  double rotatedLLLz =
+    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedHHHx = ( upper_right_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_cos_ - upper_right_[ 2 ] * polar_sin_;
-  double rotatedHHHy = -upper_right_sin[ 0 ] + upper_right_cos[ 1 ];
-  double rotatedHHHz = ( upper_right_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_sin_ + upper_right_[ 2 ] * polar_cos_;
+  double rotatedLLHx =
+    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedLLHy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+  double rotatedLLHz =
+    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedHHLx = ( upper_right_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_cos_ - lower_left_[ 2 ] * polar_sin_;
-  double rotatedHHLy = -upper_right_sin[ 0 ] + upper_right_cos[ 1 ];
-  double rotatedHHLz = ( upper_right_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_sin_ + lower_left_[ 2 ] * polar_cos_;
+  double rotatedHLLx =
+    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedHLLy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+  double rotatedHLLz =
+    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedLHHx = ( lower_left_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_cos_ - upper_right_[ 2 ] * polar_sin_;
-  double rotatedLHHy = -lower_left_sin[ 0 ] + upper_right_cos[ 1 ];
-  double rotatedLHHz = ( lower_left_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_sin_ + upper_right_[ 2 ] * polar_cos_;
+  double rotatedHLHx =
+    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedHLHy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+  double rotatedHLHz =
+    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedLHLx = ( lower_left_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_cos_ - lower_left_[ 2 ] * polar_sin_;
-  double rotatedLHLy = -lower_left_sin[ 0 ] + upper_right_cos[ 1 ];
-  double rotatedLHLz = ( lower_left_cos[ 0 ] + upper_right_sin[ 1 ] ) * polar_sin_ + lower_left_[ 2 ] * polar_cos_;
+  double rotatedHHHx =
+    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedHHHy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+  double rotatedHHHz =
+    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  min_values_[ 0 ] = std::min( rotatedLLLx, std::min( rotatedLLHx, std::min( rotatedHLLx, std::min( rotatedHLHx, std::min( rotatedHHHx, std::min( rotatedHHLx, std::min(rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
-  min_values_[ 1 ] = std::min( rotatedLLLy, std::min( rotatedLLHy, std::min( rotatedHLLy, std::min( rotatedHLHy, std::min( rotatedHHHy, std::min( rotatedHHLy, std::min(rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
-  min_values_[ 2 ] = std::min( rotatedLLLz, std::min( rotatedLLHz, std::min( rotatedHLLz, std::min( rotatedHLHz, std::min( rotatedHHHz, std::min( rotatedHHLz, std::min(rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
-  max_values_[ 0 ] = std::max( rotatedLLLx, std::max( rotatedLLHx, std::max( rotatedHLLx, std::max( rotatedHLHx, std::max( rotatedHHHx, std::max( rotatedHHLx, std::max(rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
-  max_values_[ 1 ] = std::max( rotatedLLLy, std::max( rotatedLLHy, std::max( rotatedHLLy, std::max( rotatedHLHy, std::max( rotatedHHHy, std::max( rotatedHHLy, std::max(rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
-  max_values_[ 2 ] = std::max( rotatedLLLz, std::max( rotatedLLHz, std::max( rotatedHLLz, std::max( rotatedHLHz, std::max( rotatedHHHz, std::max( rotatedHHLz, std::max(rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
+  double rotatedHHLx =
+    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedHHLy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+  double rotatedHHLz =
+    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+
+  double rotatedLHHx =
+    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedLHHy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+  double rotatedLHHz =
+    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+
+  double rotatedLHLx =
+    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+  double rotatedLHLy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+  double rotatedLHLz =
+    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+
+  min_values_[ 0 ] = std::min(
+    rotatedLLLx,
+    std::min( rotatedLLHx,
+      std::min( rotatedHLLx,
+                std::min( rotatedHLHx,
+                  std::min( rotatedHHHx,
+                            std::min( rotatedHHLx,
+                              std::min( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
+  min_values_[ 1 ] = std::min(
+    rotatedLLLy,
+    std::min( rotatedLLHy,
+      std::min( rotatedHLLy,
+                std::min( rotatedHLHy,
+                  std::min( rotatedHHHy,
+                            std::min( rotatedHHLy,
+                              std::min( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
+  min_values_[ 2 ] = std::min(
+    rotatedLLLz,
+    std::min( rotatedLLHz,
+      std::min( rotatedHLLz,
+                std::min( rotatedHLHz,
+                  std::min( rotatedHHHz,
+                            std::min( rotatedHHLz,
+                              std::min( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
+  max_values_[ 0 ] = std::max(
+    rotatedLLLx,
+    std::max( rotatedLLHx,
+      std::max( rotatedHLLx,
+                std::max( rotatedHLHx,
+                  std::max( rotatedHHHx,
+                            std::max( rotatedHHLx,
+                              std::max( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
+  max_values_[ 1 ] = std::max(
+    rotatedLLLy,
+    std::max( rotatedLLHy,
+      std::max( rotatedHLLy,
+                std::max( rotatedHLHy,
+                  std::max( rotatedHHHy,
+                            std::max( rotatedHHLy,
+                              std::max( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
+  max_values_[ 2 ] = std::max(
+    rotatedLLLz,
+    std::max( rotatedLLHz,
+      std::max( rotatedHLLz,
+                std::max( rotatedHLHz,
+                  std::max( rotatedHHHz,
+                            std::max( rotatedHHLz,
+                              std::max( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
 }
 
 template < int D >
@@ -295,7 +368,6 @@ Box< D >
 BoxMask< D >::get_bbox() const
 {
   return Box< D >( min_values_, max_values_ );
-  //return Box< D >( lower_left_, upper_right_ );
 }
 
 template < int D >
@@ -315,6 +387,7 @@ BoxMask< D >::get_dict() const
   def< std::vector< double > >( maskd, names::lower_left, lower_left_ );
   def< std::vector< double > >( maskd, names::upper_right, upper_right_ );
   def< double >( maskd, names::azimuth_angle, azimuth_angle_ );
+  def< double >( maskd, names::polar_angle, polar_angle_ );
   return d;
 }
 

--- a/topology/mask_impl.h
+++ b/topology/mask_impl.h
@@ -91,8 +91,14 @@ template <>
 bool
 BoxMask< 2 >::inside( const Position< 2 >& p ) const
 {
-  // We rotate the point down to the unrotated box, and check if it is inside
-  // said unrotated box.
+  // If the box is not rotated we just check if the point is inside the box.
+  if ( not is_rotated_ )
+  {
+    return ( lower_left_ <= p ) && ( p <= upper_right_ );
+  }
+
+  // If we have a rotated box, We rotate the point down to the unrotated box,
+  // and check if it is inside said unrotated box.
 
   // The new x, y values are calculated using a rotation matrix:
   // [new_x, new_y] = R(-azimuth)*[x - x_c, y - y_c]
@@ -121,8 +127,14 @@ template <>
 bool
 BoxMask< 3 >::inside( const Position< 3 >& p ) const
 {
-  // We rotate the point down to the unrotated box, and check if it is inside
-  // said unrotated box.
+  // If the box is not rotated we just check if the point is inside the box.
+  if ( not is_rotated_ )
+  {
+    return ( lower_left_ <= p ) && ( p <= upper_right_ );
+  }
+
+  // If we have a rotated box, We rotate the point down to the unrotated box,
+  // and check if it is inside said unrotated box.
 
   // The new x, y, z values are calculated using rotation matrices:
   // [new_x, new_y, new_z] =
@@ -184,37 +196,47 @@ void
 BoxMask< 2 >::create_min_max_values_()
 {
   // Rotate the corners of the box to find the new minimum and maximum x and y
-  // values to define the bounding box of the rotated box.
+  // values to define the bounding box of the rotated box. If the box is not
+  // rotated, the min values corresponds to the lower_left values and the max
+  // values corresponds to the upper_right values.
 
-  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
-  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
-  const Position< 2 > cntr( cntr_x, cntr_y );
+  if ( not is_rotated_ )
+  {
+    min_values_ = lower_left_;
+    max_values_ = upper_right_;
+  }
+  else
+  {
+    const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
+    const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
+    const Position< 2 > cntr( cntr_x, cntr_y );
 
-  Position< 2 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
-  Position< 2 > lower_left_sin = ( lower_left_ - cntr ) * azimuth_sin_;
-  Position< 2 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
-  Position< 2 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
+    Position< 2 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
+    Position< 2 > lower_left_sin = ( lower_left_ - cntr ) * azimuth_sin_;
+    Position< 2 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
+    Position< 2 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
 
-  double rotatedLLx = lower_left_cos[ 0 ] - lower_left_sin[ 1 ] + cntr_x;
-  double rotatedLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+    double rotatedLLx = lower_left_cos[ 0 ] - lower_left_sin[ 1 ] + cntr_x;
+    double rotatedLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
 
-  double rotatedLRx = upper_right_cos[ 0 ] - lower_left_sin[ 1 ] + cntr_x;
-  double rotatedLRy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+    double rotatedLRx = upper_right_cos[ 0 ] - lower_left_sin[ 1 ] + cntr_x;
+    double rotatedLRy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
 
-  double rotatedURx = upper_right_cos[ 0 ] - upper_right_sin[ 1 ] + cntr_x;
-  double rotatedURy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+    double rotatedURx = upper_right_cos[ 0 ] - upper_right_sin[ 1 ] + cntr_x;
+    double rotatedURy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
 
-  double rotatedULx = lower_left_cos[ 0 ] - upper_right_sin[ 1 ] + cntr_x;
-  double rotatedULy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+    double rotatedULx = lower_left_cos[ 0 ] - upper_right_sin[ 1 ] + cntr_x;
+    double rotatedULy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
 
-  min_values_[ 0 ] = std::min(
-    rotatedLLx, std::min( rotatedLRx, std::min( rotatedURx, rotatedULx ) ) );
-  min_values_[ 1 ] = std::min(
-    rotatedLLy, std::min( rotatedLRy, std::min( rotatedURy, rotatedULy ) ) );
-  max_values_[ 0 ] = std::max(
-    rotatedLLx, std::max( rotatedLRx, std::max( rotatedURx, rotatedULx ) ) );
-  max_values_[ 1 ] = std::max(
-    rotatedLLy, std::max( rotatedLRy, std::max( rotatedURy, rotatedULy ) ) );
+    min_values_[ 0 ] = std::min(
+      rotatedLLx, std::min( rotatedLRx, std::min( rotatedURx, rotatedULx ) ) );
+    min_values_[ 1 ] = std::min(
+      rotatedLLy, std::min( rotatedLRy, std::min( rotatedURy, rotatedULy ) ) );
+    max_values_[ 0 ] = std::max(
+      rotatedLLx, std::max( rotatedLRx, std::max( rotatedURx, rotatedULx ) ) );
+    max_values_[ 1 ] = std::max(
+      rotatedLLy, std::max( rotatedLRy, std::max( rotatedURy, rotatedULy ) ) );
+  }
 }
 
 template <>
@@ -236,131 +258,141 @@ BoxMask< 3 >::create_min_max_values_()
 
   // Rotate the corners of the box to find the new minimum and maximum x, y and
   // z values to define the bounding box of the rotated box. We need to rotate
-  // all eight corners.
+  // all eight corners. If the box is not rotated, the min values corresponds
+  // to the lower_left values and the max values corresponds to the upper_right
+  // values.
 
-  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
-  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
-  const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) / 2;
+  if ( not is_rotated_ )
+  {
+    min_values_ = lower_left_;
+    max_values_ = upper_right_;
+  }
+  else
+  {
+    const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
+    const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
+    const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) / 2;
 
-  Position< 3 > cntr( cntr_x, cntr_y, cntr_z );
+    Position< 3 > cntr( cntr_x, cntr_y, cntr_z );
 
-  Position< 3 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
-  Position< 3 > lower_left_sin = ( lower_left_ - cntr ) * azimuth_sin_;
-  Position< 3 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
-  Position< 3 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
+    Position< 3 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
+    Position< 3 > lower_left_sin = ( lower_left_ - cntr ) * azimuth_sin_;
+    Position< 3 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
+    Position< 3 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
 
-  double rotatedLLLx =
-    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedLLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
-  double rotatedLLLz =
-    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedLLLx =
+      ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedLLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+    double rotatedLLLz =
+      ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedLLHx =
-    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedLLHy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
-  double rotatedLLHz =
-    ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedLLHx =
+      ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedLLHy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+    double rotatedLLHz =
+      ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedHLLx =
-    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedHLLy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
-  double rotatedHLLz =
-    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedHLLx =
+      ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedHLLy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+    double rotatedHLLz =
+      ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedHLHx =
-    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedHLHy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
-  double rotatedHLHz =
-    ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedHLHx =
+      ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
+      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedHLHy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
+    double rotatedHLHz =
+      ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
+      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedHHHx =
-    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedHHHy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
-  double rotatedHHHz =
-    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedHHHx =
+      ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedHHHy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+    double rotatedHHHz =
+      ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedHHLx =
-    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedHHLy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
-  double rotatedHHLz =
-    ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedHHLx =
+      ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedHHLy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+    double rotatedHHLz =
+      ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedLHHx =
-    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-    - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedLHHy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
-  double rotatedLHHz =
-    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-    + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedLHHx =
+      ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedLHHy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+    double rotatedLHHz =
+      ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  double rotatedLHLx =
-    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-    - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
-  double rotatedLHLy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
-  double rotatedLHLz =
-    ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-    + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+    double rotatedLHLx =
+      ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
+      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+    double rotatedLHLy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
+    double rotatedLHLz =
+      ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
+      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
 
-  min_values_[ 0 ] = std::min(
-    rotatedLLLx,
-    std::min( rotatedLLHx,
-      std::min( rotatedHLLx,
-                std::min( rotatedHLHx,
-                  std::min( rotatedHHHx,
-                            std::min( rotatedHHLx,
-                              std::min( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
-  min_values_[ 1 ] = std::min(
-    rotatedLLLy,
-    std::min( rotatedLLHy,
-      std::min( rotatedHLLy,
-                std::min( rotatedHLHy,
-                  std::min( rotatedHHHy,
-                            std::min( rotatedHHLy,
-                              std::min( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
-  min_values_[ 2 ] = std::min(
-    rotatedLLLz,
-    std::min( rotatedLLHz,
-      std::min( rotatedHLLz,
-                std::min( rotatedHLHz,
-                  std::min( rotatedHHHz,
-                            std::min( rotatedHHLz,
-                              std::min( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
-  max_values_[ 0 ] = std::max(
-    rotatedLLLx,
-    std::max( rotatedLLHx,
-      std::max( rotatedHLLx,
-                std::max( rotatedHLHx,
-                  std::max( rotatedHHHx,
-                            std::max( rotatedHHLx,
-                              std::max( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
-  max_values_[ 1 ] = std::max(
-    rotatedLLLy,
-    std::max( rotatedLLHy,
-      std::max( rotatedHLLy,
-                std::max( rotatedHLHy,
-                  std::max( rotatedHHHy,
-                            std::max( rotatedHHLy,
-                              std::max( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
-  max_values_[ 2 ] = std::max(
-    rotatedLLLz,
-    std::max( rotatedLLHz,
-      std::max( rotatedHLLz,
-                std::max( rotatedHLHz,
-                  std::max( rotatedHHHz,
-                            std::max( rotatedHHLz,
-                              std::max( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
+    min_values_[ 0 ] = std::min(
+      rotatedLLLx,
+      std::min( rotatedLLHx,
+        std::min( rotatedHLLx,
+                  std::min( rotatedHLHx,
+                    std::min( rotatedHHHx,
+                              std::min( rotatedHHLx,
+                                std::min( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
+    min_values_[ 1 ] = std::min(
+      rotatedLLLy,
+      std::min( rotatedLLHy,
+        std::min( rotatedHLLy,
+                  std::min( rotatedHLHy,
+                    std::min( rotatedHHHy,
+                              std::min( rotatedHHLy,
+                                std::min( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
+    min_values_[ 2 ] = std::min(
+      rotatedLLLz,
+      std::min( rotatedLLHz,
+        std::min( rotatedHLLz,
+                  std::min( rotatedHLHz,
+                    std::min( rotatedHHHz,
+                              std::min( rotatedHHLz,
+                                std::min( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
+    max_values_[ 0 ] = std::max(
+      rotatedLLLx,
+      std::max( rotatedLLHx,
+        std::max( rotatedHLLx,
+                  std::max( rotatedHLHx,
+                    std::max( rotatedHHHx,
+                              std::max( rotatedHHLx,
+                                std::max( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
+    max_values_[ 1 ] = std::max(
+      rotatedLLLy,
+      std::max( rotatedLLHy,
+        std::max( rotatedHLLy,
+                  std::max( rotatedHLHy,
+                    std::max( rotatedHHHy,
+                              std::max( rotatedHHLy,
+                                std::max( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
+    max_values_[ 2 ] = std::max(
+      rotatedLLLz,
+      std::max( rotatedLLHz,
+        std::max( rotatedHLLz,
+                  std::max( rotatedHLHz,
+                    std::max( rotatedHHHz,
+                              std::max( rotatedHHLz,
+                                std::max( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
+  }
 }
 
 template < int D >

--- a/topology/mask_impl.h
+++ b/topology/mask_impl.h
@@ -106,8 +106,8 @@ BoxMask< 2 >::inside( const Position< 2 >& p ) const
 
   // See https://en.wikipedia.org/wiki/Rotation_matrix for more.
 
-  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
-  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
+  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) * 0.5;
+  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) * 0.5;
 
   const double new_x = ( p[ 0 ] - cntr_x ) * azimuth_cos_
     + ( p[ 1 ] - cntr_y ) * azimuth_sin_ + cntr_x;
@@ -118,7 +118,7 @@ BoxMask< 2 >::inside( const Position< 2 >& p ) const
   // We need to add a small epsilon in case of rounding errors.
   const double x_length = upper_right_[ 0 ] - lower_left_[ 0 ];
   const double y_length = upper_right_[ 1 ] - lower_left_[ 1 ];
-  const Position< 2 > eps( x_length / 1000000, y_length / 1000000 );
+  const Position< 2 > eps( x_length * 1e-12, y_length * 1e-12 );
 
   return ( lower_left_ - eps <= new_p ) && ( new_p <= upper_right_ + eps );
 }
@@ -144,9 +144,9 @@ BoxMask< 3 >::inside( const Position< 3 >& p ) const
 
   // See https://en.wikipedia.org/wiki/Rotation_matrix for more.
 
-  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
-  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
-  const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) / 2;
+  const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) * 0.5;
+  const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) * 0.5;
+  const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) * 0.5;
 
   const double new_x = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_
                          + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_cos_
@@ -163,8 +163,8 @@ BoxMask< 3 >::inside( const Position< 3 >& p ) const
   const double x_length = upper_right_[ 0 ] - lower_left_[ 0 ];
   const double y_length = upper_right_[ 1 ] - lower_left_[ 1 ];
   const double z_length = upper_right_[ 2 ] - lower_left_[ 2 ];
-  const Position< 3 > eps( x_length / 1000000, y_length / 1000000,
-    z_length / 1000000 );
+  const Position< 3 > eps( x_length * 1e-12, y_length * 1e-12,
+    z_length * 1e-12 );
 
   return ( lower_left_ - eps <= new_p ) && ( new_p <= upper_right_ + eps );
 }
@@ -180,6 +180,12 @@ template < int D >
 bool
 BoxMask< D >::outside( const Box< D >& b ) const
 {
+  // Note: There could be some inconsistencies with the boundaries. For the
+  // inside() function we had to add an epsilon because of rounding errors that
+  // can occur if GIDs are on the boundary if we have rotation. This might lead
+  // to overlap of the inside and outside functions. None of the tests have
+  // picked up any problems with this potential overlap as of yet (autumn 2017),
+  // so we don't know if it is an actual problem.
   for ( int i = 0; i < D; ++i )
   {
     if ( ( b.upper_right[ i ] < min_values_[ i ] )
@@ -207,8 +213,8 @@ BoxMask< 2 >::create_min_max_values_()
   }
   else
   {
-    const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
-    const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
+    const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) * 0.5;
+    const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) * 0.5;
     const Position< 2 > cntr( cntr_x, cntr_y );
 
     Position< 2 > lower_left_cos = ( lower_left_ - cntr ) * azimuth_cos_;
@@ -269,9 +275,9 @@ BoxMask< 3 >::create_min_max_values_()
   }
   else
   {
-    const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) / 2;
-    const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) / 2;
-    const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) / 2;
+    const double cntr_x = ( upper_right_[ 0 ] + lower_left_[ 0 ] ) * 0.5;
+    const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) * 0.5;
+    const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) * 0.5;
 
     Position< 3 > cntr( cntr_x, cntr_y, cntr_z );
 

--- a/topology/mask_impl.h
+++ b/topology/mask_impl.h
@@ -163,8 +163,8 @@ BoxMask< 3 >::inside( const Position< 3 >& p ) const
   const double x_length = upper_right_[ 0 ] - lower_left_[ 0 ];
   const double y_length = upper_right_[ 1 ] - lower_left_[ 1 ];
   const double z_length = upper_right_[ 2 ] - lower_left_[ 2 ];
-  const Position< 3 > eps( x_length * 1e-12, y_length * 1e-12,
-    z_length * 1e-12 );
+  const Position< 3 > eps(
+    x_length * 1e-12, y_length * 1e-12, z_length * 1e-12 );
 
   return ( lower_left_ - eps <= new_p ) && ( new_p <= upper_right_ + eps );
 }
@@ -234,14 +234,13 @@ BoxMask< 2 >::create_min_max_values_()
     double rotatedULx = lower_left_cos[ 0 ] - upper_right_sin[ 1 ] + cntr_x;
     double rotatedULy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
 
-    min_values_[ 0 ] = std::min(
-      rotatedLLx, std::min( rotatedLRx, std::min( rotatedURx, rotatedULx ) ) );
-    min_values_[ 1 ] = std::min(
-      rotatedLLy, std::min( rotatedLRy, std::min( rotatedURy, rotatedULy ) ) );
-    max_values_[ 0 ] = std::max(
-      rotatedLLx, std::max( rotatedLRx, std::max( rotatedURx, rotatedULx ) ) );
-    max_values_[ 1 ] = std::max(
-      rotatedLLy, std::max( rotatedLRy, std::max( rotatedURy, rotatedULy ) ) );
+    double rotated_x[] = { rotatedLLx, rotatedLRx, rotatedURx, rotatedULx };
+    double rotated_y[] = { rotatedLLy, rotatedLRy, rotatedURy, rotatedULy };
+
+    min_values_[ 0 ] = *std::min_element( rotated_x, rotated_x + 4 );
+    min_values_[ 1 ] = *std::min_element( rotated_y, rotated_y + 4 );
+    max_values_[ 0 ] = *std::max_element( rotated_x, rotated_x + 4 );
+    max_values_[ 1 ] = *std::max_element( rotated_y, rotated_y + 4 );
   }
 }
 
@@ -286,118 +285,110 @@ BoxMask< 3 >::create_min_max_values_()
     Position< 3 > upper_right_cos = ( upper_right_ - cntr ) * azimuth_cos_;
     Position< 3 > upper_right_sin = ( upper_right_ - cntr ) * azimuth_sin_;
 
+    const double lower_left_polar_cos =
+      ( lower_left_[ 2 ] - cntr_z ) * polar_cos_;
+    const double lower_left_polar_sin =
+      ( lower_left_[ 2 ] - cntr_z ) * polar_sin_;
+    const double upper_right_polar_cos =
+      ( upper_right_[ 2 ] - cntr_z ) * polar_cos_;
+    const double upper_right_polar_sin =
+      ( upper_right_[ 2 ] - cntr_z ) * polar_sin_;
+
     double rotatedLLLx =
       ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - lower_left_polar_sin + cntr_x;
     double rotatedLLLy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
     double rotatedLLLz =
       ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + lower_left_polar_cos + cntr_z;
 
     double rotatedLLHx =
       ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - upper_right_polar_sin + cntr_x;
     double rotatedLLHy = lower_left_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
     double rotatedLLHz =
       ( lower_left_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + upper_right_polar_cos + cntr_z;
 
     double rotatedHLLx =
       ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - lower_left_polar_sin + cntr_x;
     double rotatedHLLy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
     double rotatedHLLz =
       ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + lower_left_polar_cos + cntr_z;
 
     double rotatedHLHx =
       ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_cos_
-      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - upper_right_polar_sin + cntr_x;
     double rotatedHLHy = upper_right_sin[ 0 ] + lower_left_cos[ 1 ] + cntr_y;
     double rotatedHLHz =
       ( upper_right_cos[ 0 ] - lower_left_sin[ 1 ] ) * polar_sin_
-      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + upper_right_polar_cos + cntr_z;
 
     double rotatedHHHx =
       ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - upper_right_polar_sin + cntr_x;
     double rotatedHHHy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
     double rotatedHHHz =
       ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + upper_right_polar_cos + cntr_z;
 
     double rotatedHHLx =
       ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - lower_left_polar_sin + cntr_x;
     double rotatedHHLy = upper_right_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
     double rotatedHHLz =
       ( upper_right_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + lower_left_polar_cos + cntr_z;
 
     double rotatedLHHx =
       ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-      - ( upper_right_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - upper_right_polar_sin + cntr_x;
     double rotatedLHHy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
     double rotatedLHHz =
       ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-      + ( upper_right_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + upper_right_polar_cos + cntr_z;
 
     double rotatedLHLx =
       ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_cos_
-      - ( lower_left_[ 2 ] - cntr_z ) * polar_sin_ + cntr_x;
+      - lower_left_polar_sin + cntr_x;
     double rotatedLHLy = lower_left_sin[ 0 ] + upper_right_cos[ 1 ] + cntr_y;
     double rotatedLHLz =
       ( lower_left_cos[ 0 ] - upper_right_sin[ 1 ] ) * polar_sin_
-      + ( lower_left_[ 2 ] - cntr_z ) * polar_cos_ + cntr_z;
+      + lower_left_polar_cos + cntr_z;
 
-    min_values_[ 0 ] = std::min(
-      rotatedLLLx,
-      std::min( rotatedLLHx,
-        std::min( rotatedHLLx,
-                  std::min( rotatedHLHx,
-                    std::min( rotatedHHHx,
-                              std::min( rotatedHHLx,
-                                std::min( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
-    min_values_[ 1 ] = std::min(
-      rotatedLLLy,
-      std::min( rotatedLLHy,
-        std::min( rotatedHLLy,
-                  std::min( rotatedHLHy,
-                    std::min( rotatedHHHy,
-                              std::min( rotatedHHLy,
-                                std::min( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
-    min_values_[ 2 ] = std::min(
-      rotatedLLLz,
-      std::min( rotatedLLHz,
-        std::min( rotatedHLLz,
-                  std::min( rotatedHLHz,
-                    std::min( rotatedHHHz,
-                              std::min( rotatedHHLz,
-                                std::min( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
-    max_values_[ 0 ] = std::max(
-      rotatedLLLx,
-      std::max( rotatedLLHx,
-        std::max( rotatedHLLx,
-                  std::max( rotatedHLHx,
-                    std::max( rotatedHHHx,
-                              std::max( rotatedHHLx,
-                                std::max( rotatedLHHx, rotatedLHLx ) ) ) ) ) ) );
-    max_values_[ 1 ] = std::max(
-      rotatedLLLy,
-      std::max( rotatedLLHy,
-        std::max( rotatedHLLy,
-                  std::max( rotatedHLHy,
-                    std::max( rotatedHHHy,
-                              std::max( rotatedHHLy,
-                                std::max( rotatedLHHy, rotatedLHLy ) ) ) ) ) ) );
-    max_values_[ 2 ] = std::max(
-      rotatedLLLz,
-      std::max( rotatedLLHz,
-        std::max( rotatedHLLz,
-                  std::max( rotatedHLHz,
-                    std::max( rotatedHHHz,
-                              std::max( rotatedHHLz,
-                                std::max( rotatedLHHz, rotatedLHLz ) ) ) ) ) ) );
+    double rotated_x[] = { rotatedLLLx,
+      rotatedLLHx,
+      rotatedHLLx,
+      rotatedHLHx,
+      rotatedHHHx,
+      rotatedHHLx,
+      rotatedLHHx,
+      rotatedLHLx };
+    double rotated_y[] = { rotatedLLLy,
+      rotatedLLHy,
+      rotatedHLLy,
+      rotatedHLHy,
+      rotatedHHHy,
+      rotatedHHLy,
+      rotatedLHHy,
+      rotatedLHLy };
+    double rotated_z[] = { rotatedLLLz,
+      rotatedLLHz,
+      rotatedHLLz,
+      rotatedHLHz,
+      rotatedHHHz,
+      rotatedHHLz,
+      rotatedLHHz,
+      rotatedLHLz };
+
+    min_values_[ 0 ] = *std::min_element( rotated_x, rotated_x + 8 );
+    min_values_[ 1 ] = *std::min_element( rotated_y, rotated_y + 8 );
+    min_values_[ 2 ] = *std::min_element( rotated_z, rotated_z + 8 );
+    max_values_[ 0 ] = *std::max_element( rotated_x, rotated_x + 8 );
+    max_values_[ 1 ] = *std::max_element( rotated_y, rotated_y + 8 );
+    max_values_[ 2 ] = *std::max_element( rotated_z, rotated_z + 8 );
   }
 }
 

--- a/topology/mask_impl.h
+++ b/topology/mask_impl.h
@@ -97,7 +97,7 @@ BoxMask< 2 >::inside( const Position< 2 >& p ) const
     return ( lower_left_ <= p ) && ( p <= upper_right_ );
   }
 
-  // If we have a rotated box, We rotate the point down to the unrotated box,
+  // If we have a rotated box, we rotate the point down to the unrotated box,
   // and check if it is inside said unrotated box.
 
   // The new x, y values are calculated using a rotation matrix:
@@ -133,7 +133,7 @@ BoxMask< 3 >::inside( const Position< 3 >& p ) const
     return ( lower_left_ <= p ) && ( p <= upper_right_ );
   }
 
-  // If we have a rotated box, We rotate the point down to the unrotated box,
+  // If we have a rotated box, we rotate the point down to the unrotated box,
   // and check if it is inside said unrotated box.
 
   // The new x, y, z values are calculated using rotation matrices:
@@ -148,14 +148,16 @@ BoxMask< 3 >::inside( const Position< 3 >& p ) const
   const double cntr_y = ( upper_right_[ 1 ] + lower_left_[ 1 ] ) * 0.5;
   const double cntr_z = ( upper_right_[ 2 ] + lower_left_[ 2 ] ) * 0.5;
 
-  const double new_x = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_
-                         + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_cos_
-    - ( ( p[ 2 ] - cntr_z ) * polar_sin_ ) + cntr_x;
-  const double new_y = -( p[ 0 ] - cntr_x ) * azimuth_sin_
-    + ( p[ 1 ] - cntr_y ) * azimuth_cos_ + cntr_y;
-  const double new_z = ( ( p[ 0 ] - cntr_x ) * azimuth_cos_
-                         + ( p[ 1 ] - cntr_y ) * azimuth_sin_ ) * polar_sin_
-    + ( ( p[ 2 ] - cntr_z ) * polar_cos_ ) + cntr_z;
+  const Position< 3 > p_c( p[ 0 ] - cntr_x, p[ 1 ] - cntr_y, p[ 2 ] - cntr_z );
+
+  const double new_x =
+    ( p_c[ 0 ] * azimuth_cos_ + p_c[ 1 ] * azimuth_sin_ ) * polar_cos_
+    - p_c[ 2 ] * polar_sin_ + cntr_x;
+  const double new_y =
+    -p_c[ 0 ] * azimuth_sin_ + p_c[ 1 ] * azimuth_cos_ + cntr_y;
+  const double new_z =
+    ( p_c[ 0 ] * azimuth_cos_ + p_c[ 1 ] * azimuth_sin_ ) * polar_sin_
+    + p_c[ 2 ] * polar_cos_ + cntr_z;
 
   const Position< 3 > new_p( new_x, new_y, new_z );
 
@@ -199,12 +201,12 @@ BoxMask< D >::outside( const Box< D >& b ) const
 
 template <>
 void
-BoxMask< 2 >::create_min_max_values_()
+BoxMask< 2 >::calculate_min_max_values_()
 {
   // Rotate the corners of the box to find the new minimum and maximum x and y
   // values to define the bounding box of the rotated box. If the box is not
-  // rotated, the min values corresponds to the lower_left values and the max
-  // values corresponds to the upper_right values.
+  // rotated, the min values correspond to the lower_left values and the max
+  // values correspond to the upper_right values.
 
   if ( not is_rotated_ )
   {
@@ -246,7 +248,7 @@ BoxMask< 2 >::create_min_max_values_()
 
 template <>
 void
-BoxMask< 3 >::create_min_max_values_()
+BoxMask< 3 >::calculate_min_max_values_()
 {
   /*
    *        LLH      LHH
@@ -263,8 +265,8 @@ BoxMask< 3 >::create_min_max_values_()
 
   // Rotate the corners of the box to find the new minimum and maximum x, y and
   // z values to define the bounding box of the rotated box. We need to rotate
-  // all eight corners. If the box is not rotated, the min values corresponds
-  // to the lower_left values and the max values corresponds to the upper_right
+  // all eight corners. If the box is not rotated, the min values correspond
+  // to the lower_left values and the max values correspond to the upper_right
   // values.
 
   if ( not is_rotated_ )

--- a/topology/pynest/hl_api.py
+++ b/topology/pynest/hl_api.py
@@ -200,7 +200,7 @@ def CreateMask(masktype, specs, anchor=None):
 
     Notes
     -----
-    -
+    - All angles must be given in degrees.
 
 
     **Mask types**
@@ -212,8 +212,9 @@ def CreateMask(masktype, specs, anchor=None):
         ::
 
             'rectangular' :
-                {'lower_left' : [float, float],
-                 'upper_right': [float, float]}
+                {'lower_left'   : [float, float],
+                 'upper_right'  : [float, float],
+                 'azimuth_angle': float  # default:0.0}
             #or
             'circular' :
                 {'radius' : float}
@@ -233,8 +234,10 @@ def CreateMask(masktype, specs, anchor=None):
         ::
 
             'box' :
-                {'lower_left' : [float, float, float],
-                 'upper_right' : [float, float, float]}
+                {'lower_left'  : [float, float, float],
+                 'upper_right' : [float, float, float],
+                 'azimuth_angle: float  # default: 0.0,
+                 'polar_angle  : float  # defualt: 0.0}
             #or
             'spherical' :
                 {'radius' : float}

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -37,8 +37,8 @@ class RotatedRectangularMask(unittest.TestCase):
         """Test rotated rectangular mask.
 
             We have:
-                lower_left: [-1., -0.5]
-                upper_right: [1., 0.5]
+                lower_left:  [-1., -0.5]
+                upper_right: [ 1.,  0.5]
 
             So, if we have:
 
@@ -49,11 +49,12 @@ class RotatedRectangularMask(unittest.TestCase):
             5  10 15  20  25
             6  11 16  21  26
 
-            and have azimuth_angle = 0, we should get gids 9, 14, 19.
+            and have azimuth_angle = 0, we should get gids 9, 14, 19 if we
+            select GIDs by mask.
             If we have azimuth_angle = 90, we should get gids 13, 14, 15.
         """
 
-        # First test 2D layer
+        # Test 2D layer
         layer = topo.CreateLayer({'rows': 5, 'columns': 5,
                                   'extent': [5., 5.],
                                   'elements': 'iaf_psc_alpha'})
@@ -212,16 +213,17 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(sorted_gid_list, [35, 40, 45, 59, 64, 69, 83, 88, 93])
 
         # Test two symmetric masks in x and z direction. One with no polar
-        # anglecand one with a polar angle of 90 degrees. As the masks are
+        # angle and one with a polar angle of 90 degrees. As the masks are
         # symmetrical in  x and z, a polar angle of 90 degrees should give the
         # same GIDs as the one without a polar angle.
         maskdict = {'lower_left': [-1., -0.5, -1.],
                     'upper_right': [1., 0.5, 1.]}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        sorted_gid_list = sorted(gid_list)
+        sorted_gid_list_1 = sorted(gid_list)
 
-        self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
+        self.assertEqual(sorted_gid_list_1,
+                         [38, 39, 40, 63, 64, 65, 88, 89, 90])
 
         maskdict = {'lower_left': [-1., -0.5, -1.],
                     'upper_right': [1., 0.5, 1.],
@@ -231,6 +233,8 @@ class RotatedRectangularMask(unittest.TestCase):
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
+
+        self.assertEqual(sorted_gid_list_1, sorted_gid_list)
 
     def test_RotatedBoxMaskByAzimuthAndPolarAngle(self):
         """Test rotated box mask with azimuth and polar angle."""
@@ -312,7 +316,7 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (10, 11, 35, 36,))
 
         # Test that we get the correct GIDs with a azimuth rotation angle of 45
-        # degrees when the masj does not contain origo
+        # degrees when the mask does not contain origo.
         maskdict = {'lower_left': [-2.5, -1.0, 0.5],
                     'upper_right': [-0.5, -0.5, 2.5],
                     'azimuth_angle': 45.0}
@@ -322,7 +326,7 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (10, 11, 40, 41,))
 
         # Test that we get the correct GIDs with a polar rotation angle of 45
-        # degrees when the mask does not contain origo
+        # degrees when the mask does not contain origo.
         maskdict = {'lower_left': [-1.5, -2.5, 0.5],
                     'upper_right': [-1.0, -0.5, 2.5],
                     'polar_angle': 45.0}
@@ -334,9 +338,9 @@ class RotatedRectangularMask(unittest.TestCase):
     def test_ConnectWithRotatedRectangleMask(self):
         """Test connection with rotated rectangle mask.
 
-            We have: lower_left = [-1.5, -0.5]
-                 upper_right = [1.5, 0.5]
-                 azimuth_angle = 45 degrees
+            We have: lower_left  = [-1.5, -0.5]
+                     upper_right = [ 1.5,  0.5]
+                     azimuth_angle = 45 degrees
 
             Each source node should then connect to:
                 - The node in the same position in target layer

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -260,15 +260,17 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(sorted_gid_list,
                          [38, 39, 44, 58, 59, 64, 69, 70, 84, 89, 90])
 
-    def test_RotatedRectangleOutsideOrigo(self):
-        """Test rotated rectangle where the mask does not contain origo."""
+    def test_RotatedRectangleOutsideOrigin(self):
+        """
+        Test rotated rectangle where the mask does not contain the origin.
+        """
 
         layer = topo.CreateLayer({'rows': 11, 'columns': 11,
                                   'extent': [11., 11.],
                                   'elements': 'iaf_psc_alpha'})
 
         # First test that we get the correct GIDs when our mask does not
-        # contain origo.
+        # contain the origin.
         maskdict = {'lower_left': [1., 1.], 'upper_right': [4., 2.]}
         mask = topo.CreateMask('rectangular', maskdict)
         cntr = [0., 0.]
@@ -277,7 +279,7 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (71, 72, 82, 83, 93, 94, 104, 105,))
 
         # Then test that we get the correct GIDs with a azimuth rotation angle
-        # of 45 degrees when the mask does not contain origo.
+        # of 45 degrees when the mask does not contain the origin.
         maskdict = {'lower_left': [0.5, 0.5],
                     'upper_right': [4.5, 2.5],
                     'azimuth_angle': 45.0}
@@ -287,7 +289,7 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (72, 82, 83, 84, 92, 93, 94, 104,))
 
         # Test that we get the correct GIDs with a azimuth rotation angle
-        # of 90 degrees when the mask does not contain origo.
+        # of 90 degrees when the mask does not contain the origin.
         maskdict = {'lower_left': [1.0, 1.0],
                     'upper_right': [4.0, 2.0],
                     'azimuth_angle': 90.0}
@@ -296,8 +298,8 @@ class RotatedRectangularMask(unittest.TestCase):
 
         self.assertEqual(gid_list, (81, 82, 83, 84, 92, 93, 94, 95,))
 
-    def test_RotatedBoxOutsideOrigo(self):
-        """Test rotated box where the mask does not contain origo."""
+    def test_RotatedBoxOutsideOrigin(self):
+        """Test rotated box where the mask does not contain the origin."""
 
         pos = [[x * 1., y * 1., z * 1.] for x in range(-2, 3)
                for y in range(-2, 3)
@@ -307,7 +309,7 @@ class RotatedRectangularMask(unittest.TestCase):
                                   'elements': 'iaf_psc_alpha'})
 
         # First test that we get the correct GIDs when our mask does not
-        # contain origo.
+        # contain the origin.
         maskdict = {'lower_left': [-2.0, -1.0, 0.5],
                     'upper_right': [-0.5, -0.5, 2.0]}
         mask = topo.CreateMask('box', maskdict)
@@ -317,7 +319,7 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (10, 11, 35, 36,))
 
         # Test that we get the correct GIDs with a azimuth rotation angle of 45
-        # degrees when the mask does not contain origo.
+        # degrees when the mask does not contain the origin.
         maskdict = {'lower_left': [-2.5, -1.0, 0.5],
                     'upper_right': [-0.5, -0.5, 2.5],
                     'azimuth_angle': 45.0}
@@ -327,7 +329,7 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (10, 11, 40, 41,))
 
         # Test that we get the correct GIDs with a polar rotation angle of 45
-        # degrees when the mask does not contain origo.
+        # degrees when the mask does not contain the origin.
         maskdict = {'lower_left': [-1.5, -2.5, 0.5],
                     'upper_right': [-1.0, -0.5, 2.5],
                     'polar_angle': 45.0}

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+#
+# test_rotated_rect_mask.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests rotated rectangular and box masks.
+"""
+
+import unittest
+import nest
+import nest.topology as topo
+
+
+class RotatedRectangularMask(unittest.TestCase):
+
+    def setUp(self):
+        nest.ResetKernel()
+
+    def test_RotatedRectangularMask(self):
+        """Test rotated rectangular mask.
+        
+            We have:
+                lower_left: [-1., -0.5]
+                upper_right: [1., 0.5]
+            
+            So, if we have:
+
+            layer:
+            2  7  12  17  22
+            3  8  13  18  23
+            4  9  14  19  24
+            5  10 15  20  25
+            6  11 16  21  26
+            
+            and have azimuth_angle = 0, we should get gids 9, 14, 19.
+            If we have azimuth_angle = 90, we should get gids 13, 14, 15.
+        """
+        
+        # First test 2D layer
+        layer = topo.CreateLayer({'rows': 5, 'columns': 5,
+                                  'extent': [5., 5.],
+                                  'elements': 'iaf_psc_alpha'})
+
+        # First test without rotation.
+        maskdict = {'lower_left': [-1., -0.5], 'upper_right': [1., 0.5]}
+        mask = topo.CreateMask('rectangular', maskdict)
+        cntr = [0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+
+        self.assertEqual(gid_list, (9, 14, 19,))
+        
+        # Test if we get correct GIDs when rotating 90 degrees.
+        maskdict = {'lower_left': [-1., -0.5], 'upper_right': [1., 0.5], 'azimuth_angle': 90.0}
+        mask = topo.CreateMask('rectangular', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        
+        self.assertEqual(gid_list, (13, 14, 15,))
+        
+        # Test rotation with an azimuth angle of 45 degrees.
+        maskdict = {'lower_left': [-1.5, -0.5], 'upper_right': [1.5, 0.5], 'azimuth_angle': 45.0}
+        mask = topo.CreateMask('rectangular', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+
+        self.assertEqual(gid_list, (10, 14, 18,))
+        
+        # Test rotation with an azimuth angle of 135 degrees.
+        maskdict = {'lower_left': [-1.5, -0.5], 'upper_right': [1.5, 0.5], 'azimuth_angle': 135.0}
+        mask = topo.CreateMask('rectangular', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+
+        self.assertEqual(gid_list, (8, 14, 20,))
+        
+        # Test that an error is rased if we send in a polar angle to a 2D mask.
+        maskdict = {'lower_left': [-1.5, -0.5], 'upper_right': [1.5, 0.5], 'polar_angle': 45.0}
+        with self.assertRaises(nest.NESTError):
+            mask = topo.CreateMask('rectangular', maskdict)
+        
+    def test_RotatedBoxMask(self):
+        """Test rotated box mask with azimuth angle."""
+        # Test a 3D layer.
+        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+               for y in range(-2, 3)
+               for z in range(-2, 3)]
+
+        layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
+                                  'elements': 'iaf_psc_alpha'})
+
+        # First test that we get correct GIDs with box mask that is not rotated.
+        maskdict = {'lower_left': [-1., -0.5, -0.5], 'upper_right': [1., 0.5, 0.5]}
+        mask = topo.CreateMask('box', maskdict)
+        cntr = [0., 0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+
+        self.assertEqual(gid_list, (39, 64, 89,))
+        
+        # Test with a larger box mask.
+        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.]}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
+        
+        # Test the smaller box mask with a rotation of 90 degrees. Only test
+        # the azimuth angle, not the polar angle.
+        maskdict = {'lower_left': [-1., -0.5, -0.5], 'upper_right': [1., 0.5, 0.5], 'azimuth_angle': 90.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+
+        self.assertEqual(gid_list, (59, 64, 69,))
+        
+        # Test rotation of the larger box with an azimuth angle of 90 degrees.
+        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.], 'azimuth_angle': 90.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [58, 59, 60, 63, 64, 65, 68, 69, 70])
+        
+    def test_RotatedBoxMaskByPolarAngle(self):
+        """Test rotated box mask with polar angle."""
+        # Må i denne gjøre y og x like store for å få noe utslag, ellers blir gidene de samme
+        # men test dette også
+        
+        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+               for y in range(-2, 3)
+               for z in range(-2, 3)]
+
+        layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
+                                  'elements': 'iaf_psc_alpha'})
+        
+        # First test without rotation
+        maskdict = {'lower_left': [-0.5, -1.0, -1.0], 'upper_right': [0.5, 1.0, 1.0]}
+        mask = topo.CreateMask('box', maskdict)
+        cntr = [0., 0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [58, 59, 60, 63, 64, 65, 68, 69, 70])
+        
+        # Test with a polar angle of 90 degrees.
+        maskdict = {'lower_left': [-0.5, -1.0, -1.0], 'upper_right': [0.5, 1.0, 1.0], 'polar_angle': 90.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [34, 39, 44, 59, 64, 69, 84, 89, 94])
+        
+        # Test with a polar angle of 180 degrees, should be the same as the
+        # one without a polar angle.
+        maskdict = {'lower_left': [-0.5, -1.0, -1.0], 'upper_right': [0.5, 1.0, 1.0], 'polar_angle': 180.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [58, 59, 60, 63, 64, 65, 68, 69, 70])
+        
+        # Test with a polar angle of 45 degrees.
+        maskdict = {'lower_left': [-0.5, -1.5, -1.5], 'upper_right': [0.5, 1.5, 1.5], 'polar_angle': 45.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [33, 38, 43, 59, 64, 69, 85, 90, 95])
+        
+        # Test with a polar angle of 135 degrees. This should be opposite of
+        # the ones obtained by a polar angle of 45 degrees.
+        maskdict = {'lower_left': [-0.5, -1.5, -1.5], 'upper_right': [0.5, 1.5, 1.5], 'polar_angle': 135.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [35, 40, 45, 59, 64, 69, 83, 88, 93])
+        
+        # Test two symmetric masks in x and z direction. One with no polar angle
+        # and one with a polar angle of 90 degrees. As the masks are symmetrical
+        # in  x and z, a polar angle of 90 degrees should give the same GIDs as
+        # the one without a polar angle.
+        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.]}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
+        
+        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.], 'polar_angle': 90.}
+        mask = topo.CreateMask('box', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
+        
+    def test_RotatedBoxMaskByAzimuthAndPolarAngle(self):
+        """Test rotated box mask with azimuth and polar angle."""
+        pass
+    
+    def test_RotatedRectangleOutsideOrigo(self):
+        """Test rotated rectangle where mask is outside origo."""
+        
+        layer = topo.CreateLayer({'rows': 11, 'columns': 11,
+                                  'extent': [11., 11.],
+                                  'elements': 'iaf_psc_alpha'})
+
+        # First test that we get the correct GIDs when our mask does not
+        # contain origo.
+        maskdict = {'lower_left': [1., 1.], 'upper_right': [4., 2.]}
+        mask = topo.CreateMask('rectangular', maskdict)
+        cntr = [0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+
+        self.assertEqual(gid_list, (71, 72, 82, 83, 93, 94, 104, 105,))
+        
+        # Then test that we get the correct GIDs with a azimuth rotation angle
+        # of 45 degrees when the mask does not contain origo.
+        maskdict = {'lower_left': [0.5, 0.5], 'upper_right': [4.5, 2.5], 'azimuth_angle': 45.0}
+        mask = topo.CreateMask('rectangular', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        
+        self.assertEqual(gid_list, (72, 82, 83, 84, 92, 93, 94, 104,))
+
+        # Test that we get the correct GIDs with a azimuth rotation angle
+        # of 90 degrees when the mask does not contain origo.
+        maskdict = {'lower_left': [1.0, 1.0], 'upper_right': [4.0, 2.0], 'azimuth_angle': 90.0}
+        mask = topo.CreateMask('rectangular', maskdict)
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        
+        self.assertEqual(gid_list, (81, 82, 83, 84, 92, 93, 94, 95,))
+        
+    def test_RotatedBoxOutsideOrigo(self):
+        """Test rotated box where mask is outside origo."""
+        
+        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+               for y in range(-2, 3)
+               for z in range(-2, 3)]
+
+        layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
+                                  'elements': 'iaf_psc_alpha'})
+        
+        # First test that we get the correct GIDs when our mask does not
+        # contain origo.
+        maskdict = {'lower_left': [-2.0, -1.0, 0.5], 'upper_right': [-0.5, -0.5, 2.0]}
+        mask = topo.CreateMask('box', maskdict)
+        cntr = [0., 0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        
+        self.assertEqual(gid_list, (10, 11, 35, 36,))
+        
+        # Test that we get the correct GIDs with a azimuth rotation angle of 45
+        # degrees when the masj does not contain origo
+        maskdict = {'lower_left': [-2.5, -1.0, 0.5], 'upper_right': [-0.5, -0.5, 2.5], 'azimuth_angle': 45.0}
+        mask = topo.CreateMask('box', maskdict)
+        cntr = [0., 0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        
+        self.assertEqual(gid_list, (10, 11, 40, 41,)) 
+        
+        # Test that we get the correct GIDs with a polar rotation angle of 45
+        # degrees when the mask does not contain origo
+        maskdict = {'lower_left': [-1.5, -2.5, 0.5], 'upper_right': [-1.0, -0.5, 2.5], 'polar_angle': 45.0}
+        mask = topo.CreateMask('box', maskdict)
+        cntr = [0., 0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        
+        self.assertEqual(gid_list, (5, 10, 31, 36,))
+    
+    # Få inn en test hvor vi roterer både med azimuth og polar angle.
+    # Få inn en test hvor vi ikke sentrerer om null.
+    # Få inn en test med connektivitet også?
+    # Kommenter også alt i mask.h, mask_impl.h
+        
+        
+def suite():
+    suite = unittest.makeSuite(RotatedRectangularMask, 'test')
+    return suite
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -94,7 +94,8 @@ class RotatedRectangularMask(unittest.TestCase):
 
         self.assertEqual(gid_list, (8, 14, 20,))
 
-        # Test that an error is raised if we send in a polar angle to a 2D mask.
+        # Test that an error is raised if we send in a polar angle to a 2D
+        # mask.
         maskdict = {'lower_left': [-1.5, -0.5],
                     'upper_right': [1.5, 0.5],
                     'polar_angle': 45.0}

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -35,11 +35,11 @@ class RotatedRectangularMask(unittest.TestCase):
 
     def test_RotatedRectangularMask(self):
         """Test rotated rectangular mask.
-        
+
             We have:
                 lower_left: [-1., -0.5]
                 upper_right: [1., 0.5]
-            
+
             So, if we have:
 
             layer:
@@ -48,11 +48,11 @@ class RotatedRectangularMask(unittest.TestCase):
             4  9  14  19  24
             5  10 15  20  25
             6  11 16  21  26
-            
+
             and have azimuth_angle = 0, we should get gids 9, 14, 19.
             If we have azimuth_angle = 90, we should get gids 13, 14, 15.
         """
-        
+
         # First test 2D layer
         layer = topo.CreateLayer({'rows': 5, 'columns': 5,
                                   'extent': [5., 5.],
@@ -65,33 +65,41 @@ class RotatedRectangularMask(unittest.TestCase):
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
 
         self.assertEqual(gid_list, (9, 14, 19,))
-        
+
         # Test if we get correct GIDs when rotating 90 degrees.
-        maskdict = {'lower_left': [-1., -0.5], 'upper_right': [1., 0.5], 'azimuth_angle': 90.0}
+        maskdict = {'lower_left': [-1., -0.5],
+                    'upper_right': [1., 0.5],
+                    'azimuth_angle': 90.0}
         mask = topo.CreateMask('rectangular', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        
+
         self.assertEqual(gid_list, (13, 14, 15,))
-        
+
         # Test rotation with an azimuth angle of 45 degrees.
-        maskdict = {'lower_left': [-1.5, -0.5], 'upper_right': [1.5, 0.5], 'azimuth_angle': 45.0}
+        maskdict = {'lower_left': [-1.5, -0.5],
+                    'upper_right': [1.5, 0.5],
+                    'azimuth_angle': 45.0}
         mask = topo.CreateMask('rectangular', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
 
         self.assertEqual(gid_list, (10, 14, 18,))
-        
+
         # Test rotation with an azimuth angle of 135 degrees.
-        maskdict = {'lower_left': [-1.5, -0.5], 'upper_right': [1.5, 0.5], 'azimuth_angle': 135.0}
+        maskdict = {'lower_left': [-1.5, -0.5],
+                    'upper_right': [1.5, 0.5],
+                    'azimuth_angle': 135.0}
         mask = topo.CreateMask('rectangular', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
 
         self.assertEqual(gid_list, (8, 14, 20,))
-        
+
         # Test that an error is rased if we send in a polar angle to a 2D mask.
-        maskdict = {'lower_left': [-1.5, -0.5], 'upper_right': [1.5, 0.5], 'polar_angle': 45.0}
+        maskdict = {'lower_left': [-1.5, -0.5],
+                    'upper_right': [1.5, 0.5],
+                    'polar_angle': 45.0}
         with self.assertRaises(nest.NESTError):
             mask = topo.CreateMask('rectangular', maskdict)
-        
+
     def test_RotatedBoxMask(self):
         """Test rotated box mask with azimuth angle."""
         # Test a 3D layer.
@@ -102,118 +110,154 @@ class RotatedRectangularMask(unittest.TestCase):
         layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
                                   'elements': 'iaf_psc_alpha'})
 
-        # First test that we get correct GIDs with box mask that is not rotated.
-        maskdict = {'lower_left': [-1., -0.5, -0.5], 'upper_right': [1., 0.5, 0.5]}
+        # First test that we get correct GIDs with box mask that is not
+        # rotated.
+        maskdict = {'lower_left': [-1., -0.5, -0.5],
+                    'upper_right': [1., 0.5, 0.5]}
         mask = topo.CreateMask('box', maskdict)
         cntr = [0., 0., 0.]
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
 
         self.assertEqual(gid_list, (39, 64, 89,))
-        
+
         # Test with a larger box mask.
-        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.]}
+        maskdict = {'lower_left': [-1., -0.5, -1.],
+                    'upper_right': [1., 0.5, 1.]}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
-        
+
         # Test the smaller box mask with a rotation of 90 degrees. Only test
         # the azimuth angle, not the polar angle.
-        maskdict = {'lower_left': [-1., -0.5, -0.5], 'upper_right': [1., 0.5, 0.5], 'azimuth_angle': 90.}
+        maskdict = {'lower_left': [-1., -0.5, -0.5],
+                    'upper_right': [1., 0.5, 0.5],
+                    'azimuth_angle': 90.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
 
         self.assertEqual(gid_list, (59, 64, 69,))
-        
+
         # Test rotation of the larger box with an azimuth angle of 90 degrees.
-        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.], 'azimuth_angle': 90.}
+        maskdict = {'lower_left': [-1., -0.5, -1.],
+                    'upper_right': [1., 0.5, 1.],
+                    'azimuth_angle': 90.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [58, 59, 60, 63, 64, 65, 68, 69, 70])
-        
+
     def test_RotatedBoxMaskByPolarAngle(self):
         """Test rotated box mask with polar angle."""
-        # Må i denne gjøre y og x like store for å få noe utslag, ellers blir gidene de samme
-        # men test dette også
-        
+
         pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
                for y in range(-2, 3)
                for z in range(-2, 3)]
 
         layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
                                   'elements': 'iaf_psc_alpha'})
-        
+
         # First test without rotation
-        maskdict = {'lower_left': [-0.5, -1.0, -1.0], 'upper_right': [0.5, 1.0, 1.0]}
+        maskdict = {'lower_left': [-0.5, -1.0, -1.0],
+                    'upper_right': [0.5, 1.0, 1.0]}
         mask = topo.CreateMask('box', maskdict)
         cntr = [0., 0., 0.]
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [58, 59, 60, 63, 64, 65, 68, 69, 70])
-        
+
         # Test with a polar angle of 90 degrees.
-        maskdict = {'lower_left': [-0.5, -1.0, -1.0], 'upper_right': [0.5, 1.0, 1.0], 'polar_angle': 90.}
+        maskdict = {'lower_left': [-0.5, -1.0, -1.0],
+                    'upper_right': [0.5, 1.0, 1.0],
+                    'polar_angle': 90.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [34, 39, 44, 59, 64, 69, 84, 89, 94])
-        
+
         # Test with a polar angle of 180 degrees, should be the same as the
         # one without a polar angle.
-        maskdict = {'lower_left': [-0.5, -1.0, -1.0], 'upper_right': [0.5, 1.0, 1.0], 'polar_angle': 180.}
+        maskdict = {'lower_left': [-0.5, -1.0, -1.0],
+                    'upper_right': [0.5, 1.0, 1.0],
+                    'polar_angle': 180.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [58, 59, 60, 63, 64, 65, 68, 69, 70])
-        
+
         # Test with a polar angle of 45 degrees.
-        maskdict = {'lower_left': [-0.5, -1.5, -1.5], 'upper_right': [0.5, 1.5, 1.5], 'polar_angle': 45.}
+        maskdict = {'lower_left': [-0.5, -1.5, -1.5],
+                    'upper_right': [0.5, 1.5, 1.5],
+                    'polar_angle': 45.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [33, 38, 43, 59, 64, 69, 85, 90, 95])
-        
+
         # Test with a polar angle of 135 degrees. This should be opposite of
         # the ones obtained by a polar angle of 45 degrees.
-        maskdict = {'lower_left': [-0.5, -1.5, -1.5], 'upper_right': [0.5, 1.5, 1.5], 'polar_angle': 135.}
+        maskdict = {'lower_left': [-0.5, -1.5, -1.5],
+                    'upper_right': [0.5, 1.5, 1.5],
+                    'polar_angle': 135.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [35, 40, 45, 59, 64, 69, 83, 88, 93])
-        
-        # Test two symmetric masks in x and z direction. One with no polar angle
-        # and one with a polar angle of 90 degrees. As the masks are symmetrical
-        # in  x and z, a polar angle of 90 degrees should give the same GIDs as
-        # the one without a polar angle.
-        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.]}
+
+        # Test two symmetric masks in x and z direction. One with no polar
+        # anglecand one with a polar angle of 90 degrees. As the masks are
+        # symmetrical in  x and z, a polar angle of 90 degrees should give the
+        # same GIDs as the one without a polar angle.
+        maskdict = {'lower_left': [-1., -0.5, -1.],
+                    'upper_right': [1., 0.5, 1.]}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
-        
-        maskdict = {'lower_left': [-1., -0.5, -1.], 'upper_right': [1., 0.5, 1.], 'polar_angle': 90.}
+
+        maskdict = {'lower_left': [-1., -0.5, -1.],
+                    'upper_right': [1., 0.5, 1.],
+                    'polar_angle': 90.}
         mask = topo.CreateMask('box', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
         sorted_gid_list = sorted(gid_list)
 
         self.assertEqual(sorted_gid_list, [38, 39, 40, 63, 64, 65, 88, 89, 90])
-        
+
     def test_RotatedBoxMaskByAzimuthAndPolarAngle(self):
         """Test rotated box mask with azimuth and polar angle."""
-        pass
-    
+
+        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+               for y in range(-2, 3)
+               for z in range(-2, 3)]
+
+        layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
+                                  'elements': 'iaf_psc_alpha'})
+
+        # Test with a azimuth angle and polar angle of 45 degrees.
+        maskdict = {'lower_left': [-0.5, -1.5, -1.5],
+                    'upper_right': [0.5, 1.5, 1.5],
+                    'azimuth_angle': 45.,
+                    'polar_angle': 45.}
+        mask = topo.CreateMask('box', maskdict)
+        cntr = [0., 0., 0.]
+        gid_list = topo.SelectNodesByMask(layer, cntr, mask)
+        sorted_gid_list = sorted(gid_list)
+
+        self.assertEqual(sorted_gid_list,
+                         [38, 39, 44, 58, 59, 64, 69, 70, 84, 89, 90])
+
     def test_RotatedRectangleOutsideOrigo(self):
         """Test rotated rectangle where mask is outside origo."""
-        
+
         layer = topo.CreateLayer({'rows': 11, 'columns': 11,
                                   'extent': [11., 11.],
                                   'elements': 'iaf_psc_alpha'})
@@ -226,66 +270,130 @@ class RotatedRectangularMask(unittest.TestCase):
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
 
         self.assertEqual(gid_list, (71, 72, 82, 83, 93, 94, 104, 105,))
-        
+
         # Then test that we get the correct GIDs with a azimuth rotation angle
         # of 45 degrees when the mask does not contain origo.
-        maskdict = {'lower_left': [0.5, 0.5], 'upper_right': [4.5, 2.5], 'azimuth_angle': 45.0}
+        maskdict = {'lower_left': [0.5, 0.5],
+                    'upper_right': [4.5, 2.5],
+                    'azimuth_angle': 45.0}
         mask = topo.CreateMask('rectangular', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        
+
         self.assertEqual(gid_list, (72, 82, 83, 84, 92, 93, 94, 104,))
 
         # Test that we get the correct GIDs with a azimuth rotation angle
         # of 90 degrees when the mask does not contain origo.
-        maskdict = {'lower_left': [1.0, 1.0], 'upper_right': [4.0, 2.0], 'azimuth_angle': 90.0}
+        maskdict = {'lower_left': [1.0, 1.0],
+                    'upper_right': [4.0, 2.0],
+                    'azimuth_angle': 90.0}
         mask = topo.CreateMask('rectangular', maskdict)
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        
+
         self.assertEqual(gid_list, (81, 82, 83, 84, 92, 93, 94, 95,))
-        
+
     def test_RotatedBoxOutsideOrigo(self):
         """Test rotated box where mask is outside origo."""
-        
+
         pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
                for y in range(-2, 3)
                for z in range(-2, 3)]
 
         layer = topo.CreateLayer({'positions': pos, 'extent': [5., 5., 5.],
                                   'elements': 'iaf_psc_alpha'})
-        
+
         # First test that we get the correct GIDs when our mask does not
         # contain origo.
-        maskdict = {'lower_left': [-2.0, -1.0, 0.5], 'upper_right': [-0.5, -0.5, 2.0]}
+        maskdict = {'lower_left': [-2.0, -1.0, 0.5],
+                    'upper_right': [-0.5, -0.5, 2.0]}
         mask = topo.CreateMask('box', maskdict)
         cntr = [0., 0., 0.]
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        
+
         self.assertEqual(gid_list, (10, 11, 35, 36,))
-        
+
         # Test that we get the correct GIDs with a azimuth rotation angle of 45
         # degrees when the masj does not contain origo
-        maskdict = {'lower_left': [-2.5, -1.0, 0.5], 'upper_right': [-0.5, -0.5, 2.5], 'azimuth_angle': 45.0}
+        maskdict = {'lower_left': [-2.5, -1.0, 0.5],
+                    'upper_right': [-0.5, -0.5, 2.5],
+                    'azimuth_angle': 45.0}
         mask = topo.CreateMask('box', maskdict)
-        cntr = [0., 0., 0.]
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        
-        self.assertEqual(gid_list, (10, 11, 40, 41,)) 
-        
+
+        self.assertEqual(gid_list, (10, 11, 40, 41,))
+
         # Test that we get the correct GIDs with a polar rotation angle of 45
         # degrees when the mask does not contain origo
-        maskdict = {'lower_left': [-1.5, -2.5, 0.5], 'upper_right': [-1.0, -0.5, 2.5], 'polar_angle': 45.0}
+        maskdict = {'lower_left': [-1.5, -2.5, 0.5],
+                    'upper_right': [-1.0, -0.5, 2.5],
+                    'polar_angle': 45.0}
         mask = topo.CreateMask('box', maskdict)
-        cntr = [0., 0., 0.]
         gid_list = topo.SelectNodesByMask(layer, cntr, mask)
-        
+
         self.assertEqual(gid_list, (5, 10, 31, 36,))
-    
-    # Få inn en test hvor vi roterer både med azimuth og polar angle.
-    # Få inn en test hvor vi ikke sentrerer om null.
-    # Få inn en test med connektivitet også?
-    # Kommenter også alt i mask.h, mask_impl.h
-        
-        
+
+    def test_ConnectWithRotatedRectangleMask(self):
+        """Test connection with rotated rectangle mask.
+
+            We have: lower_left = [-1.5, -0.5]
+                 upper_right = [1.5, 0.5]
+                 azimuth_angle = 45 degrees
+
+            Each source node should then connect to:
+                - The node in the same position in target layer
+                - The node above the node to the right of that position
+                - The node below the node to the left of the position.
+
+            So, if we have
+
+            sources:                    targets:
+            2  7  12  17  22            28  33  38  43  48
+            3  8  13  18  23            29  34  39  44  49
+            4  9  14  19  24            30  35  40  45  50
+            5  10 15  20  25            31  36  41  46  51
+            6  11 16  21  26            32  37  42  47  52
+
+            some example connections will be:
+
+            2  -> 28
+
+                          44
+            14 ->     40
+                  36
+        """
+
+        source = topo.CreateLayer({'rows': 5, 'columns': 5,
+                                   'extent': [5., 5.],
+                                   'elements': 'iaf_psc_alpha'})
+        target = topo.CreateLayer({'rows': 5, 'columns': 5,
+                                   'extent': [5., 5.],
+                                   'elements': 'iaf_psc_alpha'})
+
+        conndict = {'connection_type': 'divergent',
+                    'mask': {'rectangular': {'lower_left': [-1.5, -0.5],
+                                             'upper_right': [1.5, 0.5],
+                                             'azimuth_angle': 45.}}}
+
+        topo.ConnectLayers(source, target, conndict)
+
+        ref = [[2, 28], [3, 29], [3, 33], [4, 30], [4, 34], [5, 31], [5, 35],
+               [6, 32], [6, 36], [7, 29], [7, 33], [8, 30], [8, 34], [8, 38],
+               [9, 31], [9, 35], [9, 39], [10, 32], [10, 36], [10, 40],
+               [11, 37], [11, 41], [12, 34], [12, 38], [13, 35], [13, 39],
+               [13, 43], [14, 36], [14, 40], [14, 44], [15, 37], [15, 41],
+               [15, 45], [16, 42], [16, 46], [17, 39], [17, 43], [18, 40],
+               [18, 44], [18, 48], [19, 41], [19, 45], [19, 49], [20, 42],
+               [20, 46], [20, 50], [21, 47], [21, 51], [22, 44], [22, 48],
+               [23, 45], [23, 49], [24, 46], [24, 50], [25, 47], [25, 51],
+               [26, 52]]
+
+        connections = nest.GetConnections()
+        print(connections)
+
+        for conn, conn_ref in zip(connections, ref):
+            conn_list = [conn[0], conn[1]]
+            self.assertEqual(conn_list, conn_ref)
+
+
 def suite():
     suite = unittest.makeSuite(RotatedRectangularMask, 'test')
     return suite

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -387,7 +387,6 @@ class RotatedRectangularMask(unittest.TestCase):
                [26, 52]]
 
         connections = nest.GetConnections()
-        print(connections)
 
         for conn, conn_ref in zip(connections, ref):
             conn_list = [conn[0], conn[1]]

--- a/topology/pynest/tests/test_rotated_rect_mask.py
+++ b/topology/pynest/tests/test_rotated_rect_mask.py
@@ -94,17 +94,17 @@ class RotatedRectangularMask(unittest.TestCase):
 
         self.assertEqual(gid_list, (8, 14, 20,))
 
-        # Test that an error is rased if we send in a polar angle to a 2D mask.
+        # Test that an error is raised if we send in a polar angle to a 2D mask.
         maskdict = {'lower_left': [-1.5, -0.5],
                     'upper_right': [1.5, 0.5],
                     'polar_angle': 45.0}
         with self.assertRaises(nest.NESTError):
             mask = topo.CreateMask('rectangular', maskdict)
 
-    def test_RotatedBoxMask(self):
+    def test_RotatedBoxMaskByAzimuthAngle(self):
         """Test rotated box mask with azimuth angle."""
         # Test a 3D layer.
-        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+        pos = [[x * 1., y * 1., z * 1.] for x in range(-2, 3)
                for y in range(-2, 3)
                for z in range(-2, 3)]
 
@@ -153,7 +153,7 @@ class RotatedRectangularMask(unittest.TestCase):
     def test_RotatedBoxMaskByPolarAngle(self):
         """Test rotated box mask with polar angle."""
 
-        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+        pos = [[x * 1., y * 1., z * 1.] for x in range(-2, 3)
                for y in range(-2, 3)
                for z in range(-2, 3)]
 
@@ -201,8 +201,8 @@ class RotatedRectangularMask(unittest.TestCase):
 
         self.assertEqual(sorted_gid_list, [33, 38, 43, 59, 64, 69, 85, 90, 95])
 
-        # Test with a polar angle of 135 degrees. This should be opposite of
-        # the ones obtained by a polar angle of 45 degrees.
+        # Test with a polar angle of 135 degrees. The GIDs should be
+        # perpendicular to the ones obtained by a polar angle of 45 degrees.
         maskdict = {'lower_left': [-0.5, -1.5, -1.5],
                     'upper_right': [0.5, 1.5, 1.5],
                     'polar_angle': 135.}
@@ -239,7 +239,7 @@ class RotatedRectangularMask(unittest.TestCase):
     def test_RotatedBoxMaskByAzimuthAndPolarAngle(self):
         """Test rotated box mask with azimuth and polar angle."""
 
-        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+        pos = [[x * 1., y * 1., z * 1.] for x in range(-2, 3)
                for y in range(-2, 3)
                for z in range(-2, 3)]
 
@@ -260,7 +260,7 @@ class RotatedRectangularMask(unittest.TestCase):
                          [38, 39, 44, 58, 59, 64, 69, 70, 84, 89, 90])
 
     def test_RotatedRectangleOutsideOrigo(self):
-        """Test rotated rectangle where mask is outside origo."""
+        """Test rotated rectangle where the mask does not contain origo."""
 
         layer = topo.CreateLayer({'rows': 11, 'columns': 11,
                                   'extent': [11., 11.],
@@ -296,9 +296,9 @@ class RotatedRectangularMask(unittest.TestCase):
         self.assertEqual(gid_list, (81, 82, 83, 84, 92, 93, 94, 95,))
 
     def test_RotatedBoxOutsideOrigo(self):
-        """Test rotated box where mask is outside origo."""
+        """Test rotated box where the mask does not contain origo."""
 
-        pos = [[x*1., y*1., z*1.] for x in range(-2, 3)
+        pos = [[x * 1., y * 1., z * 1.] for x in range(-2, 3)
                for y in range(-2, 3)
                for z in range(-2, 3)]
 
@@ -357,12 +357,16 @@ class RotatedRectangularMask(unittest.TestCase):
             6  11 16  21  26            32  37  42  47  52
 
             some example connections will be:
-
-            2  -> 28
-
-                          44
-            14 ->     40
-                  36
+                            ______
+                          /       /
+            2  ->      /  28    /
+                    /        /
+                  /_______ /
+                            _______
+                          /     44 /
+            14 ->      /    40  /
+                    /   36   /
+                  /_______ /
         """
 
         source = topo.CreateLayer({'rows': 5, 'columns': 5,
@@ -400,6 +404,7 @@ class RotatedRectangularMask(unittest.TestCase):
 def suite():
     suite = unittest.makeSuite(RotatedRectangularMask, 'test')
     return suite
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
This PR adds the optional parameters `azimuth_angle` and `polar_angle` to the rectangular and box mask dictionaries so that the masks can be rotated.

This have led to some changes in the `boxMask` class, most notably with the `inside(..)` function and when finding the boundary box.  When checking if a point is inside the mask, we have to take rotation into account. If we have rotation, we can no longer use `lower_left` and `upper_right` to define the boundary box, so we have to calculate the minimum and maximum values of the mask. This is done in `create_min_max_values_()`.

The functions check to see if we have rotation as much as possible, so that we can use `lower_left` and `upper_right` and avoid unnecessary rotation calculations if we do not have rotation.

I have also added a test.