### PR TITLE
Fix version display during startup

### DIFF
--- a/extras/create_rcsinfo.sh
+++ b/extras/create_rcsinfo.sh
@@ -28,6 +28,5 @@ mkdir -p $sli_libdir
 
 # create rcsinfo.sli
 echo "statusdict /rcsinfo ($version) put" > $sli_libdir/rcsinfo.sli
-echo $version
 
 exit 0

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -1691,14 +1691,6 @@ systemdict /GNUreadline known
 } ifelse
 
 
-/warranty
-{
- (This program is provided AS IS and comes with) =
- (NO WARRANTY. See the file LICENSE for details.) =
- () =  
-} def
-
-
 /:helptext
 {
   (Type 'helpindex' to see the list of commands.) =
@@ -1745,48 +1737,46 @@ SeeAlso: nestrc
 
 /welcome
 {
-   statusdict begin
-   cout endl
-   argv 0 get reverse 0 3 getinterval
+   () =
+   statusdict/argv :: 0 get reverse 0 3 getinterval
    (ils) eq
    {
-       (               -- S L I --) <- endl
-   } 
+     (               -- S L I --) =
+   }
    {
-       (              -- N E S T --) <- endl
+     (              -- N E S T --) =
    } ifelse
-   endl
-   (  Copyright (C) 2004 The NEST Initiative) <- endl
-   (  Version ) <- 
-   prgmajor <- (.) <- prgminor <- (.) <- prgpatch <-
-   ( ) <- built <- endl endl ;
-   end
-   warranty
-
-   (Problems or suggestions?) =
-   (  Visit http://www.nest-simulator.org) =
+   (  Copyright (C) 2004 The NEST Initiative) = () =
+   ( Version: ) =only statusdict/rcsinfo :: =
+   ( Built: ) =only statusdict/built :: =
    () =
 
-   (Type 'help' to get more information.) =
-   (Type 'quit' or CTRL-D to quit NEST.) =
-   () =  
+   ( This program is provided AS IS and comes with) =
+   ( NO WARRANTY. See the file LICENSE for details.) =
+   () =
+
+   ( Problems or suggestions?) =
+   (   Visit http://www.nest-simulator.org) =
+   () =
+
+   ( Type 'help' to get more information.) =
+   ( Type 'quit' or press CTRL-D to quit.) =
+   () =
    :warnings
 } def
 
 /shortwelcome
 {
-   statusdict begin
-   cout
-   argv 0 get reverse 0 3 getinterval
+   statusdict/argv :: 0 get reverse 0 3 getinterval
    (ils) eq
    {
-       (SLI v) <-
-   } 
+       (SLI ) =only
+   }
    {
-       (NEST v) <-
+       (NEST ) =only
    } ifelse
-   version <- ( (C) 2004 The NEST Initiative) <- endl ;
-   end     
+   statusdict/rcsinfo :: =only
+   ( (C) 2004 The NEST Initiative) =
 } def
 
 
@@ -2077,7 +2067,7 @@ moduleinitializers
     printversion
     {
       statusdict begin
-	cout (NEST version ) <- version <- (, built on ) <- built <- ( for ) <- host <- endl
+	cout (NEST version ) <- rcsinfo <- (, built on ) <- built <- ( for ) <- host <- endl
 	(Copyright (C) 2004 The NEST Initiative) <- endl endl
       end
       quit
@@ -2136,6 +2126,15 @@ moduleinitializers
 
 /start {
   {
+    % Check for rcsinfo SLI file and run it. If it does not
+    % exist, put an empty string into statusdict/rcsinfo.
+    mark
+      { (rcsinfo) (r) file } stopped not
+        { (rcsinfo) run }
+        { statusdict /rcsinfo () put }
+      ifelse
+    ] ;
+
     :commandline
     { % we have an interactive session
       welcome
@@ -2338,16 +2337,6 @@ SeeAlso: statusdict
 {
   statusdict/threading :: ToLowercase (openmp) searchif
 } def
-
-% Check for rcsinfo SLI file and run it. If it does not
-% exist, put an empty string into statusdict/rcsinfo.
-mark
-  { (rcsinfo) (r) file } stopped not
-    { (rcsinfo) run }
-    { statusdict /rcsinfo () put }
-  ifelse
-] ;
-
 
 % Add directories in environment variable SLI_PATH to the search path
 % for SLI files. Directories have to be separated by colon.

--- a/pynest/nest/pynest-init.sli
+++ b/pynest/nest/pynest-init.sli
@@ -77,26 +77,23 @@ def
 
 /pywelcome
 {
-  cout endl
+  () =
+  (              -- N E S T --) =
+  (  Copyright (C) 2004 The NEST Initiative) = () =
+  ( Version: ) =only statusdict/rcsinfo :: =
+  ( Built: ) =only statusdict/built :: =
+  () =
 
-  statusdict begin
-    (              -- N E S T --) <- endl
-    endl
-    (  Copyright (C) 2004 The NEST Initiative) <- endl
-    (  Version ) <- 
-    prgmajor <- (.) <- prgminor <- (.) <- prgpatch <-
-    ( ) <- built <- endl endl ;
-  end
+  ( This program is provided AS IS and comes with) =
+  ( NO WARRANTY. See the file LICENSE for details.) =
+  () =
 
-  warranty
+  ( Problems or suggestions?) =
+  (   Visit http://www.nest-simulator.org) =
+  () =
 
-  cout
-  (Problems or suggestions?) <- endl
-  (  Visit http://www.nest-simulator.org) <- endl
-
-  endl
-  (Type 'nest.help()' to find out more about NEST.) <- endl ;
-
+  ( Type 'nest.help()' to find out more about NEST.) =
+  () =
   :warnings
 } def
 
@@ -121,3 +118,13 @@ def
   } if
   not % invert the return value of stopped
 } bind def
+
+
+% Check for rcsinfo SLI file and run it. If it does not
+% exist, put an empty string into statusdict/rcsinfo.
+mark
+  { (rcsinfo) (r) file } stopped not
+    { (rcsinfo) run }
+    { statusdict /rcsinfo () put }
+  ifelse
+] ;


### PR DESCRIPTION
This PR addresses two issues:
* remove the confusing printout of the git branch and hash during the run of `cmake`
* make `nest` and `sli` print the correct version information or git branch and hash during startup instead of always the last released version number.

As these issues were initially discussed by @steffengraber and @heplesser on the mailing list, I suggest them to be reviewers for the PR. 