### PR TITLE
Improved structure of secondary event types

### DIFF
--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -120,20 +120,7 @@ void DiffusionConnectionEvent::operator()()
 {
   receiver_->handle( *this );
 }
-
-std::vector< synindex > GapJunctionEvent::supported_syn_ids_;
-size_t GapJunctionEvent::coeff_length_ = 0;
-
-std::vector< synindex > InstantaneousRateConnectionEvent::supported_syn_ids_;
-size_t InstantaneousRateConnectionEvent::coeff_length_ = 0;
-
-std::vector< synindex > DelayedRateConnectionEvent::supported_syn_ids_;
-size_t DelayedRateConnectionEvent::coeff_length_ = 0;
-
-std::vector< synindex > DiffusionConnectionEvent::supported_syn_ids_;
-size_t DiffusionConnectionEvent::coeff_length_ = 0;
 }
-
 
 nest::index
 nest::Event::get_receiver_gid( void ) const

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -856,8 +856,8 @@ public:
 
 /**
  * This template function returns the number of uints covered by a variable of
- * type T. This function is used to determine the storage demands for a variable
- * of type T in the NEST communication buffer, which is of type
+ * type T. This function is used to determine the storage demands for a
+ * variable of type T in the NEST communication buffer, which is of type
  * std::vector<unsigned int>.
  */
 template < typename T >
@@ -878,11 +878,9 @@ number_of_uints_covered( void )
  * Please note that this function does not increase the size of the vector,
  * it just writes the data to the position given by the iterator.
  * The function is used to write data from SecondaryEvents to the NEST
- * communcation buffer.
- * The pos iterator is advanced during execution.
+ * communication buffer. The pos iterator is advanced during execution.
  * For a discussion on the functionality of this function see github issue #181
- * and pull request
- * #184.
+ * and pull request #184.
  */
 template < typename T >
 void
@@ -909,11 +907,9 @@ write_to_comm_buffer( T d, std::vector< unsigned int >::iterator& pos )
 /**
  * This template function reads data of type T from a given position of a
  * std::vector< unsigned int >. The function is used to read SecondaryEvents
- * data from
- * the NEST communcation buffer.
- * The pos iterator is advanced during execution.
- * For a discussion on the functionality of this function see github issue #181
- * and pull request #184.
+ * data from the NEST communication buffer. The pos iterator is advanced
+ * during execution. For a discussion on the functionality of this function see
+ * github issue #181 and pull request #184.
  */
 template < typename T >
 void
@@ -938,11 +934,15 @@ read_from_comm_buffer( T& d, std::vector< unsigned int >::iterator& pos )
 }
 
 /**
- * Event for gap-junction information.
- * The event transmits the interpolation of the membrane potential
- * to the connected neurons.
- * Technically the GapJunctionEvent only contains iterators pointing to
- * the memory location of the interpolation array.
+ * Template class for the storage and communication of a std::vector of type D.
+ * The class provides the functionality to communicate homogeneous data
+ * of type D. The second template type E is used to distinguish
+ * derived classes of the same type D. This is required because of the
+ * included static variables (as otherwise all derived classes of the same
+ * data type would share the same static variables).
+ *
+ * Technically the DataSecondaryEvent only contains iterators pointing to
+ * the memory location of the std::vector< D >.
  *
  * Conceptually, there is a one-to-one mapping between a SecondaryEvent
  * and a SecondaryConnectorModel. The synindex of this particular
@@ -955,18 +955,144 @@ read_from_comm_buffer( T& d, std::vector< unsigned int >::iterator& pos )
  * supports_syn_id()-function allows testing if a particular synid is mapped
  * with the SecondaryEvent in question.
  */
-class GapJunctionEvent : public SecondaryEvent
+template < typename D, typename E >
+class DataSecondaryEvent : public SecondaryEvent
 {
 private:
-  // we chose std::vector over std::set because we expect this always to be
-  // short
+  // we chose std::vector over std::set because we expect this to be short
   static std::vector< synindex > supported_syn_ids_;
   static size_t coeff_length_; // length of coeffarray
 
-  std::vector< double >::iterator coeffarray_as_doubles_begin_;
-  std::vector< double >::iterator coeffarray_as_doubles_end_;
+  typename std::vector< D >::iterator coeffarray_as_d_begin_;
+  typename std::vector< D >::iterator coeffarray_as_d_end_;
   std::vector< unsigned int >::iterator coeffarray_as_uints_begin_;
   std::vector< unsigned int >::iterator coeffarray_as_uints_end_;
+
+public:
+  /**
+   * This function is needed to set the synid on model registration.
+   * At this point no object of this type is available and the
+   * add_syn_id-function cannot be used as it is virtual in the base class
+   * and therefore cannot be declared as static.
+   */
+  static void
+  set_syn_id( const synindex synid )
+  {
+    VPManager::assert_single_threaded();
+    supported_syn_ids_.push_back( synid );
+  }
+
+  /**
+   * This function is needed to add additional synids when the
+   * corresponded connector model is copied.
+   * This function needs to be a virtual function of the base class as
+   * it is called from a pointer on SecondaryEvent.
+   */
+  void
+  add_syn_id( const synindex synid )
+  {
+    assert( not supports_syn_id( synid ) );
+    VPManager::assert_single_threaded();
+    supported_syn_ids_.push_back( synid );
+  }
+
+  static void
+  set_coeff_length( const size_t coeff_length )
+  {
+    VPManager::assert_single_threaded();
+    coeff_length_ = coeff_length;
+  }
+
+  bool
+  supports_syn_id( const synindex synid ) const
+  {
+    return (
+      std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid )
+      != supported_syn_ids_.end() );
+  }
+
+  void
+  set_coeffarray( std::vector< D >& ca )
+  {
+    coeffarray_as_d_begin_ = ca.begin();
+    coeffarray_as_d_end_ = ca.end();
+    assert( coeff_length_ == ca.size() );
+  }
+
+  /**
+   * The following operator is used to read the information of the
+   * DataSecondaryEvent from the buffer in EventDeliveryManager::deliver_events
+   */
+  std::vector< unsigned int >::iterator& operator<<(
+    std::vector< unsigned int >::iterator& pos )
+  {
+    // The synid can be skipped here as it is stored in a static vector
+    pos += number_of_uints_covered< synindex >();
+    read_from_comm_buffer( sender_gid_, pos );
+
+    // generating a copy of the coeffarray is too time consuming
+    // therefore we save an iterator to the beginning+end of the coeffarray
+    coeffarray_as_uints_begin_ = pos;
+
+    pos += coeff_length_ * number_of_uints_covered< D >();
+
+    coeffarray_as_uints_end_ = pos;
+
+    return pos;
+  }
+
+  /**
+   * The following operator is used to write the information of the
+   * DataSecondaryEvent into the secondary_events_buffer_.
+   * All DataSecondaryEvents are identified by the synid of the
+   * first element in supported_syn_ids_.
+   */
+  std::vector< unsigned int >::iterator& operator>>(
+    std::vector< unsigned int >::iterator& pos )
+  {
+    write_to_comm_buffer( *( supported_syn_ids_.begin() ), pos );
+    write_to_comm_buffer( sender_gid_, pos );
+    for ( typename std::vector< D >::iterator i = coeffarray_as_d_begin_;
+          i != coeffarray_as_d_end_;
+          i++ )
+    {
+      write_to_comm_buffer( *i, pos );
+    }
+    return pos;
+  }
+
+  size_t
+  size()
+  {
+    size_t s = number_of_uints_covered< synindex >();
+    s += number_of_uints_covered< index >();
+    s += number_of_uints_covered< D >() * coeff_length_;
+
+    return s;
+  }
+
+  const std::vector< unsigned int >::iterator&
+  begin()
+  {
+    return coeffarray_as_uints_begin_;
+  }
+
+  const std::vector< unsigned int >::iterator&
+  end()
+  {
+    return coeffarray_as_uints_end_;
+  }
+
+  D get_coeffvalue( std::vector< unsigned int >::iterator& pos );
+};
+
+/**
+ * Event for gap-junction information. The event transmits the interpolation
+ * of the membrane potential to the connected neurons.
+ */
+class GapJunctionEvent
+  : public DataSecondaryEvent< double, int /*only used to distinguish events*/ >
+{
 
 public:
   GapJunctionEvent()
@@ -975,139 +1101,16 @@ public:
 
   void operator()();
   GapJunctionEvent* clone() const;
-
-  /**
-   * This function is needed to set the synid on model registration.
-   * At this point no object of this type is available and the
-   * add_syn_id-function cannot be used as it is virtual in the base class
-   * and therefore cannot be declared as static.
-   */
-  static void
-  set_syn_id( const synindex synid )
-  {
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  /**
-   * This function is needed to add additional synids when the
-   * corresponded connector model is copied.
-   * This function needs to be a virtual function of the base class as
-   * it is called from a pointer on SecondaryEvent.
-   */
-  void
-  add_syn_id( const synindex synid )
-  {
-    assert( not supports_syn_id( synid ) );
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  static void
-  set_coeff_length( const size_t coeff_length )
-  {
-    VPManager::assert_single_threaded();
-    coeff_length_ = coeff_length;
-  }
-
-  bool
-  supports_syn_id( const synindex synid ) const
-  {
-    return (
-      std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid )
-      != supported_syn_ids_.end() );
-  }
-
-  void
-  set_coeffarray( std::vector< double >& ca )
-  {
-    coeffarray_as_doubles_begin_ = ca.begin();
-    coeffarray_as_doubles_end_ = ca.end();
-    assert( coeff_length_ == ca.size() );
-  }
-
-  /**
-   * The following operator is used to read the information
-   * of the GapJunctionEvent from the buffer in Scheduler::deliver_events_
-   */
-  std::vector< unsigned int >::iterator& operator<<(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    // The synid can be skipped here as it is stored in a static vector
-    pos += number_of_uints_covered< synindex >();
-    read_from_comm_buffer( sender_gid_, pos );
-
-    // generating a copy of the coeffarray is too time consuming
-    // therefore we save an iterator to the beginning+end of the coeffarray
-    coeffarray_as_uints_begin_ = pos;
-
-    pos += coeff_length_ * number_of_uints_covered< double >();
-
-    coeffarray_as_uints_end_ = pos;
-
-    return pos;
-  }
-
-  /**
-   * The following operator is used to write the information
-   * of the GapJunctionEvent into the secondary_events_buffer_
-   * All GapJunctionEvents are identified by the synid of the
-   * first element in supported_syn_ids_
-   */
-  std::vector< unsigned int >::iterator& operator>>(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    write_to_comm_buffer( *( supported_syn_ids_.begin() ), pos );
-    write_to_comm_buffer( sender_gid_, pos );
-    for ( std::vector< double >::iterator i = coeffarray_as_doubles_begin_;
-          i != coeffarray_as_doubles_end_;
-          i++ )
-    {
-      write_to_comm_buffer( *i, pos );
-    }
-    return pos;
-  }
-
-  size_t
-  size()
-  {
-    size_t s = number_of_uints_covered< synindex >();
-    s += number_of_uints_covered< index >();
-    s += number_of_uints_covered< double >() * coeff_length_;
-
-    return s;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  begin()
-  {
-    return coeffarray_as_uints_begin_;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  end()
-  {
-    return coeffarray_as_uints_end_;
-  }
-
-  double get_coeffvalue( std::vector< unsigned int >::iterator& pos );
 };
 
 /**
- * Event for rate model connections without delay.
+ * Event for rate model connections without delay. The event transmits
+ * the rate to the connected neurons.
  */
-class InstantaneousRateConnectionEvent : public SecondaryEvent
+class InstantaneousRateConnectionEvent
+  : public DataSecondaryEvent< double,
+      char /*only used to distinguish events*/ >
 {
-private:
-  // we chose std::vector over std::set because we expect this always to be
-  // short
-  static std::vector< synindex > supported_syn_ids_;
-  static size_t coeff_length_; // length of coeffarray
-
-  std::vector< double >::iterator coeffarray_as_doubles_begin_;
-  std::vector< double >::iterator coeffarray_as_doubles_end_;
-  std::vector< unsigned int >::iterator coeffarray_as_uints_begin_;
-  std::vector< unsigned int >::iterator coeffarray_as_uints_end_;
 
 public:
   InstantaneousRateConnectionEvent()
@@ -1116,141 +1119,33 @@ public:
 
   void operator()();
   InstantaneousRateConnectionEvent* clone() const;
-
-  /**
-   * This function is needed to set the synid on model registration.
-   * At this point no object of this type is available and the
-   * add_syn_id-function cannot be used as it is virtual in the base class
-   * and therefore cannot be declared as static.
-   */
-  static void
-  set_syn_id( const synindex synid )
-  {
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  /**
-   * This function is needed to add additional synids when the
-   * corresponded connector model is copied.
-   * This function needs to be a virtual function of the base class as
-   * it is called from a pointer on SecondaryEvent.
-   */
-  void
-  add_syn_id( const synindex synid )
-  {
-    assert( not supports_syn_id( synid ) );
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  static void
-  set_coeff_length( const size_t coeff_length )
-  {
-    VPManager::assert_single_threaded();
-    coeff_length_ = coeff_length;
-  }
-
-  bool
-  supports_syn_id( const synindex synid ) const
-  {
-    return (
-      std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid )
-      != supported_syn_ids_.end() );
-  }
-
-  void
-  set_coeffarray( std::vector< double >& ca )
-  {
-    coeffarray_as_doubles_begin_ = ca.begin();
-    coeffarray_as_doubles_end_ = ca.end();
-    assert( coeff_length_ == ca.size() );
-  }
-
-  /**
-   * The following operator is used to read the information
-   * of the InstantaneousRateConnectionEvent from the buffer in
-   * Scheduler::deliver_events_
-   */
-  std::vector< unsigned int >::iterator& operator<<(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    // The synid can be skipped here as it is stored in a static vector
-    pos += number_of_uints_covered< synindex >();
-    read_from_comm_buffer( sender_gid_, pos );
-
-    // generating a copy of the coeffarray is too time consuming
-    // therefore we save an iterator to the beginning+end of the coeffarray
-    coeffarray_as_uints_begin_ = pos;
-
-    pos += coeff_length_ * number_of_uints_covered< double >();
-
-    coeffarray_as_uints_end_ = pos;
-
-    return pos;
-  }
-
-  /**
-   * The following operator is used to write the information
-   * of the InstantaneousRateConnectionEvent into the secondary_events_buffer_
-   * All InstantaneousRateConnectionEvents are identified by the synid of the
-   * first element in supported_syn_ids_
-   */
-  std::vector< unsigned int >::iterator& operator>>(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    write_to_comm_buffer( *( supported_syn_ids_.begin() ), pos );
-    write_to_comm_buffer( sender_gid_, pos );
-    for ( std::vector< double >::iterator i = coeffarray_as_doubles_begin_;
-          i != coeffarray_as_doubles_end_;
-          i++ )
-    {
-      write_to_comm_buffer( *i, pos );
-    }
-    return pos;
-  }
-
-  size_t
-  size()
-  {
-    size_t s = number_of_uints_covered< synindex >();
-    s += number_of_uints_covered< index >();
-    s += number_of_uints_covered< double >() * coeff_length_;
-
-    return s;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  begin()
-  {
-    return coeffarray_as_uints_begin_;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  end()
-  {
-    return coeffarray_as_uints_end_;
-  }
-
-  double get_coeffvalue( std::vector< unsigned int >::iterator& pos );
 };
 
 /**
- * Event for diffusion connections.
+ * Event for rate model connections with delay. The event transmits
+ * the rate to the connected neurons.
  */
-class DiffusionConnectionEvent : public SecondaryEvent
+class DelayedRateConnectionEvent : public DataSecondaryEvent< double,
+                                     bool /*only used to distinguish events*/ >
+{
+
+public:
+  DelayedRateConnectionEvent()
+  {
+  }
+
+  void operator()();
+  DelayedRateConnectionEvent* clone() const;
+};
+
+/**
+ * Event for diffusion connections (rate model connections for the
+ * siegert_neuron). The event transmits the rate to the connected neurons.
+ */
+class DiffusionConnectionEvent : public DataSecondaryEvent< double,
+                                   float /*only used to distinguish events*/ >
 {
 private:
-  // we chose std::vector over std::set because we expect this always to be
-  // short
-  static std::vector< synindex > supported_syn_ids_;
-  static size_t coeff_length_; // length of coeffarray
-
-  std::vector< double >::iterator coeffarray_as_doubles_begin_;
-  std::vector< double >::iterator coeffarray_as_doubles_end_;
-  std::vector< unsigned int >::iterator coeffarray_as_uints_begin_;
-  std::vector< unsigned int >::iterator coeffarray_as_uints_end_;
-
   // drift factor of the corresponding connection
   weight drift_factor_;
   // diffusion factor of the corresponding connection
@@ -1264,121 +1159,6 @@ public:
   void operator()();
   DiffusionConnectionEvent* clone() const;
 
-  /**
-   * This function is needed to set the synid on model registration.
-   * At this point no object of this type is available and the
-   * add_syn_id-function cannot be used as it is virtual in the base class
-   * and therefore cannot be declared as static.
-   */
-  static void
-  set_syn_id( const synindex synid )
-  {
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  /**
-   * This function is needed to add additional synids when the
-   * corresponded connector model is copied.
-   * This function needs to be a virtual function of the base class as
-   * it is called from a pointer on SecondaryEvent.
-   */
-  void
-  add_syn_id( const synindex synid )
-  {
-    assert( not supports_syn_id( synid ) );
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  static void
-  set_coeff_length( const size_t coeff_length )
-  {
-    VPManager::assert_single_threaded();
-    coeff_length_ = coeff_length;
-  }
-
-  bool
-  supports_syn_id( const synindex synid ) const
-  {
-    return (
-      std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid )
-      != supported_syn_ids_.end() );
-  }
-
-  void
-  set_coeffarray( std::vector< double >& ca )
-  {
-    coeffarray_as_doubles_begin_ = ca.begin();
-    coeffarray_as_doubles_end_ = ca.end();
-    assert( coeff_length_ == ca.size() );
-  }
-
-  /**
-   * The following operator is used to read the information
-   * of the DiffusionConnectionEvent from the buffer in
-   * Scheduler::deliver_events_
-   */
-  std::vector< unsigned int >::iterator& operator<<(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    // The synid can be skipped here as it is stored in a static vector
-    pos += number_of_uints_covered< synindex >();
-    read_from_comm_buffer( sender_gid_, pos );
-
-    // generating a copy of the coeffarray is too time consuming
-    // therefore we save an iterator to the beginning+end of the coeffarray
-    coeffarray_as_uints_begin_ = pos;
-
-    pos += coeff_length_ * number_of_uints_covered< double >();
-
-    coeffarray_as_uints_end_ = pos;
-
-    return pos;
-  }
-
-  /**
-   * The following operator is used to write the information
-   * of the DiffusionConnectionEvent into the secondary_events_buffer_
-   * All DiffusionConnectionEvents are identified by the synid of the
-   * first element in supported_syn_ids_
-   */
-  std::vector< unsigned int >::iterator& operator>>(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    write_to_comm_buffer( *( supported_syn_ids_.begin() ), pos );
-    write_to_comm_buffer( sender_gid_, pos );
-    for ( std::vector< double >::iterator i = coeffarray_as_doubles_begin_;
-          i != coeffarray_as_doubles_end_;
-          i++ )
-    {
-      write_to_comm_buffer( *i, pos );
-    }
-    return pos;
-  }
-
-  size_t
-  size()
-  {
-    size_t s = number_of_uints_covered< synindex >();
-    s += number_of_uints_covered< index >();
-    s += number_of_uints_covered< double >() * coeff_length_;
-
-    return s;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  begin()
-  {
-    return coeffarray_as_uints_begin_;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  end()
-  {
-    return coeffarray_as_uints_end_;
-  }
-
   void
   set_diffusion_factor( weight t )
   {
@@ -1391,176 +1171,30 @@ public:
     drift_factor_ = t;
   };
 
-  double get_coeffvalue( std::vector< unsigned int >::iterator& pos );
-
   weight get_drift_factor() const;
   weight get_diffusion_factor() const;
 };
 
-
-/**
- * Event for rate model connections with delay.
- */
-class DelayedRateConnectionEvent : public SecondaryEvent
+template < typename D, typename E >
+inline D
+DataSecondaryEvent< D, E >::get_coeffvalue(
+  std::vector< unsigned int >::iterator& pos )
 {
-private:
-  // we chose std::vector over std::set because we expect this always to be
-  // short
-  static std::vector< synindex > supported_syn_ids_;
-  static size_t coeff_length_; // length of coeffarray
-
-  std::vector< double >::iterator coeffarray_as_doubles_begin_;
-  std::vector< double >::iterator coeffarray_as_doubles_end_;
-  std::vector< unsigned int >::iterator coeffarray_as_uints_begin_;
-  std::vector< unsigned int >::iterator coeffarray_as_uints_end_;
-
-public:
-  DelayedRateConnectionEvent()
-  {
-  }
-
-  void operator()();
-  DelayedRateConnectionEvent* clone() const;
-
-  /**
-   * This function is needed to set the synid on model registration.
-   * At this point no object of this type is available and the
-   * add_syn_id-function cannot be used as it is virtual in the base class
-   * and therefore cannot be declared as static.
-   */
-  static void
-  set_syn_id( const synindex synid )
-  {
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  /**
-   * This function is needed to add additional synids when the
-   * corresponded connector model is copied.
-   * This function needs to be a virtual function of the base class as
-   * it is called from a pointer on SecondaryEvent.
-   */
-  void
-  add_syn_id( const synindex synid )
-  {
-    assert( not supports_syn_id( synid ) );
-    VPManager::assert_single_threaded();
-    supported_syn_ids_.push_back( synid );
-  }
-
-  static void
-  set_coeff_length( const size_t coeff_length )
-  {
-    VPManager::assert_single_threaded();
-    coeff_length_ = coeff_length;
-  }
-
-  bool
-  supports_syn_id( const synindex synid ) const
-  {
-    return (
-      std::find( supported_syn_ids_.begin(), supported_syn_ids_.end(), synid )
-      != supported_syn_ids_.end() );
-  }
-
-  void
-  set_coeffarray( std::vector< double >& ca )
-  {
-    coeffarray_as_doubles_begin_ = ca.begin();
-    coeffarray_as_doubles_end_ = ca.end();
-    assert( coeff_length_ == ca.size() );
-  }
-
-  /**
-   * The following operator is used to read the information
-   * of the DelayedRateConnectionEvent from the buffer in
-   * Scheduler::deliver_events_
-   */
-  std::vector< unsigned int >::iterator& operator<<(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    // The synid can be skipped here as it is stored in a static vector
-    pos += number_of_uints_covered< synindex >();
-    read_from_comm_buffer( sender_gid_, pos );
-
-    // generating a copy of the coeffarray is too time consuming
-    // therefore we save an iterator to the beginning+end of the coeffarray
-    coeffarray_as_uints_begin_ = pos;
-
-    pos += coeff_length_ * number_of_uints_covered< double >();
-
-    coeffarray_as_uints_end_ = pos;
-
-    return pos;
-  }
-
-  /**
-   * The following operator is used to write the information
-   * of the DelayedRateConnectionEvent into the secondary_events_buffer_
-   * All DelayedRateConnectionEvents are identified by the synid of the
-   * first element in supported_syn_ids_
-   */
-  std::vector< unsigned int >::iterator& operator>>(
-    std::vector< unsigned int >::iterator& pos )
-  {
-    write_to_comm_buffer( *( supported_syn_ids_.begin() ), pos );
-    write_to_comm_buffer( sender_gid_, pos );
-    for ( std::vector< double >::iterator i = coeffarray_as_doubles_begin_;
-          i != coeffarray_as_doubles_end_;
-          i++ )
-    {
-      write_to_comm_buffer( *i, pos );
-    }
-    return pos;
-  }
-
-  size_t
-  size()
-  {
-    size_t s = number_of_uints_covered< synindex >();
-    s += number_of_uints_covered< index >();
-    s += number_of_uints_covered< double >() * coeff_length_;
-
-    return s;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  begin()
-  {
-    return coeffarray_as_uints_begin_;
-  }
-
-  const std::vector< unsigned int >::iterator&
-  end()
-  {
-    return coeffarray_as_uints_end_;
-  }
-
-  double get_coeffvalue( std::vector< unsigned int >::iterator& pos );
-};
-
-inline double
-GapJunctionEvent::get_coeffvalue( std::vector< unsigned int >::iterator& pos )
-{
-  double elem = 0.0;
+  D elem;
   read_from_comm_buffer( elem, pos );
   return elem;
 }
+
+template < typename D, typename E >
+std::vector< synindex > DataSecondaryEvent< D, E >::supported_syn_ids_;
+
+template < typename D, typename E >
+size_t DataSecondaryEvent< D, E >::coeff_length_ = 0;
 
 inline GapJunctionEvent*
 GapJunctionEvent::clone() const
 {
   return new GapJunctionEvent( *this );
-}
-
-inline double
-InstantaneousRateConnectionEvent::get_coeffvalue(
-  std::vector< unsigned int >::iterator& pos )
-{
-  double elem = 0.0;
-  read_from_comm_buffer( elem, pos );
-  return elem;
 }
 
 inline InstantaneousRateConnectionEvent*
@@ -1569,34 +1203,16 @@ InstantaneousRateConnectionEvent::clone() const
   return new InstantaneousRateConnectionEvent( *this );
 }
 
-inline double
-DiffusionConnectionEvent::get_coeffvalue(
-  std::vector< unsigned int >::iterator& pos )
+inline DelayedRateConnectionEvent*
+DelayedRateConnectionEvent::clone() const
 {
-  double elem = 0.0;
-  read_from_comm_buffer( elem, pos );
-  return elem;
+  return new DelayedRateConnectionEvent( *this );
 }
 
 inline DiffusionConnectionEvent*
 DiffusionConnectionEvent::clone() const
 {
   return new DiffusionConnectionEvent( *this );
-}
-
-inline double
-DelayedRateConnectionEvent::get_coeffvalue(
-  std::vector< unsigned int >::iterator& pos )
-{
-  double elem = 0.0;
-  read_from_comm_buffer( elem, pos );
-  return elem;
-}
-
-inline DelayedRateConnectionEvent*
-DelayedRateConnectionEvent::clone() const
-{
-  return new DelayedRateConnectionEvent( *this );
 }
 
 inline weight


### PR DESCRIPTION
This PR removes a lot of redundant code from `event.h`. Previously the classes `GapJunctionEvent`, `DelayedRateConnectionEvent`, `InstantaneousRateConnectionEvent` and `DiffusionConnectionEvent` all contained a lot of identical code, which is now moved to a general template base class `DataSecondaryEvent< typename D, typename E >`. One template typename specifies the data type that is stored, the second is used to distinguish different classes which use the same data type in order to have seperate static variables for all derived classes