### PR TITLE
Add skip_if_without_music to nest dictionary

### DIFF
--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -1453,12 +1453,6 @@ Description:
 } bind def
 
 
-/skip_if_without_music
-{
-  statusdict/have_music :: not {statusdict/exitcodes/success :: quit_i} if
-} def
-
-
 % Install modules in environment variable NEST_MODULES. Modules have
 % to be separated by colon.
 (NEST_MODULES) getenv { (:) breakup { Install } forall } if

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -1453,6 +1453,12 @@ Description:
 } bind def
 
 
+/skip_if_without_music
+{
+  statusdict/have_music :: not {statusdict/exitcodes/success :: quit_i} if
+} def
+
+
 % Install modules in environment variable NEST_MODULES. Modules have
 % to be separated by colon.
 (NEST_MODULES) getenv { (:) breakup { Install } forall } if

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -2341,3 +2341,21 @@ SeeAlso: statusdict
 % Add directories in environment variable SLI_PATH to the search path
 % for SLI files. Directories have to be separated by colon.
 (SLI_PATH) getenv { (:) breakup { addpath } forall } if
+
+
+/* BeginDocumentation
+Name: skip_if_* - End script and report it as skipped
+Synopsis: skip_if_* -> -
+Description:
+These functions will terminate NEST/SLI with a return code signaling that the
+script was skipped. It should be used to leave test/example scripts that have
+special prerequisites.
+SeeAlso: exit_test_gracefully
+*/
+
+/skip_if_no_mpi { statusdict/is_mpi :: not { /skipped_no_mpi exit_test_gracefully } if } def
+/skip_if_have_mpi { statusdict/is_mpi :: { /skipped_have_mpi exit_test_gracefully } if } def
+/skip_if_not_threaded { is_threaded not { /skipped_no_threading exit_test_gracefully } if } def
+/skip_if_without_gsl { statusdict/have_gsl :: not { /skipped_no_gsl exit_test_gracefully } if } def
+/skip_if_without_music { statusdict/have_music :: not { /skipped_no_music exit_test_gracefully } if } def
+

--- a/lib/sli/unittest.sli
+++ b/lib/sli/unittest.sli
@@ -53,12 +53,6 @@ is_threaded not { /skipped_no_openmp exit_test_gracefully } if
   statusdict/exitcodes :: exch get quit_i
 } bind def
 
-/skip_if_no_mpi { statusdict/is_mpi :: not { /skipped_no_mpi exit_test_gracefully } if } def
-/skip_if_have_mpi { statusdict/is_mpi :: { /skipped_have_mpi exit_test_gracefully } if } def
-/skip_if_not_threaded { is_threaded not { /skipped_no_threading exit_test_gracefully } if } def
-/skip_if_without_gsl { statusdict/have_gsl :: not { /skipped_no_gsl exit_test_gracefully } if } def
-/skip_if_without_music { statusdict/have_music :: not { /skipped_no_music exit_test_gracefully } if } def
-
 
 /* BeginDocumentation
 Name: unittest::assert_or_die - Check condition and quit with exit code 1 if it fails


### PR DESCRIPTION
In PR #1005, `skip_if_without_music` was added to some music examples. There was previously a `statusdict/have_music :: not {statusdict/exitcodes/success :: quit_i} if` in these examples, and calling `skip_if_without_music` is cleaner. `skip_if_without_music` is only defined in the SLI `unittest` namespace however, so when trying to run the music examples we now get

```
SLIInterpreter::execute [Error]: DictError
    Key '/skip_if_without_music' does not exist in dictionary.
```

even if we have compiled NEST with music. In this PR I therefore add `skip_if_without_music` to the SLI NEST namespace to get the examples to run. It is still also defined in the `unittest` namespace.