### PR TITLE
Correct documentation on libneurosim requirements

### DIFF
--- a/pynest/examples/csa_example.py
+++ b/pynest/examples/csa_example.py
@@ -55,7 +55,7 @@ except ImportError:
     print("This example requires CSA to be installed in order to run.\n" +
           "Please make sure you compiled NEST using\n" +
           "  -Dwith-libneurosim=[OFF|ON|</path/to/libneurosim>]\n" +
-          "and CSA and libneurosim are available from PYTHONPATH.")
+          "and CSA and libneurosim are available.")
     import sys
     sys.exit()
 

--- a/pynest/examples/csa_topology_example.py
+++ b/pynest/examples/csa_topology_example.py
@@ -59,7 +59,7 @@ except ImportError:
     print("This example requires CSA to be installed in order to run.\n" +
           "Please make sure you compiled NEST using\n" +
           "  -Dwith-libneurosim=[OFF|ON|</path/to/libneurosim>]\n" +
-          "and CSA and libneurosim are available from PYTHONPATH.")
+          "and CSA and libneurosim are available.")
     import sys
     sys.exit()
 


### PR DESCRIPTION
Addresses #1063

[skip ci]

A really minor change that corrects the comments in the two examples that refer to libneurosim being needed in PYTHONPATH.