### PR TITLE
Fix SLI sleep function (fixes #973)

### DIFF
--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -632,9 +632,9 @@ SeeAlso: over, index
 
 /* BeginDocumentation
  Name: sleep - Pauses current process.
- Synopsis:  x sleep -> -
+ Synopsis:  t sleep -> -
  Description: 
-  Pauses the process for x seconds. n can be integer or double.
+  Pauses the process for t seconds. t can be integer or double.
   Resolution is given by pclockspersec.
  Examples:
   5 sleep %wait for 5 seconds
@@ -644,7 +644,7 @@ SeeAlso: over, index
 */
 
 /sleep trie
-  [/integertype] /sleep_i load addtotrie
+  [/integertype] { cvd sleep_d } bind addtotrie
   [/doubletype]  /sleep_d load addtotrie
 def
 

--- a/sli/slicontrol.cc
+++ b/sli/slicontrol.cc
@@ -33,6 +33,9 @@
 #include <time.h>
 #include <unistd.h>
 
+// C++ includes:
+#include <limits>
+
 // Generated includes:
 #include "config.h"
 

--- a/sli/slicontrol.cc
+++ b/sli/slicontrol.cc
@@ -1697,22 +1697,21 @@ Sleep_dFunction::execute( SLIInterpreter* i ) const
   {
     throw BadParameterValue( "t >= 0 required." );
   }
-  else if ( t > std::numeric_limits< int >::max() )
+
+  if ( t > std::numeric_limits< int >::max() )
   {
     throw BadParameterValue( String::compose(
       "t < %1s required.", std::numeric_limits< int >::max() ) );
   }
-  else if ( t > 0 )
-  {
-    // split into second and microsecond part
-    // limited to 32-bit signed int, see #973.
-    const int t_sec = static_cast< int >( t );
-    const int t_musec = static_cast< int >( ( t - t_sec ) * 1e6 );
 
-    // on some systems, select may modify tv, therefore, it cannot be const
-    struct timeval tv = { t_sec, t_musec };
-    select( 0, 0, 0, 0, &tv );
-  }
+  // split into second and microsecond part
+  // limited to 32-bit signed int, see #973.
+  const int t_sec = static_cast< int >( t );
+  const int t_musec = static_cast< int >( ( t - t_sec ) * 1e6 );
+
+  // on some systems, select may modify tv, therefore, it cannot be const
+  struct timeval tv = { t_sec, t_musec };
+  select( 0, 0, 0, 0, &tv );
 
   i->OStack.pop();
   i->EStack.pop();

--- a/sli/slicontrol.h
+++ b/sli/slicontrol.h
@@ -535,15 +535,6 @@ public:
   void execute( SLIInterpreter* ) const;
 };
 
-class Sleep_iFunction : public SLIFunction
-{
-public:
-  Sleep_iFunction()
-  {
-  }
-  void execute( SLIInterpreter* ) const;
-};
-
 class Sleep_dFunction : public SLIFunction
 {
 public:


### PR DESCRIPTION
Revise implementation of sleep to work correctly with 32-bit signed int; remove duplicity of implementation for int and double arg. This eliminates a warning about narrowing, which is an error in strict C++11.

Also, it seemed that sleep times given as doubles were not handled correctly in the past, e.g. 2.75 s.

This fixes #973.