### PR TITLE
Enable the use of connections without delay in Topology

### DIFF
--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -139,8 +139,15 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   }
   if ( not delay_.valid() )
   {
-    delay_ =
-      TopologyModule::create_parameter( ( *syn_defaults )[ names::delay ] );
+    if ( not getValue< bool >( ( *syn_defaults )[ names::has_delay ] ) )
+    {
+      delay_ = TopologyModule::create_parameter( numerics::nan );
+    }
+    else
+    {
+      delay_ =
+        TopologyModule::create_parameter( ( *syn_defaults )[ names::delay ] );
+    }
   }
 
   if ( connection_type == names::convergent )


### PR DESCRIPTION
This fixes #1114 (as already proposed in #960, which was closed due to unrelated problems with topology and `make_symmetric`).