### PR TITLE
Make GetConnection filter by synapse label when only target attribute is given

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1232,7 +1232,8 @@ nest::ConnectionManager::get_connections(
           for ( size_t i = 0; i < source_lcids.size(); ++i )
           {
             if ( synapse_label == UNLABELED_CONNECTION
-                 or connections->get_syn_label( source_lcids[ i ] ) == synapse_label )
+              or connections->get_syn_label( source_lcids[ i ] )
+                == synapse_label )
             {
               conns_in_thread.push_back( ConnectionDatum( ConnectionID(
                 source_table_.get_gid( tid, syn_id, source_lcids[ i ] ),

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1231,13 +1231,18 @@ nest::ConnectionManager::get_connections(
 
           for ( size_t i = 0; i < source_lcids.size(); ++i )
           {
-            conns_in_thread.push_back( ConnectionDatum( ConnectionID(
-              source_table_.get_gid( tid, syn_id, source_lcids[ i ] ),
-              *t_gid,
-              tid,
-              syn_id,
-              source_lcids[ i ] ) ) );
+            if ( synapse_label == UNLABELED_CONNECTION
+                 or connections->get_syn_label( source_lcids[ i ] ) == synapse_label )
+            {
+              conns_in_thread.push_back( ConnectionDatum( ConnectionID(
+                source_table_.get_gid( tid, syn_id, source_lcids[ i ] ),
+                *t_gid,
+                tid,
+                syn_id,
+                source_lcids[ i ] ) ) );
+            }
           }
+
           // target_table_devices_ contains connections both to and from
           // devices. First we get connections from devices.
           target_table_devices_.get_connections_from_devices_(

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -78,6 +78,11 @@ public:
   virtual size_t size() const = 0;
 
   /**
+   * Return synapse_label of connection at position lcid.
+   */
+  virtual long get_syn_label( index lcid ) = 0;
+
+  /**
    * Write status of the connection at position lcid to the dictionary
    * dict.
    */
@@ -245,6 +250,12 @@ public:
   size() const
   {
     return C_.size();
+  }
+
+  long
+  get_syn_label( index lcid )
+  {
+    return C_[ lcid ].get_label();
   }
 
   void

--- a/testsuite/regressiontests/issue-1085.sli
+++ b/testsuite/regressiontests/issue-1085.sli
@@ -42,7 +42,7 @@ M_ERROR setverbosity
 {
   ResetKernel
 
-  /nodes /iaf_cond_exp 5 Create def
+  /nodes /iaf_psc_alpha 5 Create def
   /nodes [nodes] Range def
   
   nodes nodes << /rule /all_to_all >>
@@ -57,7 +57,7 @@ assert_or_die
 {
   ResetKernel
 
-  /nodes /iaf_cond_exp 5 Create def
+  /nodes /iaf_psc_alpha 5 Create def
   /nodes [nodes] Range def
   
   nodes nodes << /rule /all_to_all >>
@@ -72,7 +72,7 @@ assert_or_die
 {
   ResetKernel
 
-  /nodes /iaf_cond_exp 5 Create def
+  /nodes /iaf_psc_alpha 5 Create def
   /nodes [nodes] Range def
   
   nodes nodes << /rule /all_to_all >>

--- a/testsuite/regressiontests/issue-1085.sli
+++ b/testsuite/regressiontests/issue-1085.sli
@@ -84,19 +84,4 @@ assert_or_die
 }
 assert_or_die
 
-{
-  ResetKernel
-
-  /nodes /iaf_cond_exp 5 Create def
-  /nodes [nodes] Range def
-  
-  nodes nodes << /rule /all_to_all >>
-              << /model /static_synapse_lbl /synapse_label 123 >> Connect
-  nodes nodes << /rule /all_to_all >>
-              << /model /static_synapse_lbl /synapse_label 456 >> Connect
-  
-  << /source nodes /synapse_label 123 >> GetConnections length_a 25 eq
-}
-assert_or_die
-
 endusing

--- a/testsuite/regressiontests/issue-1085.sli
+++ b/testsuite/regressiontests/issue-1085.sli
@@ -1,0 +1,102 @@
+/*
+ *  issue-1085.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1085
+
+Synopsis: (issue-1085) run -> NEST exits if test fails
+
+Description:
+This test checks that GetConnection filter by synapse label.
+
+Author: Stine Brekke Vennemo
+FirstVersion: December 2018
+SeeAlso:
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+  ResetKernel
+
+  /nodes /iaf_cond_exp 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /source nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+{
+  ResetKernel
+
+  /nodes /iaf_cond_exp 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /source nodes /target nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+{
+  ResetKernel
+
+  /nodes /iaf_cond_exp 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /target nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+{
+  ResetKernel
+
+  /nodes /iaf_cond_exp 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /source nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+endusing


### PR DESCRIPTION
This PR fixes #1085.

I have added a check for synapse label in `ConnectionManager::get_connections` for the case when `GetConnection` is called with only the `target` attribute.