### PR TITLE
Prevent execution of --debug and --verbosity options as files

### DIFF
--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -2030,6 +2030,12 @@ moduleinitializers
 	  exit
 	} if
 
+	% options --debug and --verbosity were alreay handled in the
+	% constructor of SLIStartup, here we just skip over them to
+	% prevent their addition to the files-to-be-executed list
+	dup (--debug) eq over (-d) eq or { pop exit } if
+	size 12 geq { dup 0 12 getinterval (--verbosity=) eq { pop exit } if } if
+
 	% the argument is not an option, so we take it as a file to execute:
 	statusdict begin
 	  /interactive false def

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -442,7 +442,8 @@ CODES_SKIPPED=\
 ' 202 Skipped (build with-mpi=OFF required),'\
 ' 203 Skipped (Threading required),'\
 ' 204 Skipped (GSL required),'\
-' 205 Skipped (MUSIC required),'
+' 205 Skipped (MUSIC required),'\
+' 206 Skipped (PyNEST required),'
 
 echo
 echo 'Phase 1: Testing if SLI can execute scripts and report errors'

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -442,8 +442,7 @@ CODES_SKIPPED=\
 ' 202 Skipped (build with-mpi=OFF required),'\
 ' 203 Skipped (Threading required),'\
 ' 204 Skipped (GSL required),'\
-' 205 Skipped (MUSIC required),'\
-' 206 Skipped (PyNEST required),'
+' 205 Skipped (MUSIC required),'
 
 echo
 echo 'Phase 1: Testing if SLI can execute scripts and report errors'

--- a/testsuite/regressiontests/issue-779-1016.py
+++ b/testsuite/regressiontests/issue-779-1016.py
@@ -29,28 +29,22 @@ This is a regression test for GitHub issues 779 and 1016.
 from subprocess import check_output, STDOUT
 from os.path import join
 from tempfile import mktemp
-from sys import exit
+from sys import exit, version_info
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 126
 EXIT_SKIPPED = 206
 
-try:
-    import nest
-except:
-    exit(EXIT_SKIPPED)
+decode = lambda x: x if version_info < (3,) else x.decode("utf8")
 
 nestscript = mktemp(".sli")
-nestcmd = [join(nest.sli_func("statusdict/prefix ::"), "bin", "nest"),
-           "-d",
-           "--verbosity=ALL",
-           nestscript]
+nestcmd = ["nest", "-d", "--verbosity=ALL", nestscript]
 
 with open(nestscript, "w") as f:
     f.write("statusdict/argv :: ==")
 
 raw_output = check_output(nestcmd, stderr=STDOUT)
-output = [x for x in raw_output.split("\n") if x != ""]
+output = [x for x in decode(raw_output).split("\n") if x != ""]
 
 expected = "[(" + ") (".join(nestcmd) + ")]"
 

--- a/testsuite/regressiontests/issue-779-1016.py
+++ b/testsuite/regressiontests/issue-779-1016.py
@@ -40,8 +40,7 @@ nestscript = mktemp(".sli")
 nestcmd = [join(nest.sli_func("statusdict/prefix ::"), "bin", "nest"),
            "-d",
            "--verbosity=ALL",
-           nestscript,
-]
+           nestscript]
 
 with open(nestscript, "w") as f:
     f.write("statusdict/argv :: ==")

--- a/testsuite/regressiontests/issue-779-1016.py
+++ b/testsuite/regressiontests/issue-779-1016.py
@@ -33,7 +33,6 @@ from sys import exit, version_info
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 126
-EXIT_SKIPPED = 206
 
 decode = lambda x: x if version_info < (3,) else x.decode("utf8")
 

--- a/testsuite/regressiontests/issue-779-1016.py
+++ b/testsuite/regressiontests/issue-779-1016.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# issue-779-1016.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This script ensures that NEST parses commandline arguments correctly
+and makes all of them available in the argv array in the statusdict.
+
+This is a regression test for GitHub issues 779 and 1016.
+"""
+
+from subprocess import check_output, STDOUT
+from os.path import join
+from tempfile import mktemp
+from sys import exit
+
+import nest
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 126
+
+nestscript = mktemp(".sli")
+nestcmd = [join(nest.sli_func("statusdict/prefix ::"), "bin", "nest"),
+           "-d",
+           "--verbosity=ALL",
+           nestscript,
+]
+
+with open(nestscript, "w") as f:
+    f.write("statusdict/argv :: ==")
+
+raw_output = check_output(nestcmd, stderr=STDOUT)
+output = [x for x in raw_output.split("\n") if x != ""]
+
+expected = "[(" + ") (".join(nestcmd) + ")]"
+
+if output[-1] == expected:
+    exit(EXIT_SUCCESS)
+else:
+    exit(EXIT_FAILURE)

--- a/testsuite/regressiontests/issue-779-1016.py
+++ b/testsuite/regressiontests/issue-779-1016.py
@@ -31,10 +31,14 @@ from os.path import join
 from tempfile import mktemp
 from sys import exit
 
-import nest
-
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 126
+EXIT_SKIPPED = 206
+
+try:
+    import nest
+except:
+    exit(EXIT_SKIPPED)
 
 nestscript = mktemp(".sli")
 nestcmd = [join(nest.sli_func("statusdict/prefix ::"), "bin", "nest"),


### PR DESCRIPTION
This is a replacement for #1017, which fixes #1016, while keeping the fix for #779 from #840 intact.

It also adds a regression test that uses a combination of `verbosity` and `debug` flags and makes sure they get not used as files and at all arguments still end up properly in the `argv` array in the `statusdict`.