### PR TITLE
Rename {get,set}_delay to {get,set}_delay_steps

### DIFF
--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -565,7 +565,7 @@ nest::aeif_cond_alpha::update( Time const& origin,
 void
 nest::aeif_cond_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -584,7 +584,7 @@ nest::aeif_cond_alpha::handle( SpikeEvent& e )
 void
 nest::aeif_cond_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_cond_alpha_RK5.cpp
+++ b/models/aeif_cond_alpha_RK5.cpp
@@ -579,7 +579,7 @@ void nest::aeif_cond_alpha_RK5::update( Time const& origin,
 void
 nest::aeif_cond_alpha_RK5::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -598,7 +598,7 @@ nest::aeif_cond_alpha_RK5::handle( SpikeEvent& e )
 void
 nest::aeif_cond_alpha_RK5::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -646,7 +646,7 @@ aeif_cond_alpha_multisynapse::handle( SpikeEvent& e )
       "Synaptic weights for conductance-based multisynapse models "
       "must be positive." );
   }
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   assert(
     ( e.get_rport() > 0 ) && ( ( size_t ) e.get_rport() <= P_.n_receptors() ) );
 
@@ -658,7 +658,7 @@ aeif_cond_alpha_multisynapse::handle( SpikeEvent& e )
 void
 aeif_cond_alpha_multisynapse::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -684,7 +684,7 @@ aeif_cond_beta_multisynapse::handle( SpikeEvent& e )
       "Synaptic weights for conductance-based multisynapse models "
       "must be positive." );
   }
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   assert(
     ( e.get_rport() > 0 ) && ( ( size_t ) e.get_rport() <= P_.n_receptors() ) );
 
@@ -696,7 +696,7 @@ aeif_cond_beta_multisynapse::handle( SpikeEvent& e )
 void
 aeif_cond_beta_multisynapse::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -553,7 +553,7 @@ nest::aeif_cond_exp::update( const Time& origin,
 void
 nest::aeif_cond_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -572,7 +572,7 @@ nest::aeif_cond_exp::handle( SpikeEvent& e )
 void
 nest::aeif_cond_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -555,7 +555,7 @@ nest::aeif_psc_alpha::update( Time const& origin,
 void
 nest::aeif_psc_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -574,7 +574,7 @@ nest::aeif_psc_alpha::handle( SpikeEvent& e )
 void
 nest::aeif_psc_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -544,7 +544,7 @@ nest::aeif_psc_delta::update( const Time& origin,
 void
 nest::aeif_psc_delta::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -554,7 +554,7 @@ nest::aeif_psc_delta::handle( SpikeEvent& e )
 void
 nest::aeif_psc_delta::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -536,7 +536,7 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
 void
 nest::aeif_psc_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -555,7 +555,7 @@ nest::aeif_psc_exp::handle( SpikeEvent& e )
 void
 nest::aeif_psc_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -467,7 +467,7 @@ nest::amat2_psc_exp::update( Time const& origin,
 void
 nest::amat2_psc_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() >= 0.0 )
   {
@@ -486,7 +486,7 @@ nest::amat2_psc_exp::handle( SpikeEvent& e )
 void
 nest::amat2_psc_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/bernoulli_connection.h
+++ b/models/bernoulli_connection.h
@@ -161,7 +161,7 @@ public:
     {
       e_spike.set_multiplicity( n_spikes_out );
       e.set_weight( weight_ );
-      e.set_delay( get_delay_steps() );
+      e.set_delay_steps( get_delay_steps() );
       e.set_receiver( *get_target( t ) );
       e.set_rport( get_rport() );
       e();

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -514,7 +514,7 @@ template < class TGainfunction >
 void
 binary_neuron< TGainfunction >::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // The following logic implements the encoding:
   // A single spike signals a transition to 0 state, two spikes in same time
@@ -575,7 +575,7 @@ template < class TGainfunction >
 void
 binary_neuron< TGainfunction >::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/cont_delay_connection.h
+++ b/models/cont_delay_connection.h
@@ -238,12 +238,12 @@ ContDelayConnection< targetidentifierT >::send( Event& e,
   // seems save.
   if ( total_offset < Time::get_resolution().get_ms() )
   {
-    e.set_delay( get_delay_steps() );
+    e.set_delay_steps( get_delay_steps() );
     e.set_offset( total_offset );
   }
   else
   {
-    e.set_delay( get_delay_steps() - 1 );
+    e.set_delay_steps( get_delay_steps() - 1 );
     e.set_offset( total_offset - Time::get_resolution().get_ms() );
   }
   e();

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -598,7 +598,7 @@ nest::gif_cond_exp::update( Time const& origin, const long from, const long to )
 void
 nest::gif_cond_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // EX: We must compute the arrival time of the incoming spike
   //     explicitly, since it depends on delay and offset within
@@ -621,7 +621,7 @@ nest::gif_cond_exp::handle( SpikeEvent& e )
 void
 nest::gif_cond_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -682,7 +682,7 @@ nest::gif_cond_exp_multisynapse::handle( SpikeEvent& e )
       "Synaptic weights for conductance based models "
       "must be positive." );
   }
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   assert(
     ( e.get_rport() > 0 ) && ( ( size_t ) e.get_rport() <= P_.n_receptors() ) );
 
@@ -694,7 +694,7 @@ nest::gif_cond_exp_multisynapse::handle( SpikeEvent& e )
 void
 nest::gif_cond_exp_multisynapse::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -669,7 +669,7 @@ nest::gif_pop_psc_exp::update( Time const& origin,
 void
 gif_pop_psc_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double s = e.get_weight() * e.get_multiplicity();
 
@@ -690,7 +690,7 @@ gif_pop_psc_exp::handle( SpikeEvent& e )
 void
 nest::gif_pop_psc_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -417,7 +417,7 @@ nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
 void
 nest::gif_psc_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // EX: We must compute the arrival time of the incoming spike
   //     explicitly, since it depends on delay and offset within
@@ -440,7 +440,7 @@ nest::gif_psc_exp::handle( SpikeEvent& e )
 void
 nest::gif_psc_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -452,7 +452,7 @@ nest::gif_psc_exp_multisynapse::update( Time const& origin,
 void
 gif_psc_exp_multisynapse::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   assert( ( e.get_rport() > 0 )
     && ( ( size_t ) e.get_rport() <= P_.n_receptors_() ) );
 
@@ -464,7 +464,7 @@ gif_psc_exp_multisynapse::handle( SpikeEvent& e )
 void
 nest::gif_psc_exp_multisynapse::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -478,7 +478,7 @@ nest::hh_cond_exp_traub::update( Time const& origin,
 void
 nest::hh_cond_exp_traub::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -499,7 +499,7 @@ nest::hh_cond_exp_traub::handle( SpikeEvent& e )
 void
 nest::hh_cond_exp_traub::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -485,7 +485,7 @@ nest::hh_psc_alpha::update( Time const& origin, const long from, const long to )
 void
 nest::hh_psc_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -504,7 +504,7 @@ nest::hh_psc_alpha::handle( SpikeEvent& e )
 void
 nest::hh_psc_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -671,7 +671,7 @@ nest::hh_psc_alpha_gap::update_( Time const& origin,
 void
 nest::hh_psc_alpha_gap::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -690,7 +690,7 @@ nest::hh_psc_alpha_gap::handle( SpikeEvent& e )
 void
 nest::hh_psc_alpha_gap::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/ht_connection.h
+++ b/models/ht_connection.h
@@ -180,7 +180,7 @@ HTConnection< targetidentifierT >::send( Event& e,
   // send the spike to the target
   e.set_receiver( *get_target( t ) );
   e.set_weight( weight_ * p_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -917,7 +917,7 @@ ht_neuron::update( Time const& origin, const long from, const long to )
 void
 nest::ht_neuron::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   assert( e.get_rport() < static_cast< int >( B_.spike_inputs_.size() ) );
 
   B_.spike_inputs_[ e.get_rport() ].add_value(
@@ -928,7 +928,7 @@ nest::ht_neuron::handle( SpikeEvent& e )
 void
 nest::ht_neuron::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -285,7 +285,7 @@ nest::iaf_chs_2007::update( const Time& origin, const long from, const long to )
 void
 nest::iaf_chs_2007::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() >= 0.0 )
   {

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -473,7 +473,7 @@ nest::iaf_chxk_2008::update( Time const& origin,
 void
 nest::iaf_chxk_2008::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -492,7 +492,7 @@ nest::iaf_chxk_2008::handle( SpikeEvent& e )
 void
 nest::iaf_chxk_2008::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // add weighted current; HEP 2002-10-04
   B_.currents_.add_value(

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -456,7 +456,7 @@ nest::iaf_cond_alpha::update( Time const& origin,
 void
 nest::iaf_cond_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -475,7 +475,7 @@ nest::iaf_cond_alpha::handle( SpikeEvent& e )
 void
 nest::iaf_cond_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // add weighted current; HEP 2002-10-04
   B_.currents_.add_value(

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -674,7 +674,7 @@ nest::iaf_cond_alpha_mc::update( Time const& origin,
 void
 nest::iaf_cond_alpha_mc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   assert( 0 <= e.get_rport() && e.get_rport() < 2 * NCOMP );
 
   B_.spikes_[ e.get_rport() ].add_value(
@@ -685,7 +685,7 @@ nest::iaf_cond_alpha_mc::handle( SpikeEvent& e )
 void
 nest::iaf_cond_alpha_mc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   // not 100% clean, should look at MIN, SUP
   assert( 0 <= e.get_rport() && e.get_rport() < NCOMP );
 

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -422,7 +422,7 @@ nest::iaf_cond_exp::update( Time const& origin, const long from, const long to )
 void
 nest::iaf_cond_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -441,7 +441,7 @@ nest::iaf_cond_exp::handle( SpikeEvent& e )
 void
 nest::iaf_cond_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -474,7 +474,7 @@ nest::iaf_cond_exp_sfa_rr::update( Time const& origin,
 void
 nest::iaf_cond_exp_sfa_rr::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -493,7 +493,7 @@ nest::iaf_cond_exp_sfa_rr::handle( SpikeEvent& e )
 void
 nest::iaf_cond_exp_sfa_rr::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -384,7 +384,7 @@ iaf_psc_alpha::update( Time const& origin, const long from, const long to )
 void
 iaf_psc_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double s = e.get_weight() * e.get_multiplicity();
 
@@ -405,7 +405,7 @@ iaf_psc_alpha::handle( SpikeEvent& e )
 void
 iaf_psc_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -423,7 +423,7 @@ iaf_psc_alpha_multisynapse::handles_test_event( SpikeEvent&,
 void
 iaf_psc_alpha_multisynapse::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[ e.get_rport() - 1 ].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -433,7 +433,7 @@ iaf_psc_alpha_multisynapse::handle( SpikeEvent& e )
 void
 iaf_psc_alpha_multisynapse::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -346,7 +346,7 @@ nest::iaf_psc_delta::update( Time const& origin,
 void
 nest::iaf_psc_delta::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // EX: We must compute the arrival time of the incoming spike
   //     explicity, since it depends on delay and offset within
@@ -360,7 +360,7 @@ nest::iaf_psc_delta::handle( SpikeEvent& e )
 void
 nest::iaf_psc_delta::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -350,7 +350,7 @@ nest::iaf_psc_exp::update( const Time& origin, const long from, const long to )
 void
 nest::iaf_psc_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() >= 0.0 )
   {
@@ -369,7 +369,7 @@ nest::iaf_psc_exp::handle( SpikeEvent& e )
 void
 nest::iaf_psc_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -395,7 +395,7 @@ iaf_psc_exp_multisynapse::handles_test_event( SpikeEvent&, rport receptor_type )
 void
 iaf_psc_exp_multisynapse::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[ e.get_rport() - 1 ].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -405,7 +405,7 @@ iaf_psc_exp_multisynapse::handle( SpikeEvent& e )
 void
 iaf_psc_exp_multisynapse::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/models/iaf_tum_2000.cpp
+++ b/models/iaf_tum_2000.cpp
@@ -367,7 +367,7 @@ nest::iaf_tum_2000::update( Time const& origin, const long from, const long to )
 void
 nest::iaf_tum_2000::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() >= 0.0 )
   {
@@ -386,7 +386,7 @@ nest::iaf_tum_2000::handle( SpikeEvent& e )
 void
 nest::iaf_tum_2000::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -258,7 +258,7 @@ nest::izhikevich::update( Time const& origin, const long from, const long to )
 void
 nest::izhikevich::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
   B_.spikes_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     e.get_weight() * e.get_multiplicity() );
@@ -267,7 +267,7 @@ nest::izhikevich::handle( SpikeEvent& e )
 void
 nest::izhikevich::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -377,7 +377,7 @@ nest::mat2_psc_exp::update( Time const& origin, const long from, const long to )
 void
 nest::mat2_psc_exp::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() >= 0.0 )
   {
@@ -396,7 +396,7 @@ nest::mat2_psc_exp::handle( SpikeEvent& e )
 void
 nest::mat2_psc_exp::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -475,7 +475,7 @@ nest::pp_pop_psc_delta::update( Time const& origin,
 void
 nest::pp_pop_psc_delta::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // EX: We must compute the arrival time of the incoming spike
   //     explicitly, since it depends on delay and offset within
@@ -489,7 +489,7 @@ nest::pp_pop_psc_delta::handle( SpikeEvent& e )
 void
 nest::pp_pop_psc_delta::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -476,7 +476,7 @@ nest::pp_psc_delta::update( Time const& origin, const long from, const long to )
 void
 nest::pp_psc_delta::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   // EX: We must compute the arrival time of the incoming spike
   //     explicitly, since it depends on delay and offset within
@@ -490,7 +490,7 @@ nest::pp_psc_delta::handle( SpikeEvent& e )
 void
 nest::pp_psc_delta::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/models/quantal_stp_connection.h
+++ b/models/quantal_stp_connection.h
@@ -225,7 +225,7 @@ Quantal_StpConnection< targetidentifierT >::send( Event& e,
   {
     e.set_receiver( *get_target( t ) );
     e.set_weight( n_release * weight_ );
-    e.set_delay( get_delay_steps() );
+    e.set_delay_steps( get_delay_steps() );
     e.set_rport( get_rport() );
     e();
     a_ -= n_release;

--- a/models/rate_connection_delayed.h
+++ b/models/rate_connection_delayed.h
@@ -111,7 +111,7 @@ public:
   send( Event& e, thread t, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
-    e.set_delay( get_delay_steps() );
+    e.set_delay_steps( get_delay_steps() );
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -437,7 +437,7 @@ nest::rate_neuron_ipn< TNonlinearities >::handle(
   DelayedRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
-  const long delay = e.get_delay();
+  const long delay = e.get_delay_steps();
 
   size_t i = 0;
   std::vector< unsigned int >::iterator it = e.begin();

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -415,7 +415,7 @@ nest::rate_neuron_opn< TNonlinearities >::handle(
   DelayedRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
-  const long delay = e.get_delay();
+  const long delay = e.get_delay_steps();
 
   size_t i = 0;
   std::vector< unsigned int >::iterator it = e.begin();

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -312,7 +312,7 @@ nest::rate_transformer_node< TNonlinearities >::handle(
   DelayedRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
-  const long delay = e.get_delay();
+  const long delay = e.get_delay_steps();
 
   size_t i = 0;
   std::vector< unsigned int >::iterator it = e.begin();

--- a/models/static_connection.h
+++ b/models/static_connection.h
@@ -157,7 +157,7 @@ public:
   send( Event& e, const thread tid, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
-    e.set_delay( get_delay_steps() );
+    e.set_delay_steps( get_delay_steps() );
     e.set_receiver( *get_target( tid ) );
     e.set_rport( get_rport() );
     e();

--- a/models/static_connection_hom_w.h
+++ b/models/static_connection_hom_w.h
@@ -165,7 +165,7 @@ public:
   send( Event& e, const thread tid, const CommonPropertiesHomW& cp )
   {
     e.set_weight( cp.get_weight() );
-    e.set_delay( get_delay_steps() );
+    e.set_delay_steps( get_delay_steps() );
     e.set_receiver( *get_target( tid ) );
     e.set_rport( get_rport() );
     e();

--- a/models/stdp_connection.h
+++ b/models/stdp_connection.h
@@ -258,7 +258,7 @@ STDPConnection< targetidentifierT >::send( Event& e,
   e.set_weight( weight_ );
   // use accessor functions (inherited from Connection< >) to obtain delay in
   // steps and rport
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/stdp_connection_facetshw_hom.h
+++ b/models/stdp_connection_facetshw_hom.h
@@ -513,7 +513,7 @@ STDPFACETSHWConnectionHom< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *get_target( t ) );
   e.set_weight( weight_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/stdp_connection_hom.h
+++ b/models/stdp_connection_hom.h
@@ -311,7 +311,7 @@ STDPConnectionHom< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *target );
   e.set_weight( weight_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/stdp_dopa_connection.h
+++ b/models/stdp_dopa_connection.h
@@ -580,7 +580,7 @@ STDPDopaConnection< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *target );
   e.set_weight( weight_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/stdp_pl_connection_hom.h
+++ b/models/stdp_pl_connection_hom.h
@@ -265,7 +265,7 @@ STDPPLConnectionHom< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *target );
   e.set_weight( weight_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/stdp_triplet_connection.h
+++ b/models/stdp_triplet_connection.h
@@ -275,7 +275,7 @@ STDPTripletConnection< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *target );
   e.set_weight( weight_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/tsodyks2_connection.h
+++ b/models/tsodyks2_connection.h
@@ -212,7 +212,7 @@ Tsodyks2Connection< targetidentifierT >::send( Event& e,
   e.set_receiver( *target );
   e.set_weight( x_ * u_ * weight_ );
   // send the spike to the target
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -256,7 +256,7 @@ TsodyksConnection< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *target );
   e.set_weight( delta_y_tsp * weight_ );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/tsodyks_connection_hom.h
+++ b/models/tsodyks_connection_hom.h
@@ -287,7 +287,7 @@ TsodyksConnectionHom< targetidentifierT >::send( Event& e,
 
   e.set_receiver( *get_target( t ) );
   e.set_weight( delta_y_tsp * cp.get_weight() );
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/models/vogels_sprekeler_connection.h
+++ b/models/vogels_sprekeler_connection.h
@@ -233,7 +233,7 @@ VogelsSprekelerConnection< targetidentifierT >::send( Event& e,
   e.set_weight( weight_ );
   // use accessor functions (inherited from Connection< >) to obtain delay in
   // steps and rport
-  e.set_delay( get_delay_steps() );
+  e.set_delay_steps( get_delay_steps() );
   e.set_rport( get_rport() );
   e();
 

--- a/nest/sli_neuron.cpp
+++ b/nest/sli_neuron.cpp
@@ -228,7 +228,7 @@ nest::sli_neuron::execute_sli_protected( DictionaryDatum state, Name cmd )
 void
 nest::sli_neuron::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   if ( e.get_weight() > 0.0 )
   {
@@ -247,7 +247,7 @@ nest::sli_neuron::handle( SpikeEvent& e )
 void
 nest::sli_neuron::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double I = e.get_current();
   const double w = e.get_weight();

--- a/nestkernel/connector_base_impl.h
+++ b/nestkernel/connector_base_impl.h
@@ -49,7 +49,7 @@ Connector< ConnectionT >::send_weight_event( const thread tid,
     wr_e.set_sender_gid(
       kernel().connection_manager.get_source_gid( tid, syn_id_, lcid ) );
     wr_e.set_weight( e.get_weight() );
-    wr_e.set_delay( e.get_delay() );
+    wr_e.set_delay_steps( e.get_delay_steps() );
     // Set weight_recorder as receiver
     wr_e.set_receiver( *cp.get_weight_recorder()->get_thread_sibling( tid ) );
     // Put the gid of the postsynaptic node as receiver gid

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -160,14 +160,14 @@ public:
    * @param t delay.
    */
 
-  void set_delay( delay );
+  void set_delay_steps( delay );
 
   /**
    * Return transmission delay of the event.
    * The delay refers to the time until the event is
    * expected to arrive at the receiver.
    */
-  delay get_delay() const;
+  delay get_delay_steps() const;
 
   /**
    * Relative spike delivery time in steps.
@@ -1331,7 +1331,7 @@ Event::set_stamp( Time const& s )
 }
 
 inline delay
-Event::get_delay() const
+Event::get_delay_steps() const
 {
   return d_;
 }
@@ -1347,7 +1347,7 @@ Event::get_rel_delivery_steps( const Time& t ) const
 }
 
 inline void
-Event::set_delay( delay d )
+Event::set_delay_steps( delay d )
 {
   d_ = d;
 }

--- a/precise/iaf_psc_alpha_canon.cpp
+++ b/precise/iaf_psc_alpha_canon.cpp
@@ -459,13 +459,13 @@ nest::iaf_psc_alpha_canon::update( Time const& origin,
 void
 nest::iaf_psc_alpha_canon::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   /* We need to compute the absolute time stamp of the delivery time
      of the spike, since spikes might spend longer than min_delay_
      in the queue.  The time is computed according to Time Memo, Rule 3.
   */
-  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay() - 1;
+  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
   B_.events_.add_spike(
     e.get_rel_delivery_steps(
       nest::kernel().simulation_manager.get_slice_origin() ),
@@ -477,7 +477,7 @@ nest::iaf_psc_alpha_canon::handle( SpikeEvent& e )
 void
 nest::iaf_psc_alpha_canon::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/precise/iaf_psc_alpha_presc.cpp
+++ b/precise/iaf_psc_alpha_presc.cpp
@@ -432,7 +432,7 @@ nest::iaf_psc_alpha_presc::update( Time const& origin,
 void
 nest::iaf_psc_alpha_presc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const long Tdeliver = e.get_rel_delivery_steps(
     nest::kernel().simulation_manager.get_slice_origin() );
@@ -459,7 +459,7 @@ nest::iaf_psc_alpha_presc::handle( SpikeEvent& e )
 void
 nest::iaf_psc_alpha_presc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/precise/iaf_psc_delta_canon.cpp
+++ b/precise/iaf_psc_delta_canon.cpp
@@ -538,13 +538,13 @@ nest::iaf_psc_delta_canon::emit_instant_spike_( Time const& origin,
 void
 iaf_psc_delta_canon::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   /* We need to compute the absolute time stamp of the delivery time
      of the spike, since spikes might spend longer than min_delay_
      in the queue.  The time is computed according to Time Memo, Rule 3.
   */
-  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay() - 1;
+  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
   B_.events_.add_spike(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     Tdeliver,
@@ -555,7 +555,7 @@ iaf_psc_delta_canon::handle( SpikeEvent& e )
 void
 iaf_psc_delta_canon::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/precise/iaf_psc_exp_ps.cpp
+++ b/precise/iaf_psc_exp_ps.cpp
@@ -443,13 +443,13 @@ nest::iaf_psc_exp_ps::update( const Time& origin,
 void
 nest::iaf_psc_exp_ps::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   /* We need to compute the absolute time stamp of the delivery time
      of the spike, since spikes might spend longer than min_delay_
      in the queue.  The time is computed according to Time Memo, Rule 3.
   */
-  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay() - 1;
+  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
   B_.events_.add_spike(
     e.get_rel_delivery_steps(
@@ -462,7 +462,7 @@ nest::iaf_psc_exp_ps::handle( SpikeEvent& e )
 void
 nest::iaf_psc_exp_ps::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/precise/iaf_psc_exp_ps_lossless.cpp
+++ b/precise/iaf_psc_exp_ps_lossless.cpp
@@ -493,13 +493,13 @@ nest::iaf_psc_exp_ps_lossless::update( const Time& origin,
 void
 nest::iaf_psc_exp_ps_lossless::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   /* We need to compute the absolute time stamp of the delivery time
      of the spike, since spikes might spend longer than min_delay_
      in the queue.  The time is computed according to Time Memo, Rule 3.
   */
-  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay() - 1;
+  const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
   B_.events_.add_spike(
     e.get_rel_delivery_steps(
@@ -512,7 +512,7 @@ nest::iaf_psc_exp_ps_lossless::handle( SpikeEvent& e )
 void
 nest::iaf_psc_exp_ps_lossless::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   const double c = e.get_current();
   const double w = e.get_weight();

--- a/precise/parrot_neuron_ps.cpp
+++ b/precise/parrot_neuron_ps.cpp
@@ -117,12 +117,12 @@ parrot_neuron_ps::handle( SpikeEvent& e )
   // Repeat only spikes incoming on port 0, port 1 will be ignored
   if ( 0 == e.get_rport() )
   {
-    assert( e.get_delay() > 0 );
+    assert( e.get_delay_steps() > 0 );
 
     // We need to compute the absolute time stamp of the delivery time
     // of the spike, since spikes might spend longer than min_delay_
     // in the queue.  The time is computed according to Time Memo, Rule 3.
-    const long Tdeliver = e.get_stamp().get_steps() + e.get_delay() - 1;
+    const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
     // parrot ignores weight of incoming connection, store multiplicity
     B_.events_.add_spike(


### PR DESCRIPTION
These functions return/accept delays in steps so their name should reflect this.
Fixes #1025 
@heplesser 