### PR TITLE
do not search for libreadline when with-readline=OFF requested by user

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,11 @@ nest_process_tics_per_ms()
 nest_process_tics_per_step()
 nest_process_with_ps_array()
 nest_process_with_libltdl()
-nest_process_with_readline()
+
+if ( with-readline )
+  nest_process_with_readline()
+endif ()
+
 nest_process_with_gsl()
 nest_process_with_python()
 nest_process_with_openmp()


### PR DESCRIPTION
This PR addresses issue #1006.

I checked with `ldd` that there is no more dependency on libreadline after building with `with-readline=OFF`, for all of the generated .so files. (Note that this issue was irrespective of static vs. dynamic linking.)