### PR TITLE
Fix incorrect error message when connecting with bad delay

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -180,6 +180,11 @@ nest::ConnectionManager::set_status( const DictionaryDatum& d )
   {
     delay_checkers_[ i ].set_status( d );
   }
+  //  Need to update the saved values if we have changed the delay bounds.
+  if ( d->known( names::min_delay ) or d->known( names::max_delay ) )
+  {
+    update_delay_extrema_();
+  }
 }
 
 nest::DelayChecker&


### PR DESCRIPTION
This PR fixes #287 by updating the saved values of the delay bounds if the delay bounds are updated. 