### PR TITLE
Support linking against topology when building extension modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ set( ALL_LIBS
   "-lrandom"
   "-lsli"
   "-lnestkernel"
+  "-ltopology"
   "${OpenMP_CXX_FLAGS}"
   "${LTDL_LIBRARIES}"
   "${READLINE_LIBRARIES}"


### PR DESCRIPTION
This PR fixes #841 by adding topology to `ALL_LIBS`, the CMake variable listing all libraries against which to link when, e.g., building extension modules. 

I assume it worked on some systems because there linkers delayed look-up until runtime. Since topology was loaded on NEST startup, the necessary symbols are available when loading the module at runtime.

@TomBugnon Could you test if this fix solves your problem? 