### PR TITLE
nest.Disconnect parameters are consistent with documentation

### DIFF
--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -549,8 +549,8 @@ def CGSelectImplementation(tag, library):
 
 
 @check_stack
-@deprecated('', 'DisconnectOneToOne is deprecated and will be removed with \
-NEST-3., use Disconnect instead.')
+@deprecated('', 'DisconnectOneToOne is deprecated and will be removed in \
+NEST-3.0. Use Disconnect instead.')
 def DisconnectOneToOne(source, target, syn_spec):
     """Disconnect a currently existing synapse.
 

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -644,7 +644,7 @@ def Disconnect(pre, post, conn_spec='one_to_one', syn_spec='static_synapse'):
         syn_spec = {'model': syn_spec}
     if not syn_spec:
         syn_spec = {'model': 'static_synapse'}
-    
+
     sps(conn_spec)
     sps(syn_spec)
 

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -549,6 +549,8 @@ def CGSelectImplementation(tag, library):
 
 
 @check_stack
+@deprecated('', 'DisconnectOneToOne is deprecated and will be removed with \
+NEST-3., use Disconnect instead.')
 def DisconnectOneToOne(source, target, syn_spec):
     """Disconnect a currently existing synapse.
 
@@ -564,15 +566,14 @@ def DisconnectOneToOne(source, target, syn_spec):
 
     sps(source)
     sps(target)
-    if syn_spec is not None:
-        sps(syn_spec)
-        if is_string(syn_spec):
-            sr("cvlit")
+    if is_string(syn_spec):
+        syn_spec = {'model': syn_spec}
+    sps(syn_spec)
     sr('Disconnect')
 
 
 @check_stack
-def Disconnect(pre, post, conn_spec, syn_spec):
+def Disconnect(pre, post, conn_spec='one_to_one', syn_spec='static_synapse'):
     """Disconnect pre neurons from post neurons.
 
     Neurons in pre and post are disconnected using the specified disconnection
@@ -604,6 +605,10 @@ def Disconnect(pre, post, conn_spec, syn_spec):
     string describing one synapse model (synapse models are listed in the
     synapsedict) or as a dictionary as described below.
 
+    Note that only the synapse type is checked when we disconnect and that if
+    syn_spec is given as a non-empty dictionary, the 'model' parameter must be
+    present.
+
     If no synapse model is specified the default model 'static_synapse'
     will be used.
 
@@ -621,11 +626,10 @@ def Disconnect(pre, post, conn_spec, syn_spec):
     types in NEST or manually specified synapses created via CopyModel().
 
     All other parameters are not currently implemented.
-    Note: model is alias for syn_spec for backward compatibility.
 
     Notes
     -----
-    Disconnect does not iterate over subnets, it only connects explicitly
+    Disconnect does not iterate over subnets, it only disconnects explicitly
     specified nodes.
     """
 
@@ -634,14 +638,14 @@ def Disconnect(pre, post, conn_spec, syn_spec):
     sps(post)
     sr('cvgidcollection')
 
-    if conn_spec is not None:
-        sps(conn_spec)
-        if is_string(conn_spec):
-            sr("cvlit")
-
-    if syn_spec is not None:
-        sps(syn_spec)
-        if is_string(syn_spec):
-            sr("cvlit")
+    if is_string(conn_spec):
+        conn_spec = {'rule': conn_spec}
+    if is_string(syn_spec):
+        syn_spec = {'model': syn_spec}
+    if not syn_spec:
+        syn_spec = {'model': 'static_synapse'}
+    
+    sps(conn_spec)
+    sps(syn_spec)
 
     sr('Disconnect_g_g_D_D')

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -642,8 +642,6 @@ def Disconnect(pre, post, conn_spec='one_to_one', syn_spec='static_synapse'):
         conn_spec = {'rule': conn_spec}
     if is_string(syn_spec):
         syn_spec = {'model': syn_spec}
-    if not syn_spec:
-        syn_spec = {'model': 'static_synapse'}
 
     sps(conn_spec)
     sps(syn_spec)

--- a/pynest/nest/tests/test_sp/test_disconnect.py
+++ b/pynest/nest/tests/test_sp/test_disconnect.py
@@ -111,6 +111,14 @@ class TestDisconnectSingle(unittest.TestCase):
                 except nest.NESTError:
                     print("Synapse deletion ok: " + syn_model)
 
+    def test_simple(self):
+        nodes = nest.Create('iaf_psc_alpha', 5)
+        nest.Connect(nodes, nodes, 'one_to_one')
+
+        nest.DisconnectOneToOne(nodes[0], nodes[0], 'static_synapse')
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 4)
+
 
 def suite():
     test_suite = unittest.makeSuite(TestDisconnectSingle, 'test')

--- a/pynest/nest/tests/test_sp/test_disconnect_multiple.py
+++ b/pynest/nest/tests/test_sp/test_disconnect_multiple.py
@@ -260,17 +260,6 @@ class TestDisconnect(unittest.TestCase):
 
         self.assertEqual(nest.GetKernelStatus('num_connections'), 20)
 
-    def test_disconnect_dict(self):
-
-        nodes = nest.Create('iaf_psc_alpha', 5)
-        nest.Connect(nodes, nodes)
-
-        self.assertEqual(nest.GetKernelStatus('num_connections'), 25)
-
-        nest.Disconnect(nodes, nodes, 'all_to_all', {})
-
-        self.assertEqual(nest.GetKernelStatus('num_connections'), 0)
-
 
 def suite():
     test_suite = unittest.makeSuite(TestDisconnect, 'test')

--- a/pynest/nest/tests/test_sp/test_disconnect_multiple.py
+++ b/pynest/nest/tests/test_sp/test_disconnect_multiple.py
@@ -228,6 +228,49 @@ class TestDisconnect(unittest.TestCase):
                     [neurons[srcId]], [neurons[targId]], syn_model)
                 assert not conns
 
+    def test_disconnect_defaults(self):
+
+        nodes = nest.Create('iaf_psc_alpha', 5)
+        nest.Connect(nodes, nodes)
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 25)
+
+        nest.Disconnect(nodes, nodes)
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 20)
+
+    def test_disconnect_all_to_all(self):
+
+        nodes = nest.Create('iaf_psc_alpha', 5)
+        nest.Connect(nodes, nodes)
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 25)
+
+        nest.Disconnect(nodes, nodes, 'all_to_all')
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 0)
+
+    def test_disconnect_static_synapse(self):
+
+        nodes = nest.Create('iaf_psc_alpha', 5)
+        nest.Connect(nodes, nodes)
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 25)
+
+        nest.Disconnect(nodes, nodes, syn_spec='static_synapse')
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 20)
+
+    def test_disconnect_dict(self):
+
+        nodes = nest.Create('iaf_psc_alpha', 5)
+        nest.Connect(nodes, nodes)
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 25)
+
+        nest.Disconnect(nodes, nodes, 'all_to_all', {})
+
+        self.assertEqual(nest.GetKernelStatus('num_connections'), 0)
+
 
 def suite():
     test_suite = unittest.makeSuite(TestDisconnect, 'test')


### PR DESCRIPTION
Fixed PyNEST's `Disconnect` to work as stated in the documentation. With this PR, you can for instance call `Disconnect` as:
```
nest.Disconnect(nodes, nodes)
nest.Disconnect(nodes, nodes, 'all_to_all')
nest.Disconnect(nodes, nodes, 'all_to_all', 'static_synapse')
nest.Disconnect(nodes, nodes, syn_spec='static_synapse')
nest.Disconnect(nodes, nodes, conn_spec, syn_spec)
``` 
This fixes #1042, see also #786.

I have also added a deprecation warning to `DisconnectOneToOne` as this is removed in the nest-3 branch. We have removed the function because we don't really deal with individual GID's on the Python level anymore. Indexing into a `GIDCollection` returns a `GIDCollection`, so `Disconnect` can be used instead.