### PR TITLE
Bug fixed on cmake with user modules

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -215,11 +215,11 @@ function( NEST_PROCESS_EXTERNAL_MODULES )
       # find module header
       find_file( ${mod}_EXT_MOD_INCLUDE
           NAMES ${mod}module.h
-          HINTS "${CMAKE_INSTALL_FULL_INCLUDEDIR}"
+          HINTS "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${mod}module"
           )
       if ( ${mod}_EXT_MOD_INCLUDE STREQUAL "${mod}_EXT_MOD_INCLUDE-NOTFOUND" )
         message( FATAL_ERROR "Cannot find header for external module '${mod}'. "
-          "Should be '${CMAKE_INSTALL_FULL_INCLUDEDIR}/${mod}module.h' ." )
+          "Should be '${CMAKE_INSTALL_FULL_INCLUDEDIR}/${mod}module/${mod}module.h' ." )
       endif ()
       list( APPEND EXTERNAL_MODULE_INCLUDES ${${mod}_EXT_MOD_INCLUDE} )
 


### PR DESCRIPTION
User module headers are now searched on a specific module folder (<nest_prefix>/include/<module_name>/). It is intended to solve issue #868.