### PR TITLE
fixed minor issue in WeightRecorderEvent

### DIFF
--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -412,11 +412,11 @@ public:
   void set_receiver_gid( index );
 
 protected:
-  index receiver_gid_; //!< GID of receiver or -1.
+  index receiver_gid_; //!< GID of receiver or 0.
 };
 
 inline WeightRecorderEvent::WeightRecorderEvent()
-  : receiver_gid_( -1 )
+  : receiver_gid_( 0 )
 {
 }
 


### PR DESCRIPTION
As mentioned in #989, the `WeightRecorderEvent::receiver_gid` is defined as an unsigned integer but is initialized with `-1`. This did not lead to any issues in the simulation or recording, but I anyway fixed this with this PR.

The `receiver_gid` is now initialized with `0`.