### PR TITLE
Make test_refractory.py run with make installcheck

### DIFF
--- a/pynest/nest/tests/test_refractory.py
+++ b/pynest/nest/tests/test_refractory.py
@@ -43,6 +43,7 @@ trigger immediate spiking
 Untested models
 ---------------
 * ``aeif_cond_alpha_RK5``
+* ``amat2_psc_exp``
 * ``erfc_neuron``
 * ``gauss_rate_ipn``
 * ``gif_pop_psc_exp``
@@ -115,7 +116,6 @@ neurons_V_clamped = [
 # neurons that must be tested through a high current to spike immediately
 # (t_ref = interspike)
 neurons_interspike = [
-    "amat2_psc_exp",
     "ht_neuron",
 ]
 
@@ -129,6 +129,7 @@ neurons_interspike_ps = [
 # models that cannot be tested
 ignore_model = [
     "aeif_cond_alpha_RK5",  # this one is faulty and will be removed
+    "amat2_psc_exp",
     "erfc_neuron",
     "gauss_rate_ipn",
     "gif_pop_psc_exp",

--- a/pynest/nest/tests/test_refractory.py
+++ b/pynest/nest/tests/test_refractory.py
@@ -58,6 +58,11 @@ Untested models
 * ``lin_rate_ipn``
 * ``lin_rate_opn``
 * ``mcculloch_pitts_neuron``
+* ``music_cont_in_proxy``
+* ``music_cont_out_proxy``
+* ``music_event_in_proxy``
+* ``music_event_out_proxy``
+* ``music_message_in_proxy``
 * ``parrot_neuron``
 * ``parrot_neuron_ps``
 * ``pp_pop_psc_delta``
@@ -139,6 +144,11 @@ ignore_model = [
     "lin_rate_ipn",
     "lin_rate_opn",
     "mcculloch_pitts_neuron",
+    "music_cont_in_proxy",
+    "music_cont_out_proxy",
+    "music_event_in_proxy",
+    "music_event_out_proxy",
+    "music_message_in_proxy",
     "parrot_neuron",
     "parrot_neuron_ps",
     "pp_pop_psc_delta",

--- a/pynest/nest/tests/test_refractory.py
+++ b/pynest/nest/tests/test_refractory.py
@@ -57,6 +57,7 @@ Untested models
 * ``izhikevich``
 * ``lin_rate_ipn``
 * ``lin_rate_opn``
+* ``mat2_psc_exp``
 * ``mcculloch_pitts_neuron``
 * ``music_cont_in_proxy``
 * ``music_cont_out_proxy``
@@ -116,7 +117,6 @@ neurons_V_clamped = [
 neurons_interspike = [
     "amat2_psc_exp",
     "ht_neuron",
-    "mat2_psc_exp",
 ]
 
 neurons_interspike_ps = [
@@ -143,6 +143,7 @@ ignore_model = [
     "izhikevich",
     "lin_rate_ipn",
     "lin_rate_opn",
+    "mat2_psc_exp",
     "mcculloch_pitts_neuron",
     "music_cont_in_proxy",
     "music_cont_out_proxy",

--- a/pynest/nest/tests/test_refractory.py
+++ b/pynest/nest/tests/test_refractory.py
@@ -43,46 +43,13 @@ trigger immediate spiking
 Untested models
 ---------------
 * ``aeif_cond_alpha_RK5``
-* ``amat2_psc_exp``
-* ``erfc_neuron``
-* ``gauss_rate_ipn``
 * ``gif_pop_psc_exp``
-* ``ginzburg_neuron``
 * ``hh_cond_exp_traub``
 * ``hh_psc_alpha``
 * ``hh_psc_alpha_gap``
-* ``iaf_chs_2007``
-* ``iaf_chxk_2008``
 * ``iaf_psc_exp_ps_lossless``
-* ``iaf_tum_2000``
-* ``izhikevich``
-* ``lin_rate_ipn``
-* ``lin_rate_opn``
-* ``mat2_psc_exp``
-* ``mcculloch_pitts_neuron``
-* ``music_cont_in_proxy``
-* ``music_cont_out_proxy``
-* ``music_event_in_proxy``
-* ``music_event_out_proxy``
-* ``music_message_in_proxy``
-* ``parrot_neuron``
-* ``parrot_neuron_ps``
-* ``pp_pop_psc_delta``
-* ``pp_psc_delta``
-* ``rate_transformer_gauss``
-* ``rate_transformer_lin``
-* ``rate_transformer_sigmoid``
-* ``rate_transformer_sigmoid_gg_1998``
-* ``rate_transformer_tanh``
-* ``rate_transformer_threshold_lin``
 * ``sli_neuron``
 * ``siegert_neuron``
-* ``sigmoid_rate_gg_1998_ipn``
-* ``sigmoid_rate_ipn``
-* ``tanh_rate_ipn``
-* ``tanh_rate_opn``
-* ``threshold_lin_rate_ipn``
-* ``threshold_lin_rate_opn``
 """
 
 
@@ -90,33 +57,12 @@ Untested models
 #  Models, specific parameters
 # --------------------------------------------------------------------------- #
 
-# list of all neuronal models that can be tested by looking at clamped V
-neurons_V_clamped = [
-    'aeif_cond_alpha',
-    'aeif_cond_alpha_multisynapse',
-    'aeif_cond_beta_multisynapse',
-    'aeif_cond_exp',
-    'aeif_psc_alpha',
-    'aeif_psc_exp',
-    'gif_cond_exp',
-    'gif_cond_exp_multisynapse',
-    'gif_psc_exp',
-    'gif_psc_exp_multisynapse',
-    'iaf_cond_alpha',
-    'iaf_cond_alpha_mc',
-    'iaf_cond_exp',
-    'iaf_cond_exp_sfa_rr',
-    'iaf_psc_alpha',
-    'iaf_psc_alpha_multisynapse',
-    'iaf_psc_delta',
-    'iaf_psc_exp',
-    'iaf_psc_exp_multisynapse',
-]
-
-# neurons that must be tested through a high current to spike immediately
+# Neurons that must be tested through a high current to spike immediately
 # (t_ref = interspike)
 neurons_interspike = [
+    "amat2_psc_exp",
     "ht_neuron",
+    "mat2_psc_exp",
 ]
 
 neurons_interspike_ps = [
@@ -126,55 +72,22 @@ neurons_interspike_ps = [
     "iaf_psc_exp_ps",
 ]
 
-# models that cannot be tested
+# Models that cannot be tested
 ignore_model = [
-    "aeif_cond_alpha_RK5",  # this one is faulty and will be removed
-    "amat2_psc_exp",
-    "erfc_neuron",
-    "gauss_rate_ipn",
-    "gif_pop_psc_exp",
-    "ginzburg_neuron",
-    "hh_cond_exp_traub",
-    "hh_psc_alpha",
-    "hh_psc_alpha_gap",
-    "iaf_chs_2007",
-    "iaf_chxk_2008",
-    "iaf_psc_exp_ps_lossless",
-    "iaf_tum_2000",
-    "izhikevich",
-    "lin_rate_ipn",
-    "lin_rate_opn",
-    "mat2_psc_exp",
-    "mcculloch_pitts_neuron",
-    "music_cont_in_proxy",
-    "music_cont_out_proxy",
-    "music_event_in_proxy",
-    "music_event_out_proxy",
-    "music_message_in_proxy",
-    "parrot_neuron",
-    "parrot_neuron_ps",
-    "pp_pop_psc_delta",
-    "pp_psc_delta",
-    "rate_transformer_gauss",
-    "rate_transformer_lin",
-    "rate_transformer_sigmoid",
-    "rate_transformer_sigmoid_gg_1998",
-    "rate_transformer_tanh",
-    "rate_transformer_threshold_lin",
-    "sli_neuron",
-    "siegert_neuron",
-    "sigmoid_rate_gg_1998_ipn",
-    "sigmoid_rate_ipn",
-    "tanh_rate_ipn",
-    "tanh_rate_opn",
-    "threshold_lin_rate_ipn",
-    "threshold_lin_rate_opn",
+     "aeif_cond_alpha_RK5",      # This one is faulty and will be removed
+     "gif_pop_psc_exp",          # This one commits spikes at same time
+     "hh_cond_exp_traub",        # This one does not support V_reset
+     "hh_psc_alpha",             # This one does not support V_reset
+     "hh_psc_alpha_gap",         # This one does not support V_reset
+     "iaf_psc_exp_ps_lossless",  # This one use presice times
+     "sli_neuron",               # This one is not optimal for PyNEST
+     "siegert_neuron",           # This one does not connect to voltmeter
 ]
 
 tested_models = [m for m in nest.Models("nodes") if (nest.GetDefaults(
                  m, "element_type") == "neuron" and m not in ignore_model)]
 
-# additional parameters for the connector
+# Additional parameters for the connector
 add_connect_param = {
     "iaf_cond_alpha_mc": {"receptor_type": 7},
 }
@@ -186,8 +99,6 @@ add_connect_param = {
 
 simtime = 100
 resolution = 0.1
-min_steps = 1    # minimal number of refractory steps (t_ref = resolution)
-max_steps = 200  # maximal number of steps (t_ref = 200 * resolution)
 
 
 # --------------------------------------------------------------------------- #
@@ -205,10 +116,10 @@ class TestRefractoryCase(unittest.TestCase):
 
         msd = 123456
         N_vp = nest.GetKernelStatus(['total_num_virtual_procs'])[0]
-        pyrngs = [np.random.RandomState(s) for s in range(msd, msd + N_vp)]
 
         nest.SetKernelStatus({
-            'resolution': resolution, 'grng_seed': msd + N_vp,
+            'resolution': resolution,
+            'grng_seed': msd + N_vp,
             'rng_seeds': range(msd + N_vp + 1, msd + 2 * N_vp + 1)})
 
     def compute_reftime(self, model, sd, vm, neuron):
@@ -232,24 +143,29 @@ class TestRefractoryCase(unittest.TestCase):
             Value of the simulated refractory period.
         '''
         spike_times = nest.GetStatus(sd, "events")[0]["times"]
+
         if model in neurons_interspike:
-            # spike emitted at next timestep so substract resolution
+            # Spike emitted at next timestep so substract resolution
             return spike_times[1]-spike_times[0]-resolution
         elif model in neurons_interspike_ps:
             return spike_times[1]-spike_times[0]
         else:
             Vr = nest.GetStatus(neuron, "V_reset")[0]
             times = nest.GetStatus(vm, "events")[0]["times"]
-            # index of the 2nd spike
+
+            # Index of the 2nd spike
             idx_max = np.argwhere(times == spike_times[1])[0][0]
             name_Vm = "V_m.s" if model == "iaf_cond_alpha_mc" else "V_m"
             Vs = nest.GetStatus(vm, "events")[0][name_Vm]
-            # get the index at which the spike occured
+
+            # Get the index at which the spike occured
             idx_spike = np.argwhere(times == spike_times[0])[0][0]
-            # find end of refractory period between 1st and 2nd spike
+
+            # Find end of refractory period between 1st and 2nd spike
             idx_end = np.where(
                 np.isclose(Vs[idx_spike:idx_max], Vr, 1e-6))[0][-1]
             t_ref_sim = idx_end * resolution
+
             return t_ref_sim
 
     def test_refractory_time(self):
@@ -258,34 +174,44 @@ class TestRefractoryCase(unittest.TestCase):
         '''
         for model in tested_models:
             self.reset()
-            # randomly set a refractory period
-            t_ref = resolution * np.random.randint(min_steps, max_steps)
-            # create the neuron and devices
+
+            if "t_ref" not in nest.GetDefaults(model):
+                continue
+
+            # Randomly set a refractory period
+            t_ref = 1.7
+            # Create the neuron and devices
             nparams = {"t_ref": t_ref}
             neuron = nest.Create(model, params=nparams)
+
             name_Vm = "V_m.s" if model == "iaf_cond_alpha_mc" else "V_m"
             vm_params = {"interval": resolution, "record_from": [name_Vm]}
             vm = nest.Create("voltmeter", params=vm_params)
             sd = nest.Create("spike_detector", params={'precise_times': True})
             cg = nest.Create("dc_generator", params={"amplitude": 900.})
-            # for models that do not clamp V_m, use very large current to
+
+            # For models that do not clamp V_m, use very large current to
             # trigger almost immediate spiking => t_ref almost equals
             # interspike
             if model in neurons_interspike_ps:
                 nest.SetStatus(cg, "amplitude", 10000000.)
-            elif model in neurons_interspike:
+            elif model == 'ht_neuron':
+                # ht_neuron use too long time with a very large amplitude
                 nest.SetStatus(cg, "amplitude", 2000.)
-            # connect them and simulate
+            elif model in neurons_interspike:
+                nest.SetStatus(cg, "amplitude", 15000.)
+
+            # Connect them and simulate
             nest.Connect(vm, neuron)
             nest.Connect(cg, neuron, syn_spec=add_connect_param.get(model, {}))
             nest.Connect(neuron, sd)
 
             nest.Simulate(simtime)
 
-            # get and compare t_ref
+            # Get and compare t_ref
             t_ref_sim = self.compute_reftime(model, sd, vm, neuron)
 
-            # approximate result for precise spikes (interpolation error)
+            # Approximate result for precise spikes (interpolation error)
             if model in neurons_interspike_ps:
                 self.assertAlmostEqual(t_ref, t_ref_sim, places=3,
                                        msg='''Error in model {}:

--- a/pynest/nest/tests/test_refractory.py
+++ b/pynest/nest/tests/test_refractory.py
@@ -189,11 +189,12 @@ class TestRefractoryCase(unittest.TestCase):
     """
 
     def reset(self):
+        nest.ResetKernel()
+
         msd = 123456
         N_vp = nest.GetKernelStatus(['total_num_virtual_procs'])[0]
         pyrngs = [np.random.RandomState(s) for s in range(msd, msd + N_vp)]
 
-        nest.ResetKernel()
         nest.SetKernelStatus({
             'resolution': resolution, 'grng_seed': msd + N_vp,
             'rng_seeds': range(msd + N_vp + 1, msd + 2 * N_vp + 1)})


### PR DESCRIPTION
`test_refractory.py` is currently not being run when doing `make installcheck` when `nosetests` is available. The reason seems to be that the test use a decorator to test all neurons available in NEST, and `make installcheck` does not like it. I don't know why. So instead of using the decorator I loop through all models in NEST with a for-loop.

Since this test has not been run in a while there were several models that made the test fail. This was mostly because the models in question do not use `t_ref`, and so the test would fail when trying to set this variable. I have put all these models in the `ignore_model` list. In addition to this, `iaf_psc_exp_ps_lossless` caused the test to fail because it use precise times for spikes, and so the test would not detect that spiking time corresponded to the same times as when a voltmeter would detect a spike ([found here in the test](https://github.com/nest/nest-simulator/blob/master/pynest/nest/tests/test_refractory.py#L204)). I tried to round the `spike_times[1]` variable, but I got into trouble with floating point accuracy, so the test would still fail. I therefore put `iaf_psc_exp_ps_lossless` into `ignore_list` as well.

Furthermore, the `siegert_neuron` model caused the test to fail because it could not be connected to a `voltmeter`. I don't know if this is as it should be?

The `gif_pop_psc_exp` model caused the test to fail because `V_reset` (which is 0.0) is not close to the potential recorded from the voltmeter. We get a python `IndexError` [here](https://github.com/nest/nest-simulator/blob/master/pynest/nest/tests/test_refractory.py#L211), and I do not know enough about the model to know if the test is supposed to pass.