### PR TITLE
Make test for "long long max" C++11-safe on all systems

### DIFF
--- a/nestkernel/nest_types.h
+++ b/nestkernel/nest_types.h
@@ -81,7 +81,7 @@ namespace nest
 
 #ifdef HAVE_LONG_LONG
 typedef long long tic_t;
-#ifdef IS_K
+#ifdef LLONG_MAX
 const tic_t tic_t_max = LLONG_MAX;
 const tic_t tic_t_min = LLONG_MIN;
 #else


### PR DESCRIPTION
This is a partial fix for #990, making the selection between `LLONG_{MIN,MAX}` and `LONG_LONG_{MIN,MAX}` robust across compilers and C++ standards.