### PR TITLE
Clean up modification of dynamic recordables map in models

### DIFF
--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -693,8 +693,6 @@ aeif_cond_alpha_multisynapse::set_status( const DictionaryDatum& d )
    * Here is where we must update the recordablesMap_ if new receptors
    * are added!
    */
-  DynamicRecordablesMap< aeif_cond_alpha_multisynapse > rtmp =
-    recordablesMap_;                         // temporary copy in case of errors
   if ( ptmp.E_rev.size() > P_.E_rev.size() ) // Number of receptors increased
   {
     for ( size_t receptor = P_.E_rev.size(); receptor < ptmp.E_rev.size();
@@ -703,7 +701,7 @@ aeif_cond_alpha_multisynapse::set_status( const DictionaryDatum& d )
       size_t elem = aeif_cond_alpha_multisynapse::State_::G
         + receptor * aeif_cond_alpha_multisynapse::State_::
                        NUM_STATE_ELEMENTS_PER_RECEPTOR;
-      rtmp.insert(
+      recordablesMap_.insert(
         get_g_receptor_name( receptor ), get_data_access_functor( elem ) );
     }
   }
@@ -712,14 +710,13 @@ aeif_cond_alpha_multisynapse::set_status( const DictionaryDatum& d )
     for ( size_t receptor = ptmp.E_rev.size(); receptor < P_.E_rev.size();
           ++receptor )
     {
-      rtmp.erase( get_g_receptor_name( receptor ) );
+      recordablesMap_.erase( get_g_receptor_name( receptor ) );
     }
   }
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;
   S_ = stmp;
-  recordablesMap_ = rtmp;
 }
 
 } // namespace nest

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -731,8 +731,6 @@ aeif_cond_beta_multisynapse::set_status( const DictionaryDatum& d )
    * Here is where we must update the recordablesMap_ if new receptors
    * are added!
    */
-  DynamicRecordablesMap< aeif_cond_beta_multisynapse > rtmp =
-    recordablesMap_;                         // temporary copy in case of errors
   if ( ptmp.E_rev.size() > P_.E_rev.size() ) // Number of receptors increased
   {
     for ( size_t receptor = P_.E_rev.size(); receptor < ptmp.E_rev.size();
@@ -741,7 +739,7 @@ aeif_cond_beta_multisynapse::set_status( const DictionaryDatum& d )
       size_t elem = aeif_cond_beta_multisynapse::State_::G
         + receptor * aeif_cond_beta_multisynapse::State_::
                        NUM_STATE_ELEMENTS_PER_RECEPTOR;
-      rtmp.insert(
+      recordablesMap_.insert(
         get_g_receptor_name( receptor ), get_data_access_functor( elem ) );
     }
   }
@@ -750,14 +748,13 @@ aeif_cond_beta_multisynapse::set_status( const DictionaryDatum& d )
     for ( size_t receptor = ptmp.E_rev.size(); receptor < P_.E_rev.size();
           ++receptor )
     {
-      rtmp.erase( get_g_receptor_name( receptor ) );
+      recordablesMap_.erase( get_g_receptor_name( receptor ) );
     }
   }
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;
   S_ = stmp;
-  recordablesMap_ = rtmp;
 }
 
 } // namespace nest

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -468,8 +468,6 @@ iaf_psc_alpha_multisynapse::set_status( const DictionaryDatum& d )
    * Here is where we must update the recordablesMap_ if new receptors
    * are added!
    */
-  DynamicRecordablesMap< iaf_psc_alpha_multisynapse > rtmp =
-    recordablesMap_; // temporary copy in case of errors
   if ( ptmp.tau_syn_.size()
     > P_.tau_syn_.size() ) // Number of receptors increased
   {
@@ -479,7 +477,8 @@ iaf_psc_alpha_multisynapse::set_status( const DictionaryDatum& d )
       size_t elem = iaf_psc_alpha_multisynapse::State_::I_SYN
         + i_syn
           * iaf_psc_alpha_multisynapse::State_::NUM_STATE_ELEMENTS_PER_RECEPTOR;
-      rtmp.insert( get_i_syn_name( i_syn ), get_data_access_functor( elem ) );
+      recordablesMap_.insert(
+        get_i_syn_name( i_syn ), get_data_access_functor( elem ) );
     }
   }
   else if ( ptmp.tau_syn_.size() < P_.tau_syn_.size() )
@@ -487,14 +486,13 @@ iaf_psc_alpha_multisynapse::set_status( const DictionaryDatum& d )
     for ( size_t i_syn = ptmp.tau_syn_.size(); i_syn < P_.tau_syn_.size();
           ++i_syn )
     {
-      rtmp.erase( get_i_syn_name( i_syn ) );
+      recordablesMap_.erase( get_i_syn_name( i_syn ) );
     }
   }
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;
   S_ = stmp;
-  recordablesMap_ = rtmp;
 }
 
 } // namespace

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -440,8 +440,6 @@ iaf_psc_exp_multisynapse::set_status( const DictionaryDatum& d )
    * Here is where we must update the recordablesMap_ if new receptors
    * are added!
    */
-  DynamicRecordablesMap< iaf_psc_exp_multisynapse > rtmp =
-    recordablesMap_; // temporary copy in case of errors
   if ( ptmp.tau_syn_.size()
     > P_.tau_syn_.size() ) // Number of receptors increased
   {
@@ -451,7 +449,8 @@ iaf_psc_exp_multisynapse::set_status( const DictionaryDatum& d )
       size_t elem = iaf_psc_exp_multisynapse::State_::I_SYN
         + i_syn
           * iaf_psc_exp_multisynapse::State_::NUM_STATE_ELEMENTS_PER_RECEPTOR;
-      rtmp.insert( get_i_syn_name( i_syn ), get_data_access_functor( elem ) );
+      recordablesMap_.insert(
+        get_i_syn_name( i_syn ), get_data_access_functor( elem ) );
     }
   }
   else if ( ptmp.tau_syn_.size() < P_.tau_syn_.size() )
@@ -459,14 +458,13 @@ iaf_psc_exp_multisynapse::set_status( const DictionaryDatum& d )
     for ( size_t i_syn = ptmp.tau_syn_.size(); i_syn < P_.tau_syn_.size();
           ++i_syn )
     {
-      rtmp.erase( get_i_syn_name( i_syn ) );
+      recordablesMap_.erase( get_i_syn_name( i_syn ) );
     }
   }
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;
   S_ = stmp;
-  recordablesMap_ = rtmp;
 }
 
 } // namespace

--- a/nestkernel/recordables_map.h
+++ b/nestkernel/recordables_map.h
@@ -167,9 +167,9 @@ public:
  */
 template < typename HostNode >
 class DynamicRecordablesMap
-  : public std::map< Name, DataAccessFunctor< HostNode > >
+  : public std::map< Name, const DataAccessFunctor< HostNode > >
 {
-  typedef std::map< Name, DataAccessFunctor< HostNode > > Base_;
+  typedef std::map< Name, const DataAccessFunctor< HostNode > > Base_;
 
 public:
   virtual ~DynamicRecordablesMap()


### PR DESCRIPTION
Do changes directly to `recordablesMap_`, not to a temporary variable. Also reinstate constant  in `DynamicRecordablesMap`. Fixes #996.