### PR TITLE
Added parameter to get/set function in tanh_rate model

### DIFF
--- a/models/tanh_rate.cpp
+++ b/models/tanh_rate.cpp
@@ -29,12 +29,14 @@ void
 nonlinearities_tanh_rate::get( DictionaryDatum& d ) const
 {
   def< double >( d, names::g, g_ );
+  def< double >( d, names::theta, theta_ );
 }
 
 void
 nonlinearities_tanh_rate::set( const DictionaryDatum& d )
 {
   updateValue< double >( d, names::g, g_ );
+  updateValue< double >( d, names::theta, theta_ );
 }
 
 /*


### PR DESCRIPTION
The tanh_rate model contains a parameter `theta` that cannot be set at the moment. This PR fixes this small bug.