### PR TITLE
Make testsuite run when nosetests is unavailable

### DIFF
--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -24,74 +24,108 @@ import nest
 
 from . import compatibility
 
-from . import test_errors
-from . import test_stack
-from . import test_create
-from . import test_status
-from . import test_onetooneconnect
+from . import test_aeif_lsodar
+from . import test_connect_all_patterns
 from . import test_connect_all_to_all
+from . import test_connect_array_fixed_indegree
+from . import test_connect_array_fixed_outdegree
+from . import test_connect_distributions
 from . import test_connect_fixed_indegree
 from . import test_connect_fixed_outdegree
 from . import test_connect_fixed_total_number
 from . import test_connect_one_to_one
 from . import test_connect_pairwise_bernoulli
-from . import test_connect_array_fixed_indegree
-from . import test_connect_array_fixed_outdegree
-from . import test_getconnections
-from . import test_dataconnect
-from . import test_events
-from . import test_networks
-from . import test_threads
+from . import test_connect_parameters
+from . import test_connect_symmetric_pairwise_bernoulli
+from . import test_create
 from . import test_csa
-from . import test_quantal_stp_synapse
-from . import test_sp
+from . import test_current_recording_generators
+from . import test_dataconnect
+from . import test_erfc_neuron
+from . import test_errors
+from . import test_events
+from . import test_facetshw_stdp
+from . import test_getconnections
+from . import test_helper_functions
+from . import test_labeled_synapses
+from . import test_mc_neuron
+from . import test_networks
+from . import test_onetooneconnect
+from . import test_parrot_neuron_ps
 from . import test_parrot_neuron
-from . import test_stdp_triplet_synapse
-from . import test_weight_recorder
-from . import test_aeif_lsodar
+from . import test_pp_psc_delta
+from . import test_pp_psc_delta_stdp
+from . import test_quantal_stp_synapse
 from . import test_rate_copy_model
 from . import test_rate_instantaneous_and_delayed
 from . import test_rate_neuron
 from . import test_rate_neuron_communication
+from . import test_refractory
 from . import test_siegert_neuron
+from . import test_sp
+from . import test_split_simulation
+from . import test_stack
+from . import test_status
+from . import test_stdp_multiplicity
+from . import test_stdp_triplet_synapse
+from . import test_threads
 from . import test_use_gid_in_filename
+from . import test_vogels_sprekeler_synapse
+from . import test_weight_recorder
 
 
 def suite():
 
     suite = unittest.TestSuite()
 
-    suite.addTest(test_errors.suite())
-    suite.addTest(test_stack.suite())
-    suite.addTest(test_create.suite())
-    suite.addTest(test_status.suite())
-    suite.addTest(test_onetooneconnect.suite())
+    suite.addTest(test_aeif_lsodar.suite())
+    suite.addTest(test_connect_all_patterns.suite())
     suite.addTest(test_connect_all_to_all.suite())
+    suite.addTest(test_connect_array_fixed_indegree.suite())
+    suite.addTest(test_connect_array_fixed_outdegree.suite())
+    suite.addTest(test_connect_distributions.suite())
     suite.addTest(test_connect_fixed_indegree.suite())
     suite.addTest(test_connect_fixed_outdegree.suite())
     suite.addTest(test_connect_fixed_total_number.suite())
     suite.addTest(test_connect_one_to_one.suite())
     suite.addTest(test_connect_pairwise_bernoulli.suite())
-    suite.addTest(test_connect_array_fixed_indegree.suite())
-    suite.addTest(test_connect_array_fixed_outdegree.suite())
-    suite.addTest(test_getconnections.suite())
-    suite.addTest(test_dataconnect.suite())
-    suite.addTest(test_events.suite())
-    suite.addTest(test_networks.suite())
-    suite.addTest(test_threads.suite())
+    suite.addTest(test_connect_parameters.suite())
+    suite.addTest(test_connect_symmetric_pairwise_bernoulli.suite())
+    suite.addTest(test_create.suite())
     suite.addTest(test_csa.suite())
-    suite.addTest(test_quantal_stp_synapse.suite())
-    suite.addTest(test_sp.suite())
+    suite.addTest(test_current_recording_generators.suite())
+    suite.addTest(test_dataconnect.suite())
+    suite.addTest(test_erfc_neuron.suite())
+    suite.addTest(test_errors.suite())
+    suite.addTest(test_events.suite())
+    suite.addTest(test_facetshw_stdp.suite())
+    suite.addTest(test_getconnections.suite())
+    suite.addTest(test_helper_functions.suite())
+    suite.addTest(test_labeled_synapses.suite())
+    suite.addTest(test_mc_neuron.suite())
+    suite.addTest(test_networks.suite())
+    suite.addTest(test_onetooneconnect.suite())
+    suite.addTest(test_parrot_neuron_ps.suite())
     suite.addTest(test_parrot_neuron.suite())
-    suite.addTest(test_stdp_triplet_synapse.suite())
-    suite.addTest(test_weight_recorder.suite())
-    suite.addTest(test_aeif_lsodar.suite())
+    suite.addTest(test_pp_psc_delta.suite())
+    suite.addTest(test_pp_psc_delta_stdp.suite())
+    suite.addTest(test_quantal_stp_synapse.suite())
     suite.addTest(test_rate_copy_model.suite())
     suite.addTest(test_rate_instantaneous_and_delayed.suite())
     suite.addTest(test_rate_neuron.suite())
     suite.addTest(test_rate_neuron_communication.suite())
+    suite.addTest(test_refractory.suite())
     suite.addTest(test_siegert_neuron.suite())
+    suite.addTest(test_sp.suite())
+    suite.addTest(test_split_simulation.suite())
+    suite.addTest(test_stack.suite())
+    suite.addTest(test_status.suite())
+    suite.addTest(test_stdp_multiplicity.suite())
+    suite.addTest(test_stdp_triplet_synapse.suite())
+    suite.addTest(test_threads.suite())
     suite.addTest(test_use_gid_in_filename.suite())
+    suite.addTest(test_vogels_sprekeler_synapse.suite())
+    suite.addTest(test_weight_recorder.suite())
 
     return suite
 

--- a/pynest/nest/tests/test_connect_all_patterns.py
+++ b/pynest/nest/tests/test_connect_all_patterns.py
@@ -60,6 +60,10 @@ class TestConnectAllPatterns(unittest.TestCase):
                         ", ".join(failing_tests))
 
 
-if __name__ == '__main__':
+def suite():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestConnectAllPatterns)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/pynest/nest/tests/test_connect_distributions.py
+++ b/pynest/nest/tests/test_connect_distributions.py
@@ -261,9 +261,11 @@ class TestDists(unittest.TestCase):
         self.assertTrue(is_dist)
 
 
-if __name__ == '__main__':
+def suite():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestDists)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-    # suite = unittest.TestSuite()
-    # suite.addTest(TestDists('testGslBinomialDist'))
-    # unittest.TextTestRunner().run(suite)
+    return suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/pynest/nest/tests/test_connect_parameters.py
+++ b/pynest/nest/tests/test_connect_parameters.py
@@ -285,6 +285,10 @@ class TestParams(unittest.TestCase):
             self.setUp()
 
 
-if __name__ == '__main__':
+def suite():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestParams)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/pynest/nest/tests/test_mc_neuron.py
+++ b/pynest/nest/tests/test_mc_neuron.py
@@ -155,6 +155,10 @@ class TestMCNeuron(unittest.TestCase):
                                     self.gex_dist_test))
 
 
-if __name__ == '__main__':
+def suite():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestMCNeuron)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/pynest/nest/tests/test_sp/test_all.py
+++ b/pynest/nest/tests/test_sp/test_all.py
@@ -22,14 +22,16 @@
 import unittest
 import nest
 
-from . import test_synaptic_elements
 from . import test_conn_builder
-from . import test_growth_curves
-from . import test_sp_manager
 from . import test_disconnect
 from . import test_disconnect_multiple
 from . import test_enable_multithread
 from . import test_get_sp_status
+from . import test_growth_curves
+from . import test_sp_manager
+from . import test_synaptic_elements
+from . import test_update_synaptic_elements
+
 
 HAVE_MPI = nest.sli_func("statusdict/have_mpi ::")
 if HAVE_MPI:
@@ -63,15 +65,15 @@ def suite():
             raise
     test_suite = unittest.TestSuite()
 
-    test_suite.addTest(test_synaptic_elements.suite())
     test_suite.addTest(test_conn_builder.suite())
-    test_suite.addTest(test_growth_curves.suite())
-    test_suite.addTest(test_sp_manager.suite())
-    test_suite.addTest(test_synaptic_elements.suite())
     test_suite.addTest(test_disconnect.suite())
     test_suite.addTest(test_disconnect_multiple.suite())
     test_suite.addTest(test_enable_multithread.suite())
     test_suite.addTest(test_get_sp_status.suite())
+    test_suite.addTest(test_growth_curves.suite())
+    test_suite.addTest(test_sp_manager.suite())
+    test_suite.addTest(test_synaptic_elements.suite())
+    test_suite.addTest(test_update_synaptic_elements.suite())
 
     return test_suite
 

--- a/pynest/nest/tests/test_split_simulation.py
+++ b/pynest/nest/tests/test_split_simulation.py
@@ -76,6 +76,11 @@ class TestSplit(unittest.TestCase):
         r1 = self.simulate()
         self.assertEqual(r0, r1)
 
-if __name__ == '__main__':
+
+def suite():
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSplit)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/topology/pynest/tests/test_all.py
+++ b/topology/pynest/tests/test_all.py
@@ -38,6 +38,7 @@ from . import test_connection_with_elliptical_mask
 from . import test_dumping
 from . import test_plotting
 from . import test_random_parameter
+from . import test_rotated_rect_mask
 from . import test_selection_function_and_elliptical_mask
 from . import test_spatial_kernels
 
@@ -50,6 +51,7 @@ def suite():
     suite.addTest(test_dumping.suite())
     suite.addTest(test_plotting.suite())
     suite.addTest(test_random_parameter.suite())
+    suite.addTest(test_rotated_rect_mask.suite())
     suite.addTest(test_selection_function_and_elliptical_mask.suite())
     suite.addTest(test_spatial_kernels.suite())
 

--- a/topology/pynest/tests/test_spatial_kernels.py
+++ b/topology/pynest/tests/test_spatial_kernels.py
@@ -755,15 +755,20 @@ class TestSpatial3D(unittest.TestCase):
         self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
 
 
+def suite():
+    suite = unittest.TestSuite([
+        unittest.TestLoader().loadTestsFromTestCase(TestSpatial2D),
+        unittest.TestLoader().loadTestsFromTestCase(TestSpatial2DOBC),
+        unittest.TestLoader().loadTestsFromTestCase(TestSpatial3D),
+        ])
+    return suite
+
+
 if __name__ == '__main__':
 
     if not DEBUG_MODE:
-        suite = unittest.TestSuite([
-            unittest.TestLoader().loadTestsFromTestCase(TestSpatial2D),
-            unittest.TestLoader().loadTestsFromTestCase(TestSpatial2DOBC),
-            unittest.TestLoader().loadTestsFromTestCase(TestSpatial3D),
-            ])
-        unittest.TextTestRunner(verbosity=2).run(suite)
+        runner = unittest.TextTestRunner(verbosity=2)
+        runner.run(suite())
     elif PLOTTING_POSSIBLE:
         test = PlottingSpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
                                      kernel_name='gaussian')


### PR DESCRIPTION
When the testsuite is run, but `nosetests` is **not** available, do_test.sh crash before finishing all the tests and give `AttributeError: module 'nest.topology.tests.test_spatial_kernels' has no attribute 'suite'`. This comes from the fact that when we do not have `nosetests` available, we go through the suites defined in the `test_all.py` files, and run the corresponding tests. Topology's `test_all.py` call the `suite()` function of `test_spatial_kernels.py`, but `test_spatial_kernels.py` do not have a `suite()` function defined. So in this PR I have added the function to make the testsuite run to completion.

I have also added a bunch of missing test-files to the different `test_all`, to make more tests run when `nosetests` is unavailable, and added `suite()` functions to the files that were missing them.

NB!! Even though this PR pass on Travis, the testsuite will report one failure if you run `make installcheck` on your local computer and you do not have `nosetests`. The failing test is `test_refactory.py` which, as it turns out, has not been run in a while. I have made a separate PR for this issue, #1018, as that failure has nothing to do with `nosetests`. Once this PR and #1018 is merged though, all test will run and pass with or without `nosetests`.