### PR TITLE
Fixed the documentation get vacant synaptic elements

### DIFF
--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -88,8 +88,10 @@ public:
 
   /**
    * \fn int get_synaptic_elements_vacant(Name n)
-   * get the number of synaptic elements of type n which are available
+   * Get the number of synaptic elements of type n which are available
    * for new synapse creation
+   * Returns a negative number to indicate that synaptic elements
+   * must be deleted during the next update
    */
   int get_synaptic_elements_vacant( Name n ) const;
 

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -166,6 +166,8 @@ public:
   /**
   * \fn double get_z_value(Archiving_Node const *a, double t) const
   * Get the number of synaptic_element at the time t (in ms)
+  * Returns a negative number when synaptic elements must be deleted
+  * during the next update
   * @param a node of this synaptic_element
   * @param t Current time (in ms)
   */


### PR DESCRIPTION
This PR addresses issue  non-obvious semantics of get_synaptic_elements_vacant() #839

Fixed the documentation regarding the function to get vacant synaptic elements to clarify that negative values returned from this function are used to know how many synaptic elements must be deleted in the next update.
