### PR TITLE
Make sure that Run and Cleanup are called after Prepare

### DIFF
--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -379,6 +379,13 @@ nest::SimulationManager::prepare()
 {
   assert( kernel().is_initialized() );
 
+  if ( prepared_ )
+  {
+    std::string msg = "Prepare called twice.";
+    LOG( M_ERROR, "SimulationManager::prepare", msg );
+    throw KernelException();
+  }
+
   if ( inconsistent_state_ )
   {
     throw KernelException(

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -169,7 +169,8 @@ private:
   delay to_step_;         //!< update clock_+from_step<=T<clock_+to_step_
   timeval t_slice_begin_; //!< Wall-clock time at the begin of a time slice
   timeval t_slice_end_;   //!< Wall-clock time at the end of time slice
-  long t_real_;     //!< Accumunated wall-clock time spent simulating (in us)
+  long t_real_;   //!< Accumulated wall-clock time spent simulating (in us)
+  bool prepared_; //!< indicates whether the SimulationManager has already been
   bool simulating_; //!< true if simulation in progress
   bool simulated_; //!< indicates whether the SimulationManager has already been
                    //!< simulated for sometime

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -170,7 +170,8 @@ private:
   timeval t_slice_begin_; //!< Wall-clock time at the begin of a time slice
   timeval t_slice_end_;   //!< Wall-clock time at the end of time slice
   long t_real_;   //!< Accumulated wall-clock time spent simulating (in us)
-  bool prepared_; //!< indicates whether the SimulationManager has already been
+  bool prepared_; //!< Indicates whether the SimulationManager is in a prepared
+                  //!< state
   bool simulating_; //!< true if simulation in progress
   bool simulated_; //!< indicates whether the SimulationManager has already been
                    //!< simulated for sometime

--- a/testsuite/regressiontests/issue-659.sli
+++ b/testsuite/regressiontests/issue-659.sli
@@ -47,6 +47,13 @@ M_ERROR setverbosity
 } fail_or_die
 
 {
+  % Prepare twice.
+  ResetKernel
+  Prepare
+  Prepare
+} fail_or_die
+
+{
   % Run after cleanup, without prepare.
   ResetKernel
   Prepare

--- a/testsuite/regressiontests/issue-659.sli
+++ b/testsuite/regressiontests/issue-659.sli
@@ -1,0 +1,57 @@
+/*
+ *  issue-659.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* BeginDocumentation
+
+Name: testsuite::issue-659 Check that we get an error if trying to call Run or Cleanup without calling Prepare first.
+
+Synopsis: (issue-659) run -> NEST exits if test fails
+
+Author: Håkon Mørk, 2018-03-07
+ */
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+  % Run without prepare.
+  ResetKernel
+  10 Run
+} fail_or_die
+
+{
+  % Cleanup without prepare.
+  ResetKernel
+  Cleanup
+} fail_or_die
+
+{
+  % Run after cleanup, without prepare.
+  ResetKernel
+  Prepare
+  10 Run
+  Cleanup
+  10 Run
+} fail_or_die
+


### PR DESCRIPTION
An error will now be raised if `Run()` or `Cleanup()` are called without calling `Prepare()` first.

This fixes #659.