### PR TITLE
Support for gap junctions in Topology

### DIFF
--- a/testsuite/unittests/test_gap_junction.sli
+++ b/testsuite/unittests/test_gap_junction.sli
@@ -204,5 +204,83 @@ M_ERROR setverbosity
   and
 } assert_or_die
 
+% Check that we can use gap junction with target-driven connect in topology
+{
+  ResetKernel
+  /lr << /rows 2
+         /columns 3
+         /elements /hh_psc_alpha_gap      
+      >> CreateLayer def
+  
+  lr lr << /connection_type (convergent)
+           /synapse_model /gap_junction
+           /make_symmetric true
+           /weights 0.5
+        >> ConnectLayers
+} pass_or_die
+
+% Check that we can use gap junction with source-driven connect in topology
+{
+  ResetKernel
+  /lr << /rows 2
+         /columns 3
+         /elements /hh_psc_alpha_gap      
+      >> CreateLayer def
+  
+  lr lr << /connection_type (divergent)
+           /synapse_model /gap_junction 
+           /make_symmetric true
+           /weights 0.5
+        >> ConnectLayers
+} pass_or_die
+
+% Check that we can use gap junction with convergent connect in topology
+{
+  ResetKernel
+  /lr << /rows 2
+         /columns 3
+         /elements /hh_psc_alpha_gap      
+      >> CreateLayer def
+  
+  lr lr << /connection_type (convergent)
+           /synapse_model /gap_junction 
+           /make_symmetric true
+           /weights 0.5
+           /number_of_connections 3
+        >> ConnectLayers
+} pass_or_die
+
+
+% Check that we can use gap junction with divergent connect in topology
+{
+  ResetKernel
+  /lr << /rows 2
+         /columns 3
+         /elements /hh_psc_alpha_gap      
+      >> CreateLayer def
+  
+  lr lr << /connection_type (divergent)
+           /synapse_model /gap_junction 
+           /make_symmetric true
+           /weights 0.5
+           /number_of_connections 3
+        >> ConnectLayers
+} pass_or_die
+
+% Check that non-symmetric gap junctions cannot be created in topology
+{
+  ResetKernel
+  /lr << /rows 2
+         /columns 3
+         /elements /hh_psc_alpha_gap      
+      >> CreateLayer def
+  
+  lr lr << /connection_type (convergent)
+           /synapse_model /gap_junction 
+           /make_symmetric false
+           /weights 0.5
+        >> ConnectLayers
+} fail_or_die
+
 endusing
 

--- a/testsuite/unittests/test_gap_junction.sli
+++ b/testsuite/unittests/test_gap_junction.sli
@@ -204,79 +204,93 @@ M_ERROR setverbosity
   and
 } assert_or_die
 
-% Check that we can use gap junction with target-driven connect in topology
+% Check that using gap-junction in topology gives the correct connections.
+{
+  /tgt_driven << /connection_type (convergent)
+                 /synapse_model /gap_junction
+                 /make_symmetric true
+                 /weights << /uniform << /min 0.3 /max 0.6 >> >>
+              >> def
+  /src_driven << /connection_type (divergent)
+                 /synapse_model /gap_junction
+                 /make_symmetric true
+                 /weights << /uniform << /min 0.3 /max 0.6 >> >>
+              >> def
+  /convergent << /connection_type (convergent)
+                 /synapse_model /gap_junction
+                 /make_symmetric true
+                 /weights << /uniform << /min 0.3 /max 0.6 >> >>
+                 /number_of_connections 3
+              >> def
+  /divergent << /connection_type (divergent)
+                /synapse_model /gap_junction
+                /make_symmetric true
+                /weights << /uniform << /min 0.3 /max 0.6 >> >>
+                /number_of_connections 3
+             >> def
+  
+  true
+  [ tgt_driven src_driven convergent divergent  ]
+  {
+    /connspec Set
+    ResetKernel
+    
+    /src_lr << /rows 2
+           /columns 3
+           /elements /hh_psc_alpha_gap
+        >> CreateLayer def
+    /tgt_lr << /rows 2
+           /columns 3
+           /elements /hh_psc_alpha_gap
+        >> CreateLayer def
+    
+    src_lr tgt_lr connspec ConnectLayers
+    
+    % Storing connection info to array.
+    /nodes src_lr GetLocalLeaves def
+    << /source nodes >> GetConnections
+    dup length exch 
+    {
+      dup /source get exch
+      dup /target get exch
+      dup /synapse_model get exch
+      /weight get
+      4 arraystore exch
+    } forall
+    arraystore
+    /source_array Set
+    
+    % With flipped source and target position,
+    % this array should contain the same elements as the source array.
+    /nodes tgt_lr GetLocalLeaves def
+    << /source nodes >> GetConnections
+    dup length exch 
+    {
+      dup /target get exch
+      dup /source get exch
+      /gap_junction exch
+      /weight get
+      4 arraystore exch
+    } forall
+    arraystore
+    /target_array Set
+    
+    source_array length target_array length eq
+    source_array { target_array exch MemberQ and } Fold
+    and
+  } Fold
+} assert_or_die
+
+% Check that non-symmetric gap-junctions cannot be created in topology
 {
   ResetKernel
   /lr << /rows 2
          /columns 3
-         /elements /hh_psc_alpha_gap      
+         /elements /hh_psc_alpha_gap
       >> CreateLayer def
   
   lr lr << /connection_type (convergent)
            /synapse_model /gap_junction
-           /make_symmetric true
-           /weights 0.5
-        >> ConnectLayers
-} pass_or_die
-
-% Check that we can use gap junction with source-driven connect in topology
-{
-  ResetKernel
-  /lr << /rows 2
-         /columns 3
-         /elements /hh_psc_alpha_gap      
-      >> CreateLayer def
-  
-  lr lr << /connection_type (divergent)
-           /synapse_model /gap_junction 
-           /make_symmetric true
-           /weights 0.5
-        >> ConnectLayers
-} pass_or_die
-
-% Check that we can use gap junction with convergent connect in topology
-{
-  ResetKernel
-  /lr << /rows 2
-         /columns 3
-         /elements /hh_psc_alpha_gap      
-      >> CreateLayer def
-  
-  lr lr << /connection_type (convergent)
-           /synapse_model /gap_junction 
-           /make_symmetric true
-           /weights 0.5
-           /number_of_connections 3
-        >> ConnectLayers
-} pass_or_die
-
-
-% Check that we can use gap junction with divergent connect in topology
-{
-  ResetKernel
-  /lr << /rows 2
-         /columns 3
-         /elements /hh_psc_alpha_gap      
-      >> CreateLayer def
-  
-  lr lr << /connection_type (divergent)
-           /synapse_model /gap_junction 
-           /make_symmetric true
-           /weights 0.5
-           /number_of_connections 3
-        >> ConnectLayers
-} pass_or_die
-
-% Check that non-symmetric gap junctions cannot be created in topology
-{
-  ResetKernel
-  /lr << /rows 2
-         /columns 3
-         /elements /hh_psc_alpha_gap      
-      >> CreateLayer def
-  
-  lr lr << /connection_type (convergent)
-           /synapse_model /gap_junction 
            /make_symmetric false
            /weights 0.5
         >> ConnectLayers

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -131,8 +131,17 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   }
   if ( not delay_.valid() )
   {
-    delay_ =
-      TopologyModule::create_parameter( ( *syn_defaults )[ names::delay ] );
+    if ( synapse_model_
+      == static_cast< index >( kernel().model_manager.get_synapsedict()->lookup(
+           "gap_junction" ) ) )
+    {
+      delay_ = TopologyModule::create_parameter( numerics::nan );
+    }
+    else
+    {
+      delay_ =
+        TopologyModule::create_parameter( ( *syn_defaults )[ names::delay ] );
+    }
   }
 
   if ( connection_type == names::convergent )

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -28,6 +28,7 @@ namespace nest
 ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   : allow_autapses_( true )
   , allow_multapses_( true )
+  , make_symmetric_( false )
   , source_filter_()
   , target_filter_()
   , number_of_connections_( 0 )
@@ -57,6 +58,11 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
     {
 
       allow_multapses_ = getValue< bool >( dit->second );
+    }
+    else if ( dit->first == names::make_symmetric )
+    {
+
+      make_symmetric_ = getValue< bool >( dit->second );
     }
     else if ( dit->first == names::allow_oversized_mask )
     {

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -61,7 +61,6 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
     }
     else if ( dit->first == names::make_symmetric )
     {
-
       make_symmetric_ = getValue< bool >( dit->second );
     }
     else if ( dit->first == names::allow_oversized_mask )
@@ -137,9 +136,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   }
   if ( not delay_.valid() )
   {
-    if ( synapse_model_
-      == static_cast< index >( kernel().model_manager.get_synapsedict()->lookup(
-           "gap_junction" ) ) )
+    if ( not getValue< bool >( ( *syn_defaults )[ names::has_delay ] ) )
     {
       delay_ = TopologyModule::create_parameter( numerics::nan );
     }

--- a/topology/connection_creator.h
+++ b/topology/connection_creator.h
@@ -165,6 +165,13 @@ private:
     double d,
     index syn );
 
+  void make_symmetric_connection_( const index& s,
+    const Node* target,
+    const thread& target_thread,
+    const index& syn,
+    const double& d,
+    const double& w );
+
   /**
    * Calculate parameter values for this position.
    *
@@ -180,6 +187,7 @@ private:
   bool allow_autapses_;
   bool allow_multapses_;
   bool allow_oversized_;
+  bool make_symmetric_;
   Selector source_filter_;
   Selector target_filter_;
   index number_of_connections_;
@@ -208,8 +216,26 @@ ConnectionCreator::connect_( index s,
       // TODO implement in terms of nest-api
       kernel().connection_manager.connect(
         s, target, target_thread, syn, d, w );
+      if ( make_symmetric_ )
+      {
+        make_symmetric_connection_( s, target, target_thread, syn, d, w );
+      }
     }
   }
+}
+
+inline void
+ConnectionCreator::make_symmetric_connection_( const index& s,
+  const Node* target,
+  const thread& target_thread,
+  const index& syn,
+  const double& d,
+  const double& w )
+{
+  const index s_thread = kernel().vp_manager.get_thread_id();
+  Node* const s_node = kernel().node_manager.get_node( s, s_thread );
+  kernel().connection_manager.connect(
+    target->get_gid(), s_node, s_thread, syn, d, w );
 }
 
 } // namespace nest

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -367,6 +367,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
               d );
             kernel().connection_manager.connect(
               iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+            if ( make_symmetric_ )
+            {
+              make_symmetric_connection_(
+                iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+            }
           }
         }
       }
@@ -390,6 +395,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
             target.compute_displacement( iter->first, target_pos ), rng, w, d );
           kernel().connection_manager.connect(
             iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+          if ( make_symmetric_ )
+          {
+            make_symmetric_connection_(
+              iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+          }
         }
       }
     }
@@ -447,6 +457,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
               d );
             kernel().connection_manager.connect(
               iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+            if ( make_symmetric_ )
+            {
+              make_symmetric_connection_(
+                iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+            }
           }
         }
       }
@@ -470,6 +485,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
             target.compute_displacement( iter->first, target_pos ), rng, w, d );
           kernel().connection_manager.connect(
             iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+          if ( make_symmetric_ )
+          {
+            make_symmetric_connection_(
+              iter->second, *tgt_it, target_thread, synapse_model_, d, w );
+          }
         }
       }
     }
@@ -610,6 +630,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             d );
           kernel().connection_manager.connect(
             source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          if ( make_symmetric_ )
+          {
+            make_symmetric_connection_(
+              source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          }
           is_selected[ random_id ] = true;
         }
       }
@@ -652,6 +677,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             d );
           kernel().connection_manager.connect(
             source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          if ( make_symmetric_ )
+          {
+            make_symmetric_connection_(
+              source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          }
           is_selected[ random_id ] = true;
         }
       }
@@ -744,6 +774,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             source.compute_displacement( target_pos, source_pos ), rng, w, d );
           kernel().connection_manager.connect(
             source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          if ( make_symmetric_ )
+          {
+            make_symmetric_connection_(
+              source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          }
           is_selected[ random_id ] = true;
         }
       }
@@ -779,6 +814,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             source.compute_displacement( target_pos, source_pos ), rng, w, d );
           kernel().connection_manager.connect(
             source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          if ( make_symmetric_ )
+          {
+            make_symmetric_connection_(
+              source_id, *tgt_it, target_thread, synapse_model_, d, w );
+          }
           is_selected[ random_id ] = true;
         }
       }
@@ -921,6 +961,15 @@ ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
       Node* target_ptr = kernel().node_manager.get_node( target_id );
       kernel().connection_manager.connect(
         source_id, target_ptr, target_ptr->get_thread(), synapse_model_, d, w );
+      if ( make_symmetric_ )
+      {
+        make_symmetric_connection_( source_id,
+          target_ptr,
+          target_ptr->get_thread(),
+          synapse_model_,
+          d,
+          w );
+      }
     }
   }
 }

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -42,7 +42,7 @@ void
 ConnectionCreator::connect( Layer< D >& source, Layer< D >& target )
 {
   if ( kernel().model_manager.connector_requires_symmetric( synapse_model_ )
-    and not( make_symmetric_ ) )
+    and not make_symmetric_ )
   {
     throw BadProperty(
       "Connections with this synapse model can only be created "

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -41,6 +41,14 @@ template < int D >
 void
 ConnectionCreator::connect( Layer< D >& source, Layer< D >& target )
 {
+  if ( kernel().model_manager.connector_requires_symmetric( synapse_model_ )
+    and not( make_symmetric_ ) )
+  {
+    throw BadProperty(
+      "Connections with this synapse model can only be created "
+      "with \"make_symmetric\" set to true." );
+  }
+
   switch ( type_ )
   {
   case Target_driven:


### PR DESCRIPTION
This PR adds support for gap junctions in `ConnectLayers`. It also adds a `make_symmetric` option, as this is needed by the gap junction synapse model.

Fixes #939.