### PR TITLE
Add balanced random network example using evolution strategies

### DIFF
--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -1,0 +1,531 @@
+# -*- coding: utf-8 -*-
+#
+# brunel_alpha_evolution_strategies.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+'''Using evolution strategies to find parameters for a random
+balanced network with alpha synapses
+----------------------------------------------------------------
+
+This script finds the appropiate parameter values for the external
+drive "eta" and the relative ratio of excitation and inhibition "g"
+for a balanced random network that lead to particular
+population-averaged rates, coefficients of variation and correlations.
+
+The network contains an excitatory and an inhibitory population on
+the basis of the network used in
+
+Brunel N, Dynamics of Sparsely Connected Networks of Excitatory and
+Inhibitory Spiking Neurons, Journal of Computational Neuroscience 8,
+183-208 (2000).
+
+The optimization algorithm (evolution strategies) is described in
+
+Wierstra et al. (2014). Natural evolution strategies. Journal of
+Machine Learning Research, 15(1), 949-980.
+
+Author: Jakob Jordan, based in brunel_alpha_nest.py
+Year: 2018
+
+'''
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import Ellipse
+import numpy as np
+
+import nest
+
+from numpy import exp
+
+
+'''
+Analysis
+'''
+
+
+def cut_warmup_time(spikes, warmup_time):
+    '''Removes initial warmup time from recorded spikes'''
+    spikes['senders'] = spikes['senders'][
+        spikes['times'] > warmup_time]
+    spikes['times'] = spikes['times'][
+        spikes['times'] > warmup_time]
+
+    return spikes
+
+
+def compute_rate(spikes, N_rec, sim_time):
+    '''Computes average rate from recorded spikes'''
+    return (1. * len(spikes['times']) / N_rec / sim_time * 1e3)
+
+
+def sort_spikes(spikes):
+    '''Sorts recorded spikes by gid'''
+    unique_gids = sorted(np.unique(spikes['senders']))
+    spiketrains = []
+    for gid in unique_gids:
+        spiketrains.append(spikes['times'][spikes['senders'] == gid])
+    return unique_gids, spiketrains
+
+
+def compute_cv(spiketrains):
+    '''Computes coefficient of variation from sorted spikes'''
+    if spiketrains:
+        isis = np.hstack([np.diff(st) for st in spiketrains])
+        if len(isis) > 1:
+            return np.std(isis) / np.mean(isis)
+        else:
+            return 0.
+    else:
+        return 0.
+
+
+def bin_spiketrains(spiketrains, t_min, t_max, t_bin):
+    '''Bins sorted spikes'''
+    bins = np.arange(t_min, t_max, t_bin)
+    return bins, [np.histogram(s, bins=bins)[0] for s in spiketrains]
+
+
+def compute_correlations(binned_spiketrains):
+    '''Computes correlations from binned spiketrains'''
+    n = len(binned_spiketrains)
+    if n > 1:
+        cc = np.corrcoef(binned_spiketrains)
+        return 1. / (n * (n - 1.)) * (np.sum(cc) - n)
+    else:
+        return 0.
+
+
+def compute_statistics(parameters, espikes, ispikes):
+    '''Computes population-averaged rates coefficients of variation and
+    correlations from recorded spikes of excitatory and inhibitory
+    population
+
+    '''
+
+    espikes = cut_warmup_time(espikes, parameters['warmup_time'])
+    ispikes = cut_warmup_time(ispikes, parameters['warmup_time'])
+
+    erate = compute_rate(espikes, parameters['N_rec'], parameters['sim_time'])
+    irate = compute_rate(espikes, parameters['N_rec'], parameters['sim_time'])
+
+    egids, espiketrains = sort_spikes(espikes)
+    igids, ispiketrains = sort_spikes(ispikes)
+
+    ecv = compute_cv(espiketrains)
+    icv = compute_cv(ispiketrains)
+
+    ecorr = compute_correlations(
+        bin_spiketrains(espiketrains, 0., parameters['sim_time'], 1.)[1])
+    icorr = compute_correlations(
+        bin_spiketrains(ispiketrains, 0., parameters['sim_time'], 1.)[1])
+
+    return (np.mean([erate, irate]),
+            np.mean([ecv, icv]),
+            np.mean([ecorr, icorr]))
+
+
+'''
+Network simulation
+'''
+
+
+def simulate(parameters):
+    '''Simulates the network and returns recorded spikes for excitatory
+    and inhibitory population
+
+    Code taken from brunel_alpha_nest.py
+
+    '''
+
+    def LambertWm1(x):
+        nest.sli_push(x)
+        nest.sli_run('LambertWm1')
+        y = nest.sli_pop()
+        return y
+
+    def ComputePSPnorm(tauMem, CMem, tauSyn):
+        a = (tauMem / tauSyn)
+        b = (1.0 / tauSyn - 1.0 / tauMem)
+
+        # time of maximum
+        t_max = 1.0 / b * (-LambertWm1(-exp(-1.0 / a) / a) - 1.0 / a)
+
+        # maximum of PSP for current of unit amplitude
+        return (exp(1.0) / (tauSyn * CMem * b) *
+                ((exp(-t_max / tauMem) - exp(-t_max / tauSyn)) / b -
+                 t_max * exp(-t_max / tauSyn)))
+
+    # number of excitatory neurons
+    NE = int(parameters['gamma'] * parameters['N'])
+    # number of inhibitory neurons
+    NI = parameters['N'] - NE
+
+    CE = int(parameters['epsilon'] * NE)  # number of excitatory
+                                          # synapses per neuron
+    CI = int(parameters['epsilon'] * NI)  # number of inhibitory
+                                          # synapses per neuron
+
+    tauSyn = 0.5  # synaptic time constant in ms
+    tauMem = 20.0  # time constant of membrane potential in ms
+    CMem = 250.0  # capacitance of membrane in in pF
+    theta = 20.0  # membrane threshold potential in mV
+    neuron_parameters = {
+        'C_m': CMem,
+        'tau_m': tauMem,
+        'tau_syn_ex': tauSyn,
+        'tau_syn_in': tauSyn,
+        't_ref': 2.0,
+        'E_L': 0.0,
+        'V_reset': 0.0,
+        'V_m': 0.0,
+        'V_th': theta
+    }
+    J = 0.1        # postsynaptic amplitude in mV
+    J_unit = ComputePSPnorm(tauMem, CMem, tauSyn)
+    J_ex = J / J_unit  # amplitude of excitatory postsynaptic current
+    J_in = -parameters['g'] * J_ex  # amplitude of inhibitory
+                                    # postsynaptic current
+
+    nu_th = (theta * CMem) / (J_ex * CE * exp(1) * tauMem * tauSyn)
+    nu_ex = parameters['eta'] * nu_th
+    p_rate = 1000.0 * nu_ex * CE
+
+    nest.ResetKernel()
+    nest.set_verbosity('M_FATAL')
+
+    nest.SetKernelStatus({'rng_seeds': [parameters['seed']],
+                          'resolution': parameters['dt']})
+
+    nest.SetDefaults('iaf_psc_alpha', neuron_parameters)
+    nest.SetDefaults('poisson_generator', {'rate': p_rate})
+
+    nodes_ex = nest.Create('iaf_psc_alpha', NE)
+    nodes_in = nest.Create('iaf_psc_alpha', NI)
+    noise = nest.Create('poisson_generator')
+    espikes = nest.Create('spike_detector')
+    ispikes = nest.Create('spike_detector')
+
+    nest.SetStatus(espikes, [{'label': 'brunel-py-ex',
+                              'withtime': True,
+                              'withgid': True,
+                              'to_file': False}])
+
+    nest.SetStatus(ispikes, [{'label': 'brunel-py-in',
+                              'withtime': True,
+                              'withgid': True,
+                              'to_file': False}])
+
+    nest.CopyModel('static_synapse', 'excitatory',
+                   {'weight': J_ex, 'delay': parameters['delay']})
+    nest.CopyModel('static_synapse', 'inhibitory',
+                   {'weight': J_in, 'delay': parameters['delay']})
+
+    nest.Connect(noise, nodes_ex, syn_spec='excitatory')
+    nest.Connect(noise, nodes_in, syn_spec='excitatory')
+
+    if parameters['N_rec'] > NE:
+        raise ValueError(
+            'Requested recording from {} neurons, but only {} in excitatory population'.format(parameters['N_rec'], NE))
+    if parameters['N_rec'] > NI:
+        raise ValueError(
+            'Requested recording from {} neurons, but only {} in inhibitory population'.format(parameters['N_rec'], NI))
+    nest.Connect(nodes_ex[:parameters['N_rec']], espikes)
+    nest.Connect(nodes_in[:parameters['N_rec']], ispikes)
+
+    conn_parameters_ex = {'rule': 'fixed_indegree', 'indegree': CE}
+    nest.Connect(
+        nodes_ex, nodes_ex + nodes_in, conn_parameters_ex, 'excitatory')
+
+    conn_parameters_in = {'rule': 'fixed_indegree', 'indegree': CI}
+    nest.Connect(
+        nodes_in, nodes_ex + nodes_in, conn_parameters_in, 'inhibitory')
+
+    nest.Simulate(parameters['sim_time'])
+
+    return (nest.GetStatus(espikes, 'events')[0],
+            nest.GetStatus(ispikes, 'events')[0])
+
+
+'''
+Optimization
+'''
+
+
+def default_population_size(dimensions):
+    '''Returns a population size suited for the given number of dimensions
+    See Wierstra et al. (2014)
+
+    '''
+    return 4 + int(np.floor(3 * np.log(dimensions)))
+
+
+def default_learning_rate_mu():
+    '''Returns a default learning rate for mean of search distribution
+    See Wierstra et al. (2014)
+
+    '''
+    return 1
+
+
+def default_learning_rate_sigma(dimensions):
+    '''Returns a default learning rate for standard deviation of search
+    distribution for the given number of dimensions
+    See Wierstra et al. (2014)
+
+    '''
+    return (3 + np.log(dimensions)) / (12. * np.sqrt(dimensions))
+
+
+def compute_utility(fitness):
+    '''Computes utility and order used for fitness shaping
+    See Wierstra et al. (2014)
+
+    '''
+
+    n = len(fitness)
+    order = np.argsort(fitness)[::-1]
+    fitness = fitness[order]
+
+    utility = [
+        np.max([0, np.log((n / 2) + 1)]) - np.log(k + 1) for k in range(n)]
+    utility = utility / np.sum(utility) - 1. / n
+
+    return order, utility
+
+
+def optimize(func, mu, sigma, learning_rate_mu=None, learning_rate_sigma=None,
+             population_size=None, fitness_shaping=True,
+             mirrored_sampling=True, record_history=False,
+             max_generations=2000, min_sigma=1e-8, verbosity=0):
+    '''Optimizes an objective function via evolution strategies using
+    the natural gradient of multinormal search distributions in
+    natural coordinates.  Does not consider covariances between
+    parameters ("Separable natural evolution strategies").
+    See Wierstra et al. (2014)
+
+    '''
+
+    if not isinstance(mu, np.ndarray):
+        raise TypeError('mu needs to be of type np.ndarray')
+    if not isinstance(sigma, np.ndarray):
+        raise TypeError('sigma needs to be of type np.ndarray')
+
+    if learning_rate_mu is None:
+        learning_rate_mu = default_learning_rate_mu()
+    if learning_rate_sigma is None:
+        learning_rate_sigma = default_learning_rate_sigma(mu.size)
+    if population_size is None:
+        population_size = default_population_size(mu.size)
+
+    generation = 0
+    mu_history = []
+    sigma_history = []
+    pop_history = []
+    fitness_history = []
+
+    while True:
+
+        # create new population using the search distribution
+        s = np.random.normal(0, 1, size=(population_size, *np.shape(mu)))
+        z = mu + sigma * s
+
+        # add mirrored perturbations if enabled
+        if mirrored_sampling:
+            z = np.vstack([z, mu - sigma * s])
+            s = np.vstack([s, -s])
+
+        # evaluate fitness for every individual in population
+        fitness = np.fromiter((func(*zi) for zi in z), np.float)
+
+        # print status if enabled
+        if verbosity > 0:
+            print('# Generation {:d} | fitness {:.3f} | mu {} | sigma {}'.format(
+                generation, np.mean(fitness),
+                ', '.join(str(np.round(mu_i, 3)) for mu_i in mu),
+                ', '.join(str(np.round(sigma_i, 3)) for sigma_i in sigma)
+            ))
+
+        # apply fitness shaping if enabled
+        if fitness_shaping:
+            order, utility = compute_utility(fitness)
+            s = s[order]
+            z = z[order]
+        else:
+            utility = fitness
+
+        # bookkeeping
+        if record_history:
+            mu_history.append(mu.copy())
+            sigma_history.append(sigma.copy())
+            pop_history.append(z.copy())
+            fitness_history.append(fitness)
+
+        # exit if max generations reached or search distributions are
+        # very narrow
+        if generation == max_generations or np.all(sigma < min_sigma):
+            break
+
+        # update parameter of search distribution via natural gradient
+        # descent in natural coordinates
+        mu += learning_rate_mu * sigma * np.dot(utility, s)
+        sigma *= np.exp(learning_rate_sigma / 2. * np.dot(utility, s**2 - 1))
+
+        generation += 1
+
+    return {
+        'mu': mu,
+        'sigma': sigma,
+        'fitness_history': np.array(fitness_history),
+        'mu_history': np.array(mu_history),
+        'sigma_history': np.array(sigma_history),
+        'pop_history': np.array(pop_history)
+    }
+
+
+def optimize_network(optimization_parameters, simulation_parameters):
+    '''Searches for suitable network parameters to fulfill defined
+    constraints
+
+    '''
+
+    np.random.seed(simulation_parameters['seed'])
+
+    def objective_function(g, eta):
+        '''Returns the fitness of a specific network parametrization'''
+
+        # create local copy of parameters that uses parameters given
+        # by optimization algorithm
+        simulation_parameters_local = simulation_parameters.copy()
+        simulation_parameters_local['g'] = g
+        simulation_parameters_local['eta'] = eta
+
+        # perform the network simulation
+        espikes, ispikes = simulate(simulation_parameters_local)
+
+        # analyse the result and compute fitness
+        rate, cv, corr = compute_statistics(
+            simulation_parameters, espikes, ispikes)
+        fitness = - optimization_parameters['fitness_weight_rate'] * (
+                rate - optimization_parameters['target_rate']) ** 2 \
+            - optimization_parameters['fitness_weight_cv'] * (
+                cv - optimization_parameters['target_cv']) ** 2 \
+            - optimization_parameters['fitness_weight_corr'] * (
+                corr - optimization_parameters['target_corr']) ** 2
+
+        return fitness
+
+    return optimize(
+        objective_function,
+        np.array(optimization_parameters['mu']),
+        np.array(optimization_parameters['sigma']),
+        max_generations=optimization_parameters['max_generations'],
+        record_history=True,
+        verbosity=optimization_parameters['verbosity']
+    )
+
+
+'''
+Main
+'''
+
+if __name__ == '__main__':
+    simulation_parameters = {
+        'seed': 123,
+        'dt': 0.1,            # (ms) simulation resolution
+        'sim_time': 1000.,     # (ms) simulation duration
+        'warmup_time': 300.,  # (ms) duration ignored during analysis
+        'delay': 1.5,         # (ms) synaptic delay
+        'g': None,            # relative ratio of excitation and inhibition
+        'eta': None,          # relative strength of external drive
+        'epsilon': 0.1,       # average connectivity of network
+        'N': 400,             # number of neurons in network
+        'gamma': 0.8,         # relative size of excitatory and
+                              # inhibitory population
+        'N_rec': 40,          # number of neurons to record activity from
+    }
+
+    optimization_parameters = {
+        'verbosity': 1,             # print progress over generations
+        'max_generations': 20,      # maximal number of generations
+        'target_rate': 1.89,        # target rate in
+        'target_corr': 0.0,         # target correlation
+        'target_cv': 1.,            # target coefficient of variation
+        'mu': [1., 3.],             # initial mean for search distribution
+                                    # (mu(g), mu(eta))
+        'sigma': [0.15, 0.05],      # initial sigma for search
+                                    # distribution (sigma(g), sigma(eta))
+
+        # hyperparameters of the fitness function
+        'fitness_weight_rate': 1.,  # relative weight of rate deviation
+        'fitness_weight_cv': 10.,    # relative weight of cv deviation
+        'fitness_weight_corr': 100.,  # relative weight of corr deviation
+    }
+
+    # optimize network parameters
+    optimization_result = optimize_network(optimization_parameters,
+                                           simulation_parameters)
+
+    simulation_parameters['g'] = optimization_result['mu'][0]
+    simulation_parameters['eta'] = optimization_result['mu'][1]
+
+    espikes, ispikes = simulate(simulation_parameters)
+
+    rate, cv, corr = compute_statistics(
+        simulation_parameters, espikes, ispikes)
+    print('Statistics after optimization:', end=' ')
+    print('Rate: {:.3f}, cv: {:.3f}, correlation: {:.3f}'.format(
+        rate, cv, corr))
+
+    # plot results
+    fig = plt.figure(figsize=(10, 4))
+    ax1 = fig.add_axes([0.06, 0.12, 0.25, 0.8])
+    ax2 = fig.add_axes([0.4, 0.12, 0.25, 0.8])
+    ax3 = fig.add_axes([0.74, 0.12, 0.25, 0.8])
+
+    ax1.set_xlabel('Time (ms)')
+    ax1.set_ylabel('Neuron id')
+
+    ax2.set_xlabel(r'Relative strength of inhibition $g$')
+    ax2.set_ylabel(r'Relative strength of external drive $\eta$')
+
+    ax3.set_xlabel('Generation')
+    ax3.set_ylabel('Fitness')
+
+    # raster plot
+    ax1.plot(espikes['times'], espikes['senders'], ls='', marker='.')
+
+    # search distributions and individuals
+    for mu, sigma in zip(optimization_result['mu_history'],
+                         optimization_result['sigma_history']):
+        ellipse = Ellipse(
+            xy=mu, width=2*sigma[0], height=2*sigma[1], alpha=0.5, fc='k')
+        ellipse.set_clip_box(ax2.bbox)
+        ax2.add_artist(ellipse)
+    ax2.plot(optimization_result['mu_history'][:, 0],
+             optimization_result['mu_history'][:, 1],
+             marker='.', color='k', alpha=0.5)
+    for generation in optimization_result['pop_history']:
+        ax2.scatter(generation[:, 0], generation[:, 1])
+
+    # fitness over generations
+    ax3.errorbar(np.arange(len(optimization_result['fitness_history'])),
+                 np.mean(optimization_result['fitness_history'], axis=1),
+                 yerr=np.std(optimization_result['fitness_history'], axis=1))
+
+    fig.savefig('brunel_alpha_evolution_strategies.pdf')

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -23,22 +23,23 @@
 balanced network with alpha synapses
 ----------------------------------------------------------------
 
-This script uses an optimization algorithm to find the appropiate
+This script uses an optimization algorithm to find the appropriate
 parameter values for the external drive "eta" and the relative ratio
 of excitation and inhibition "g" for a balanced random network that
 lead to particular population-averaged rates, coefficients of
 variation and correlations.
 
 From an initial Gaussian search distribution parameterized with mean
-and standard deviation, individuals, i.e., networks are sampled. These
-networks are simulated and evaluated according to an objective
-function that measures how close the activity statistics are to their
-desired values (~fitness). From these fitness values the approximate
-natural gradient of the fitness landscape is computed and used to
-update the parameters of the search distribution. This procedure is
-repeated until the maximal number of function evaluations is reached
-or the width of the search distribution becomes extremely small.
-We use the following fitness function:
+and standard deviation network parameters are sampled. Network
+realizations of these parameters are simulated and evaluated according
+to an objective function that measures how close the activity
+statistics are to their desired values (~fitness). From these fitness
+values the approximate natural gradient of the fitness landscape is
+computed and used to update the parameters of the search
+distribution. This procedure is repeated until the maximal number of
+function evaluations is reached or the width of the search
+distribution becomes extremely small.  We use the following fitness
+function:
 
  f = - alpha(r - r*)^2 - beta(cv - cv*)^2 - gamma(corr - corr*)^2
 
@@ -48,17 +49,18 @@ target values.
 The network contains an excitatory and an inhibitory population on
 the basis of the network used in
 
-Brunel N, Dynamics of Sparsely Connected Networks of Excitatory and
-Inhibitory Spiking Neurons, Journal of Computational Neuroscience 8,
-183-208 (2000).
+Brunel N (2000). Dynamics of Sparsely Connected Networks of Excitatory
+and Inhibitory Spiking Neurons. Journal of Computational Neuroscience
+8, 183-208.
 
 The optimization algorithm (evolution strategies) is described in
 
 Wierstra et al. (2014). Natural evolution strategies. Journal of
 Machine Learning Research, 15(1), 949-980.
 
-Author: Jakob Jordan, based on brunel_alpha_nest.py
+Author: Jakob Jordan
 Year: 2018
+See Also: brunel_alpha_nest.py
 
 '''
 
@@ -131,7 +133,7 @@ def compute_correlations(binned_spiketrains):
 def compute_statistics(parameters, espikes, ispikes):
     '''Computes population-averaged rates coefficients of variation and
     correlations from recorded spikes of excitatory and inhibitory
-    population
+    populations
 
     '''
 
@@ -193,10 +195,10 @@ def simulate(parameters):
     # number of inhibitory neurons
     NI = parameters['N'] - NE
 
-    CE = int(parameters['epsilon'] * NE)  # number of excitatory
-                                          # synapses per neuron
-    CI = int(parameters['epsilon'] * NI)  # number of inhibitory
-                                          # synapses per neuron
+    # number of excitatory synapses per neuron
+    CE = int(parameters['epsilon'] * NE)
+    # number of inhibitory synapses per neuron
+    CI = int(parameters['epsilon'] * NI)
 
     tauSyn = 0.5  # synaptic time constant in ms
     tauMem = 20.0  # time constant of membrane potential in ms
@@ -216,8 +218,8 @@ def simulate(parameters):
     J = 0.1        # postsynaptic amplitude in mV
     J_unit = ComputePSPnorm(tauMem, CMem, tauSyn)
     J_ex = J / J_unit  # amplitude of excitatory postsynaptic current
-    J_in = -parameters['g'] * J_ex  # amplitude of inhibitory
-                                    # postsynaptic current
+    # amplitude of inhibitory postsynaptic current
+    J_in = -parameters['g'] * J_ex
 
     nu_th = (theta * CMem) / (J_ex * CE * exp(1) * tauMem * tauSyn)
     nu_ex = parameters['eta'] * nu_th
@@ -258,10 +260,14 @@ def simulate(parameters):
 
     if parameters['N_rec'] > NE:
         raise ValueError(
-            'Requested recording from {} neurons, but only {} in excitatory population'.format(parameters['N_rec'], NE))
+            'Requested recording from {} neurons, \
+            but only {} in excitatory population'.format(
+                parameters['N_rec'], NE))
     if parameters['N_rec'] > NI:
         raise ValueError(
-            'Requested recording from {} neurons, but only {} in inhibitory population'.format(parameters['N_rec'], NI))
+            'Requested recording from {} neurons, \
+            but only {} in inhibitory population'.format(
+                parameters['N_rec'], NI))
     nest.Connect(nodes_ex[:parameters['N_rec']], espikes)
     nest.Connect(nodes_in[:parameters['N_rec']], ispikes)
 
@@ -293,7 +299,8 @@ def default_population_size(dimensions):
 
 
 def default_learning_rate_mu():
-    '''Returns a default learning rate for mean of search distribution
+    '''Returns a default learning rate for the mean of the search
+    distribution
     See Wierstra et al. (2014)
 
     '''
@@ -301,8 +308,8 @@ def default_learning_rate_mu():
 
 
 def default_learning_rate_sigma(dimensions):
-    '''Returns a default learning rate for standard deviation of search
-    distribution for the given number of dimensions
+    '''Returns a default learning rate for the standard deviation of the
+    search distribution for the given number of dimensions
     See Wierstra et al. (2014)
 
     '''
@@ -357,7 +364,7 @@ def optimize(func, mu, sigma, learning_rate_mu=None, learning_rate_sigma=None,
         Whether to use mirrored sampling, i.e., evaluating a mirrored
         sample for each sample, see Wierstra et al. (2014).
     record_history: bool
-        Whether to record history of searhc distribution parameters,
+        Whether to record history of search distribution parameters,
         fitness values and individuals.
     max_generations: int
         Maximal number of generations.
@@ -366,7 +373,7 @@ def optimize(func, mu, sigma, learning_rate_mu=None, learning_rate_sigma=None,
         distribution. If any dimension has a value smaller than this,
         the search is stoppped.
     verbosity: bool
-        Whether to continously print progress information.
+        Whether to continuously print progress information.
 
     Returns
     -------
@@ -410,11 +417,12 @@ def optimize(func, mu, sigma, learning_rate_mu=None, learning_rate_sigma=None,
 
         # print status if enabled
         if verbosity > 0:
-            print('# Generation {:d} | fitness {:.3f} | mu {} | sigma {}'.format(
-                generation, np.mean(fitness),
-                ', '.join(str(np.round(mu_i, 3)) for mu_i in mu),
-                ', '.join(str(np.round(sigma_i, 3)) for sigma_i in sigma)
-            ))
+            print(
+                '# Generation {:d} | fitness {:.3f} | mu {} | sigma {}'.format(
+                    generation, np.mean(fitness),
+                    ', '.join(str(np.round(mu_i, 3)) for mu_i in mu),
+                    ', '.join(str(np.round(sigma_i, 3)) for sigma_i in sigma)
+                ))
 
         # apply fitness shaping if enabled
         if fitness_shaping:

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -519,7 +519,7 @@ if __name__ == '__main__':
     optimization_parameters = {
         'verbosity': 1,             # print progress over generations
         'max_generations': 20,      # maximal number of generations
-        'target_rate': 1.89,        # (Hz) target rate
+        'target_rate': 1.89,        # (spikes/s) target rate
         'target_corr': 0.0,         # target correlation
         'target_cv': 1.,            # target coefficient of variation
         'mu': [1., 3.],             # initial mean for search distribution


### PR DESCRIPTION
This new example builds on the balanced random network example (brunel_alpha_nest.py) to demonstrate how to use evolution strategies to tune the parameters of a network model to optimize a given fitness function. Here we optimize the network to have certain rates, coefficients of variation and correlations.

Note that this is not an implementation striving for maximum performance, but for maximum clarity. For example, it does not make use of multi threading. Nevertheless I believe it is useful to demonstrate how to use standard optimization techniques to optimize network parameters.

The following shows an optimization of the network for 40 generations, to have the following activity statistics: Rate: 1.89, cv: 1, correlation: 0

The fitness grew from -5340 to -2.3, achieving the following activity statistics:
Rate: 1.775, cv: 0.541, correlation: 0.001

The full output reads:

```bash
# Generation 0 | fitness -5340.949 | mu 1.0, 3.0 | sigma 0.15, 0.05
# Generation 1 | fitness -4847.064 | mu 1.246, 2.876 | sigma 0.138, 0.054
# Generation 2 | fitness -4361.933 | mu 1.085, 2.714 | sigma 0.154, 0.062
# Generation 3 | fitness -3698.488 | mu 1.091, 2.511 | sigma 0.146, 0.077
# Generation 4 | fitness -3252.178 | mu 1.047, 2.363 | sigma 0.136, 0.084
# Generation 5 | fitness -2463.288 | mu 0.908, 2.086 | sigma 0.131, 0.095
# Generation 6 | fitness -1953.073 | mu 0.988, 1.905 | sigma 0.128, 0.099
# Generation 7 | fitness -1343.387 | mu 1.106, 1.668 | sigma 0.128, 0.106
# Generation 8 | fitness -797.923 | mu 1.168, 1.418 | sigma 0.126, 0.109
# Generation 9 | fitness -134.683 | mu 1.125, 0.985 | sigma 0.126, 0.132
# Generation 10 | fitness -13.572 | mu 1.3, 0.682 | sigma 0.121, 0.126
# Generation 11 | fitness -20.315 | mu 1.264, 0.772 | sigma 0.123, 0.13
# Generation 12 | fitness -12.487 | mu 1.174, 0.662 | sigma 0.13, 0.123
# Generation 13 | fitness -28.238 | mu 1.339, 0.86 | sigma 0.139, 0.149
# Generation 14 | fitness -18.507 | mu 1.369, 0.798 | sigma 0.139, 0.138
# Generation 15 | fitness -40.784 | mu 1.373, 0.798 | sigma 0.134, 0.135
# Generation 16 | fitness -35.668 | mu 1.326, 0.847 | sigma 0.134, 0.1
# Generation 17 | fitness -26.581 | mu 1.405, 0.917 | sigma 0.149, 0.061
# Generation 18 | fitness -9.337 | mu 1.387, 0.855 | sigma 0.146, 0.051
# Generation 19 | fitness -7.494 | mu 1.613, 0.918 | sigma 0.148, 0.047
# Generation 20 | fitness -11.334 | mu 1.85, 0.885 | sigma 0.14, 0.047
# Generation 21 | fitness -13.297 | mu 1.857, 0.901 | sigma 0.134, 0.036
# Generation 22 | fitness -3.587 | mu 1.833, 0.887 | sigma 0.137, 0.021
# Generation 23 | fitness -5.279 | mu 1.982, 0.909 | sigma 0.137, 0.02
# Generation 24 | fitness -4.934 | mu 1.889, 0.875 | sigma 0.125, 0.018
# Generation 25 | fitness -3.631 | mu 1.737, 0.902 | sigma 0.118, 0.018
# Generation 26 | fitness -3.467 | mu 1.798, 0.888 | sigma 0.116, 0.017
# Generation 27 | fitness -4.857 | mu 1.781, 0.914 | sigma 0.115, 0.015
# Generation 28 | fitness -2.630 | mu 1.759, 0.896 | sigma 0.115, 0.014
# Generation 29 | fitness -3.812 | mu 1.656, 0.901 | sigma 0.126, 0.013
# Generation 30 | fitness -2.319 | mu 1.575, 0.893 | sigma 0.115, 0.009
# Generation 31 | fitness -2.536 | mu 1.583, 0.903 | sigma 0.102, 0.009
# Generation 32 | fitness -2.631 | mu 1.64, 0.889 | sigma 0.106, 0.009
# Generation 33 | fitness -2.485 | mu 1.725, 0.903 | sigma 0.104, 0.009
# Generation 34 | fitness -2.840 | mu 1.693, 0.893 | sigma 0.12, 0.008                         
# Generation 35 | fitness -2.423 | mu 1.68, 0.902 | sigma 0.115, 0.006                                                               
# Generation 36 | fitness -2.773 | mu 1.699, 0.888 | sigma 0.11, 0.005                                                                                        
# Generation 37 | fitness -2.069 | mu 1.731, 0.901 | sigma 0.104, 0.006                                                                                 
# Generation 38 | fitness -2.217 | mu 1.704, 0.896 | sigma 0.11, 0.006                                                                                        
# Generation 39 | fitness -2.132 | mu 1.821, 0.9 | sigma 0.138, 0.005                                                                                         
# Generation 40 | fitness -2.347 | mu 1.69, 0.892 | sigma 0.121, 0.004                                                                                          
Statistics after optimization: Rate: 1.775, cv: 0.541, correlation: 0.001
```

The script generates the following plot, illustrating the search and activity in the final network:
![brunel_alpha_evolution_strategies](https://user-images.githubusercontent.com/1562742/34984199-6173b1f8-fab0-11e7-8373-dddcb1baafe6.png)

I suggest @sdiazpier and @jessica-mitchell as reviewers