### PR TITLE
run nosetests with the Python interpreter (2 vs. 3) that was requeste…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,12 @@ endif ()
 ##################           Find utility programs            ##################
 ################################################################################
 
+# needed for pynest test suite
+if ( ${with-python} STREQUAL "ON" OR  ${with-python} STREQUAL "2" OR  ${with-python} STREQUAL "3" )
+  find_program( NOSETESTS NAMES nosetests )
+endif ()
+
 # needed for target doc and fulldoc
-find_program( NOSETESTS NAMES nosetests )
 find_package( Doxygen )
 find_program( SED NAMES sed gsed )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ endif ()
 ################################################################################
 
 # needed for target doc and fulldoc
+find_program( NOSETESTS NAMES nosetests )
 find_package( Doxygen )
 find_program( SED NAMES sed gsed )
 

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -724,26 +724,13 @@ if test "x${TEST_PYNEST}" = xtrue ; then
     #    of support for nosetests. We use the TEST_OUTDIR as Python-free
     #    dummy directory to search for tests.
 
-    if command -v nosetests >/dev/null 2>&1 && nosetests --with-xunit --xunit-file=/dev/null --where=${TEST_OUTDIR} >/dev/null 2>&1; then
+    if command -v @NOSETESTS@ >/dev/null 2>&1 && @NOSETESTS@ --with-xunit --xunit-file=/dev/null --where=${TEST_OUTDIR} >/dev/null 2>&1; then
 
         echo
         echo "  Using nosetests."
         echo
 
-        # if possible, pick the python version that was specified during the installation
-
-        WITH_PYTHON=`cat CMakeCache.txt | grep with-python | cut -d "=" -f2`
-        if [ "${WITH_PYTHON}" = "2" ]; then
-            python_binary=`which python2`
-        elif [ "${WITH_PYTHON}" = "3" ]; then
-            python_binary=`which python3`
-        else
-            python_binary=`which python`
-        fi
-
-        nosetests_binary=`which nosetests`
-
-        $python_binary $nosetests_binary -v --with-xunit --xunit-file=${TEST_OUTDIR}/pynest_tests.xml ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/tests ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/topology/tests 2>&1 \
+        @PYTHON@ @NOSETESTS@ -v --with-xunit --xunit-file=${TEST_OUTDIR}/pynest_tests.xml ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/tests ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/topology/tests 2>&1 \
             | tee -a "${TEST_LOGFILE}" | grep -i --line-buffered "\.\.\. ok\|fail\|skip\|error" | sed 's/^/  /'
 
         PYNEST_TEST_TOTAL="$(  tail -n 3 ${TEST_LOGFILE} | grep Ran | cut -d' ' -f2 )"

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -730,7 +730,20 @@ if test "x${TEST_PYNEST}" = xtrue ; then
         echo "  Using nosetests."
         echo
 
-        nosetests -v --with-xunit --xunit-file=${TEST_OUTDIR}/pynest_tests.xml ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/tests ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/topology/tests 2>&1 \
+        # if possible, pick the python version that was specified during the installation
+
+        WITH_PYTHON=`cat CMakeCache.txt | grep with-python | cut -d "=" -f2`
+        if [ "${WITH_PYTHON}" = "2" ]; then
+            python_binary=`which python2`
+        elif [ "${WITH_PYTHON}" = "3" ]; then
+            python_binary=`which python3`
+        else
+            python_binary=`which python`
+        fi
+
+        nosetests_binary=`which nosetests`
+
+        $python_binary $nosetests_binary -v --with-xunit --xunit-file=${TEST_OUTDIR}/pynest_tests.xml ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/tests ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/topology/tests 2>&1 \
             | tee -a "${TEST_LOGFILE}" | grep -i --line-buffered "\.\.\. ok\|fail\|skip\|error" | sed 's/^/  /'
 
         PYNEST_TEST_TOTAL="$(  tail -n 3 ${TEST_LOGFILE} | grep Ran | cut -d' ' -f2 )"

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -724,7 +724,7 @@ if test "x${TEST_PYNEST}" = xtrue ; then
     #    of support for nosetests. We use the TEST_OUTDIR as Python-free
     #    dummy directory to search for tests.
 
-    if command -v @NOSETESTS@ >/dev/null 2>&1 && @NOSETESTS@ --with-xunit --xunit-file=/dev/null --where=${TEST_OUTDIR} >/dev/null 2>&1; then
+    if command -v @NOSETESTS@ >/dev/null 2>&1 && @PYTHON@ @NOSETESTS@ --with-xunit --xunit-file=/dev/null --where=${TEST_OUTDIR} >/dev/null 2>&1; then
 
         echo
         echo "  Using nosetests."


### PR DESCRIPTION
*run nosetests with the Python interpreter (2 vs. 3) that was requested when invoking cmake*

I ran into the same problem as #892, that is, nosetests fails because it is run using the system default Python version (in my case, /usr/bin/python -> python2.7), instead of the one that is requested during the installation process (in my case, cmake [...] -Dwith-python=3).

The proposed code tries to extract the requested version from CMakeCache.txt and selects the binary accordingly by invoking "which".

Tested on Linux, but it should work on any system where the "which" utility is available.