### PR TITLE
Fixed a bug in the SecondaryEvent delivery

### DIFF
--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -1057,7 +1057,9 @@ public:
           i != coeffarray_as_d_end_;
           i++ )
     {
-      write_to_comm_buffer( *i, pos );
+      // we need the static_cast here as the size of a stand-alone variable
+      // and a std::vector entry may differ (e.g. for std::vector< bool >)
+      write_to_comm_buffer( static_cast< DataType >( *i ), pos );
     }
     return pos;
   }


### PR DESCRIPTION
This PR fixes #955. The origin of the error is explained in the corresponding issue. 

All SecondaryEvents which exist at the moment use `double` as data type. In this cases the sizes in question are the same (this is actually the case for most data types that I checked), which is why this error remained undetected until now (and cannot be tested with the current master). 

I have created a branch (based on 5g) where I created an additional SecondaryEvent with `bool` data (see https://github.com/janhahne/nest-simulator/tree/5g_bool_sec_event). After merging the fix everything works fine there now.