### PR TITLE
local_spike_counter takes multiplicity into account

### DIFF
--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -63,7 +63,8 @@ EventDeliveryManager::send< SpikeEvent >( Node& source,
   e.set_sender_gid( source_gid );
   if ( source.has_proxies() )
   {
-    ++local_spike_counter_[ tid ];
+    local_spike_counter_[ tid ] += e.get_multiplicity();
+
     e.set_stamp(
       kernel().simulation_manager.get_slice_origin() + Time::step( lag + 1 ) );
     e.set_sender( source );

--- a/testsuite/regressiontests/issue-1100.sli
+++ b/testsuite/regressiontests/issue-1100.sli
@@ -27,8 +27,9 @@ Name: testsuite::issue-1100
 Synopsis: (issue-1100) run -> NEST exits if test fails
 
 Description:
-This test ensures that local_spike_counter also counts the spikes with
-multiplicity.
+Creates a parrot neuron, which receives one spike with multiplicity two from a
+spike generator. The parrot neuron should then emit a spike with multiplicity
+two, which should be counted as two spikes by the local spike counter.
 
 Author: Stine Brekke Vennemo
 FirstVersion: January 2019
@@ -40,26 +41,20 @@ FirstVersion: January 2019
 M_ERROR setverbosity
 
 {
-  /s_to /parrot_neuron 4000 Create def
-  /t_to /parrot_neuron 10 Create def
+  /parrot /parrot_neuron 1 Create def
 
-  /sources 1 s_to cvgidcollection def
-  /targets s_to 1 add t_to cvgidcollection def
-
-  /pg /poisson_generator << /rate 1.0 >> Create def
+  /sg /spike_generator << /spike_times [ 1.0 ]
+                          /spike_multiplicities [ 2 ] >> Create def
   /sd /spike_detector Create def
 
-  pg pg cvgidcollection sources Connect
-  sources targets Connect
+  sg parrot Connect
 
-  sources sd sd cvgidcollection Connect
-  targets sd sd cvgidcollection Connect
+  parrot sd Connect
 
   10.0 Simulate
 
   0 GetStatus /local_spike_counter get
-  sd GetStatus /n_events get
-  eq
+  2 eq
 } assert_or_die
 
 endusing

--- a/testsuite/regressiontests/issue-1100.sli
+++ b/testsuite/regressiontests/issue-1100.sli
@@ -1,0 +1,65 @@
+/*
+ *  issue-1100.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1100
+
+Synopsis: (issue-1100) run -> NEST exits if test fails
+
+Description:
+This test ensures that local_spike_counter also counts the spikes with
+multiplicity.
+
+Author: Stine Brekke Vennemo
+FirstVersion: January 2019
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+  /s_to /parrot_neuron 4000 Create def
+  /t_to /parrot_neuron 10 Create def
+
+  /sources 1 s_to cvgidcollection def
+  /targets s_to 1 add t_to cvgidcollection def
+
+  /pg /poisson_generator << /rate 1.0 >> Create def
+  /sd /spike_detector Create def
+
+  pg pg cvgidcollection sources Connect
+  sources targets Connect
+
+  sources sd sd cvgidcollection Connect
+  targets sd sd cvgidcollection Connect
+
+  10.0 Simulate
+
+  0 GetStatus /local_spike_counter get
+  sd GetStatus /n_events get
+  eq
+} assert_or_die
+
+endusing


### PR DESCRIPTION
With this PR, the `local_spike_counter` will also add the multiplicity so that we get the correct spike count.

This fixes #1100.