### PR TITLE
Fix header installation and multiplicity handling in MyModule

### DIFF
--- a/examples/MyModule/drop_odd_spike_connection.h
+++ b/examples/MyModule/drop_odd_spike_connection.h
@@ -182,7 +182,7 @@ DropOddSpikeConnection< targetidentifierT >::send( nest::Event& e,
   // Even time stamp, we send the spike using the normal sending mechanism
   // send the spike to the target
   e.set_weight( weight_ );
-  e.set_delay( ConnectionBase::get_delay_steps() );
+  e.set_delay_steps( ConnectionBase::get_delay_steps() );
   e.set_receiver( *ConnectionBase::get_target( t ) );
   e.set_rport( ConnectionBase::get_rport() );
   e(); // this sends the event

--- a/examples/MyModule/pif_psc_alpha.cpp
+++ b/examples/MyModule/pif_psc_alpha.cpp
@@ -284,17 +284,17 @@ mynest::pif_psc_alpha::update( Time const& slice_origin,
 void
 mynest::pif_psc_alpha::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
-    e.get_weight() );
+    e.get_weight() * e.get_multiplicity() );
 }
 
 void
 mynest::pif_psc_alpha::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/libnestutil/CMakeLists.txt
+++ b/libnestutil/CMakeLists.txt
@@ -18,15 +18,16 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 set( nestutil_sources
-    stopwatch.h stopwatch.cpp
+    block_vector.h
+    compose.hpp
+    lockptr.h
+    logging_event.h logging_event.cpp
+    logging.h
     numerics.h numerics.cpp
     propagator_stability.h propagator_stability.cpp
-    lockptr.h
-    compose.hpp
-    string_utils.h
     sort.h
-    logging.h
-    logging_event.h logging_event.cpp
+    stopwatch.h stopwatch.cpp
+    string_utils.h
     vector_util.h
     )
 


### PR DESCRIPTION
This is a follow-up to #1068.

- Ensure `block_vector.h` is installed as a NEST header.
- Sort list of libnestutil source files alphabetically for easier checking.
- Make `pif_psc_alpha` respect multiplicity.