### PR TITLE
Fixes for the gif multisynapse and quantal_stp model

### DIFF
--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -324,10 +324,10 @@ aeif_cond_alpha_multisynapse::State_::get( DictionaryDatum& d ) const
               / State_::NUM_STATE_ELEMENTS_PER_RECEPTOR );
         ++i )
   {
-    dg->push_back( y_[ State_::DG
-      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
-    g->push_back( y_[ State_::G
-      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
+    dg->push_back(
+      y_[ State_::DG + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
+    g->push_back(
+      y_[ State_::G + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
   }
 
   ( *d )[ names::dg ] = DoubleVectorDatum( dg );
@@ -584,8 +584,7 @@ aeif_cond_alpha_multisynapse::update( Time const& origin,
 
     for ( size_t i = 0; i < P_.n_receptors(); ++i )
     {
-      S_.y_[ State_::DG
-        + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
+      S_.y_[ State_::DG + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
         B_.spikes_[ i ].get_value( lag ) * V_.g0_[ i ]; // add incoming spike
     }
     // set new input current

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -99,7 +99,7 @@ aeif_cond_alpha_multisynapse_dynamics( double,
   double I_syn = 0.0;
   for ( size_t i = 0; i < node.P_.n_receptors(); ++i )
   {
-    const size_t j = i * S::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR;
+    const size_t j = i * S::NUM_STATE_ELEMENTS_PER_RECEPTOR;
     I_syn += y[ S::G + j ] * ( node.P_.E_rev[ i ] - V );
   }
 
@@ -118,7 +118,7 @@ aeif_cond_alpha_multisynapse_dynamics( double,
 
   for ( size_t i = 0; i < node.P_.n_receptors(); ++i )
   {
-    const size_t j = i * S::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR;
+    const size_t j = i * S::NUM_STATE_ELEMENTS_PER_RECEPTOR;
     // Synaptic conductance derivative dG/dt
     f[ S::DG + j ] = -y[ S::DG + j ] / node.P_.tau_syn[ i ];
     f[ S::G + j ] = y[ S::DG + j ] - y[ S::G + j ] / node.P_.tau_syn[ i ];
@@ -321,13 +321,13 @@ aeif_cond_alpha_multisynapse::State_::get( DictionaryDatum& d ) const
 
   for ( size_t i = 0;
         i < ( ( y_.size() - State_::NUMBER_OF_FIXED_STATES_ELEMENTS )
-              / State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR );
+              / State_::NUM_STATE_ELEMENTS_PER_RECEPTOR );
         ++i )
   {
     dg->push_back( y_[ State_::DG
-      + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * i ) ] );
+      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
     g->push_back( y_[ State_::G
-      + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * i ) ] );
+      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
   }
 
   ( *d )[ names::dg ] = DoubleVectorDatum( dg );
@@ -481,7 +481,7 @@ aeif_cond_alpha_multisynapse::calibrate()
 
   B_.spikes_.resize( P_.n_receptors() );
   S_.y_.resize( State_::NUMBER_OF_FIXED_STATES_ELEMENTS
-      + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * P_.n_receptors() ),
+      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * P_.n_receptors() ),
     0.0 );
 
   // reallocate instance of stepping function for ODE GSL solver
@@ -585,7 +585,7 @@ aeif_cond_alpha_multisynapse::update( Time const& origin,
     for ( size_t i = 0; i < P_.n_receptors(); ++i )
     {
       S_.y_[ State_::DG
-        + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * i ) ] +=
+        + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
         B_.spikes_[ i ].get_value( lag ) * V_.g0_[ i ]; // add incoming spike
     }
     // set new input current

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -286,7 +286,7 @@ private:
       STATE_VECTOR_MIN_SIZE
     };
 
-    static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 2;        // V_M, W
+    static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 2; // V_M, W
     static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 2; // DG, G
 
     std::vector< double > y_; //!< neuron state

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -287,7 +287,7 @@ private:
     };
 
     static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 2;        // V_M, W
-    static const size_t NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR = 2; // DG, G
+    static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 2; // DG, G
 
     std::vector< double > y_; //!< neuron state
     int r_;                   //!< number of refractory steps remaining

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -335,10 +335,10 @@ aeif_cond_beta_multisynapse::State_::get( DictionaryDatum& d ) const
               / State_::NUM_STATE_ELEMENTS_PER_RECEPTOR );
         ++i )
   {
-    dg->push_back( y_[ State_::DG
-      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
-    g->push_back( y_[ State_::G
-      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
+    dg->push_back(
+      y_[ State_::DG + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
+    g->push_back(
+      y_[ State_::G + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
   }
 
   ( *d )[ names::dg ] = DoubleVectorDatum( dg );
@@ -623,8 +623,7 @@ aeif_cond_beta_multisynapse::update( Time const& origin,
 
     for ( size_t i = 0; i < P_.n_receptors(); ++i )
     {
-      S_.y_[ State_::DG
-        + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
+      S_.y_[ State_::DG + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
         B_.spikes_[ i ].get_value( lag ) * V_.g0_[ i ]; // add incoming spike
     }
     // set new input current

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -99,7 +99,7 @@ aeif_cond_beta_multisynapse_dynamics( double,
   double I_syn = 0.0;
   for ( size_t i = 0; i < node.P_.n_receptors(); ++i )
   {
-    const size_t j = i * S::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR;
+    const size_t j = i * S::NUM_STATE_ELEMENTS_PER_RECEPTOR;
     I_syn += y[ S::G + j ] * ( node.P_.E_rev[ i ] - V );
   }
 
@@ -118,7 +118,7 @@ aeif_cond_beta_multisynapse_dynamics( double,
 
   for ( size_t i = 0; i < node.P_.n_receptors(); ++i )
   {
-    const size_t j = i * S::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR;
+    const size_t j = i * S::NUM_STATE_ELEMENTS_PER_RECEPTOR;
     // Synaptic conductance derivative dG/dt
     f[ S::DG + j ] = -y[ S::DG + j ] / node.P_.tau_rise[ i ];
     f[ S::G + j ] = y[ S::DG + j ] - y[ S::G + j ] / node.P_.tau_decay[ i ];
@@ -332,13 +332,13 @@ aeif_cond_beta_multisynapse::State_::get( DictionaryDatum& d ) const
 
   for ( size_t i = 0;
         i < ( ( y_.size() - State_::NUMBER_OF_FIXED_STATES_ELEMENTS )
-              / State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR );
+              / State_::NUM_STATE_ELEMENTS_PER_RECEPTOR );
         ++i )
   {
     dg->push_back( y_[ State_::DG
-      + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * i ) ] );
+      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
     g->push_back( y_[ State_::G
-      + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * i ) ] );
+      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] );
   }
 
   ( *d )[ names::dg ] = DoubleVectorDatum( dg );
@@ -520,7 +520,7 @@ aeif_cond_beta_multisynapse::calibrate()
 
   B_.spikes_.resize( P_.n_receptors() );
   S_.y_.resize( State_::NUMBER_OF_FIXED_STATES_ELEMENTS
-      + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * P_.n_receptors() ),
+      + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * P_.n_receptors() ),
     0.0 );
 
   // reallocate instance of stepping function for ODE GSL solver
@@ -624,7 +624,7 @@ aeif_cond_beta_multisynapse::update( Time const& origin,
     for ( size_t i = 0; i < P_.n_receptors(); ++i )
     {
       S_.y_[ State_::DG
-        + ( State_::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR * i ) ] +=
+        + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
         B_.spikes_[ i ].get_value( lag ) * V_.g0_[ i ]; // add incoming spike
     }
     // set new input current

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -291,7 +291,7 @@ private:
       STATE_VECTOR_MIN_SIZE
     };
 
-    static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 2;        // V_M, W
+    static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 2; // V_M, W
     static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 2; // DG, G
 
     std::vector< double > y_; //!< neuron state

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -292,7 +292,7 @@ private:
     };
 
     static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 2;        // V_M, W
-    static const size_t NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR = 2; // DG, G
+    static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 2; // DG, G
 
     std::vector< double > y_; //!< neuron state
     int r_;                   //!< number of refractory steps remaining

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -127,7 +127,7 @@ nest::gif_cond_exp_multisynapse::Parameters_::Parameters_()
   , V_reset_( -55.0 )  // mV
   , Delta_V_( 0.5 )    // mV
   , V_T_star_( -35 )   // mV
-  , lambda_0_( 1. )    // 1/s
+  , lambda_0_( 0.001 ) // 1/ms
   , t_ref_( 4.0 )      // ms
   , c_m_( 80.0 )       // pF
   , tau_stc_()         // ms
@@ -390,8 +390,8 @@ nest::gif_cond_exp_multisynapse::State_::set( const DictionaryDatum& d,
 {
   updateValue< double >( d, names::V_m, y_[ V_M ] );
   y_.resize( State_::NUMBER_OF_FIXED_STATES_ELEMENTS
-                + State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * p.n_receptors(),
-                0.0 );
+      + State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * p.n_receptors(),
+    0.0 );
 
   sfa_elems_.resize( p.tau_sfa_.size(), 0.0 );
   stc_elems_.resize( p.tau_stc_.size(), 0.0 );
@@ -478,8 +478,10 @@ void
 nest::gif_cond_exp_multisynapse::init_buffers_()
 {
   B_.spikes_.resize( P_.n_receptors() );
-  for (size_t i =0; i < P_.n_receptors(); ++i)
-    B_.spikes_[i].clear();   // includes resize
+  for ( size_t i = 0; i < P_.n_receptors(); ++i )
+  {
+    B_.spikes_[ i ].clear(); // includes resize
+  }
 
   B_.currents_.clear(); //!< includes resize
   B_.logger_.reset();   //!< includes resize
@@ -618,8 +620,8 @@ nest::gif_cond_exp_multisynapse::update( Time const& origin,
 
     for ( size_t i = 0; i < P_.n_receptors(); i++ )
     {
-      S_.y_[ State_::G + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR
-                           * i ) ] += B_.spikes_[ i ].get_value( lag );
+      S_.y_[ State_::G + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * i ) ] +=
+        B_.spikes_[ i ].get_value( lag );
     }
 
     if ( S_.r_ref_ == 0 ) // neuron is not in refractory period

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -240,7 +240,7 @@ private:
     double V_reset_;
     double Delta_V_;
     double V_T_star_;
-    double lambda_0_; /** 1/s */
+    double lambda_0_; /** 1/ms */
 
     /** Refractory period in ms. */
     double t_ref_;
@@ -305,10 +305,10 @@ private:
       STATE_VEC_SIZE
     };
 
-    static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 1;        //!< V_M
-    static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 1;        //!< G
+    static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 1; //!< V_M
+    static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 1; //!< G
 
-    std::vector< double > y_;        //!< neuron state
+    std::vector< double > y_; //!< neuron state
 
     double I_stim_; //!< This is piecewise constant external current
     double sfa_; //!< This is the change of the 'threshold' due to adaptation.

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -124,7 +124,7 @@
                                   (sfa) after each spike emission in mV.
     tau_sfa    vector of double - Time constants of sfa variables in ms.
     Delta_V    double - Stochasticity level in mV.
-    lambda_0   double - Stochastic intensity at firing threshold V_T in 1/ms.
+    lambda_0   double - Stochastic intensity at firing threshold V_T in 1/s.
     V_T_star   double - Base threshold in mV.
 
   Synaptic parameters
@@ -240,7 +240,7 @@ private:
     double V_reset_;
     double Delta_V_;
     double V_T_star_;
-    double lambda_0_; /** 1/ms */
+    double lambda_0_; /** 1/s */
 
     /** Refractory period in ms. */
     double t_ref_;
@@ -306,7 +306,7 @@ private:
     };
 
     static const size_t NUMBER_OF_FIXED_STATES_ELEMENTS = 1;        //!< V_M
-    static const size_t NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR = 1; //!< G
+    static const size_t NUM_STATE_ELEMENTS_PER_RECEPTOR = 1;        //!< G
 
     std::vector< double > y_;        //!< neuron state
 

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -118,14 +118,14 @@
 
   Spike adaptation and firing intensity parameters:
     q_stc      vector of double - Values added to spike-triggered currents (stc)
-                                  after each spike emission in nA.
+                                  after each spike emission in pA.
     tau_stc    vector of double - Time constants of stc variables in ms.
     q_sfa      vector of double - Values added to spike-frequency adaptation
                                   (sfa) after each spike emission in mV.
     tau_sfa    vector of double - Time constants of sfa variables in ms.
     Delta_V    double - Stochasticity level in mV.
-    lambda_0   double - Stochastic intensity at firing threshold V_T in 1/s.
-    V_T_star   double - Base threshold in mV
+    lambda_0   double - Stochastic intensity at firing threshold V_T in 1/ms.
+    V_T_star   double - Base threshold in mV.
 
   Synaptic parameters
     tau_syn    double vector - Time constants of the synaptic conductance
@@ -309,7 +309,6 @@ private:
     static const size_t NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR = 1; //!< G
 
     std::vector< double > y_;        //!< neuron state
-    unsigned int size_neuron_state_; // size of neuron state array
 
     double I_stim_; //!< This is piecewise constant external current
     double sfa_; //!< This is the change of the 'threshold' due to adaptation.

--- a/models/quantal_stp_connection.h
+++ b/models/quantal_stp_connection.h
@@ -197,8 +197,6 @@ Quantal_StpConnection< targetidentifierT >::send( Event& e,
   double t_lastspike,
   const CommonSynapseProperties& )
 {
-  const int vp = get_target( t )->get_vp();
-
   const double h = e.get_stamp().get_ms() - t_lastspike;
 
   // Compute the decay factors, based on the time since the last spike.

--- a/models/quantal_stp_connection.h
+++ b/models/quantal_stp_connection.h
@@ -212,7 +212,7 @@ Quantal_StpConnection< targetidentifierT >::send( Event& e,
   // Compute number of sites that recovered during the interval.
   for ( int depleted = n_ - a_; depleted > 0; --depleted )
   {
-    if ( kernel().rng_manager.get_rng( vp )->drand() < ( 1.0 - p_decay ) )
+    if ( kernel().rng_manager.get_rng( t )->drand() < ( 1.0 - p_decay ) )
     {
       ++a_;
     }
@@ -222,7 +222,7 @@ Quantal_StpConnection< targetidentifierT >::send( Event& e,
   int n_release = 0;
   for ( int i = a_; i > 0; --i )
   {
-    if ( kernel().rng_manager.get_rng( vp )->drand() < u_ )
+    if ( kernel().rng_manager.get_rng( t )->drand() < u_ )
     {
       ++n_release;
     }


### PR DESCRIPTION
This request fixes some problems in the gif_cond_exp_multisynapse model relating to the resizing of the neuron state and a minor bug in the quantal_stp model (using thread id instead of virtual process id).

Marc-Oliver Gewaltig
Dimitri Rodarie
Till Schumann