### PR TITLE
Fix 990 / Compilation issues with C++11 and libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ include( CPackVariables )
 include( CheckExtraCompilerFeatures )
 include( ConfigureSummary )
 include( GetTriple )
+include( DefaultCompilerFlags )
 
 # get triples arch-vendor-os
 get_host_triple( NEST_HOST_TRIPLE NEST_HOST_ARCH NEST_HOST_VENDOR NEST_HOST_OS )
@@ -133,6 +134,9 @@ get_target_triple( NEST_TARGET_TRIPLE NEST_TARGET_ARCH NEST_TARGET_VENDOR NEST_T
 # set cpack variables and
 # generate CPackConfig.cmake CPackSourceConfig.cmake files
 nest_set_cpack_variables()
+
+# set default compiler flags
+nest_set_default_compiler_flags()
 
 # Process the command line arguments
 nest_process_with_optimize()

--- a/cmake/DefaultCompilerFlags.cmake
+++ b/cmake/DefaultCompilerFlags.cmake
@@ -1,0 +1,26 @@
+# cmake/DefaultCompilerFlags.cmake
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+# Here all user defined options will be processed.
+
+# set default compiler flags for all compilers
+function( NEST_SET_DEFAULT_COMPILER_FLAGS )
+   # no default flags for C
+   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" PARENT_SCOPE )
+endfunction()

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -90,7 +90,7 @@ aeif_cond_alpha_multisynapse::insert_conductance_recordables( size_t first )
 DataAccessFunctor< aeif_cond_alpha_multisynapse >
 aeif_cond_alpha_multisynapse::get_data_access_functor( size_t elem )
 {
-  return DataAccessFunctor< aeif_cond_alpha_multisynapse >( this, elem );
+  return DataAccessFunctor< aeif_cond_alpha_multisynapse >( *this, elem );
 }
 
 /* ----------------------------------------------------------------

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -89,7 +89,7 @@ aeif_cond_beta_multisynapse::insert_conductance_recordables( size_t first )
 DataAccessFunctor< aeif_cond_beta_multisynapse >
 aeif_cond_beta_multisynapse::get_data_access_functor( size_t elem )
 {
-  return DataAccessFunctor< aeif_cond_beta_multisynapse >( this, elem );
+  return DataAccessFunctor< aeif_cond_beta_multisynapse >( *this, elem );
 }
 
 /* ----------------------------------------------------------------

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -87,7 +87,7 @@ iaf_psc_alpha_multisynapse::insert_current_recordables( size_t first )
 DataAccessFunctor< iaf_psc_alpha_multisynapse >
 iaf_psc_alpha_multisynapse::get_data_access_functor( size_t elem )
 {
-  return DataAccessFunctor< iaf_psc_alpha_multisynapse >( this, elem );
+  return DataAccessFunctor< iaf_psc_alpha_multisynapse >( *this, elem );
 }
 
 /* ----------------------------------------------------------------

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -87,7 +87,7 @@ iaf_psc_exp_multisynapse::insert_current_recordables( size_t first )
 DataAccessFunctor< iaf_psc_exp_multisynapse >
 iaf_psc_exp_multisynapse::get_data_access_functor( size_t elem )
 {
-  return DataAccessFunctor< iaf_psc_exp_multisynapse >( this, elem );
+  return DataAccessFunctor< iaf_psc_exp_multisynapse >( *this, elem );
 }
 
 /* ----------------------------------------------------------------

--- a/nestkernel/nest_types.h
+++ b/nestkernel/nest_types.h
@@ -81,7 +81,7 @@ namespace nest
 
 #ifdef HAVE_LONG_LONG
 typedef long long tic_t;
-#ifdef IS_K
+#ifdef LLONG_MAX
 const tic_t tic_t_max = LLONG_MAX;
 const tic_t tic_t_min = LLONG_MIN;
 #else

--- a/nestkernel/recordables_map.h
+++ b/nestkernel/recordables_map.h
@@ -135,34 +135,20 @@ RecordablesMap< HostNode >::create()
 template < typename HostNode >
 class DataAccessFunctor
 {
+  // Pointer instead of reference required to avoid problems with
+  // copying element in std::map when using libc++ under C++11.
   HostNode* parent_;
   size_t elem_;
 
 public:
   DataAccessFunctor( HostNode& n, size_t elem )
-    : elem_( elem )
-  {
-    parent_ = &n;
-  };
-
-  DataAccessFunctor( HostNode* n, size_t elem )
-    : elem_( elem )
-  {
-    parent_ = n;
-  };
+    : parent_( &n )
+    , elem_( elem ){};
 
   double operator()() const
   {
     return parent_->get_state_element( elem_ );
   };
-
-  DataAccessFunctor< HostNode >& operator=(
-    const DataAccessFunctor< HostNode >& other )
-  {
-    this->elem_ = other.elem_;
-    this->parent_ = other.parent_;
-    return *this;
-  }
 };
 
 
@@ -181,9 +167,9 @@ public:
  */
 template < typename HostNode >
 class DynamicRecordablesMap
-  : public std::map< Name, const DataAccessFunctor< HostNode > >
+  : public std::map< Name, DataAccessFunctor< HostNode > >
 {
-  typedef std::map< Name, const DataAccessFunctor< HostNode > > Base_;
+  typedef std::map< Name, DataAccessFunctor< HostNode > > Base_;
 
 public:
   virtual ~DynamicRecordablesMap()


### PR DESCRIPTION
Note that the issues fixed here **do not occur with gcc and libstdc++**, they only occur with LLVM/Clang compilers using libc++ in C++11 mode and with some other compilers that do not use libstdc++.