### PR TITLE
Remove assertion that argv[0] is a non-empty string in slistartup

### DIFF
--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -275,9 +275,10 @@ SLIStartup::SLIStartup( int argc, char** argv )
 
   // argv[0] is the name of the program that was given to the shell.
   // This name must be given to SLI, otherwise initialization fails.
-  // To catch accidental removal, e.g. in pyNEST, we explicitly assert
-  // that argv[0] is a non-empty string.
-  assert( std::strlen( argv[ 0 ] ) > 0 );
+  // If we import NEST directly from the Python interpreter, that is, not from
+  // a script but by using an interactive session in Python, argv[0] is an
+  // empty string, see documentation for argv in
+  // https://docs.python.org/3/library/sys.html
   for ( int i = 0; i < argc; ++i )
   {
     StringDatum* sd = new StringDatum( argv[ i ] );


### PR DESCRIPTION
This PR fixes #933 

Python defines `argv[0]` to be an empty string if no script is passed to the Python interpreter. That means that if we import NEST directly from the python interpreter in an interactive session, and not from within a script, `argv[0]` should be an empty string. However in [`slistartup`](https://github.com/nest/nest-simulator/blob/master/sli/slistartup.cc#L280) we assert that `argv[0]` is non-empty, and so we are not able to import NEST.

Previously we defined `argv[0]` to be "pynest" if we opened NEST with python, but this was removed in #840, so I now remove the assertion in `slistartup`, as the assertion is not needed anymore.