### PR TITLE
Remove check target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,12 +202,6 @@ else ()
   )
 endif ()
 
-add_custom_target( check
-    COMMAND export CTEST_OUTPUT_ON_FAILURE=1 &&
-    ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE}
-    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
-    )
-
 ################################################################################
 ##################        Define Subdirectories here          ##################
 ################################################################################


### PR DESCRIPTION
This PR removes the `check` target for now, because its existence easily misleads users (see recent discussion on NEST User mailing list).