### PR TITLE
hpc_benchmark.sli is now invariant under different MPI-process/thread splits with fixed VP number

### DIFF
--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -38,8 +38,8 @@
      computers. Front. Neuroinform. 8:78
 
 
-   The difference between this script and hpc_benchmark.sli is that this version
-   is invariant under mpi/thread splits. This affects
+   The difference between this script and hpc_benchmark_2_16.sli is that this
+   version is invariant under mpi/thread splits. This affects
      - Randomization of the membrane potential (here it is based on the virtual
        processes)
      - Neurons that are being recorded from (here we always record from the

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -371,6 +371,12 @@ Aborting the simulation!) message
   {
     E_detector ComputeRate cvs ( # average rate) join logger /log call
   } if
+  
+  E_neurons size I_neurons size add cvs ( # num_neurons) join logger /log call
+  0 /num_connections get cvs ( # num_connections) join logger /log call
+  0 /min_delay get cvs ( # min_delay) join logger /log call
+  0 /max_delay get cvs ( # max_delay) join logger /log call
+  0 /local_spike_counter get cvs ( # local_spike_counter) join logger /log call
 
   logger /done call
 } def
@@ -460,7 +466,6 @@ def
 	} if
         Rank max_rank_cout lt {
             cout Rank <- ( ) <- value <- endl flush pop
-            cerr Rank <- ( ) <- value <- endl flush pop
 	} if
     }
 

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -171,6 +171,9 @@ def
   
   /eta 1.685              % scaling of external stimulus
   /filestem path_name
+  
+  /max_rank_cout 5  % copy output to cout for ranks 0..max_rank_cout-1
+  /max_rank_log 30  % write to log files for ranks 0..max_rank_log-1
 
 >> def
 
@@ -191,6 +194,8 @@ brunel_params dup using
      /resolution  dt
      /overwrite_files true
   >> SetStatus
+  
+  %------------------------- Creation -----------------------------------------
 
   /iaf_psc_alpha    model_params    SetDefaults
   M_INFO (BuildNetwork)
@@ -298,6 +303,7 @@ brunel_params dup using
   stdp_params /weight JE_pA put 
   /stdp_pl_synapse_hom_hpc stdp_params SetDefaults
 
+ %------------------------- Connection -----------------------------------------
 
   M_INFO (BuildNetwork)
   (Connecting stimulus generators.) message
@@ -356,6 +362,8 @@ brunel_params dup using
   memory_thisjob cvs ( # virt_mem_after_edges) join logger /log call
 
  } def % end of buildnetwork
+
+%-------------------------- Simulation -----------------------------------------
 
 /RunSimulation
 {
@@ -437,14 +445,12 @@ def
 
 /*
     This function defines a logger class used to properly log memory and timing
-    information from network simulations. It is used by hpc_benchmark_invariant.sli
+    information from network simulations. It is used by hpc_benchmark.sli
     to store the information to the log files.
 */
 
 /logger
 <<
-  /max_rank_cout 5  % copy output to cout for ranks 0..max_rank_cout-1
-  /max_rank_log 30  % write to log files for ranks 0..max_rank_log-1
   /line_counter 0
 
   % constructor

--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -1,5 +1,5 @@
 /*
- *  hpc_benchmark_invariant.sli
+ *  hpc_benchmark.sli
  *
  *  This file is part of NEST.
  *

--- a/examples/nest/hpc_benchmark_2_16.sli
+++ b/examples/nest/hpc_benchmark_2_16.sli
@@ -1,5 +1,5 @@
 /*
- *  hpc_benchmark.sli
+ *  hpc_benchmark_2_16.sli
  *
  *  This file is part of NEST.
  *
@@ -21,6 +21,10 @@
  */
 
 /*
+   This script was previously called hpc_benchmark.sli. If you want to
+   reproduce your hpc_benchmark results from NEST versions 2.16 and below, you
+   should use this version.
+
    This script produces a balanced random network of scale*11250 neurons in
    which the excitatory-excitatory neurons exhibit STDP with
    multiplicative depression and power-law potentiation. A mutual

--- a/examples/nest/hpc_benchmark_invariant.sli
+++ b/examples/nest/hpc_benchmark_invariant.sli
@@ -1,0 +1,512 @@
+/*
+ *  hpc_benchmark_invariant.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+   This script produces a balanced random network of scale*11250 neurons in
+   which the excitatory-excitatory neurons exhibit STDP with
+   multiplicative depression and power-law potentiation. A mutual
+   equilibrium is obtained between the activity dynamics (low rate in
+   asynchronous irregular regime) and the synaptic weight distribution
+   (unimodal). The number of incoming connections per neuron is fixed
+   and independent of network size (indegree=11250).
+
+   This is the standard network investigated in:
+   Morrison et al (2007). Spike-timing-dependent plasticity in balanced random
+     networks. Neural Comput 19(6):1437-67
+   Helias et al (2012). Supercomputers ready for use as discovery machines for
+     neuroscience. Front. Neuroinform. 6:26
+   Kunkel et al (2014). Spiking network simulation code for petascale 
+     computers. Front. Neuroinform. 8:78
+
+
+   The difference between this script and hpc_benchmark.sli is that this version
+   is invariant under mpi/thread splits. This affects
+     - Randomization of the membrane potential (here it is based on the virtual
+       processes)
+     - Neurons that are being recorded from (here we always record from the
+       first Nrec neurons).
+ 
+ 
+   A note on scaling
+   -----------------
+   
+   This benchmark was originally developed for very large-scale simulations on
+   supercomputers with more than 1 million neurons in the network and
+   11.250 incoming synapses per neuron. For such large networks, synaptic input
+   to a single neuron will be little correlated across inputs and network
+   activity will remain stable over long periods of time.
+   
+   The original network size corresponds to a scale parameter of 100 or more.
+   In order to make it possible to test this benchmark script on desktop
+   computers, the scale parameter is set to 1 below, while the number of
+   11.250 incoming synapses per neuron is retained. In this limit, correlations
+   in input to neurons are large and will lead to increasing synaptic weights.
+   Over time, network dynamics will therefore become unstable and all neurons
+   in the network will fire in synchrony, leading to extremely slow simulation
+   speeds.
+   
+   Therefore, the presimulation time is reduced to 50 ms below and the
+   simulation time to 250 ms, while we usually use 100 ms presimulation and
+   1000 ms simulation time.
+   
+   For meaningful use of this benchmark, you should use a scale > 10 and check
+   that the firing rate reported at the end of the benchmark is below 10 spikes
+   per second. 
+*/
+  
+%%%%%%%%%%%%%%%%%%%%%%%%% PARAMETER SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% define all relevant parameters: changes should be made here
+% all data is placed in the userdict dictionary
+
+/nvp 1 def              % total number of virtual processes
+/scale 1.0 def          % scaling factor of the network size,
+                        % total network size = scale*11250 neurons
+/simtime 250. def       % total simulation time in ms
+/presimtime 50. ms def  % simulation time until reaching equilibrium
+/dt 0.1 ms def          % simulation step
+/record_spikes true def % switch to record spikes of excitatory neurons to file
+/path_name (.) def      % path where all files will have to be written
+/log_file (log) def     % naming scheme for the log files
+
+% -----------------------------------------------------------------------------
+
+%%%%%%%%% Define function to convert synapse weight from  mV to pA %%%%%%%%%%%
+
+/ConvertSynapseWeight
+{
+  /tauMem Set
+  /tauSyn Set
+  /CMem Set
+  % This function is specific to the used neuron model
+  % Leaky integrate-and-fire neuron with alpha-shaped
+  % postsynaptic currents
+  (
+    % compute time to maximum of V_m after spike input to neuron at rest
+    a = tauMem / tauSyn;
+    b = 1.0 / tauSyn - 1.0 / tauMem;
+    t_rise = 1.0/b * (-LambertWm1(-exp(-1.0/a)/a)-1.0/a);
+  
+    % maximum of PSP for current of unit amplitude
+    exp(1.0)/(tauSyn*CMem*b) * ((exp(-t_rise/tauMem) - exp(-t_rise/tauSyn)) / b - t_rise*exp(-t_rise/tauSyn))
+  ) ExecMath
+  1 exch div
+}
+def
+
+% For compatiblity with earlier benchmarks, we require a rise time of
+% t_rise = 1.700759 ms and we choose tau_syn to achieve this for given
+% tau_m. This requires numerical inversion of the expression for t_rise
+% in ConvertSynapseWeight. We computed this value once and hard-code 
+% it here.
+
+/tau_syn 0.32582722403722841 ms def
+
+% -----------------------------------------------------------------------------
+
+/brunel_params
+<<
+  /NE 9000 scale mul round cvi   % number of excitatory neurons
+  /NI 2250 scale mul round cvi   % number of inhibitory neurons
+
+  % number of neurons to record spikes from
+  /Nrec 1000
+
+  /model_params
+  <<
+    % Set variables for iaf_psc_alpha
+    /E_L     0.0  mV  % Resting membrane potential (mV)
+    /C_m   250.0  pF  % Capacity of the membrane (pF)
+    /tau_m  10.0  ms  % Membrane time constant (ms)
+    /t_ref   0.5  ms  % duration of refractory period (ms)
+    /V_th   20.0  mV  % Threshold (mV)
+    /V_reset 0.0  mV  % Reset Potential (mV)
+    /tau_syn_ex   tau_syn % time const. postsynaptic excitatory currents (ms)
+    /tau_syn_in   tau_syn % time const. postsynaptic inhibitory currents (ms)
+    /tau_minus 30.0 ms %time constant for STDP (depression)
+    % V can be randomly initialized see below
+    /V_m 5.7 mV % mean value of membrane potential
+  >>
+
+  /randomize_Vm true
+  /mean_potential 5.7 mV  % Note that Kunkel et al. (2014) report different values. The values
+  /sigma_potential 7.2 mV % in the paper were used for the benchmarks on K, the values given
+                          % here were used for the benchmark on JUQUEEN.
+
+  /delay 1.5 ms           % synaptic delay, all connections (ms)
+
+   % synaptic weight
+  /JE 0.14 mV             % peak of EPSP
+
+  /sigma_w 3.47 pA        % standard dev. of E->E synapses (pA)
+  /g  -5.0
+
+  /stdp_params
+  <<
+    /delay 1.5 ms
+    /alpha  0.0513
+    /lambda 0.1           % STDP step size
+    /mu     0.4           % STDP weight dependence exponent (potentiation)
+    /tau_plus 15.0        % time constant for potentiation
+  >>
+  
+  /eta 1.685              % scaling of external stimulus
+  /filestem path_name
+
+>> def
+
+% Here we resolve parameter dependencies, by making the independent
+% values visible
+brunel_params dup using
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%% FUNCTION SECTION %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+/BuildNetwork
+{
+  
+  tic % start timer on construction
+  % set global kernel parameters
+  0
+  <<
+     /total_num_virtual_procs nvp
+     /resolution  dt
+     /overwrite_files true
+  >> SetStatus
+
+  /iaf_psc_alpha    model_params    SetDefaults
+  M_INFO (BuildNetwork)
+  (Creating excitatory population.) message     % show message
+  /iaf_psc_alpha [NE] LayoutNetwork /E_net Set  % subnet gets own gid
+  /E_from E_net 1 add def                       % gid of first child
+  /E_to E_from NE add 1 sub def                 % gid of last child
+  
+  M_INFO (BuildNetwork)
+  (Creating inhibitory population.) message     % show message
+  /iaf_psc_alpha [NI] LayoutNetwork /I_net Set  % subnet gets own gid
+  /I_from I_net 1 add def                       % gid of first child
+  /I_to I_from NI add 1 sub def                 % gid of last child
+
+
+  randomize_Vm
+  {
+      M_INFO (BuildNetwork)
+      (Randomzing membrane potentials.) message
+
+      /base_seed 0 GetStatus /rng_seeds get Last def
+      /rdevs
+        [ nvp ]
+        { base_seed add rngdict/MT19937 :: exch CreateRNG rdevdict/normal :: CreateRDV }
+        Table
+      def
+
+      E_net GetLocalNodes
+      {
+        dup
+        /vp get rdevs exch get /normal Set  % Gaussian generator for VP of node
+        <<
+          /V_m mean_potential sigma_potential normal Random mul add
+        >>
+        SetStatus
+      } forall
+
+      I_net GetLocalNodes
+      { 
+        dup
+        /vp get rdevs exch get /normal Set  % Gaussian generator for VP of node
+        <<
+          /V_m mean_potential sigma_potential normal Random mul add
+        >>
+        SetStatus
+      } forall
+  } if
+  
+
+  /E_neurons E_from E_to cvgidcollection def % get memory efficient GIDCollection
+  /I_neurons I_from I_to cvgidcollection def % get memory efficient GIDCollection
+
+  /CE NE scale cvd div iround def % number of incoming excitatory connections
+  /CI NI scale cvd div iround def % number of incoming inhibitory connections
+
+  M_INFO (BuildNetwork)
+  (Creating excitatory stimulus generator.) message
+
+  model_params using
+
+  % Convert synapse weight from mV to pA
+  C_m tau_syn tau_m ConvertSynapseWeight /conversion_factor Set
+  /JE_pA conversion_factor JE mul def
+
+  /nu_thresh V_th CE tau_m C_m div mul JE_pA mul 1.0 exp mul tau_syn mul div def
+  /nu_ext nu_thresh eta mul def
+  endusing
+
+  /E_stimulus /poisson_generator Create def
+  E_stimulus
+  <<
+     /rate nu_ext CE mul 1000. mul
+  >> SetStatus
+
+  M_INFO (BuildNetwork)
+  (Creating excitatory spike detector.) message
+
+  record_spikes
+  {
+    /detector_label  filestem (/alpha_) join stdp_params /alpha get cvs join (_spikes) join def
+    /E_detector /spike_detector Create def
+    E_detector
+    <<
+       /withtime true
+       /to_file true
+       /label detector_label
+    >> SetStatus
+  } if
+
+  memory_thisjob cvs ( # virt_mem_after_nodes) join logger /log call
+
+  toc /BuildNodeTime Set
+
+  BuildNodeTime cvs ( # build_time_nodes) join logger /log call
+
+  tic
+
+  % Create custom synapse types with appropriate values for
+  % our excitatory and inhibitory connections
+  /static_synapse_hpc << /delay delay >> SetDefaults
+  /static_synapse_hpc /syn_std  CopyModel
+  /static_synapse_hpc /syn_ex << /weight JE_pA >> CopyModel
+  /static_synapse_hpc /syn_in << /weight JE_pA g mul >> CopyModel
+
+  stdp_params /weight JE_pA put 
+  /stdp_pl_synapse_hom_hpc stdp_params SetDefaults
+
+
+  M_INFO (BuildNetwork)
+  (Connecting stimulus generators.) message
+
+  % Connect Poisson generator to neuron
+
+  E_stimulus E_stimulus cvgidcollection E_neurons << /rule (all_to_all) >> << /model /syn_ex >> Connect
+  E_stimulus E_stimulus cvgidcollection I_neurons << /rule (all_to_all) >> << /model /syn_ex >> Connect
+
+  M_INFO (BuildNetwork)
+  (Connecting excitatory -> excitatory population.) message
+
+  E_neurons E_neurons << /rule (fixed_indegree) /indegree CE /autapses false /multapses true >>
+                      << /model /stdp_pl_synapse_hom_hpc >> Connect
+
+  M_INFO (BuildNetwork)
+  (Connecting inhibitory -> excitatory population.) message
+
+  I_neurons E_neurons << /rule (fixed_indegree) /indegree CI /autapses false /multapses true >>
+                      << /model /syn_in >> Connect
+
+  M_INFO (BuildNetwork)
+  (Connecting excitatory -> inhibitory population.) message
+
+  E_neurons I_neurons << /rule (fixed_indegree) /indegree CE /autapses false /multapses true >>
+                      << /model /syn_ex >> Connect
+
+  M_INFO (BuildNetwork)
+  (Connecting inhibitory -> inhibitory population.) message
+
+  I_neurons I_neurons << /rule (fixed_indegree) /indegree CI /autapses false /multapses true >>
+                      << /model /syn_in >> Connect
+
+
+  record_spikes true eq
+  {
+    E_neurons size Nrec lt
+    {
+      M_ERROR (BuildNetwork)
+      (Networks is smaller than number of neurons to record from!) message
+      1 quit_i
+    } if
+
+    M_INFO (BuildNetwork)
+    (Connecting spike detectors.) message
+
+    /recordees E_from E_from Nrec add 1 sub cvgidcollection def
+    /detector E_detector E_detector cvgidcollection def
+    recordees detector << /rule (all_to_all) >> << /model /syn_std >> Connect
+  } if  
+
+  % read out time used for building
+  toc /BuildEdgeTime Set
+
+  BuildEdgeTime cvs ( # build_edge_time ) join logger /log call
+  memory_thisjob cvs ( # virt_mem_after_edges) join logger /log call
+
+ } def % end of buildnetwork
+
+/RunSimulation
+{
+
+  % open log file
+  log_file logger /init call
+
+  ResetKernel
+
+  memory_thisjob cvs ( # virt_mem_0) join logger /log call
+
+  BuildNetwork
+
+  tic
+
+  Prepare
+  presimtime Run
+
+  toc /PreparationTime Set
+
+  memory_thisjob cvs ( # virt_mem_after_presim) join logger /log call
+  PreparationTime cvs ( # presim_time) join logger /log call
+
+  tic
+
+  simtime Run
+
+  toc /SimCPUTime Set
+
+  memory_thisjob cvs ( # virt_mem_after_sim) join logger /log call
+  SimCPUTime cvs ( # sim_time) join logger /log call
+  
+  Cleanup
+
+  0 ShowStatus
+
+  record_spikes true eq
+  {
+    E_detector ComputeRate cvs ( # average rate) join logger /log call
+  } if
+  
+  
+  E_neurons size I_neurons size add cvs ( # num_neurons) join logger /log call
+  0 /num_connections get cvs ( # num_connections) join logger /log call
+  0 /min_delay get cvs ( # min_delay) join logger /log call
+  0 /max_delay get cvs ( # max_delay) join logger /log call
+  0 /local_spike_counter get cvs ( # local_spike_counter) join logger /log call
+
+  logger /done call
+} def
+
+% -----------------------------------------------------------------------------
+
+% Take spike detector, find total number of spikes registered,
+% return average rate per neuron in Hz.
+% NOTE: If you are running with several MPI processes, this
+%       function only gives an approximation to the true rate.
+%
+% spike_det ComputeRate -> rate
+/ComputeRate
+{
+  << >> begin  % anonymous dictionary for local variables
+
+  /sdet Set
+
+  % We need to guess how many neurons we record from.
+  % This assumes an even distribution of nodes across
+  % processes, as well as homogeneous activity in the
+  % network. So this is really a hack. NEST needs better
+  % support for rate calculations, such as giving the
+  % number of neurons recorded from by each spike detector.
+
+  /n_local_neurons Nrec cvd NumProcesses div def
+  sdet /n_events get cvd n_local_neurons simtime mul div
+  1000 mul         % convert from mHz to Hz, leave on stack
+
+  end
+} bind             % optional, improves performance
+def
+
+% -----------------------------------------------------------------------------
+
+/*
+    This function defines a logger class used to properly log memory and timing
+    information from network simulations. It is used by hpc_benchmark_invariant.sli
+    to store the information to the log files.
+*/
+
+/logger
+<<
+  /max_rank_cout 5  % copy output to cout for ranks 0..max_rank_cout-1
+  /max_rank_log 30  % write to log files for ranks 0..max_rank_log-1
+  /line_counter 0
+
+  % constructor
+  % expects file name on stack
+  /init
+  {
+    Rank max_rank_log lt
+    {
+      (_) join
+
+      % convert rank to string, prepend 0 if necessary to make
+      % numbers equally wide for all ranks
+      Rank cvs 
+      dup length max_rank_log cvs length exch sub
+      {
+        48 prepend   % 48 is ASCII code for 0
+      }
+      repeat
+      join
+      (.dat) join
+
+      /f exch (w) ofsopen
+      {
+        def
+      }
+      {
+        /Logger_init /CannotOpenFile raiseerror
+      } ifelse
+
+    } if
+  }
+
+  % logging function
+  % expects one operand on stack to write to file
+  /log
+  {
+    /value Set
+    Rank max_rank_log lt
+    {
+      f line_counter <- ( ) <- Rank <- ( ) <- value <- (\n) <- pop
+      /line_counter line_counter 1 add def
+    } if
+    Rank max_rank_cout lt
+    {
+      cout Rank <- ( ) <- value <- endl flush pop
+    } if
+  }
+
+  % closes file
+  /done
+  {
+    Rank max_rank_log lt
+    {
+      f close
+    } if
+  }
+
+>> def
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%% RUN BENCHMARK %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+RunSimulation

--- a/examples/nest/hpc_benchmark_invariant.sli
+++ b/examples/nest/hpc_benchmark_invariant.sli
@@ -337,7 +337,7 @@ brunel_params dup using
     E_neurons size Nrec lt
     {
       M_ERROR (BuildNetwork)
-      (Networks is smaller than number of neurons to record from!) message
+      (The exitatory network is smaller than number of neurons to record from!) message
       1 quit_i
     } if
 
@@ -371,8 +371,7 @@ brunel_params dup using
 
   tic
 
-  Prepare
-  presimtime Run
+  presimtime Simulate
 
   toc /PreparationTime Set
 
@@ -381,14 +380,12 @@ brunel_params dup using
 
   tic
 
-  simtime Run
+  simtime Simulate
 
   toc /SimCPUTime Set
 
   memory_thisjob cvs ( # virt_mem_after_sim) join logger /log call
   SimCPUTime cvs ( # sim_time) join logger /log call
-  
-  Cleanup
 
   0 ShowStatus
 


### PR DESCRIPTION
This PR fixes #247.

I have added a new example, `hpc_benchmark_invariant.sli`, a mpi/thread-split invariant version of `hpc_benchmark.sli`. To make it invariant under mpi/thread splits, we
- record from a fixed set of neurons (the Nrec first exitatory), instead of a fixed number of local neurons
- randomize the membrane potential based on the virtual processes, not the mpi processes.

With this new version, we get the following average rates (also averaged over processes). I include the rates from hpc_bencmark as well for comparison, scale = 1.0.

| Num_vps | Split | hpc_benchmark_invariant | hpc_benchmark |
|:------------:|:------:|:-----------------------------------:|:---------------------:|
|        1       | 1 mpi proc., 1 thread   |  11.832  |        11.832         |
|        4       | 1 mpi proc., 4 threads |    13.5    |        11.812         |
|        4       | 2 mpi proc., 2 threads |    13.5    |         29.06          |
|        4       | 4 mpi proc., 1 thread   |    13.5    |         54.58          |
 


