### PR TITLE
MyModule example missing Event methods

### DIFF
--- a/examples/MyModule/drop_odd_spike_connection.h
+++ b/examples/MyModule/drop_odd_spike_connection.h
@@ -182,7 +182,7 @@ DropOddSpikeConnection< targetidentifierT >::send( nest::Event& e,
   // Even time stamp, we send the spike using the normal sending mechanism
   // send the spike to the target
   e.set_weight( weight_ );
-  e.set_delay( ConnectionBase::get_delay_steps() );
+  e.set_delay_steps( ConnectionBase::get_delay_steps() );
   e.set_receiver( *ConnectionBase::get_target( t ) );
   e.set_rport( ConnectionBase::get_rport() );
   e(); // this sends the event

--- a/examples/MyModule/pif_psc_alpha.cpp
+++ b/examples/MyModule/pif_psc_alpha.cpp
@@ -284,7 +284,7 @@ mynest::pif_psc_alpha::update( Time const& slice_origin,
 void
 mynest::pif_psc_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -294,7 +294,7 @@ mynest::pif_psc_alpha::handle( SpikeEvent& e )
 void
 mynest::pif_psc_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),


### PR DESCRIPTION
Hello everyone!
As a first extension test, I have set up the example “MyModule” [as described here](http://nest.github.io/nest-simulator/extension_modules) and came across some calls to missing methods of the Event class ({get, set}_delay). These have recently been renamed (https://github.com/nest/nest-simulator/commit/df1e8b298a9e79a1b211a9cfac3ab06d528b5793#diff-3570aeceb89ee949f32c8e8c1bcd4f0c) and probably overlooked in this example.

