### PR TITLE
Removing pointless comparison with uint

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -271,7 +271,7 @@ public:
     const DictionaryDatum& dict,
     ConnectorModel& cm )
   {
-    assert( lcid >= 0 and lcid < C_.size() );
+    assert( lcid < C_.size() );
 
     C_[ lcid ].set_status(
       dict, static_cast< GenericConnectorModel< ConnectionT >& >( cm ) );

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -564,7 +564,6 @@ inline void
 MPIManager::set_chunk_size_secondary_events_in_int(
   const size_t chunk_size_in_int )
 {
-  assert( chunk_size_in_int >= 0 );
   chunk_size_secondary_events_in_int_ = chunk_size_in_int;
 }
 


### PR DESCRIPTION
This patch silences the warnings observed with FCC on the K computer login node:
```
"/.../nest-simulator/nestkernel/connector_base.h", line 283: warning: pointless comparison of unsigned integer with zero
      assert( lcid >= 0 and lcid < C_.size() );
                   ^

"/.../nest-simulator/nestkernel/mpi_manager.h", line 567: warning: pointless comparison of unsigned integer with zero
    assert( chunk_size_in_int >= 0 );
                              ^
```