### PR TITLE
Follow-up patch on the CMake with-warning variable and add -Xg flag to CMAKE_CXX_FLAGS

### DIFF
--- a/cmake/Platform/Fujitsu-Sparc64.cmake
+++ b/cmake/Platform/Fujitsu-Sparc64.cmake
@@ -50,8 +50,8 @@ set( CMAKE_FIND_LIBRARY_PREFIXES "lib" )
 set( CMAKE_FIND_LIBRARY_SUFFIXES ".a" )
 
 # set the compiler
-set( CMAKE_C_COMPILER mpifccpx )
-set( CMAKE_CXX_COMPILER mpiFCCpx )
+set( CMAKE_C_COMPILER mpifccpx CACHE FILEPATH "Override C compiler" )
+set( CMAKE_CXX_COMPILER mpiFCCpx CACHE FILEPATH "Override C++ compiler" )
 
 # Prevent CMake from adding GNU-specific linker flags (-rdynamic)
 set( CMAKE_C_COMPILER_ID "Fujitsu" CACHE STRING "Fujitsu C cross-compiler" FORCE )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -49,6 +49,8 @@ function( NEST_PROCESS_WITH_WARNING )
     if ( with-warning STREQUAL "ON" )
       if ( NOT k-computer STREQUAL "ON" )
         set( with-warning "-Wall" )
+      else()
+        set( with-warning "" )
       endif()
     endif ()
     foreach ( flag ${with-warning} )
@@ -109,7 +111,8 @@ function( NEST_PROCESS_K_COMPUTER )
     set( IS_K ON PARENT_SCOPE )
     # need alternative tokens command to compile NEST
     set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --alternative_tokens" PARENT_SCOPE )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --alternative_tokens" PARENT_SCOPE )
+    # FCC accepts GNU flags when -Xg is supplied
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xg --alternative_tokens" PARENT_SCOPE )
   endif ()
 endfunction()
 


### PR DESCRIPTION
Given that the with-warning variable’s default value is "ON", when building NEST on K computer, we need to set explicitly the variable to “”.

FCC requires -Xg if GNU flags need to be supplied to the driver, add it.