### PR TITLE
Refactor GetConnections to improve performance

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1221,23 +1221,23 @@ nest::ConnectionManager::get_connections(
       ConnectorBase* connections = connections_[ tid ][ syn_id ];
       if ( connections != NULL )
       {
+        const size_t num_connections_in_thread = connections->size();
+        for ( index lcid = 0; lcid < num_connections_in_thread; ++lcid )
+        {
+          const index source_gid = source_table_.get_gid( tid, syn_id, lcid );
+          connections->get_connection_with_specified_targets( source_gid,
+            target_neuron_gids,
+            tid,
+            lcid,
+            synapse_label,
+            conns_in_thread );
+        }
+
         for ( std::vector< index >::const_iterator t_gid =
                 target_neuron_gids.begin();
               t_gid != target_neuron_gids.end();
               ++t_gid )
         {
-          std::vector< index > source_lcids;
-          connections->get_source_lcids( tid, *t_gid, source_lcids );
-
-          for ( size_t i = 0; i < source_lcids.size(); ++i )
-          {
-            conns_in_thread.push_back( ConnectionDatum( ConnectionID(
-              source_table_.get_gid( tid, syn_id, source_lcids[ i ] ),
-              *t_gid,
-              tid,
-              syn_id,
-              source_lcids[ i ] ) ) );
-          }
           // target_table_devices_ contains connections both to and from
           // devices. First we get connections from devices.
           target_table_devices_.get_connections_from_devices_(
@@ -1305,18 +1305,12 @@ nest::ConnectionManager::get_connections(
             }
             else
             {
-              for ( std::vector< index >::const_iterator t_gid =
-                      target_neuron_gids.begin();
-                    t_gid != target_neuron_gids.end();
-                    ++t_gid )
-              {
-                connections->get_connection( source_gid,
-                  *t_gid,
-                  tid,
-                  lcid,
-                  synapse_label,
-                  conns_in_thread );
-              }
+              connections->get_connection_with_specified_targets( source_gid,
+                target_neuron_gids,
+                tid,
+                lcid,
+                synapse_label,
+                conns_in_thread );
             }
           }
         }

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -106,6 +106,18 @@ public:
     std::deque< ConnectionID >& conns ) const = 0;
 
   /**
+   * Add ConnectionID with given source_gid and lcid to conns. If
+   * target_neuron_gids is given, only add connection if
+   * target_neuron_gids contains the gid of the target of the connection.
+   */
+  virtual void get_connection_with_specified_targets( const index source_gid,
+    const std::vector< size_t >& target_neuron_gids,
+    const thread tid,
+    const index lcid,
+    const long synapse_label,
+    std::deque< ConnectionID >& conns ) const = 0;
+
+  /**
    * Add ConnectionIDs with given source_gid to conns, looping over
    * all lcids. If target_gid is given, only add connection if
    * target_gid matches the gid of the target of the connection.
@@ -296,6 +308,32 @@ public:
         const index current_target_gid =
           C_[ lcid ].get_target( tid )->get_gid();
         if ( current_target_gid == target_gid or target_gid == 0 )
+        {
+          conns.push_back( ConnectionDatum( ConnectionID(
+            source_gid, current_target_gid, tid, syn_id_, lcid ) ) );
+        }
+      }
+    }
+  }
+
+  void
+  get_connection_with_specified_targets( const index source_gid,
+    const std::vector< size_t >& target_neuron_gids,
+    const thread tid,
+    const index lcid,
+    const long synapse_label,
+    std::deque< ConnectionID >& conns ) const
+  {
+    if ( not C_[ lcid ].is_disabled() )
+    {
+      if ( synapse_label == UNLABELED_CONNECTION
+        or C_[ lcid ].get_label() == synapse_label )
+      {
+        const index current_target_gid =
+          C_[ lcid ].get_target( tid )->get_gid();
+        if ( std::find( target_neuron_gids.begin(),
+               target_neuron_gids.end(),
+               current_target_gid ) != target_neuron_gids.end() )
         {
           conns.push_back( ConnectionDatum( ConnectionID(
             source_gid, current_target_gid, tid, syn_id_, lcid ) ) );

--- a/testsuite/regressiontests/issue-1085.sli
+++ b/testsuite/regressiontests/issue-1085.sli
@@ -1,0 +1,87 @@
+/*
+ *  issue-1085.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1085
+
+Synopsis: (issue-1085) run -> NEST exits if test fails
+
+Description:
+This test checks that GetConnection filter by synapse label.
+
+Author: Stine Brekke Vennemo
+FirstVersion: December 2018
+SeeAlso:
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+  ResetKernel
+
+  /nodes /iaf_psc_alpha 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /source nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+{
+  ResetKernel
+
+  /nodes /iaf_psc_alpha 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /source nodes /target nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+{
+  ResetKernel
+
+  /nodes /iaf_psc_alpha 5 Create def
+  /nodes [nodes] Range def
+  
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 123 >> Connect
+  nodes nodes << /rule /all_to_all >>
+              << /model /static_synapse_lbl /synapse_label 456 >> Connect
+  
+  << /target nodes /synapse_label 123 >> GetConnections length_a 25 eq
+}
+assert_or_die
+
+endusing


### PR DESCRIPTION
This PR refactors parts of the `GetConnections` function to improve performance when specifying target nodes.

In the following benchmarks there are two populations of 5000 neurons each, connected with `all_to_all`. `GetConnections` is then called specifying target neurons, i.e. calling
```
<< /target target_nrns >> GetConnections
```
Times are given for the call to `GetConnections` only, in seconds.

| threads | v2.14 | ad5ef5c | refactor | v2.14 / refactor | ad5ef5c / refactor | 
|---------|---------|-------------|-----------------|-------------|-------------|
| 1       | 319.14  | 843.65      | 35.03           | 9.11        | 24.08       |
| 2       | 136.6   | 352.71      | 22.48           | 6.08        | 15.69       |
| 4       | 60.85   | 164         | 16.38           | 3.71        | 10.01       |
| 8       | 31.37   | 118.51      | 13.39           | 2.34        | 8.85        |
| 16      | 31.98   | 117.52      | 16.25           | 1.97        | 7.23        |

With the same setup, but now specifying both source and target neurons, i.e. calling
```
<< /source source_nrns /target target_nrns >> GetConnections
```

| threads | v2.14 | ad5ef5c | refactor | v2.14 / refactor | ad5ef5c / refactor |
|---------|---------|-------------|-----------------|-------------|-------------|
| 1       | 326.34  | 665.25      | 43.28           |  7.54       | 15.37       |
| 2       | 137.24  | 347.76      | 39.99           |  3.43       | 8.70        |
| 4       | 61.46   | 254.3       | 96.32           |  0.64       | 2.64        |
| 8       | 32.42   | 103.9       | 19.07           |  1.70       | 5.45        |
| 16      | 34.38   | 127.29      | 21.6            |  1.59       | 5.89        |

In both setups the refactored `GetConnections` is in almost all cases many times faster compared to both master (ad5ef5c) and v2.14. However with 4 threads the time for the refactored `GetConnections` is surprisingly long, but still an improvement on ad5ef5c.

Fixes #1096. Fixes #1085.
