### PR TITLE
Issue error message when attempting to set an invalid resolution

### DIFF
--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -134,6 +134,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
     updateValue< double >( d, names::tics_per_ms, tics_per_ms );
   double resd = 0.0;
   bool res_updated = updateValue< double >( d, names::resolution, resd );
+  double integer_part; // Dummy variable to be used with std::modf().
 
   if ( tics_per_ms_updated || res_updated )
   {
@@ -173,6 +174,13 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
+      else if ( std::modf( resd * tics_per_ms, &integer_part ) != 0 )
+      {
+        LOG( M_ERROR,
+          "SimulationManager::set_status",
+          "Resolution must be a multiple of the tic length. Value unchanged." );
+        throw KernelException();
+      }
       else
       {
         nest::Time::set_resolution( tics_per_ms, resd );
@@ -203,6 +211,13 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "SimulationManager::set_status",
           "Resolution must be greater than or equal to one tic. Value "
           "unchanged." );
+        throw KernelException();
+      }
+      else if ( std::modf( resd / Time::get_ms_per_tic(), &integer_part ) != 0 )
+      {
+        LOG( M_ERROR,
+          "SimulationManager::set_status",
+          "Resolution must be a multiple of the tic length. Value unchanged." );
         throw KernelException();
       }
       else

--- a/testsuite/regressiontests/issue-888.sli
+++ b/testsuite/regressiontests/issue-888.sli
@@ -1,0 +1,47 @@
+/*
+ *  issue-888.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* BeginDocumentation
+
+Name: testsuite::issue-888 Ensure that the resolution is set as a multiple of tics.
+
+Synopsis: (issue-888) run -> NEST exits if test fails
+
+Author: Håkon Mørk, 2018-03-05
+ */
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+% Only setting resolution.
+{
+  ResetKernel
+  0 << /resolution 0.03125 >> SetStatus
+} fail_or_die
+
+% Setting both resolution and tics per ms.
+{
+  ResetKernel
+  0 << /tics_per_ms 1000. /resolution 0.03125 >> SetStatus
+} fail_or_die


### PR DESCRIPTION
Issues an error message when attempting to change the resolution to something which is not a multiple of the tic size.

Fixes #643.