### PR TITLE
fix for interpretation of `verbosity` and `debug` command line arguments as input script filename

### DIFF
--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -282,7 +282,6 @@ SLIStartup::SLIStartup( int argc, char** argv )
   for ( int i = 0; i < argc; ++i )
   {
     StringDatum* sd = new StringDatum( argv[ i ] );
-    ad.push_back( Token( sd ) );
 
     if ( *sd == "-d" || *sd == "--debug" )
     {
@@ -336,6 +335,8 @@ SLIStartup::SLIStartup( int argc, char** argv )
       verbosity_ = SLIInterpreter::M_QUIET;
       continue;
     }
+
+    ad.push_back( Token( sd ) );
   }
   targs = ad;
 }


### PR DESCRIPTION
This fixes #1016