### PR TITLE
Fix test_disconnect by converting filter object to list for len

### DIFF
--- a/pynest/nest/tests/test_sp/test_disconnect.py
+++ b/pynest/nest/tests/test_sp/test_disconnect.py
@@ -83,14 +83,14 @@ class TestDisconnectSingle(unittest.TestCase):
                 if mpi_test:
                     conns = self.comm.allgather(conns)
                     conns = filter(None, conns)
-                assert len(conns) == 1
+                assert len(list(conns)) == 1
                 nest.DisconnectOneToOne(neurons[0], neurons[2], syn_dict)
                 conns = nest.GetConnections(
                     [neurons[0]], [neurons[2]], syn_model)
                 if mpi_test:
                     conns = self.comm.allgather(conns)
                     conns = filter(None, conns)
-                assert len(conns) == 0
+                assert len(list(conns)) == 0
 
                 # Assert that one can not delete a non existent connection
                 conns1 = nest.GetConnections(
@@ -98,7 +98,7 @@ class TestDisconnectSingle(unittest.TestCase):
                 if mpi_test:
                     conns1 = self.comm.allgather(conns1)
                     conns1 = filter(None, conns1)
-                assert len(conns1) == 0
+                assert len(list(conns1)) == 0
                 try:
                     nest.DisconnectOneToOne(neurons[0], neurons[1], syn_dict)
                     assertFail()


### PR DESCRIPTION
This test fails for Python 3 if filter objects are not converted to lists before calling `len`.

I suggest @jougs as reviewer