### PR TITLE
Remove strong dependency on matplotlib

### DIFF
--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -23,10 +23,8 @@ from scipy.integrate import quad
 import math
 import numpy
 from numpy import testing
-import pylab
 import unittest
 import nest
-from nest import raster_plot
 import time
 HAVE_OPENMP = nest.sli_func("is_threaded")
 
@@ -339,22 +337,27 @@ class TestGrowthCurve(unittest.TestCase):
                     self.se_nest[n_i], self.se_python[sei_i], decimal=5)
 
     def plot(self):
-        pylab.ion()
-        for i, sei in enumerate(self.se_integrator):
-            pylab.figure()
-            pylab.subplot(1, 2, 1)
-            pylab.title('Ca')
-            pylab.plot(self.sim_steps, self.ca_nest[0, :])
-            pylab.plot(self.sim_steps, self.ca_python[i])
-            pylab.legend(('nest', sei.__class__.__name__))
-            pylab.subplot(1, 2, 2)
-            pylab.title('Synaptic Element')
-            pylab.plot(self.sim_steps, self.se_nest[0, :])
-            pylab.plot(self.sim_steps, self.se_python[i])
-            pylab.legend(('nest', sei.__class__.__name__))
-            pylab.savefig('sp' + sei.__class__.__name__ + '.png')
-        raster_plot.from_device(self.spike_detector)
-        pylab.savefig('sp_raster_plot.png')
+        try:
+            import pylab
+            from nest import raster_plot
+            pylab.ion()
+            for i, sei in enumerate(self.se_integrator):
+                pylab.figure()
+                pylab.subplot(1, 2, 1)
+                pylab.title('Ca')
+                pylab.plot(self.sim_steps, self.ca_nest[0, :])
+                pylab.plot(self.sim_steps, self.ca_python[i])
+                pylab.legend(('nest', sei.__class__.__name__))
+                pylab.subplot(1, 2, 2)
+                pylab.title('Synaptic Element')
+                pylab.plot(self.sim_steps, self.se_nest[0, :])
+                pylab.plot(self.sim_steps, self.se_python[i])
+                pylab.legend(('nest', sei.__class__.__name__))
+                pylab.savefig('sp' + sei.__class__.__name__ + '.png')
+            raster_plot.from_device(self.spike_detector)
+            pylab.savefig('sp_raster_plot.png')
+        except ImportError:
+            pass
 
     def test_linear_growth_curve(self):
         beta_ca = 0.0001

--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -287,7 +287,9 @@ class TestGrowthCurve(unittest.TestCase):
 
         # build
         self.pop = nest.Create('iaf_psc_alpha', 10)
-        self.local_nodes = nest.GetNodes([0], {'model': 'iaf_psc_alpha'}, True)[0]
+        self.local_nodes = nest.GetNodes([0],
+                                         {'model': 'iaf_psc_alpha'},
+                                         True)[0]
         self.spike_detector = nest.Create('spike_detector')
         nest.Connect(self.pop, self.spike_detector, 'all_to_all')
         noise = nest.Create('poisson_generator')
@@ -490,6 +492,7 @@ class TestGrowthCurve(unittest.TestCase):
 def suite():
     test_suite = unittest.makeSuite(TestGrowthCurve, 'test')
     return test_suite
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -338,7 +338,10 @@ class TestGrowthCurve(unittest.TestCase):
                 testing.assert_almost_equal(
                     self.se_nest[n_i], self.se_python[sei_i], decimal=5)
 
-    def plot(self):
+    def _plot(self):
+        """
+        Can be called by tearDown() to cross-check tests.
+        """
         try:
             import pylab
             from nest import raster_plot
@@ -485,7 +488,7 @@ class TestGrowthCurve(unittest.TestCase):
 
     def tearDown(self):
         # uncomment this line if you want to plot values
-        # self.plot()
+        # self._plot()
         return
 
 

--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -338,32 +338,6 @@ class TestGrowthCurve(unittest.TestCase):
                 testing.assert_almost_equal(
                     self.se_nest[n_i], self.se_python[sei_i], decimal=5)
 
-    def _plot(self):
-        """
-        Can be called by tearDown() to cross-check tests.
-        """
-        try:
-            import pylab
-            from nest import raster_plot
-            pylab.ion()
-            for i, sei in enumerate(self.se_integrator):
-                pylab.figure()
-                pylab.subplot(1, 2, 1)
-                pylab.title('Ca')
-                pylab.plot(self.sim_steps, self.ca_nest[0, :])
-                pylab.plot(self.sim_steps, self.ca_python[i])
-                pylab.legend(('nest', sei.__class__.__name__))
-                pylab.subplot(1, 2, 2)
-                pylab.title('Synaptic Element')
-                pylab.plot(self.sim_steps, self.se_nest[0, :])
-                pylab.plot(self.sim_steps, self.se_python[i])
-                pylab.legend(('nest', sei.__class__.__name__))
-                pylab.savefig('sp' + sei.__class__.__name__ + '.png')
-            raster_plot.from_device(self.spike_detector)
-            pylab.savefig('sp_raster_plot.png')
-        except ImportError:
-            pass
-
     def test_linear_growth_curve(self):
         beta_ca = 0.0001
         tau_ca = 10000.0
@@ -485,11 +459,6 @@ class TestGrowthCurve(unittest.TestCase):
                     self.se_nest[self.local_nodes.index(n), 30], expected[
                         self.pop.index(n)],
                     decimal=5)
-
-    def tearDown(self):
-        # uncomment this line if you want to plot values
-        # self._plot()
-        return
 
 
 def suite():


### PR DESCRIPTION
PyNEST only uses pylab (matplotlib.pylab) in `raster_plot` and `voltage_trace`. In
tests, this matplotlib is mostly optional - except for `test_sp/test_growth_curves.py`.
This PR makes matplotlib completely optional for test.

Making matplotlib optional will greatly simplify maintaining the nest `homebrew` formula in [`homebrew-core`](https://github.com/Homebrew/homebrew-core/pull/21561), as `homebrew-science` will be [deprecated](https://github.com/Homebrew/homebrew-science/issues/6365).