### PR TITLE
Fix typo in SimulationManager status output

### DIFF
--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -612,7 +612,7 @@ nest::SimulationManager::call_update_()
 
   size_t num_active_nodes = kernel().node_manager.get_num_active_nodes();
   os << "Number of local nodes: " << num_active_nodes << std::endl;
-  os << "Simulaton time (ms): " << t_sim;
+  os << "Simulation time (ms): " << t_sim;
 
 #ifdef _OPENMP
   os << std::endl


### PR DESCRIPTION
This PR just fixes a typo in the status output of `SimulationManager`. Apparently this existed since 2d3c316e9