### PR TITLE
Make lid to gid conversion (and vice versa) in the VPManager more consistent

### DIFF
--- a/nestkernel/vp_manager_impl.h
+++ b/nestkernel/vp_manager_impl.h
@@ -82,13 +82,16 @@ VPManager::is_gid_vp_local( const index gid ) const
 inline index
 VPManager::gid_to_lid( const index gid ) const
 {
-  return floor( static_cast< double >( gid ) / get_num_virtual_processes() );
+  // starts at lid 0 for gids >= 1 (expected value for neurons, excl. gid 0)
+  return ceil( static_cast< double >( gid ) / get_num_virtual_processes() ) - 1;
 }
 
 inline index
 VPManager::lid_to_gid( const index lid ) const
 {
-  return lid * get_num_virtual_processes() + get_vp();
+  const index vp = get_vp();
+  return ( lid + static_cast< index >( vp == 0 ) ) * get_num_virtual_processes()
+    + vp;
 }
 
 inline thread


### PR DESCRIPTION
The purpose of this code change is to make the conversion between vp-local node ids (lid) and global node ids (gid) more consistent in the corresponding helper functions in the VPManager.

Before the change, the first node on VP 0 got the local id 1, while the first node on all other VPs got the local id 0. After the change, the first node on all VPs gets the local id 0.

The new conversion scheme provides no meaningful conversion for gid 0. This was also the case in the old conversion scheme.

Suggested reviewers: @suku248 , @stinebuu 