### PR TITLE
Fix static linking of modules

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -163,6 +163,9 @@ function( NEST_PROCESS_STATIC_LIBRARIES )
       # be used, so we'll add both to the preference list.
       set( CMAKE_FIND_LIBRARY_SUFFIXES ".a;.lib;.dylib;.so" PARENT_SCOPE )
     endif ()
+    if ( UNIX )
+      set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --static" PARENT_SCOPE )
+    endif ()
   else ()
     set( BUILD_SHARED_LIBS ON PARENT_SCOPE )
 

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -154,6 +154,11 @@ endfunction()
 function( NEST_PROCESS_STATIC_LIBRARIES )
   # build static or shared libraries
   if ( static-libraries )
+
+    if ( with-readline )
+      message( FATAL_ERROR "-Dstatic-libraries=ON requires -Dwith-readline=OFF" )
+    endif ()
+
     set( BUILD_SHARED_LIBS OFF PARENT_SCOPE )
     # set RPATH stuff
     set( CMAKE_SKIP_RPATH TRUE PARENT_SCOPE )
@@ -163,9 +168,9 @@ function( NEST_PROCESS_STATIC_LIBRARIES )
       # be used, so we'll add both to the preference list.
       set( CMAKE_FIND_LIBRARY_SUFFIXES ".a;.lib;.dylib;.so" PARENT_SCOPE )
     endif ()
-    if ( UNIX )
-      set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --static" PARENT_SCOPE )
-    endif ()
+
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --static" PARENT_SCOPE )
+
   else ()
     set( BUILD_SHARED_LIBS ON PARENT_SCOPE )
 


### PR DESCRIPTION
This pull request resolves issue #1006.

The change adds linker flag `--static` if the build is configured with `-Dstatic-libraries=ON`. Unlike suggested in issue #1006, `-Dwith-readline=ON` will not be allowed for static linking and CMake terminates with an error message. It has turned out that static linking against a static version of `libreadline` does not only require the `termcap` library, which may not be available in some environments, also CMake seems to have problems with setting the correct linker options (`-Bdynamic` is added). Since `-Dwith-readline=OFF` is not critical, and static linking is the exceptional case anyway, this is a pragmatic solution that should work on all systems. 