### PR TITLE
Source code comment blocks refactored

### DIFF
--- a/examples/MyModule/drop_odd_spike_connection.h
+++ b/examples/MyModule/drop_odd_spike_connection.h
@@ -27,6 +27,9 @@
 #include "connection.h"
 
 
+namespace mynest
+{
+
 /** @BeginDocumentation
   Name: drop_odd_spike - Synapse dropping spikes with odd time stamps.
 
@@ -41,16 +44,6 @@
 
   SeeAlso: synapsedict
 */
-
-namespace mynest
-{
-
-/**
- * Connection class for illustration purposes.
- *
- * For a discussion of how synapses are created and represented in NEST 2.6,
- * please see Kunkel et al, Front Neuroinform 8:78 (2014), Sec 3.3.
- */
 template < typename targetidentifierT >
 class DropOddSpikeConnection : public nest::Connection< targetidentifierT >
 {

--- a/examples/MyModule/pif_psc_alpha.h
+++ b/examples/MyModule/pif_psc_alpha.h
@@ -87,10 +87,6 @@ Hans Ekkehard Plesser, based on iaf_psc_alpha
 
 SeeAlso: iaf_psc_delta, iaf_psc_exp, iaf_psc_alpha
 */
-
-/**
- * Non-leaky integrate-and-fire neuron with alpha-shaped PSCs.
- */
 class pif_psc_alpha : public nest::Archiving_Node
 {
 public:

--- a/precise/iaf_psc_exp_ps_lossless.h
+++ b/precise/iaf_psc_exp_ps_lossless.h
@@ -42,7 +42,9 @@
 #include "slice_ring_buffer.h"
 
 
-/*Begin Documentation
+namespace nest
+{
+/** @BeginDocumentation
 Name: iaf_psc_exp_ps_lossless - Leaky integrate-and-fire neuron
 with exponential postsynaptic currents; precise implementation;
 predicts exact number of spikes by applying state space analysis
@@ -79,6 +81,9 @@ Note: In the current implementation, tau_syn_ex and tau_syn_in must be equal.
   Support for different time constants may be added in the future, see issue
   #921.
 
+Remarks:
+  @todo Implement current input in consistent way.
+
 References:
 [1] Krishnan J, Porta Mana P, Helias M, Diesmann M and Di Napoli E
     (2018) Perfect Detection of Spikes in the Linear Sub-threshold
@@ -93,13 +98,6 @@ Receives: SpikeEvent, CurrentEvent, DataLoggingRequest
 
 SeeAlso: iaf_psc_exp_ps
 */
-
-namespace nest
-{
-/**
- * Leaky iaf neuron, exponential PSC synapses, lossless implementation.
- * @todo Implement current input in consistent way.
- */
 class iaf_psc_exp_ps_lossless : public Archiving_Node
 {
 public:


### PR DESCRIPTION
Small follow-up to https://github.com/nest/nest-simulator/pull/1062 (Source code comment blocks refactored to allow doxygen to parse them).

This PR fixes the documentation of a few files that were missed in #1062.