### PR TITLE
Fix C++17 issues

### DIFF
--- a/models/correlation_detector.cpp
+++ b/models/correlation_detector.cpp
@@ -344,7 +344,7 @@ nest::correlation_detector::handle( SpikeEvent& e )
     SpikelistType::iterator insert_pos =
       std::find_if( S_.incoming_[ sender ].begin(),
         S_.incoming_[ sender ].end(),
-        std::bind2nd( std::greater< Spike_ >(), sp_i ) );
+        std::bind( std::greater< Spike_ >(), std::placeholders::_1, sp_i ) );
 
     // insert before the position we have found
     // if no element greater found, insert_pos == end(), so append at the end of

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -310,7 +310,7 @@ nest::correlomatrix_detector::handle( SpikeEvent& e )
     const Spike_ sp_i( spike_i, e.get_multiplicity() * e.get_weight(), sender );
     SpikelistType::iterator insert_pos = std::find_if( S_.incoming_.begin(),
       S_.incoming_.end(),
-      std::bind2nd( std::greater< Spike_ >(), sp_i ) );
+      std::bind( std::greater< Spike_ >(), std::placeholders::_1, sp_i ) );
 
     // insert before the position we have found
     // if no element greater found, insert_pos == end(), so append at the end of

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -406,10 +406,11 @@ nest::correlospinmatrix_detector::handle( SpikeEvent& e )
       // must happen here so event is taken into account in autocorrelation
       const BinaryPulse_ bp_i( t_i_on, t_i_off, i );
 
-      BinaryPulselistType::iterator insert_pos =
-        std::find_if( S_.incoming_.begin(),
-          S_.incoming_.end(),
-          std::bind2nd( std::greater< BinaryPulse_ >(), bp_i ) );
+      BinaryPulselistType::iterator insert_pos = std::find_if(
+        S_.incoming_.begin(),
+        S_.incoming_.end(),
+        std::bind(
+          std::greater< BinaryPulse_ >(), std::placeholders::_1, bp_i ) );
 
       // insert before the position we have found
       // if no element greater found, insert_pos == end(), so append at the end

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -216,7 +216,7 @@ DynamicLoaderModule::LoadModuleFunction::execute( SLIInterpreter* i ) const
   // modules. We can only perform it after we have loaded the module.
   if ( std::find_if( DynamicLoaderModule::getLinkedModules().begin(),
          DynamicLoaderModule::getLinkedModules().end(),
-         std::bind2nd( std::ptr_fun( has_name ), pModule->name() ) )
+         std::bind( has_name, std::placeholders::_1, pModule->name() ) )
     != DynamicLoaderModule::getLinkedModules().end() )
   {
     lt_dlclose( hModule ); // close module again


### PR DESCRIPTION
This PR fixes errors raised when compiling NEST with C++17. This includes
- Changing `std::bind2nd()` to `std::bind()`.
- Removing `std::ptr_fun()`.

Fixes #974.