### PR TITLE
Resize Connector vectors when adding connection models

### DIFF
--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -705,9 +705,6 @@ ModelsModule::init( SLIInterpreter* )
     .model_manager
     .register_connection_model< BernoulliConnection< TargetIdentifierPtrRport > >(
       "bernoulli_synapse" );
-
-  // resize all connection tables to number of registered synapses
-  kernel().connection_manager.resize_connections();
 }
 
 } // namespace nest

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -630,6 +630,10 @@ ModelManager::register_connection_model_( ConnectorModel* cf )
 
   synapsedict_->insert( cf->get_name(), syn_id );
 
+  // Need to resize Connector vectors in case connection model is added after
+  // ConnectionManager is initialised.
+  kernel().connection_manager.resize_connections();
+
   return syn_id;
 }
 


### PR DESCRIPTION
When adding connection models after NEST has been initialised, the vectors containing Connectors (which contains synapses for one particular synapse type) have to be resized, as the number of synapse types have increased. This happens when a module adds a connection model and is dynamically loaded at runtime.

Fixes #1002.