### PR TITLE
Update help generation for MyModule and fix Py27-unicode 

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -353,7 +353,7 @@ function( NEST_PROCESS_WITH_PYTHON )
       set( PYTHONINTERP_FOUND "${PYTHONINTERP_FOUND}" PARENT_SCOPE )
       set( PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE} PARENT_SCOPE )
       set( PYTHON ${PYTHON_EXECUTABLE} PARENT_SCOPE )
-      set( PYTHON_VERSION ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} PARENT_SCOPE )
+      set( PYTHON_VERSION ${PYTHON_VERSION_STRING} PARENT_SCOPE )
 
       # Localize Python lib/header files and make sure that their version matches 
       # the Python interpreter version !

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+# NOTE: Remember to update the help-generation section in 
+#       MyModule/CMakeLists.txt
+
 
 if ( NOT CMAKE_CROSSCOMPILING )
 

--- a/examples/MyModule/CMakeLists.txt
+++ b/examples/MyModule/CMakeLists.txt
@@ -96,6 +96,22 @@ set( CMAKE_CXX_COMPILER "${NEST_COMPILER}" )
 
 project( ${MODULE_NAME} CXX )
 
+# Get the Python executable (for help generation).
+execute_process(
+    COMMAND ${NEST_CONFIG} --python-executable
+    RESULT_VARIABLE RES_VAR
+    OUTPUT_VARIABLE PYTHON_EXECUTABLE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get the Python executable (for help generation).
+execute_process(
+    COMMAND ${NEST_CONFIG} --python-version
+    RESULT_VARIABLE RES_VAR
+    OUTPUT_VARIABLE PYTHON_VERSION_STRING
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 # Get the install prefix.
 execute_process(
     COMMAND ${NEST_CONFIG} --prefix
@@ -267,31 +283,40 @@ install( TARGETS ${MODULE_NAME}_lib DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 install( FILES ${MODULE_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${MODULE_NAME} )
 install( DIRECTORY sli DESTINATION ${CMAKE_INSTALL_DATADIR} )
 
-# Install help.
-if ( NOT CMAKE_CROSSCOMPILING )
-  add_custom_target( generate_help ALL )
-  # Extract help from all source files in the source code, put them in
-  # doc/help and generate a local help index in the build directory containing
-  # links to the help files.
-  add_custom_command( TARGET generate_help POST_BUILD
-    COMMAND python -B generate_help.py "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}"
-    COMMAND python -B generate_helpindex.py "${PROJECT_BINARY_DIR}/doc"
-    WORKING_DIRECTORY "${NEST_INSTALL_PREFIX}/${NEST_INSTALL_DATADIR}/help_generator"
-    COMMENT "Extracting help information; this may take a litte while."
-    )
-  # Copy the local doc/help directory to the global installation
-  # directory for documentation.
-  install( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doc/help"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}"
-    )
-  # Update the global help index to contain all help files that are
-  # located in the global installation directory for documentation.
-  install( CODE
-    "execute_process(
-      COMMAND python -B generate_helpindex.py \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}\"
-      WORKING_DIRECTORY \"${CMAKE_INSTALL_PREFIX}/${NEST_INSTALL_DATADIR}/help_generator\"
-    )"
-    )
+# Install help --- based on doc/CMakeLists.txt
+# Install only if Py >= 2.7.8 and NEST was installed with help
+if ( ( NOT CMAKE_CROSSCOMPILING ) 
+     AND PYTHON_EXECUTABLE 
+     AND ( ${PYTHON_VERSION_STRING} VERSION_GREATER "2.7.7" )
+     AND ( IS_DIRECTORY ${NEST_INSTALL_PREFIX}/${NEST_INSTALL_DOCDIR}/help )
+   )
+
+    # Extract help from all source files in the source code, put
+    # them in doc/help and generate a local help index in the
+    # build directory containing links to the help files.
+    install( CODE
+      "execute_process(
+         COMMAND ${PYTHON_EXECUTABLE} -B generate_help.py \"${PROJECT_SOURCE_DIR}\" \"${PROJECT_BINARY_DIR}\"
+         WORKING_DIRECTORY \"${NEST_INSTALL_PREFIX}/${NEST_INSTALL_DATADIR}/help_generator\"
+         )"
+      )
+  
+    # Copy the local doc/help directory to the global installation
+    # directory for documentation.
+    install( DIRECTORY "${PROJECT_BINARY_DIR}/doc/help"
+      DESTINATION "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}"
+      OPTIONAL
+      )
+  
+    # Update the global help index to include all help files in
+    # the global installation directory for documentation.
+    install( CODE
+      "execute_process(
+         COMMAND ${PYTHON_EXECUTABLE} -B generate_helpindex.py \"${NEST_INSTALL_PREFIX}/${NEST_INSTALL_DOCDIR}\"
+         WORKING_DIRECTORY \"${NEST_INSTALL_PREFIX}/${NEST_INSTALL_DATADIR}/help_generator\"
+         )"
+      )
+
 endif ()
 
 

--- a/extras/help_generator/writers.py
+++ b/extras/help_generator/writers.py
@@ -125,7 +125,7 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
             htmllist.append('<b>Source:</b><pre>%s</pre>' % value)
             hlplist.append('Source:\n\n%s' % value)
     htmllist.append('</div>')
-    htmlstring = ('\n'.join(htmllist))
+    htmlstring = (u'\n'.join(htmllist))
     cmdindexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                   title=name, footer=footertempl)
 
@@ -142,7 +142,7 @@ def write_help_html(doc_dic, helpdir, fname, sli_command_list, keywords):
 
         f_file_name_hlp = io.open(os.path.join(path, '{}.hlp'.format(name)),
                                   mode='w', encoding='utf-8')
-        f_file_name_hlp.write('\n'.join(hlplist))
+        f_file_name_hlp.write(u'\n'.join(hlplist))
         f_file_name_hlp.close()
 
 
@@ -229,7 +229,7 @@ def write_helpindex(helpdir):
         html_list.append('</table></center>')
 
     # html_list.append(footer)
-    htmlstring = ('\n'.join(html_list))
+    htmlstring = (u'\n'.join(html_list))
     indexstring = s.substitute(indexbody=htmlstring, css=csstempl,
                                footer=footertempl)
 
@@ -241,7 +241,7 @@ def write_helpindex(helpdir):
     # Todo: using string template for .hlp
     f_helphlpindex = io.open(os.path.join(helpdir, 'helpindex.hlp'), mode='w',
                              encoding='utf-8')
-    f_helphlpindex.write('\n'.join(hlp_list))
+    f_helphlpindex.write(u'\n'.join(hlp_list))
     f_helphlpindex.close()
 
 

--- a/extras/nest-config.in
+++ b/extras/nest-config.in
@@ -16,6 +16,8 @@ Known values for OPTION are:
   --cflags              print pre-processor and compiler flags
   --includes            print includes
   --compiler            print the compiler used to compile NEST
+  --python-executable   print full path to Python interpreter used
+  --python-version      print Python version string for interpreter
   --static-libraries    print "ON" if configured for static libraries, "OFF" otherwise
   --docdir              print the relative path (to prefix) to the installed documentation
   --datadir             print the relative path (to prefix) to the installed data
@@ -68,6 +70,12 @@ while test $# -gt 0; do
         ;;
     --compiler)
         echo "@CMAKE_CXX_COMPILER@"
+        ;;
+    --python-executable)
+        echo "@PYTHON_EXECUTABLE@"
+        ;;
+    --python-version)
+        echo "@PYTHON_VERSION@"
         ;;
 
     --static-libraries)


### PR DESCRIPTION
This brings help generation for MyModule in step with recent changes in help generation for main NEST.
It also solves a unicode problem in help generation under Python 2.7 reported by David Kappel on NEST User on 7 May 2018.