### PR TITLE
Move ConnectionManager methods from impl to h

### DIFF
--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -825,6 +825,42 @@ ConnectionManager::get_stdp_eps() const
   return stdp_eps_;
 }
 
+inline index
+ConnectionManager::get_target_gid( const thread tid,
+  const synindex syn_id,
+  const index lcid ) const
+{
+  return connections_[ tid ][ syn_id ]->get_target_gid( tid, lcid );
+}
+
+inline void
+ConnectionManager::send( const thread tid,
+  const synindex syn_id,
+  const index lcid,
+  const std::vector< ConnectorModel* >& cm,
+  Event& e )
+{
+  connections_[ tid ][ syn_id ]->send( tid, lcid, cm, e );
+}
+
+inline void
+ConnectionManager::restructure_connection_tables( const thread tid )
+{
+  assert( not source_table_.is_cleared() );
+  target_table_.clear( tid );
+  source_table_.reset_processed_flags( tid );
+}
+
+inline void
+ConnectionManager::set_has_source_subsequent_targets( const thread tid,
+  const synindex syn_id,
+  const index lcid,
+  const bool subsequent_targets )
+{
+  connections_[ tid ][ syn_id ]->set_has_source_subsequent_targets(
+    lcid, subsequent_targets );
+}
+
 } // namespace nest
 
 #endif /* CONNECTION_MANAGER_H */

--- a/nestkernel/connection_manager_impl.h
+++ b/nestkernel/connection_manager_impl.h
@@ -50,24 +50,6 @@ ConnectionManager::register_conn_builder( const std::string& name )
   connruledict_->insert( name, id );
 }
 
-inline index
-ConnectionManager::get_target_gid( const thread tid,
-  const synindex syn_id,
-  const index lcid ) const
-{
-  return connections_[ tid ][ syn_id ]->get_target_gid( tid, lcid );
-}
-
-inline void
-ConnectionManager::send( const thread tid,
-  const synindex syn_id,
-  const index lcid,
-  const std::vector< ConnectorModel* >& cm,
-  Event& e )
-{
-  connections_[ tid ][ syn_id ]->send( tid, lcid, cm, e );
-}
-
 inline void
 ConnectionManager::send_to_devices( const thread tid,
   const index source_gid,
@@ -84,24 +66,6 @@ ConnectionManager::send_from_device( const thread tid,
 {
   target_table_devices_.send_from_device(
     tid, ldid, e, kernel().model_manager.get_synapse_prototypes( tid ) );
-}
-
-inline void
-ConnectionManager::restructure_connection_tables( const thread tid )
-{
-  assert( not source_table_.is_cleared() );
-  target_table_.clear( tid );
-  source_table_.reset_processed_flags( tid );
-}
-
-inline void
-ConnectionManager::set_has_source_subsequent_targets( const thread tid,
-  const synindex syn_id,
-  const index lcid,
-  const bool subsequent_targets )
-{
-  connections_[ tid ][ syn_id ]->set_has_source_subsequent_targets(
-    lcid, subsequent_targets );
 }
 
 } // namespace nest


### PR DESCRIPTION
Just maintanance: this PR moves four methods that were unnecessarily put into the impl file. @hakonsbm @stinebuu could you review please?