### PR TITLE
Fix issue 830 - Make fails with UnicodeDecodeError

### DIFF
--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -28,6 +28,7 @@ The helpindex is built during installation in a separate step.
 """
 
 import os
+import io
 import re
 import sys
 import textwrap
@@ -73,7 +74,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 # searching for a sli_command_list
 for file in allfiles:
     if file.endswith('.sli'):
-        f = open(file, encoding='utf-8')
+        f = io.open(file, encoding='utf-8')
         filetext = f.read()
         f.close()
         items = re.findall(dcs, filetext, re.DOTALL)
@@ -93,7 +94,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 for fname in allfiles:
     # .py is for future use
     if not fname.endswith('.py'):
-        f = open(fname, encoding='utf-8')
+        f = io.open(fname, encoding='utf-8')
         filetext = f.read()
         f.close()
         # Multiline matching to find codeblock

--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -73,7 +73,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 # searching for a sli_command_list
 for file in allfiles:
     if file.endswith('.sli'):
-        f = open(file, mode='r', encoding='utf-8')
+        f = open(file, encoding='utf-8')
         filetext = f.read()
         f.close()
         items = re.findall(dcs, filetext, re.DOTALL)
@@ -93,7 +93,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 for fname in allfiles:
     # .py is for future use
     if not fname.endswith('.py'):
-        f = open(fname, mode='r', encoding='utf-8')
+        f = open(fname, encoding='utf-8')
         filetext = f.read()
         f.close()
         # Multiline matching to find codeblock

--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -73,7 +73,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 # searching for a sli_command_list
 for file in allfiles:
     if file.endswith('.sli'):
-        f = open(file, 'r')
+        f = open(file, 'r', encoding='utf-8')
         filetext = f.read()
         f.close()
         items = re.findall(dcs, filetext, re.DOTALL)
@@ -93,7 +93,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 for fname in allfiles:
     # .py is for future use
     if not fname.endswith('.py'):
-        f = open(fname, 'r')
+        f = open(fname, 'r', encoding='utf-8')
         filetext = f.read()
         f.close()
         # Multiline matching to find codeblock

--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -73,7 +73,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 # searching for a sli_command_list
 for file in allfiles:
     if file.endswith('.sli'):
-        f = open(file, 'r', encoding='utf-8')
+        f = open(file, mode='r', encoding='utf-8')
         filetext = f.read()
         f.close()
         items = re.findall(dcs, filetext, re.DOTALL)
@@ -93,7 +93,7 @@ dcs = r'\/\*[\s?]*[\n?]*BeginDocumentation[\s?]*\:?[\s?]*[.?]*\n(.*?)\n*?\*\/'
 for fname in allfiles:
     # .py is for future use
     if not fname.endswith('.py'):
-        f = open(fname, 'r', encoding='utf-8')
+        f = open(fname, mode='r', encoding='utf-8')
         filetext = f.read()
         f.close()
         # Multiline matching to find codeblock

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -41,15 +41,15 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
     Write html for integration in NEST Help-System
     """
     # Loading Template for commands
-    ftemplate = open('templates/cmd.tpl.html', mode='r', encoding='utf-8')
+    ftemplate = open('templates/cmd.tpl.html', encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open('templates/nest.tpl.css', mode='r', encoding='utf-8')
+    cssf = open('templates/nest.tpl.css', encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open('templates/footer.tpl.html', mode='r', encoding='utf-8')
+    footerf = open('templates/footer.tpl.html', encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -157,17 +157,17 @@ def write_helpindex(helpdir):
     hlp_list = []
 
     # Loading Template for helpindex.html
-    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), mode='r',
+    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'),
                      encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open(os.path.join('templates', 'nest.tpl.css'), mode='r',
+    cssf = open(os.path.join('templates', 'nest.tpl.css'),
                 encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open(os.path.join('templates', 'footer.tpl.html'), mode='r',
+    footerf = open(os.path.join('templates', 'footer.tpl.html'),
                    encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
@@ -191,7 +191,7 @@ def write_helpindex(helpdir):
                          % doubles[0])
         for item in sorted(filelist,
                            key=lambda name: name.lower().rsplit('/', 1)[1]):
-            fitem = open(item, mode='r', encoding='utf-8')
+            fitem = open(item, encoding='utf-8')
             itemtext = fitem.read()
             fitem.close()
             # only the basename of the file

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -41,15 +41,15 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
     Write html for integration in NEST Help-System
     """
     # Loading Template for commands
-    ftemplate = open('templates/cmd.tpl.html', 'r')
+    ftemplate = open('templates/cmd.tpl.html', 'r', encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open('templates/nest.tpl.css', 'r')
+    cssf = open('templates/nest.tpl.css', 'r', encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open('templates/footer.tpl.html', 'r')
+    footerf = open('templates/footer.tpl.html', 'r', encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -134,12 +134,12 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
         else:
             path = os.path.join(helpdir, 'cc')
 
-        f_file_name = open('{}/{}.html'.format(path, name), 'w')
+        f_file_name = open('{}/{}.html'.format(path, name), 'w', encoding='utf-8')
         "{}/{}.html".format(path, name)
         f_file_name.write(cmdindexstring)
         f_file_name.close()
 
-        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), 'w')
+        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), 'w', encoding='utf-8')
         f_file_name_hlp.write('\n'.join(hlplist))
         f_file_name_hlp.close()
 
@@ -155,15 +155,15 @@ def write_helpindex(helpdir):
     hlp_list = []
 
     # Loading Template for helpindex.html
-    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r')
+    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r', encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open(os.path.join('templates', 'nest.tpl.css'), 'r')
+    cssf = open(os.path.join('templates', 'nest.tpl.css'), 'r', encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open(os.path.join('templates', 'footer.tpl.html'), 'r')
+    footerf = open(os.path.join('templates', 'footer.tpl.html'), 'r', encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -186,7 +186,7 @@ def write_helpindex(helpdir):
                          % doubles[0])
         for item in sorted(filelist,
                            key=lambda name: name.lower().rsplit('/', 1)[1]):
-            fitem = open(item, 'r')
+            fitem = open(item, 'r', encoding='utf-8')
             itemtext = fitem.read()
             fitem.close()
             # only the basename of the file
@@ -223,12 +223,12 @@ def write_helpindex(helpdir):
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
-    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w')
+    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w', encoding='utf-8')
     f_helpindex.write(indexstring)
     f_helpindex.close()
 
     # Todo: using string template for .hlp
-    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), 'w')
+    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), 'w', encoding='utf-8')
     f_helphlpindex.write('\n'.join(hlp_list))
     f_helphlpindex.close()
 

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -136,13 +136,13 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
             path = os.path.join(helpdir, 'cc')
 
         f_file_name = io.open('{}/{}.html'.format(path, name), mode='w',
-                           encoding='utf-8')
+                              encoding='utf-8')
         "{}/{}.html".format(path, name)
         f_file_name.write(cmdindexstring)
         f_file_name.close()
 
         f_file_name_hlp = io.open('{}/{}.hlp'.format(path, name), mode='w',
-                               encoding='utf-8')
+                                  encoding='utf-8')
         f_file_name_hlp.write('\n'.join(hlplist))
         f_file_name_hlp.close()
 
@@ -159,17 +159,17 @@ def write_helpindex(helpdir):
 
     # Loading Template for helpindex.html
     ftemplate = io.open(os.path.join('templates', 'helpindex.tpl.html'),
-                     encoding='utf-8')
+                        encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
     cssf = io.open(os.path.join('templates', 'nest.tpl.css'),
-                encoding='utf-8')
+                   encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
     footerf = io.open(os.path.join('templates', 'footer.tpl.html'),
-                   encoding='utf-8')
+                      encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -230,13 +230,13 @@ def write_helpindex(helpdir):
                                footer=footertempl)
 
     f_helpindex = io.open(os.path.join(helpdir, 'helpindex.html'), mode='w',
-                       encoding='utf-8')
+                          encoding='utf-8')
     f_helpindex.write(indexstring)
     f_helpindex.close()
 
     # Todo: using string template for .hlp
     f_helphlpindex = io.open(os.path.join(helpdir, 'helpindex.hlp'), mode='w',
-                          encoding='utf-8')
+                             encoding='utf-8')
     f_helphlpindex.write('\n'.join(hlp_list))
     f_helphlpindex.close()
 

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -135,14 +135,13 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
         else:
             path = os.path.join(helpdir, 'cc')
 
-        f_file_name = io.open('{}/{}.html'.format(path, name), mode='w',
-                              encoding='utf-8')
-        "{}/{}.html".format(path, name)
+        f_file_name = io.open(os.path.join(path, '{}.html'.format(name)),
+                              mode='w', encoding='utf-8')
         f_file_name.write(cmdindexstring)
         f_file_name.close()
 
-        f_file_name_hlp = io.open('{}/{}.hlp'.format(path, name), mode='w',
-                                  encoding='utf-8')
+        f_file_name_hlp = io.open(os.path.join(path, '{}.hlp'.format(name)),
+                                  mode='w', encoding='utf-8')
         f_file_name_hlp.write('\n'.join(hlplist))
         f_file_name_hlp.close()
 

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -41,15 +41,15 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
     Write html for integration in NEST Help-System
     """
     # Loading Template for commands
-    ftemplate = open('templates/cmd.tpl.html', 'r', encoding='utf-8')
+    ftemplate = open('templates/cmd.tpl.html', mode='r', encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open('templates/nest.tpl.css', 'r', encoding='utf-8')
+    cssf = open('templates/nest.tpl.css', mode='r', encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open('templates/footer.tpl.html', 'r', encoding='utf-8')
+    footerf = open('templates/footer.tpl.html', mode='r', encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -134,13 +134,13 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
         else:
             path = os.path.join(helpdir, 'cc')
 
-        f_file_name = open('{}/{}.html'.format(path, name), 'w',
+        f_file_name = open('{}/{}.html'.format(path, name), mode='w',
                            encoding='utf-8')
         "{}/{}.html".format(path, name)
         f_file_name.write(cmdindexstring)
         f_file_name.close()
 
-        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), 'w',
+        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), mode='w',
                                encoding='utf-8')
         f_file_name_hlp.write('\n'.join(hlplist))
         f_file_name_hlp.close()
@@ -157,17 +157,17 @@ def write_helpindex(helpdir):
     hlp_list = []
 
     # Loading Template for helpindex.html
-    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r',
+    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), mode='r',
                      encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open(os.path.join('templates', 'nest.tpl.css'), 'r',
+    cssf = open(os.path.join('templates', 'nest.tpl.css'), mode='r',
                 encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open(os.path.join('templates', 'footer.tpl.html'), 'r',
+    footerf = open(os.path.join('templates', 'footer.tpl.html'), mode='r',
                    encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
@@ -191,7 +191,7 @@ def write_helpindex(helpdir):
                          % doubles[0])
         for item in sorted(filelist,
                            key=lambda name: name.lower().rsplit('/', 1)[1]):
-            fitem = open(item, 'r', encoding='utf-8')
+            fitem = open(item, mode='r', encoding='utf-8')
             itemtext = fitem.read()
             fitem.close()
             # only the basename of the file
@@ -228,13 +228,13 @@ def write_helpindex(helpdir):
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
-    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w',
+    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), mode='w',
                        encoding='utf-8')
     f_helpindex.write(indexstring)
     f_helpindex.close()
 
     # Todo: using string template for .hlp
-    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), 'w',
+    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), mode='w',
                           encoding='utf-8')
     f_helphlpindex.write('\n'.join(hlp_list))
     f_helphlpindex.close()

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -134,12 +134,14 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
         else:
             path = os.path.join(helpdir, 'cc')
 
-        f_file_name = open('{}/{}.html'.format(path, name), 'w', encoding='utf-8')
+        f_file_name = open('{}/{}.html'.format(path, name), 'w',
+                           encoding='utf-8')
         "{}/{}.html".format(path, name)
         f_file_name.write(cmdindexstring)
         f_file_name.close()
 
-        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), 'w', encoding='utf-8')
+        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), 'w',
+                               encoding='utf-8')
         f_file_name_hlp.write('\n'.join(hlplist))
         f_file_name_hlp.close()
 
@@ -155,15 +157,18 @@ def write_helpindex(helpdir):
     hlp_list = []
 
     # Loading Template for helpindex.html
-    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r', encoding='utf-8')
+    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'), 'r',
+                     encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open(os.path.join('templates', 'nest.tpl.css'), 'r', encoding='utf-8')
+    cssf = open(os.path.join('templates', 'nest.tpl.css'), 'r',
+                encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open(os.path.join('templates', 'footer.tpl.html'), 'r', encoding='utf-8')
+    footerf = open(os.path.join('templates', 'footer.tpl.html'), 'r',
+                   encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -223,12 +228,14 @@ def write_helpindex(helpdir):
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
-    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w', encoding='utf-8')
+    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), 'w',
+                       encoding='utf-8')
     f_helpindex.write(indexstring)
     f_helpindex.close()
 
     # Todo: using string template for .hlp
-    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), 'w', encoding='utf-8')
+    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), 'w',
+                          encoding='utf-8')
     f_helphlpindex.write('\n'.join(hlp_list))
     f_helphlpindex.close()
 

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -27,6 +27,7 @@ Collect all the data and write help files.
 """
 
 import glob
+import io
 import os
 import re
 import textwrap
@@ -41,15 +42,15 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
     Write html for integration in NEST Help-System
     """
     # Loading Template for commands
-    ftemplate = open('templates/cmd.tpl.html', encoding='utf-8')
+    ftemplate = io.open('templates/cmd.tpl.html', encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open('templates/nest.tpl.css', encoding='utf-8')
+    cssf = io.open('templates/nest.tpl.css', encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open('templates/footer.tpl.html', encoding='utf-8')
+    footerf = io.open('templates/footer.tpl.html', encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
 
@@ -134,13 +135,13 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
         else:
             path = os.path.join(helpdir, 'cc')
 
-        f_file_name = open('{}/{}.html'.format(path, name), mode='w',
+        f_file_name = io.open('{}/{}.html'.format(path, name), mode='w',
                            encoding='utf-8')
         "{}/{}.html".format(path, name)
         f_file_name.write(cmdindexstring)
         f_file_name.close()
 
-        f_file_name_hlp = open('{}/{}.hlp'.format(path, name), mode='w',
+        f_file_name_hlp = io.open('{}/{}.hlp'.format(path, name), mode='w',
                                encoding='utf-8')
         f_file_name_hlp.write('\n'.join(hlplist))
         f_file_name_hlp.close()
@@ -157,17 +158,17 @@ def write_helpindex(helpdir):
     hlp_list = []
 
     # Loading Template for helpindex.html
-    ftemplate = open(os.path.join('templates', 'helpindex.tpl.html'),
+    ftemplate = io.open(os.path.join('templates', 'helpindex.tpl.html'),
                      encoding='utf-8')
     templ = ftemplate.read()
     ftemplate.close()
     # Loading Template for CSS
-    cssf = open(os.path.join('templates', 'nest.tpl.css'),
+    cssf = io.open(os.path.join('templates', 'nest.tpl.css'),
                 encoding='utf-8')
     csstempl = cssf.read()
     cssf.close()
     # Loading Template for footer
-    footerf = open(os.path.join('templates', 'footer.tpl.html'),
+    footerf = io.open(os.path.join('templates', 'footer.tpl.html'),
                    encoding='utf-8')
     footertempl = footerf.read()
     footerf.close()
@@ -191,7 +192,7 @@ def write_helpindex(helpdir):
                          % doubles[0])
         for item in sorted(filelist,
                            key=lambda name: name.lower().rsplit('/', 1)[1]):
-            fitem = open(item, encoding='utf-8')
+            fitem = io.open(item, encoding='utf-8')
             itemtext = fitem.read()
             fitem.close()
             # only the basename of the file
@@ -228,13 +229,13 @@ def write_helpindex(helpdir):
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
-    f_helpindex = open(os.path.join(helpdir, 'helpindex.html'), mode='w',
+    f_helpindex = io.open(os.path.join(helpdir, 'helpindex.html'), mode='w',
                        encoding='utf-8')
     f_helpindex.write(indexstring)
     f_helpindex.close()
 
     # Todo: using string template for .hlp
-    f_helphlpindex = open(os.path.join(helpdir, 'helpindex.hlp'), mode='w',
+    f_helphlpindex = io.open(os.path.join(helpdir, 'helpindex.hlp'), mode='w',
                           encoding='utf-8')
     f_helphlpindex.write('\n'.join(hlp_list))
     f_helphlpindex.close()


### PR DESCRIPTION
This pull request fix issue #830 by using the `io.open()` instead of the `open()` statement and adding `encoding="utf8"` to it.