### PR TITLE
Throw error if creating too many connections on one thread

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -685,6 +685,10 @@ nest::ConnectionManager::increase_connection_count( const thread tid,
     num_connections_[ tid ].resize( syn_id + 1 );
   }
   ++num_connections_[ tid ][ syn_id ];
+  if ( num_connections_[ tid ][ syn_id ] >= 1 << 27 )
+  {
+    throw KernelException("Too many connections per thread for synapse.");
+  }
 }
 
 nest::index

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -687,7 +687,10 @@ nest::ConnectionManager::increase_connection_count( const thread tid,
   ++num_connections_[ tid ][ syn_id ];
   if ( num_connections_[ tid ][ syn_id ] >= ( 1 << 27 ) - 1 )
   {
-    throw KernelException( "Too many connections per thread for synapse." );
+    throw KernelException( String::compose(
+      "Too many connections: at most %1 connections supported per virtual "
+      "process and synapse model.",
+      ( 1 << 27 ) - 1 ) );
   }
 }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -687,7 +687,7 @@ nest::ConnectionManager::increase_connection_count( const thread tid,
   ++num_connections_[ tid ][ syn_id ];
   if ( num_connections_[ tid ][ syn_id ] >= 1 << 27 )
   {
-    throw KernelException("Too many connections per thread for synapse.");
+    throw KernelException( "Too many connections per thread for synapse." );
   }
 }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -685,7 +685,7 @@ nest::ConnectionManager::increase_connection_count( const thread tid,
     num_connections_[ tid ].resize( syn_id + 1 );
   }
   ++num_connections_[ tid ][ syn_id ];
-  if ( num_connections_[ tid ][ syn_id ] >= 1 << 27 )
+  if ( num_connections_[ tid ][ syn_id ] >= ( 1 << 27 ) - 1 )
   {
     throw KernelException( "Too many connections per thread for synapse." );
   }


### PR DESCRIPTION
There is currently a limit of 2²⁷ connections per synapse per thread, due to having 27 bits for the `lcid` in the `Target` class. With this PR an exception is thrown if attempting to create more connections than `Target` can handle.

Fixes #1102.