### PR TITLE
Feature/exceptions

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -113,7 +113,7 @@ def catching_sli_run(cmd):
         message = sli_pop()
         commandname = sli_pop()
         engine.run('clear')
-        
+
         exceptionCls = getattr(_kernel.NESTErrors, errorname)
         raise exceptionCls(commandname, message)
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -113,8 +113,9 @@ def catching_sli_run(cmd):
         message = sli_pop()
         commandname = sli_pop()
         engine.run('clear')
-        errorstring = '%s in %s%s' % (errorname, commandname, message)
-        raise _kernel.NESTError(encode(errorstring))
+        
+        exceptionCls = getattr(_kernel.NESTErrors, errorname)
+        raise exceptionCls(commandname, message)
 
 sli_run = hl_api.sr = catching_sli_run
 
@@ -159,7 +160,7 @@ def sli_func(s, *args, **kwargs):
         if kwargs['litconv']:
             slifun = 'sli_func_litconv'
     elif len(kwargs) > 0:
-        _kernel.NESTError(
+        raise _kernel.NESTErrors.PyNESTError(
             "'namespace' and 'litconv' are the only valid keyword arguments.")
 
     sli_push(args)       # push array of arguments on SLI stack
@@ -186,14 +187,13 @@ def init(argv):
 
     Raises
     ------
-    _kernel.NESTError
+    _kernel.NESTError.PyNESTError
     """
 
     global initialized
 
     if initialized:
-        raise _kernel.NESTError("NEST already initialized.")
-        return
+        raise _kernel.NESTErrors.PyNESTError("NEST already initialized.")
 
     quiet = False
 
@@ -232,7 +232,7 @@ def init(argv):
                 pass
 
     else:
-        _kernel.NESTError("Initiatization of NEST failed.")
+        raise _kernel.NESTErrors.PyNESTError("Initiatization of NEST failed.")
 
 
 def test():

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -167,8 +167,10 @@ class NESTMappedException(type):
             # now call init on the parent class: all of this is only needed to properly set errorname
             parent.__init__(self, commandname, errormessage, *args, errorname=errorname, **kwargs)
 
-        # and now dynamically construct the new class (NESTMappedException is a child of 'type')
-        newclass = NESTMappedException("NESTErrors." + errorname, (parent,), {'__init__': __init__})
+        # and now dynamically construct the new class
+        # not NESTMappedException, since that would mean the metaclass would let the class inherit
+        # this __getattr__
+        newclass = type("NESTErrors." + errorname, (parent,), {'__init__': __init__})
         # Cache for reuse: __getattr__ should now not get called if requested again
         setattr(NESTErrors, errorname, newclass)
 

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -76,21 +76,21 @@ except ImportError:
     pass
 
 class NESTMappedException(type):
-    """metaclass for exception namespace that dynamically creates exception classes
+    """Metaclass for exception namespace that dynamically creates exception classes.
 
     If a class (self) of this (meta)-type has an unknown attribute requested, __getattr__ defined
     below gets called, creating a class with that name (the error name) and with an __init__ taking
     commandname and errormessage (as created in the source) which is a closure on the parent and
     errorname as well, with a parent of default type (self.default_parent) or
-    self.parents[errorname] if defined """
+    self.parents[errorname] if defined. """
 
     def __getattr__(self, errorname):
         """Creates a class of type "errorname" which is a child of self.default_parent or
-        self.parents[errorname] if one is defined
+        self.parents[errorname] if one is defined.
 
         This __getattr__ function also stores the class permanently as an attribute of self for
         re-use where self is actually the class that triggered the getattr (the class that
-        NESTMappedException is a metaclass of) """
+        NESTMappedException is a metaclass of). """
 
         # Dynamic class construction, first check if we know its parent
         if errorname in self.parents:
@@ -106,15 +106,15 @@ class NESTMappedException(type):
             (parent,),
             {
                 '__init__': self.init(parent, errorname),
-                '__doc__': \
-                """Dynamically created exception {} from {}
-                
-                Created for the namespace: {}
-                Parent exception: {}
+                '__doc__':
+                """Dynamically created exception {} from {}.
+
+                Created for the namespace: {}.
+                Parent exception: {}.
                 """.format(errorname, self.source, self.__name__, parent.__name__)
             }
         )
-        
+
         # Cache for reuse: __getattr__ should now not get called if requested again
         setattr(self, errorname, newclass)
 
@@ -122,91 +122,93 @@ class NESTMappedException(type):
         return newclass
 
 class NESTErrors(metaclass=NESTMappedException):
-    """Namespace for NEST exceptions, including dynamically created classes from SLI
+    """Namespace for NEST exceptions, including dynamically created classes from SLI.
 
-    Dynamic exception creation is through __getattr__ defined in the metaclass NESTMappedException
+    Dynamic exception creation is through __getattr__ defined in the metaclass NESTMappedException.
     """
-               
+
     class NESTError(Exception):
-        """Base exception class for all NEST exceptions
+        """Base exception class for all NEST exceptions.
         """
 
         def __init__(self, message, *args, **kwargs):
-            """Initializer for NESTError base class
+            """Initializer for NESTError base class.
 
             Parameters:
             -----------
-            message: full error message to report
-            *args, **kwargs: passed through to Exception base class
+            message: full error message to report.
+            *args, **kwargs: passed through to Exception base class.
             """
 
             Exception.__init__(self, message, *args, **kwargs)
             self.message = message
 
     class SLIException(NESTError):
-        """Base class for all exceptions coming from sli
+        """Base class for all exceptions coming from sli.
         """
-        
+
         def __init__(self, commandname, errormessage, *args, errorname='SLIException', **kwargs):
-            """Initialize function
+            """Initialize function.
 
             Parameters:
             -----------
-            errorname: error name from SLI
-            commandname: command name from SLI
-            errormessage: message from SLI
-            *args, **kwargs: passed through to NESTErrors.NESTError base class
+            errorname: error name from SLI.
+            commandname: command name from SLI.
+            errormessage: message from SLI.
+            *args, **kwargs: passed through to NESTErrors.NESTError base class.
             """
             message = "{} in {}{}".format(errorname, commandname, errormessage)
             NESTErrors.NESTError.__init__(self, message, errorname, commandname, errormessage, *args, **kwargs)
-            
+
             self.errorname   = errorname
             self.commandname = commandname
-            self.errormessage  = errormessage            
+            self.errormessage  = errormessage
 
     class PyNESTError(NESTError):
-        """Exceptions produced from Python/Cython code
+        """Exceptions produced from Python/Cython code.
         """
         pass
 
     @staticmethod
     def init(parent, errorname):
-        """ Static class method to construct init's for SLIException children
+        """ Static class method to construct init's for SLIException children.
 
         Construct our new init with closure on errorname (as a default value) and parent.
         The default value allows the __init__ to be chained and set by the leaf child.
-        This also moves the paramerization of __init__ away from the class construction logic 
+        This also moves the paramerization of __init__ away from the class construction logic
         and next to the SLIException init.
 
         Parameters:
         ----------
         parent: the ancestor of the class needed to properly walk up the MRO (not possible with super() or super(type,...)
             because of the dynamic creation of the function
-             (used as a closure on the constructed __init__)
-        errorname: the class name for information purposes 
-          internally (used as a closure on the constructed __init__)
+             (used as a closure on the constructed __init__).
+        errorname: the class name for information purposes
+          internally (used as a closure on the constructed __init__).
         """
-        
+
         def __init__(self, commandname, errormessage, *args, errorname=errorname, **kwargs):
             # recursively init the parent class: all of this is only needed to properly set errorname
             parent.__init__(self, commandname, errormessage, *args, errorname=errorname, **kwargs)
 
         docstring = \
-            """Initialization function
+            """Initialization function.
 
             Parameters:
             -----------
-            commandname: sli command name
-            errormessage: sli error message
+            commandname: sli command name.
+            errormessage: sli error message.
             errorname: set by default ("{}") or passed in by child (shouldn't be explicitly set when creating an instance)
-            *args, **kwargs: passed through to base class
+            *args, **kwargs: passed through to base class.
 
-            self will be a descendant of {}
+            self will be a descendant of {}.
             """.format(errorname, parent.__name__)
 
-        try: __init__.__doc__ = docstring
-        except AttributeError: __init__.__func__.__doc__ = docstring
-        
+        try:
+            __init__.__doc__ = docstring
+        except AttributeError:
+            __init__.__func__.__doc__ = docstring
+
         return __init__
 
     # source: the dynamically created exceptions come from SLI
@@ -392,7 +394,7 @@ cdef class NESTEngine(object):
                         &argv_chars,
                         deref(self.pEngine),
                         modulepath_bytes)
-            
+
             # If using MPI, argv might now have changed, so rebuild it
             del argv[:]
             # Convert back from utf8 char* to utf8 str in both python2 & 3

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -103,12 +103,12 @@ class NESTMappedException(type):
             NESTErrors.SLIException.__init__(self, errorname, commandname, errormessage, *args, **kwargs)
 
         # Dynamic class construction
-        clz = type("NESTErrors." + errorname, (NESTErrors.SLIException,), {'__init__': __init__})
+        newclass = type("NESTErrors." + errorname, (NESTErrors.SLIException,), {'__init__': __init__})
         # Cache for reuse: __getattr__ should now not get called if requested again
-        setattr(NESTErrors, errorname, clz)
+        setattr(NESTErrors, errorname, newclass)
 
         # And now we return the exception
-        return clz
+        return newclass
 
 class NESTErrors(metaclass=NESTMappedException):
     """Namespace for nest exceptions, including dynamically created classes from SLI

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -78,20 +78,21 @@ except ImportError:
 class NESTMappedException(type):
     """metaclass for exception namespace that dynamically creates exception classes
 
-    If a class (self) of this (meta)-type has an unknown attribute requested, __getattr__ defined below
-    gets called, creating a class with that name (the error name) and with an __init__ taking
-    commandname and errormessage (as created in the source) which is a closure on the parent and errorname as well,
-    with a parent of default type (self.default_parent) or self.parents[errorname] if defined
-    """
+    If a class (self) of this (meta)-type has an unknown attribute requested, __getattr__ defined
+    below gets called, creating a class with that name (the error name) and with an __init__ taking
+    commandname and errormessage (as created in the source) which is a closure on the parent and
+    errorname as well, with a parent of default type (self.default_parent) or
+    self.parents[errorname] if defined """
 
     def __getattr__(self, errorname):
-        """Creates a class of type "errorname" which is a child of self.default_parent or self.parents[errorname] if one is defined
+        """Creates a class of type "errorname" which is a child of self.default_parent or
+        self.parents[errorname] if one is defined
 
-        This __getattr__ function also stores the class permanently as an attribute of self for re-use
-        where self is actually the class that triggered the getattr (the class that NESTMappedException is a metaclass of)
-        """
+        This __getattr__ function also stores the class permanently as an attribute of self for
+        re-use where self is actually the class that triggered the getattr (the class that
+        NESTMappedException is a metaclass of) """
 
-        # Dynamic class construction, first check if we know it's parent
+        # Dynamic class construction, first check if we know its parent
         if errorname in self.parents:
             parent = getattr(self, self.parents[errorname])
         else: # otherwise, get the default (SLIException)
@@ -121,10 +122,10 @@ class NESTMappedException(type):
         return newclass
 
 class NESTErrors(metaclass=NESTMappedException):
-    """Namespace for nest exceptions, including dynamically created classes from SLI
+    """Namespace for NEST exceptions, including dynamically created classes from SLI
 
     Dynamic exception creation is through __getattr__ defined in the metaclass NESTMappedException
-    """    
+    """
                
     class NESTError(Exception):
         """Base exception class for all NEST exceptions
@@ -164,7 +165,7 @@ class NESTErrors(metaclass=NESTMappedException):
             self.errormessage  = errormessage            
 
     class PyNESTError(NESTError):
-        """Exceptions produced from python/cython code
+        """Exceptions produced from Python/Cython code
         """
         pass
 
@@ -172,16 +173,18 @@ class NESTErrors(metaclass=NESTMappedException):
     def init(parent, errorname):
         """ Static class method to construct init's for SLIException children
 
-        Construct our new init with closure on errorname (as a default value) and parent
-        The default value allows the __init__ to be chained and set by the leaf child
-        This also moves the paramerization of __init__ away from the class construction logic
-        and next to the SLIException init
+        Construct our new init with closure on errorname (as a default value) and parent.
+        The default value allows the __init__ to be chained and set by the leaf child.
+        This also moves the paramerization of __init__ away from the class construction logic 
+        and next to the SLIException init.
 
         Parameters:
         ----------
         parent: the ancestor of the class needed to properly walk up the MRO (not possible with super() or super(type,...)
-            because of they dynamic creation of the function (used as a closure on the constructed __init__)
-        errorname: the class name for information purposes internally (used as a closure on the constructed __init__)
+            because of the dynamic creation of the function
+             (used as a closure on the constructed __init__)
+        errorname: the class name for information purposes 
+          internally (used as a closure on the constructed __init__)
         """
         
         def __init__(self, commandname, errormessage, *args, errorname=errorname, **kwargs):

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -81,7 +81,7 @@ class NESTMappedException(type):
     If a class of this (meta)-type has an unknown attribute requested, __getattr__ defined below
     gets called, creating a class with that name (the error name) and with an __init__ taking
     commandname and errormessage (as created in SLI) which is a closure on the errorname as well,
-    with a parent of type NESTErrors.SLIException
+    with a parent of type NESTErrors.SLIException or parents[errorname] if defined
     """
 
     parents = {

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -39,7 +39,6 @@ from cpython.ref cimport PyObject
 from cpython.object cimport Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE
 
 
-
 cdef string SLI_TYPE_BOOL = b"booltype"
 cdef string SLI_TYPE_INTEGER = b"integertype"
 cdef string SLI_TYPE_DOUBLE = b"doubletype"

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -128,13 +128,17 @@ class NESTErrors(metaclass=NESTMappedException):
                
     class NESTError(Exception):
         """Base exception class for all NEST exceptions
-        
-        Parameters:
-        -----------
-        message: full errormessage to report
-        *args, **kwargs: passed through to Exception base class
         """
+
         def __init__(self, message, *args, **kwargs):
+            """Initializer for NESTError base class
+
+            Parameters:
+            -----------
+            message: full error message to report
+            *args, **kwargs: passed through to Exception base class
+            """
+
             Exception.__init__(self, message, *args, **kwargs)
             self.message = message
 
@@ -175,13 +179,13 @@ class NESTErrors(metaclass=NESTMappedException):
 
         Parameters:
         ----------
-        parent of the class needed to properly walk up the MRO (not possible with super() or super(type,...)
-            because of they dynamic creation of the function
-        errorname is the class name for information purposes internally
+        parent: the ancestor of the class needed to properly walk up the MRO (not possible with super() or super(type,...)
+            because of they dynamic creation of the function (used as a closure on the constructed __init__)
+        errorname: the class name for information purposes internally (used as a closure on the constructed __init__)
         """
         
         def __init__(self, commandname, errormessage, *args, errorname=errorname, **kwargs):
-            # now call init on the parent class: all of this is only needed to properly set errorname
+            # recursively init the parent class: all of this is only needed to properly set errorname
             parent.__init__(self, commandname, errormessage, *args, errorname=errorname, **kwargs)
 
         docstring = \
@@ -202,6 +206,13 @@ class NESTErrors(metaclass=NESTMappedException):
         
         return __init__
 
+    # source: the dynamically created exceptions come from SLI
+    # default_parent: the dynamically created exceptions are descended from SLIExcepton
+    # parents: unless they happen to be mapped in this list to another exception descended from SLIException
+    #          these should be updated when new exceptions in sli are created that aren't directly descended
+    #          from SLIException (but nothing bad will happen, it's just that otherwise they'll be directly
+    #          descended from SLIException instead of an intermediate exception; they'll still be constructed
+    #          and useable)
     source = "SLI"
     default_parent = SLIException
     parents = {


### PR DESCRIPTION
Issue #151: More detailed pynest errors: subclassing the general pynest nest.NESTError class

Dynamically create python exceptions from SLIExceptions to allow finer grain catching of exceptions.
A series of exceptions of the form: nest.NESTErrors.<DictError|...> are created dynamically if a nest exception such as nest.DictError is thrown up into the SLI level and then passed to NEST. This resulting exception is then re-raised in python.

The full inheritance tree is not recreated: all nest errors that are re-raised are children of nest.NESTErrors.SLIException, all exceptions thrown from PyNest are nest.NESTErrors.PyNESTError and both are children of nest.NESTErrors.NESTError
