### PR TITLE
Use reverse iterator in get_history

### DIFF
--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -164,14 +164,14 @@ nest::Archiving_Node::get_history( double t1,
   else
   {
     std::deque< histentry >::reverse_iterator runner = history_.rbegin();
-    while ( ( runner != history_.rend() ) 
+    while ( ( runner != history_.rend() )
       and ( t2 - runner->t_ < - 1.0
                 * kernel().connection_manager.get_stdp_eps() ) )
     {
       ++runner;
     }
     *finish = runner.base();
-    while ( ( runner != history_.rend() ) 
+    while ( ( runner != history_.rend() )
       and ( t1 - runner->t_ < - 1.0
                 * kernel().connection_manager.get_stdp_eps() ) )
     {

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -163,22 +163,22 @@ nest::Archiving_Node::get_history( double t1,
   }
   else
   {
-    std::deque< histentry >::iterator runner = history_.begin();
-    while ( ( runner != history_.end() )
-      and ( t1 - runner->t_ > -1.0
+    std::deque< histentry >::reverse_iterator runner = history_.rbegin();
+    while ( ( runner != history_.rend() ) 
+      and ( t2 - runner->t_ < - 1.0
                 * kernel().connection_manager.get_stdp_eps() ) )
     {
       ++runner;
     }
-    *start = runner;
-    while ( ( runner != history_.end() )
-      and ( t2 - runner->t_ > -1.0
+    *finish = runner.base();
+    while ( ( runner != history_.rend() ) 
+      and ( t1 - runner->t_ < - 1.0
                 * kernel().connection_manager.get_stdp_eps() ) )
     {
       ( runner->access_counter_ )++;
       ++runner;
     }
-    *finish = runner;
+    *start = runner.base();
   }
 }
 

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -161,25 +161,20 @@ nest::Archiving_Node::get_history( double t1,
     *start = *finish;
     return;
   }
-  else
+  std::deque< histentry >::reverse_iterator runner = history_.rbegin();
+  const double t2_lim = t2 + kernel().connection_manager.get_stdp_eps();
+  const double t1_lim = t1 + kernel().connection_manager.get_stdp_eps();
+  while ( runner != history_.rend() and runner->t_ >= t2_lim )
   {
-    std::deque< histentry >::reverse_iterator runner = history_.rbegin();
-    while ( ( runner != history_.rend() )
-      and ( t2 - runner->t_ < -1.0
-                * kernel().connection_manager.get_stdp_eps() ) )
-    {
-      ++runner;
-    }
-    *finish = runner.base();
-    while ( ( runner != history_.rend() )
-      and ( t1 - runner->t_ < -1.0
-                * kernel().connection_manager.get_stdp_eps() ) )
-    {
-      ( runner->access_counter_ )++;
-      ++runner;
-    }
-    *start = runner.base();
+    ++runner;
   }
+  *finish = runner.base();
+  while ( runner != history_.rend() and runner->t_ >= t1_lim )
+  {
+    runner->access_counter_++;
+    ++runner;
+  }
+  *start = runner.base();
 }
 
 void

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -165,14 +165,14 @@ nest::Archiving_Node::get_history( double t1,
   {
     std::deque< histentry >::reverse_iterator runner = history_.rbegin();
     while ( ( runner != history_.rend() )
-      and ( t2 - runner->t_ < - 1.0
+      and ( t2 - runner->t_ < -1.0
                 * kernel().connection_manager.get_stdp_eps() ) )
     {
       ++runner;
     }
     *finish = runner.base();
     while ( ( runner != history_.rend() )
-      and ( t1 - runner->t_ < - 1.0
+      and ( t1 - runner->t_ < -1.0
                 * kernel().connection_manager.get_stdp_eps() ) )
     {
       ( runner->access_counter_ )++;


### PR DESCRIPTION
This pull request replaces the iterator in get_history in the archiving_node with a reverse iterator. This reverse iterator runs through the spike history starting at the back rather than in the front. The change speeds up finding the relevant range in stdp synapses, as this range tends to be located in the back. A comparison of this change with nest-master (commit 620bcf3) using the hcp_benchmark.sli with 32 nodes and 8 threads on JURECA reveals a a speedup of 2.3 %. 