### PR TITLE
Improve connection performance over threads

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -48,6 +48,8 @@
 #include "fdstream.h"
 #include "name.h"
 
+const DictionaryDatum nest::ConnBuilder::dummy_param_ = new Dictionary;
+
 nest::ConnBuilder::ConnBuilder( const GIDCollection& sources,
   const GIDCollection& targets,
   const DictionaryDatum& conn_spec,
@@ -246,8 +248,6 @@ nest::ConnBuilder::ConnBuilder( const GIDCollection& sources,
     }
   }
 }
-
-const DictionaryDatum nest::ConnBuilder::dummy_param_ = new Dictionary;
 
 nest::ConnBuilder::~ConnBuilder()
 {

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -247,6 +247,7 @@ nest::ConnBuilder::ConnBuilder( const GIDCollection& sources,
   }
 }
 
+const DictionaryDatum nest::ConnBuilder::dummy_param_ = new Dictionary;
 
 nest::ConnBuilder::~ConnBuilder()
 {
@@ -428,13 +429,10 @@ nest::ConnBuilder::single_connect_( index sgid,
 
   if ( param_dicts_.empty() ) // indicates we have no synapse params
   {
-    const DictionaryDatum params = new Dictionary; // empty parameter dictionary
-    // required by connect() calls
-
     if ( default_weight_and_delay_ )
     {
       kernel().connection_manager.connect(
-        sgid, &target, target_thread, synapse_model_id_, params );
+        sgid, &target, target_thread, synapse_model_id_, dummy_param_ );
     }
     else if ( default_weight_ )
     {
@@ -442,7 +440,7 @@ nest::ConnBuilder::single_connect_( index sgid,
         &target,
         target_thread,
         synapse_model_id_,
-        params,
+        dummy_param_,
         delay_->value_double( target_thread, rng ) );
     }
     else if ( default_delay_ )
@@ -451,7 +449,7 @@ nest::ConnBuilder::single_connect_( index sgid,
         &target,
         target_thread,
         synapse_model_id_,
-        params,
+        dummy_param_,
         numerics::nan,
         weight_->value_double( target_thread, rng ) );
     }
@@ -463,7 +461,7 @@ nest::ConnBuilder::single_connect_( index sgid,
         &target,
         target_thread,
         synapse_model_id_,
-        params,
+        dummy_param_,
         delay,
         weight );
     }

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -227,6 +227,8 @@ private:
   //! dictionaries to pass to connect function, one per thread
   std::vector< DictionaryDatum > param_dicts_;
 
+  const static DictionaryDatum dummy_param_;
+
   /**
    * Collects all array paramters in a vector.
    *

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -227,6 +227,7 @@ private:
   //! dictionaries to pass to connect function, one per thread
   std::vector< DictionaryDatum > param_dicts_;
 
+  //! empty dictionary to pass to connect function
   const static DictionaryDatum dummy_param_;
 
   /**

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -70,7 +70,9 @@ nest::ConnectionManager::ConnectionManager()
   , have_connections_changed_( true )
   , sort_connections_by_source_( true )
   , has_primary_connections_( false )
+  , check_primary_connections_()
   , secondary_connections_exist_( false )
+  , check_secondary_connections_()
   , stdp_eps_( 1.0e-6 )
 {
 }
@@ -92,6 +94,9 @@ nest::ConnectionManager::initialize()
   connections_.resize( num_threads );
   secondary_recv_buffer_pos_.resize( num_threads );
   sort_connections_by_source_ = true;
+
+  check_primary_connections_.resize( num_threads, false );
+  check_secondary_connections_.resize( num_threads, false );
 
 #pragma omp parallel
   {
@@ -633,15 +638,17 @@ nest::ConnectionManager::connect_( Node& s,
 
   increase_connection_count( tid, syn_id );
 
-  if ( is_primary )
+  if ( not check_primary_connections_[ tid ] and is_primary )
   {
-#pragma omp atomic update
-    has_primary_connections_ |= true;
+#pragma omp atomic write
+    has_primary_connections_ = true;
+    check_primary_connections_.set( tid, true );
   }
-  else
+  else if ( not check_secondary_connections_[ tid ] and not is_primary )
   {
-#pragma omp atomic update
-    secondary_connections_exist_ |= true;
+#pragma omp atomic write
+    secondary_connections_exist_ = true;
+    check_secondary_connections_.set( tid, true );
   }
 }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -638,6 +638,8 @@ nest::ConnectionManager::connect_( Node& s,
 
   increase_connection_count( tid, syn_id );
 
+  // We do not check has_primary_connections_ and secondary_connections_exist_
+  // directly as this led to worse performance on the supercomputer Piz Daint.
   if ( not check_primary_connections_[ tid ] and is_primary )
   {
 #pragma omp atomic write

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -635,11 +635,13 @@ nest::ConnectionManager::connect_( Node& s,
 
   if ( is_primary )
   {
-    has_primary_connections_ = true;
+#pragma omp atomic update
+    has_primary_connections_ |= true;
   }
   else
   {
-    secondary_connections_exist_ = true;
+#pragma omp atomic update
+    secondary_connections_exist_ |= true;
   }
 }
 

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -31,6 +31,7 @@
 #include "manager_interface.h"
 
 // Includes from nestkernel:
+#include "completed_checker.h"
 #include "conn_builder.h"
 #include "connection_id.h"
 #include "connector_base.h"
@@ -620,9 +621,11 @@ private:
 
   //! Whether primary connections (spikes) exist.
   bool has_primary_connections_;
+  CompletedChecker check_primary_connections_;
 
   //! Whether secondary connections (e.g., gap junctions) exist.
   bool secondary_connections_exist_;
+  CompletedChecker check_secondary_connections_;
 
   //! Maximum distance between (double) spike times in STDP that is
   //! still considered 0. See issue #894

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -621,10 +621,14 @@ private:
 
   //! Whether primary connections (spikes) exist.
   bool has_primary_connections_;
+
+  //! Check for primary connections (spikes) on each thread.
   CompletedChecker check_primary_connections_;
 
   //! Whether secondary connections (e.g., gap junctions) exist.
   bool secondary_connections_exist_;
+
+  //! Check for secondary connections (e.g., gap junctions) on each thread.
   CompletedChecker check_secondary_connections_;
 
   //! Maximum distance between (double) spike times in STDP that is

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -174,4 +174,6 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   }
 }
 
+const DictionaryDatum ConnectionCreator::dummy_param_ = new Dictionary;
+
 } // namespace nest

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -25,6 +25,8 @@
 namespace nest
 {
 
+const DictionaryDatum ConnectionCreator::dummy_param_ = new Dictionary;
+
 ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
   : allow_autapses_( true )
   , allow_multapses_( true )
@@ -173,7 +175,5 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
     throw BadProperty( "Unknown connection type." );
   }
 }
-
-const DictionaryDatum ConnectionCreator::dummy_param_ = new Dictionary;
 
 } // namespace nest

--- a/topology/connection_creator.h
+++ b/topology/connection_creator.h
@@ -189,6 +189,7 @@ private:
   lockPTR< TopologyParameter > weight_;
   lockPTR< TopologyParameter > delay_;
 
+  //! Empty dictionary to pass to connect functions
   const static DictionaryDatum dummy_param_;
 };
 

--- a/topology/connection_creator.h
+++ b/topology/connection_creator.h
@@ -188,6 +188,8 @@ private:
   index synapse_model_;
   lockPTR< TopologyParameter > weight_;
   lockPTR< TopologyParameter > delay_;
+
+  const static DictionaryDatum dummy_param_;
 };
 
 inline void
@@ -198,9 +200,6 @@ ConnectionCreator::connect_( index s,
   double d,
   index syn )
 {
-  DictionaryDatum dummy_params = new Dictionary; // empty parameter dictionary
-                                                 // required by connect() calls
-
   // check whether the target is on this process
   if ( kernel().node_manager.is_local_gid( target->get_gid() ) )
   {
@@ -210,7 +209,7 @@ ConnectionCreator::connect_( index s,
     {
       // TODO implement in terms of nest-api
       kernel().connection_manager.connect(
-        s, target, target_thread, syn, dummy_params, d, w );
+        s, target, target_thread, syn, dummy_param_, d, w );
     }
   }
 }

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -275,10 +275,6 @@ void
 ConnectionCreator::source_driven_connect_( Layer< D >& source,
   Layer< D >& target )
 {
-
-  DictionaryDatum dummy_params = new Dictionary; // empty parameter dictionary
-                                                 // required by connect() calls
-
   // Source driven connect is actually implemented as target driven,
   // but with displacements computed in the target layer. The Mask has been
   // reversed so that it can be applied to the source instead of the target.
@@ -373,7 +369,7 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
               *tgt_it,
               target_thread,
               synapse_model_,
-              dummy_params,
+              dummy_param_,
               d,
               w );
           }
@@ -401,7 +397,7 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
             *tgt_it,
             target_thread,
             synapse_model_,
-            dummy_params,
+            dummy_param_,
             d,
             w );
         }
@@ -463,7 +459,7 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
               *tgt_it,
               target_thread,
               synapse_model_,
-              dummy_params,
+              dummy_param_,
               d,
               w );
           }
@@ -491,7 +487,7 @@ ConnectionCreator::source_driven_connect_( Layer< D >& source,
             *tgt_it,
             target_thread,
             synapse_model_,
-            dummy_params,
+            dummy_param_,
             d,
             w );
         }
@@ -508,9 +504,6 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
   {
     return;
   }
-
-  DictionaryDatum dummy_params = new Dictionary; // empty parameter dictionary
-                                                 // required by connect() calls
 
   // Convergent connections (fixed fan in)
   //
@@ -644,7 +637,7 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             *tgt_it,
             target_thread,
             synapse_model_,
-            dummy_params,
+            dummy_param_,
             d,
             w );
           is_selected[ random_id ] = true;
@@ -691,7 +684,7 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             *tgt_it,
             target_thread,
             synapse_model_,
-            dummy_params,
+            dummy_param_,
             d,
             w );
           is_selected[ random_id ] = true;
@@ -788,7 +781,7 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             *tgt_it,
             target_thread,
             synapse_model_,
-            dummy_params,
+            dummy_param_,
             d,
             w );
           is_selected[ random_id ] = true;
@@ -828,7 +821,7 @@ ConnectionCreator::convergent_connect_( Layer< D >& source, Layer< D >& target )
             *tgt_it,
             target_thread,
             synapse_model_,
-            dummy_params,
+            dummy_param_,
             d,
             w );
           is_selected[ random_id ] = true;
@@ -847,9 +840,6 @@ ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
   {
     return;
   }
-
-  DictionaryDatum dummy_params = new Dictionary; // empty parameter dictionary
-                                                 // required by connect() calls
 
   // protect against connecting to devices without proxies
   // we need to do this before creating the first connection to leave
@@ -983,7 +973,7 @@ ConnectionCreator::divergent_connect_( Layer< D >& source, Layer< D >& target )
         target_ptr,
         target_ptr->get_thread(),
         synapse_model_,
-        dummy_params,
+        dummy_param_,
         d,
         w );
     }


### PR DESCRIPTION
This PR contains two new changes that improve the connection performance, especially over increasing number of threads and for large networks:

1. Instead of all threads writing to `has_primary_connections_` or `secondary_connections_exist_` when we add a new connection, we check if the individual thread has primary or secondary connections, and only write to the variable if the thread has not previously updated it. We also make sure that the threads don't try to write to the variable all at once.
2. Instead of creating a new empty dummy parameter dictionary every time we connect two nodes, we create a static dummy dictionary once, and then use this dummy parameter every time we need an empty dictionary.

These two fixes improves the performance of master quite a bit, but we are not on the level with the NEST version used in the 5g paper (f104c6d), see the plots below. The difference between `5g` and this updated master (`master-update`) comes from the BlockVector.

Here I have run the `hpc_benchmark` with a scale of 10, which equals 112500 neurons and 1.265738e+09 connections, on 1 node on the Piz Daint supercomputer, on an increasing number of threads per MPI process (strong scaling over threads). The number of threads are 3, 6, 9, 18, and 36. The figure shows the connection time vs threads.

![strong-scaling-threads-pr](https://user-images.githubusercontent.com/21308850/52473899-42a9ef80-2b97-11e9-879a-e562ce9c0b5e.png)

The figure below  also shows the connection time over increasing number of threads, but the number of VPs are fixed to 36. Here, the scale is 20 (almost filling the node), that is 225000 neurons and 2531476000 connections. As you can see, connection time slightly increases as the threads increases, which is strange, but at least we are on not that worse off than with 2.14.

![connection-times-threads-pr](https://user-images.githubusercontent.com/21308850/52473977-7ab13280-2b97-11e9-8c2c-4d6d7b6880d4.png)
