### PR TITLE
Add SymmetricBernoulliConnector

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -57,6 +57,7 @@ nest::ConnBuilder::ConnBuilder( const GIDCollection& sources,
   , autapses_( true )
   , multapses_( true )
   , make_symmetric_( false )
+  , own_symmetric_( false )
   , exceptions_raised_( kernel().vp_manager.get_num_threads() )
   , synapse_model_id_( kernel().model_manager.get_synapsedict()->lookup(
       "static_synapse" ) )
@@ -351,7 +352,7 @@ nest::ConnBuilder::connect()
   else
   {
     connect_();
-    if ( make_symmetric_ )
+    if ( make_symmetric_ and not own_symmetric_ )
     {
       // call reset on all parameters
       if ( weight_ )
@@ -1669,6 +1670,166 @@ nest::BernoulliBuilder::inner_connect_( const int tid,
     single_connect_( *sgid, *target, target_thread, rng );
   }
 }
+
+
+nest::SymmetricBernoulliBuilder::SymmetricBernoulliBuilder(
+  const GIDCollection& sources,
+  const GIDCollection& targets,
+  const DictionaryDatum& conn_spec,
+  const DictionaryDatum& syn_spec )
+  : ConnBuilder( sources, targets, conn_spec, syn_spec )
+  , p_( ( *conn_spec )[ names::p ] )
+{
+  own_symmetric_ = true; // this connector takes care of symmetric
+                         // connections on its own
+
+  if ( p_ < 0 or 1 <= p_ )
+  {
+    throw BadProperty( "Connection probability 0 <= p < 1 required." );
+  }
+
+  if ( not multapses_ )
+  {
+    throw BadProperty( "Multapses must be enabled." );
+  }
+
+  if ( autapses_ )
+  {
+    throw BadProperty( "Autapses must be disabled." );
+  }
+
+  if ( not make_symmetric_ )
+  {
+    throw BadProperty( "Symmetric connections must be enabled." );
+  }
+}
+
+
+void
+nest::SymmetricBernoulliBuilder::connect_()
+{
+  // allocate pointer to global random generator; used to create a
+  // random generator for each thread, each using the same seed
+  // obtained from the global rng -> all threads across all processes
+  // generate identical random number streams; this is required to
+  // generate symmetric connections: if we would loop only over local
+  // targets, we might miss the symmetric counterpart to a connection
+  // where a local target is chosen as a source
+  librandom::RngPtr grng = kernel().rng_manager.get_grng();
+  const unsigned long s =
+    grng->ulrand( std::numeric_limits< unsigned int >::max() );
+
+#pragma omp parallel
+  {
+    const thread tid = kernel().vp_manager.get_thread_id();
+
+#ifdef HAVE_GSL
+    librandom::RngPtr rng(
+      new librandom::GslRandomGen( gsl_rng_knuthran2002, s ) );
+#else
+    librandom::RngPtr rng = librandom::RandomGen::create_knuthlfg_rng( s );
+#endif
+
+    try
+    {
+#ifdef HAVE_GSL
+      librandom::GSL_BinomialRandomDev bino( rng, 0, 0 );
+#else
+      librandom::BinomialRandomDev bino( rng, 0, 0 );
+#endif
+      bino.set_p( p_ );
+      bino.set_n( sources_->size() );
+
+      unsigned long indegree;
+      std::set< index > previous_sgids;
+      Node* target;
+      thread target_thread;
+      Node* source;
+      thread source_thread;
+
+      for ( GIDCollection::const_iterator tgid = targets_->begin();
+            tgid != targets_->end();
+            ++tgid )
+      {
+        // sample indegree according to truncated Binomial distribution
+        indegree = sources_->size();
+        while ( indegree >= sources_->size() )
+        {
+          indegree = bino.ldev();
+        }
+        assert( indegree < sources_->size() );
+
+        // check whether the target is on this thread
+        if ( kernel().node_manager.is_local_gid( *tgid ) )
+        {
+          target = kernel().node_manager.get_node( *tgid, tid );
+          target_thread = target->get_thread();
+        }
+        else
+        {
+          target = NULL;
+          target_thread = invalid_thread_;
+        }
+
+        previous_sgids.clear();
+
+        // choose indegree number of sources randomly from all sources
+        index sgid;
+        size_t i = 0;
+        while ( i < indegree )
+        {
+          sgid = ( *sources_ )[ rng->ulrand( sources_->size() ) ];
+
+          // avoid autapses and multapses; due to symmetric
+          // connectivity, multapses might exist if the target neuron
+          // with gid sgid draws the source with gid tgid while
+          // choosing sources itself
+          if ( sgid == *tgid
+            or previous_sgids.find( sgid ) != previous_sgids.end() )
+          {
+            continue;
+          }
+          previous_sgids.insert( sgid );
+
+          if ( kernel().node_manager.is_local_gid( sgid ) )
+          {
+            source = kernel().node_manager.get_node( sgid, tid );
+            source_thread = source->get_thread();
+          }
+          else
+          {
+            source = NULL;
+            source_thread = invalid_thread_;
+          }
+
+          // if target is local: connect
+          if ( target_thread == tid )
+          {
+            assert( target != NULL );
+            single_connect_( sgid, *target, target_thread, rng );
+          }
+
+          // if source is local: connect
+          if ( source_thread == tid )
+          {
+            assert( source != NULL );
+            single_connect_( *tgid, *source, source_thread, rng );
+          }
+
+          ++i;
+        }
+      }
+    }
+    catch ( std::exception& err )
+    {
+      // We must create a new exception here, err's lifetime ends at
+      // the end of the catch block.
+      exceptions_raised_.at( tid ) =
+        lockPTR< WrappedThreadException >( new WrappedThreadException( err ) );
+    }
+  }
+}
+
 
 /**
  * The SPBuilder is in charge of the creation of synapses during the simulation

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -184,6 +184,7 @@ protected:
   bool autapses_;
   bool multapses_;
   bool make_symmetric_;
+  bool own_symmetric_;
 
   //! buffer for exceptions raised in threads
   std::vector< lockPTR< WrappedThreadException > > exceptions_raised_;
@@ -360,6 +361,27 @@ protected:
 
 private:
   void inner_connect_( const int, librandom::RngPtr&, Node*, index );
+  double p_; //!< connection probability
+};
+
+class SymmetricBernoulliBuilder : public ConnBuilder
+{
+public:
+  SymmetricBernoulliBuilder( const GIDCollection&,
+    const GIDCollection&,
+    const DictionaryDatum&,
+    const DictionaryDatum& );
+
+  bool
+  supports_symmetric() const
+  {
+    return true;
+  }
+
+protected:
+  void connect_();
+
+private:
   double p_; //!< connection probability
 };
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -1805,6 +1805,9 @@ NestModule::init( SLIInterpreter* i )
     "fixed_outdegree" );
   kernel().connection_manager.register_conn_builder< BernoulliBuilder >(
     "pairwise_bernoulli" );
+  kernel()
+    .connection_manager.register_conn_builder< SymmetricBernoulliBuilder >(
+      "symmetric_pairwise_bernoulli" );
   kernel().connection_manager.register_conn_builder< FixedTotalNumberBuilder >(
     "fixed_total_number" );
 

--- a/pynest/nest/tests/test_connect_helpers.py
+++ b/pynest/nest/tests/test_connect_helpers.py
@@ -316,7 +316,7 @@ def chi_squared_check(degrees, expected, distribution=None):
         p-value from chi-squared test.
     '''
 
-    if distribution == 'pairwise_bernoulli':
+    if distribution in ('pairwise_bernoulli', 'symmetric_pairwise_bernoulli'):
         observed = {}
         for degree in degrees:
             if degree not in observed:

--- a/pynest/nest/tests/test_connect_symmetric_pairwise_bernoulli.py
+++ b/pynest/nest/tests/test_connect_symmetric_pairwise_bernoulli.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# test_connect_symmetric_pairwise_bernoulli.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import collections
+import numpy as np
+import unittest
+import scipy.stats
+from . import test_connect_helpers as hf
+from .test_connect_parameters import TestParams
+
+
+class TestSymmetricPairwiseBernoulli(TestParams):
+
+    # sizes of source-, target-population and connection probability for
+    # statistical test
+    N_s = 60
+    N_t = 60
+    # specify connection pattern and specific params
+    rule = 'symmetric_pairwise_bernoulli'
+    p = 0.5
+    conn_dict = {'rule': rule, 'p': p, 'multapses': True, 'autapses': False,
+                 'make_symmetric': True}
+    # Critical values and number of iterations of two level test
+    stat_dict = {'alpha2': 0.05, 'n_runs': 20}
+
+    def testStatistics(self):
+        for fan in ['in', 'out']:
+            expected = hf.get_expected_degrees_bernoulli(
+                self.p, fan, self.N_s, self.N_t)
+
+            pvalues = []
+            for i in range(self.stat_dict['n_runs']):
+                hf.reset_seed(i, self.nr_threads)
+                self.setUpNetwork(conn_dict=self.conn_dict,
+                                  N1=self.N_s, N2=self.N_t)
+                degrees = hf.get_degrees(fan, self.pop1, self.pop2)
+                degrees = hf.gather_data(degrees)
+                # degrees = self.comm.gather(degrees, root=0)
+                # if self.rank == 0:
+                if degrees is not None:
+                    chi, p = hf.chi_squared_check(degrees, expected, self.rule)
+                    pvalues.append(p)
+                hf.mpi_barrier()
+            if degrees is not None:
+                ks, p = scipy.stats.kstest(pvalues, 'uniform')
+                self.assertTrue(p > self.stat_dict['alpha2'])
+
+    def testAutapses(self):
+        conn_params = self.conn_dict.copy()
+        conn_params['autapses'] = True
+        N = 10
+
+        # test that autapses are not permitted
+        hf.nest.ResetKernel()
+        pop = hf.nest.Create('iaf_psc_alpha', N)
+        with self.assertRaises(hf.nest.NESTError):
+            hf.nest.Connect(pop, pop, conn_params)
+
+        # test that autapses were excluded
+        conn_params['p'] = 1. - 1. / N
+        conn_params['autapses'] = False
+        hf.nest.ResetKernel()
+        pop = hf.nest.Create('iaf_psc_alpha', N)
+        hf.nest.Connect(pop, pop, conn_params)
+        M = hf.get_connectivity_matrix(pop, pop)
+        hf.mpi_assert(np.diag(M), np.zeros(N), self)
+
+    def testMultapses(self):
+        conn_params = self.conn_dict.copy()
+        conn_params['multapses'] = False
+        N = 10
+
+        # test that multapses must be permitted
+        hf.nest.ResetKernel()
+        pop = hf.nest.Create('iaf_psc_alpha', N)
+        with self.assertRaises(hf.nest.NESTError):
+            hf.nest.Connect(pop, pop, conn_params)
+
+        # test that multapses can only arise from symmetric
+        # connectivity
+        conn_params['p'] = 1. - 1. / N
+        conn_params['multapses'] = True
+        hf.nest.ResetKernel()
+        pop = hf.nest.Create('iaf_psc_alpha', N)
+        hf.nest.Connect(pop, pop, conn_params)
+
+        conn_dict = collections.defaultdict(int)
+        for conn in hf.nest.GetConnections():
+            key = tuple(conn[:2])
+            conn_dict[key] += 1
+            self.assertTrue(conn_dict[key] <= 2)
+
+    def testMakeSymmetric(self):
+        conn_params = self.conn_dict.copy()
+        N = 100
+
+        # test that make_symmetric must be enabled
+        conn_params['make_symmetric'] = False
+        hf.nest.ResetKernel()
+        pop = hf.nest.Create('iaf_psc_alpha', N)
+        with self.assertRaises(hf.nest.NESTError):
+            hf.nest.Connect(pop, pop, conn_params)
+
+        # test that all connections are symmetric
+        conn_params['make_symmetric'] = True
+        hf.nest.ResetKernel()
+        pop = hf.nest.Create('iaf_psc_alpha', N)
+        hf.nest.Connect(pop, pop, conn_params)
+
+        conns = set()
+        for conn in hf.nest.GetConnections():
+            key = tuple(conn[:2])
+            conns.add(key)
+
+        for conn in hf.nest.GetConnections():
+            key = tuple(conn[:2])
+            self.assertTrue(key[::-1] in conns)
+
+
+def suite():
+    suite = unittest.TestLoader().loadTestsFromTestCase(
+        TestSymmetricPairwiseBernoulli)
+    return suite
+
+
+def run():
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
This adds a new connector based on BernoulliConnector, which creates symmetric connections between nodes with a fixed probability p. However, instead of iterating over sources for each target and creating a connection with probability p, this connector draws a random indegree for each target and then selects number indegree many random sources. To make sure connections are created symmetrically also in the distributed case, identical indegrees and sources need to be drawn on each virtual process. To achieve this, the connector uses the global rng to seed a local rng on each virtual process with the same seed.

As reviewers I recommend @heplesser, @janhahne and @hannahbos 