### PR TITLE
Fix issues in siegert_neuron

### DIFF
--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -280,8 +280,7 @@ nest::siegert_neuron::siegert1( double theta_shift,
   }
 
   gsl_integration_qags(
-    &F, lower_bound, upper_bound, 0.0, 1.49e-8, 1000, gsl_w_, &result, &error
-  );
+    &F, lower_bound, upper_bound, 0.0, 1.49e-8, 1000, gsl_w_, &result, &error );
 
   // factor 1e3 due to conversion from kHz to Hz, as time constant in ms.
   return 1e3 * 1. / ( P_.t_ref_ + exp( y_th * y_th ) * result * P_.tau_m_ );
@@ -319,8 +318,7 @@ nest::siegert_neuron::siegert2( double theta_shift,
   }
 
   gsl_integration_qags(
-    &F, lower_bound, upper_bound, 0.0, 1.49e-8, 1000, gsl_w_, &result, &error
-  );
+    &F, lower_bound, upper_bound, 0.0, 1.49e-8, 1000, gsl_w_, &result, &error );
 
   // factor 1e3 due to conversion from kHz to Hz, as time constant in ms.
   return 1e3 * 1. / ( P_.t_ref_ + result * P_.tau_m_ );
@@ -344,7 +342,7 @@ nest::siegert_neuron::siegert( double mu, double sigma_square )
   // Catch cases where neurons get no input.
   // Use (Brunel, 2000) eq. (22) to estimate
   // firing rate to be ~ 1e-16
-  if ( (theta_shift - mu) > 6. * sigma )
+  if ( ( theta_shift - mu ) > 6. * sigma )
   {
     return 0.;
   }

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -216,6 +216,7 @@ nest::siegert_neuron::siegert_neuron()
 {
   recordablesMap_.create();
   Node::set_node_uses_wfr( kernel().simulation_manager.use_wfr() );
+  gsl_w_ = gsl_integration_workspace_alloc( 1000 );
 }
 
 nest::siegert_neuron::siegert_neuron( const siegert_neuron& n )
@@ -225,6 +226,12 @@ nest::siegert_neuron::siegert_neuron( const siegert_neuron& n )
   , B_( n.B_, *this )
 {
   Node::set_node_uses_wfr( kernel().simulation_manager.use_wfr() );
+  gsl_w_ = gsl_integration_workspace_alloc( 1000 );
+}
+
+nest::siegert_neuron::~siegert_neuron()
+{
+  gsl_integration_workspace_free( gsl_w_ );
 }
 
 /* ----------------------------------------------------------------
@@ -241,8 +248,6 @@ nest::siegert_neuron::siegert1( double theta_shift,
   y_th = ( theta_shift - mu ) / sigma;
   double y_r;
   y_r = ( V_reset_shift - mu ) / sigma;
-
-  gsl_integration_workspace* w = gsl_integration_workspace_alloc( 1000 );
 
   double result, error;
 
@@ -275,9 +280,8 @@ nest::siegert_neuron::siegert1( double theta_shift,
   }
 
   gsl_integration_qags(
-    &F, lower_bound, upper_bound, 0.1, 0.1, 1000, w, &result, &error );
-
-  gsl_integration_workspace_free( w );
+    &F, lower_bound, upper_bound, 0.0, 1.49e-8, 1000, gsl_w_, &result, &error
+  );
 
   // factor 1e3 due to conversion from kHz to Hz, as time constant in ms.
   return 1e3 * 1. / ( P_.t_ref_ + exp( y_th * y_th ) * result * P_.tau_m_ );
@@ -293,8 +297,6 @@ nest::siegert_neuron::siegert2( double theta_shift,
   y_th = ( theta_shift - mu ) / sigma;
   double y_r;
   y_r = ( V_reset_shift - mu ) / sigma;
-
-  gsl_integration_workspace* w = gsl_integration_workspace_alloc( 1000 );
 
   double result, error;
 
@@ -317,9 +319,8 @@ nest::siegert_neuron::siegert2( double theta_shift,
   }
 
   gsl_integration_qags(
-    &F, lower_bound, upper_bound, 0.1, 0.1, 1000, w, &result, &error );
-
-  gsl_integration_workspace_free( w );
+    &F, lower_bound, upper_bound, 0.0, 1.49e-8, 1000, gsl_w_, &result, &error
+  );
 
   // factor 1e3 due to conversion from kHz to Hz, as time constant in ms.
   return 1e3 * 1. / ( P_.t_ref_ + result * P_.tau_m_ );
@@ -340,7 +341,10 @@ nest::siegert_neuron::siegert( double mu, double sigma_square )
   double V_r_shift =
     P_.V_reset_ + sigma * alpha / 2. * sqrt( P_.tau_syn_ / P_.tau_m_ );
 
-  if ( std::abs( mu - 0. ) < 1e-12 )
+  // Catch cases where neurons get no input.
+  // Use (Brunel, 2000) eq. (22) to estimate
+  // firing rate to be ~ 1e-16
+  if ( (theta_shift - mu) > 6. * sigma )
   {
     return 0.;
   }

--- a/models/siegert_neuron.h
+++ b/models/siegert_neuron.h
@@ -119,6 +119,8 @@ public:
   siegert_neuron();
   siegert_neuron( const siegert_neuron& );
 
+  ~siegert_neuron();
+
   /**
    * Import sets of overloaded virtual functions.
    * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
@@ -259,6 +261,8 @@ private:
   State_ S_;
   Variables_ V_;
   Buffers_ B_;
+
+  gsl_integration_workspace* gsl_w_;
 
   //! Mapping of recordables names to access functions
   static RecordablesMap< siegert_neuron > recordablesMap_;

--- a/pynest/nest/tests/test_siegert_neuron.py
+++ b/pynest/nest/tests/test_siegert_neuron.py
@@ -87,7 +87,8 @@ class SiegertNeuronTestCase(unittest.TestCase):
             'siegert_neuron', params=siegert_params)
 
         self.siegert_drive = nest.Create(
-            'siegert_neuron', 1, params={'mean': self.rate_ex})
+            'siegert_neuron', 1,
+            params={'mean': self.rate_ex, 'theta': siegert_params['theta']})
         J_mu_ex = neuron_status['tau_m'] * 1e-3 * self.J
         J_sigma_ex = neuron_status['tau_m'] * 1e-3 * self.J ** 2
         syn_dict = {'drift_factor': J_mu_ex, 'diffusion_factor':


### PR DESCRIPTION
This is the PR for some issues detected and fixed by @mhelias in the `siegert_neuron`:
1. The absence of input was caught with `std::abs( mu - 0. ) < 1e-12`, which is only true for no / low noise levels. Fix: Use `( theta_shift - mu ) > 6. * sigma` based on Brunel 2000, eq. (22).
2. The relative and absolute errors for the numerical GSL integration routine were fixed to `0.1` for both `siegert1` and `siegert2`. However, their absolute errors differ considerably. Fix: Use zero absolute error and relative error of `1.49e-8` for both.
3. The GSL workspace was allocated on every call. Fix: Only allocate the workspace on creation of the `siegert_neuron`.

A test relied on the first issue to create a `siegert_neuron` modelling the external drive. This is also fixed by adjusting `theta` for this neuron.