### PR TITLE
Better documentation of hh_cond_exp_traub and Brette-2007-compatible refractory time

### DIFF
--- a/doc/quickref.html
+++ b/doc/quickref.html
@@ -485,15 +485,15 @@ properties.</p>
     </tr>
     <tr>
       <td width="25%"><a href="help/cc/hh_psc_alpha.html">hh_psc_alpha</a></td>
-      <td>Hodgkin Huxley neuron model.</td>
+      <td>Hodgkin-Huxley neuron model.</td>
     </tr>
     <tr>
       <td width="25%"><a href="help/cc/hh_psc_alpha_gap.html">hh_psc_alpha_gap</a></td>
-      <td>Hodgkin Huxley neuron model with gap-junction support.</td>
+      <td>Hodgkin-Huxley neuron model with gap-junction support.</td>
     </tr>
     <tr>
       <td width="25%"><a href="help/cc/hh_cond_exp_traub.html">hh_cond_exp_traub</a></td>
-      <td>Hodgkin Huxley based model, Traub modified.</td>
+      <td>Hodgkin-Huxley model for Brette et al (2007) review.</td>
     </tr>
   </tbody>
 </table>

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -148,7 +148,7 @@ nest::hh_cond_exp_traub::Parameters_::Parameters_()
   , E_in( -80.0 )
   , tau_synE( 5.0 )  // Synaptic Time Constant Excitatory Synapse (ms)
   , tau_synI( 10.0 ) // Synaptic Time Constant Excitatory Synapse (ms)
-  , t_ref_( 3.0 )    // Refractory time in ms --- as in [1, p 118]
+  , t_ref_( 2.0 )    // Refractory time in ms
   , I_e( 0.0 )       // Stimulus Current (pA)
 {
 }

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -148,7 +148,7 @@ nest::hh_cond_exp_traub::Parameters_::Parameters_()
   , E_in( -80.0 )
   , tau_synE( 5.0 )  // Synaptic Time Constant Excitatory Synapse (ms)
   , tau_synI( 10.0 ) // Synaptic Time Constant Excitatory Synapse (ms)
-  , t_ref_( 0.0 )    // Refractory time in ms
+  , t_ref_( 3.0 )    // Refractory time in ms --- as in [1, p 118]
   , I_e( 0.0 )       // Stimulus Current (pA)
 {
 }

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -57,33 +57,37 @@ extern "C" int
 hh_cond_exp_traub_dynamics( double, const double*, double*, void* );
 
 /* BeginDocumentation
-Name: hh_cond_exp_traub - Hodgin Huxley based model, Traub modified.
+Name: hh_cond_exp_traub - Hodgkin-Huxley model for Brette et al (2007) review
 
 Description:
 
- hh_cond_exp_traub is an implementation of a modified Hodkin-Huxley model
+ hh_cond_exp_traub is an implementation of a modified Hodgkin-Huxley model
 
- (1) Post-synaptic currents
- Incoming spike events induce a post-synaptic change of conductance modeled
- by an exponential function. The exponential function is normalized such that an
- event of weight 1.0 results in a peak current of 1 nS.
+ This model was specifically developed for a major review of simulators [1],
+ based on a model of hippocampal pyramidal cells by Traub and Miles[2].
+ The key differences between the current model and the model in [2] are:
 
- (2) Spike Detection
- Spike detection is done by a combined threshold-and-local-maximum search: if
- V_m >= V_T + 30 mV and membrane potential has dropped during a time step
- (i.e., V_m has just passed a maximum), the neuron emits a spike.
+ - This model is a point neuron, not a compartmental model.
+ - This model includes only I_Na and I_K, with simpler I_K dynamics than
+   in [2], so it has only three instead of eight gating variables;
+   in particular, all Ca dynamics have been removed.
+ - Incoming spikes induce an instantaneous conductance change followed by
+   exponential decay instead of activation over time.
+
+ This model is primarily provided as reference implementation for hh_coba
+ example of the Brette et al (2007) review. Default parameter values are chosen
+ to match those used with NEST 1.9.10 when preparing data for [1]. Code for all
+ simulators covered is available from ModelDB [3].
 
 Note:
- The spike-detection mechanism in this model means that as long as
- V_m >= V_T + 30 mV and the membrane potential keeps falling (downward flank
- of the action potential), the neuron would emit a spike on every time step.
- It is therefore essential to have a sufficiently long absolute refractory
- time to suppress spurious spikes. This behavior is consistent with the
- original model in [1] with t_ref = 3 ms.
+ In this model, a spike is emitted if
 
-Problems/Todo:
-Only the channel variables m,h,n are implemented. The original
-contains variables called y,s,r,q and \chi.
+          V_m >= V_T + 30 mV and V_m has fallen during the current time step
+
+ To avoid that this leads to multiple spikes during the falling flank of a
+ spike, it is essential to chose a sufficiently long refractory period.
+ Traub and Miles used t_ref = 3 ms [2, p 118], while we used t_ref = 2 ms
+ in [2].
 
 Parameters:
 
@@ -100,7 +104,7 @@ Parameters:
                      function in ms.
  tau_syn_in double - Time constant of the inhibitory synaptic exponential
                      function in ms.
- t_ref      double - Duration of refractory period in ms.
+ t_ref      double - Duration of refractory period in ms (see Note).
  E_ex       double - Excitatory synaptic reversal potential in mV.
  E_in       double - Inhibitory synaptic reversal potential in mV.
  E_Na       double - Sodium reversal potential in mV.
@@ -111,8 +115,12 @@ Parameters:
 
 References:
 
-[1] Traub, R.D. and Miles, R. (1991) Neuronal Networks of the Hippocampus.
+[1] Brette R et al (2007) Simulation of networks of spiking neurons: A review
+    of tools and strategies. J Comp Neurosci 23:349-98.
+    doi 10.1007/s10827-007-0038-6
+[2] Traub RD and Miles R (1991) Neuronal Networks of the Hippocampus.
     Cambridge University Press, Cambridge UK.
+[3] http://modeldb.yale.edu/83319
 
 Sends: SpikeEvent
 

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -70,8 +70,16 @@ Description:
 
  (2) Spike Detection
  Spike detection is done by a combined threshold-and-local-maximum search: if
- there is a local maximum above a certain threshold of the membrane potential,
- it is considered a spike.
+ V_m >= V_T + 30 mV and membrane potential has dropped during a time step
+ (i.e., V_m has just passed a maximum), the neuron emits a spike.
+
+Note:
+ The spike-detection mechanism in this model means that as long as
+ V_m >= V_T + 30 mV and the membrane potential keeps falling (downward flank
+ of the action potential), the neuron would emit a spike on every time step.
+ It is therefore essential to have a sufficiently long absolute refractory
+ time to suppress spurious spikes. This behavior is consistent with the
+ original model in [1] with t_ref = 3 ms.
 
 Problems/Todo:
 Only the channel variables m,h,n are implemented. The original
@@ -103,8 +111,8 @@ Parameters:
 
 References:
 
-Traub, R.D. and Miles, R. (1991) Neuronal Networks of the Hippocampus.
-Cambridge University Press, Cambridge UK.
+[1] Traub, R.D. and Miles, R. (1991) Neuronal Networks of the Hippocampus.
+    Cambridge University Press, Cambridge UK.
 
 Sends: SpikeEvent
 

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -58,7 +58,7 @@ namespace nest
 extern "C" int hh_psc_alpha_dynamics( double, const double*, double*, void* );
 
 /* BeginDocumentation
-Name: hh_psc_alpha - Hodgkin Huxley neuron model.
+Name: hh_psc_alpha - Hodgkin-Huxley neuron model.
 
 Description:
 

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -60,7 +60,7 @@ extern "C" int
 hh_psc_alpha_gap_dynamics( double, const double*, double*, void* );
 
 /* BeginDocumentation
-Name: hh_psc_alpha_gap - Hodgkin Huxley neuron model with gap-junction support.
+Name: hh_psc_alpha_gap - Hodgkin-Huxley neuron model with gap-junction support.
 
 Description:
 

--- a/testsuite/unittests/test_hh_cond_exp_traub.sli
+++ b/testsuite/unittests/test_hh_cond_exp_traub.sli
@@ -61,11 +61,11 @@ ResetKernel
    /E_Na    40.0
    /E_K    -80.0   
    /E_L	   -70.0
-   %/U_tr   -60.0
    /E_ex     1.0
    /E_in   -90.0
    /tau_syn_ex 0.3
    /tau_syn_in 3.0
+   /t_ref    3.5
    /I_e	     1.0
 >> /hh_params Set
 
@@ -85,6 +85,7 @@ neuron GetStatus /result Set
   result /E_in get 6 ToUnitTestPrecision -90 eq and
   result /tau_syn_ex get 6 ToUnitTestPrecision 0.3 eq and
   result /tau_syn_in get 6 ToUnitTestPrecision 3 eq and
+  result /t_ref get 6 ToUnitTestPrecision 3.5 eq and
   result /I_e get 6 ToUnitTestPrecision 1 eq and
 } assert_or_die
 
@@ -115,7 +116,7 @@ vm neuron Connect
 mm neuron Connect
 neuron sp_det Connect
 
-%% Test: Simulation
+%% Test: Simulation --- check that implementation provides consistent results
 5 Simulate
 
 {
@@ -150,5 +151,5 @@ neuron sp_det Connect
 
 {
   sp_det [/events /times] get cva dup ==
-  [2 3 4 5 6 7] eq 
+  [2] eq 
 } assert_or_die


### PR DESCRIPTION
When fixing #473 to make t_ref configurable in hh_cond_exp_traub, we configured the model with `t_ref==0` as default. This does not work properly, since the spike detection mechanism relies on an absolute refractory peroid. This PR sets the default `t_ref=2`ms as used in the Brette et al (2007) review and documents the relation of this model to the review more clearly, as well as differences from the Traub&Miles (1991) model.

See https://github.com/nest/nest-simulator/issues/329#issuecomment-385411618 for a thorough discussion.