### PR TITLE
Handle number_of_connections<1 in topology

### DIFF
--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -33,13 +33,13 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   , number_of_connections_()
   , mask_()
   , kernel_()
-  , synapse_model_( kernel().model_manager.get_synapsedict()->lookup(
-      "static_synapse" ) )
+  , synapse_model_(
+      kernel().model_manager.get_synapsedict()->lookup( "static_synapse" ) )
   , weight_()
   , delay_()
 {
   Name connection_type;
-  long number_of_connections ( -1 ); // overwritten by dict entry
+  long number_of_connections( -1 ); // overwritten by dict entry
 
   for ( Dictionary::iterator dit = dict->begin(); dit != dict->end(); ++dit )
   {
@@ -72,7 +72,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
       if ( number_of_connections < 0 )
       {
 
-        throw BadProperty("Number of connections cannot be less than zero." );
+        throw BadProperty( "Number of connections cannot be less than zero." );
       }
 
       number_of_connections_ = number_of_connections;

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -33,8 +33,8 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   , number_of_connections_()
   , mask_()
   , kernel_()
-  , synapse_model_(
-      kernel().model_manager.get_synapsedict()->lookup( "static_synapse" ) )
+  , synapse_model_( kernel().model_manager.get_synapsedict()->lookup(
+      "static_synapse" ) )
   , weight_()
   , delay_()
 {

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -30,7 +30,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   , allow_multapses_( true )
   , source_filter_()
   , target_filter_()
-  , number_of_connections_( 0 )
+  , number_of_connections_()
   , mask_()
   , kernel_()
   , synapse_model_( kernel().model_manager.get_synapsedict()->lookup(
@@ -39,6 +39,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   , delay_()
 {
   Name connection_type;
+  long number_of_connections ( -1 ); // overwritten by dict entry
 
   for ( Dictionary::iterator dit = dict->begin(); dit != dict->end(); ++dit )
   {
@@ -66,7 +67,15 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
     else if ( dit->first == names::number_of_connections )
     {
 
-      number_of_connections_ = getValue< long >( dit->second );
+      number_of_connections = getValue< long >( dit->second );
+
+      if ( number_of_connections < 0 )
+      {
+
+        throw BadProperty("Number of connections cannot be less than zero." );
+      }
+
+      number_of_connections_ = number_of_connections;
     }
     else if ( dit->first == names::mask )
     {
@@ -138,7 +147,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   if ( connection_type == names::convergent )
   {
 
-    if ( number_of_connections_ )
+    if ( number_of_connections >= 0 )
     {
       type_ = Convergent;
     }
@@ -150,7 +159,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   else if ( connection_type == names::divergent )
   {
 
-    if ( number_of_connections_ )
+    if ( number_of_connections >= 0 )
     {
       type_ = Divergent;
     }

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -71,7 +71,6 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
 
       if ( number_of_connections < 0 )
       {
-
         throw BadProperty( "Number of connections cannot be less than zero." );
       }
 

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -504,6 +504,11 @@ template < int D >
 void
 ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
 {
+  if ( number_of_connections_ < 1)
+  {
+    return;
+  }
+
   DictionaryDatum dummy_params = new Dictionary; // empty parameter dictionary
                                                  // required by connect() calls
 
@@ -838,6 +843,11 @@ template < int D >
 void
 ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
 {
+  if ( number_of_connections_ < 1)
+  {
+    return;
+  }
+
   DictionaryDatum dummy_params = new Dictionary; // empty parameter dictionary
                                                  // required by connect() calls
 

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -437,11 +437,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
       if ( kernel_.valid() )
       {
 
-        for (
-          typename std::vector< std::pair< Position< D >, index > >::iterator
-            iter = positions->begin();
-          iter != positions->end();
-          ++iter )
+        for ( typename std::vector<
+                std::pair< Position< D >, index > >::iterator iter =
+                positions->begin();
+              iter != positions->end();
+              ++iter )
         {
 
           if ( ( not allow_autapses_ ) and ( iter->second == target_id ) )
@@ -472,11 +472,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
       else
       {
 
-        for (
-          typename std::vector< std::pair< Position< D >, index > >::iterator
-            iter = positions->begin();
-          iter != positions->end();
-          ++iter )
+        for ( typename std::vector<
+                std::pair< Position< D >, index > >::iterator iter =
+                positions->begin();
+              iter != positions->end();
+              ++iter )
         {
 
           if ( ( not allow_autapses_ ) and ( iter->second == target_id ) )
@@ -504,7 +504,7 @@ template < int D >
 void
 ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
 {
-  if ( number_of_connections_ < 1)
+  if ( number_of_connections_ < 1 )
   {
     return;
   }
@@ -587,11 +587,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
         std::vector< double > probabilities;
 
         // Collect probabilities for the sources
-        for (
-          typename std::vector< std::pair< Position< D >, index > >::iterator
-            iter = positions.begin();
-          iter != positions.end();
-          ++iter )
+        for ( typename std::vector<
+                std::pair< Position< D >, index > >::iterator iter =
+                positions.begin();
+              iter != positions.end();
+              ++iter )
         {
 
           probabilities.push_back( kernel_->value(
@@ -745,11 +745,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
         std::vector< double > probabilities;
 
         // Collect probabilities for the sources
-        for (
-          typename std::vector< std::pair< Position< D >, index > >::iterator
-            iter = positions->begin();
-          iter != positions->end();
-          ++iter )
+        for ( typename std::vector<
+                std::pair< Position< D >, index > >::iterator iter =
+                positions->begin();
+              iter != positions->end();
+              ++iter )
         {
           probabilities.push_back( kernel_->value(
             source.compute_displacement( target_pos, iter->first ), rng ) );
@@ -843,7 +843,7 @@ template < int D >
 void
 ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
 {
-  if ( number_of_connections_ < 1)
+  if ( number_of_connections_ < 1 )
   {
     return;
   }
@@ -894,11 +894,10 @@ ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
   std::vector< std::pair< Position< D >, index > >* sources =
     source.get_global_positions_vector( source_filter_ );
 
-  for (
-    typename std::vector< std::pair< Position< D >, index > >::iterator src_it =
-      sources->begin();
-    src_it != sources->end();
-    ++src_it )
+  for ( typename std::vector< std::pair< Position< D >, index > >::iterator
+          src_it = sources->begin();
+        src_it != sources->end();
+        ++src_it )
   {
 
     Position< D > source_pos = src_it->first;

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -437,11 +437,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
       if ( kernel_.valid() )
       {
 
-        for ( typename std::vector<
-                std::pair< Position< D >, index > >::iterator iter =
-                positions->begin();
-              iter != positions->end();
-              ++iter )
+        for (
+          typename std::vector< std::pair< Position< D >, index > >::iterator
+            iter = positions->begin();
+          iter != positions->end();
+          ++iter )
         {
 
           if ( ( not allow_autapses_ ) and ( iter->second == target_id ) )
@@ -472,11 +472,11 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
       else
       {
 
-        for ( typename std::vector<
-                std::pair< Position< D >, index > >::iterator iter =
-                positions->begin();
-              iter != positions->end();
-              ++iter )
+        for (
+          typename std::vector< std::pair< Position< D >, index > >::iterator
+            iter = positions->begin();
+          iter != positions->end();
+          ++iter )
         {
 
           if ( ( not allow_autapses_ ) and ( iter->second == target_id ) )
@@ -587,11 +587,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
         std::vector< double > probabilities;
 
         // Collect probabilities for the sources
-        for ( typename std::vector<
-                std::pair< Position< D >, index > >::iterator iter =
-                positions.begin();
-              iter != positions.end();
-              ++iter )
+        for (
+          typename std::vector< std::pair< Position< D >, index > >::iterator
+            iter = positions.begin();
+          iter != positions.end();
+          ++iter )
         {
 
           probabilities.push_back( kernel_->value(
@@ -745,11 +745,11 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
         std::vector< double > probabilities;
 
         // Collect probabilities for the sources
-        for ( typename std::vector<
-                std::pair< Position< D >, index > >::iterator iter =
-                positions->begin();
-              iter != positions->end();
-              ++iter )
+        for (
+          typename std::vector< std::pair< Position< D >, index > >::iterator
+            iter = positions->begin();
+          iter != positions->end();
+          ++iter )
         {
           probabilities.push_back( kernel_->value(
             source.compute_displacement( target_pos, iter->first ), rng ) );
@@ -894,10 +894,11 @@ ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
   std::vector< std::pair< Position< D >, index > >* sources =
     source.get_global_positions_vector( source_filter_ );
 
-  for ( typename std::vector< std::pair< Position< D >, index > >::iterator
-          src_it = sources->begin();
-        src_it != sources->end();
-        ++src_it )
+  for (
+    typename std::vector< std::pair< Position< D >, index > >::iterator src_it =
+      sources->begin();
+    src_it != sources->end();
+    ++src_it )
   {
 
     Position< D > source_pos = src_it->first;


### PR DESCRIPTION
Previously, `number_of_connections_` was used to distinguish between `Convergent`/`Divergent` and `Target_driven`/`Source_driven` connections such that the case `number_of_connections < 1` in the projection dictionary has not been handled consistently with plain NEST.

With this PR, 
- the connection `type_` is `Convergent`/`Divergent` if the projection dictionary contains the key `number_of_connections` with a valid value. Otherwise, the `type_` is `Target_driven`/`Source_driven`.
- no connections are created if `number_of_connections = 0` is specified.
- an error similar to plain NEST with `fixed_indegree`/`fixed_outdegree` is thrown if `number_of_connections < 0` is specified.

This fixes #1073.
