### PR TITLE
Removed unused functions in hh_psc_alpha models

### DIFF
--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -149,26 +149,6 @@ public:
   port handles_test_event( CurrentEvent&, rport );
   port handles_test_event( DataLoggingRequest&, rport );
 
-  /**
-   * Return membrane potential at time t.
-potentials_.connect_logging_device();
-   * This function is not thread-safe and should not be used in threaded
-   * contexts to access the current membrane potential values.
-   * @param Time the current network time
-   *
-   */
-  double get_potential( Time const& ) const;
-
-  /**
-   * Define current membrane potential.
-   * This function is thread-safe and should be used in threaded
-   * contexts to change the current membrane potential value.
-   * @param Time     the current network time
-   * @param double new value of the mebrane potential
-   *
-   */
-  void set_potential( Time const&, double );
-
   void get_status( DictionaryDatum& ) const;
   void set_status( const DictionaryDatum& );
 

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -171,26 +171,6 @@ public:
   {
   }
 
-  /**
-   * Return membrane potential at time t.
-potentials_.connect_logging_device();
-   * This function is not thread-safe and should not be used in threaded
-   * contexts to access the current membrane potential values.
-   * @param Time the current network time
-   *
-   */
-  double get_potential( Time const& ) const;
-
-  /**
-   * Define current membrane potential.
-   * This function is thread-safe and should be used in threaded
-   * contexts to change the current membrane potential value.
-   * @param Time     the current network time
-   * @param double new value of the mebrane potential
-   *
-   */
-  void set_potential( Time const&, double );
-
   void get_status( DictionaryDatum& ) const;
   void set_status( const DictionaryDatum& );
 


### PR DESCRIPTION
While reviewing #1098 I noticed that the functions `get_potential` and `set_potential` of the `hh_psc_alpha` model are used nowhere in the entire NEST code. Thus this PR removes them.