### PR TITLE
Serialize output of GetStatus and GetDefaults for JSON

### DIFF
--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -163,6 +163,7 @@ def get_unistring_type():
         return basestring
     return str
 
+
 uni_str = get_unistring_type()
 
 
@@ -572,7 +573,8 @@ def serializable(data):
         result = [serializable(d) for d in data]
 
     elif isinstance(data, dict):
-        result = dict([(key, serializable(value)) for key, value in data.items()])
+        result = dict([(key, serializable(value))
+                       for key, value in data.items()])
 
     else:
         result = data

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -32,6 +32,8 @@ import subprocess
 import os
 import re
 import sys
+import numpy
+import json
 
 from string import Template
 
@@ -53,10 +55,12 @@ __all__ = [
     'is_string',
     'load_help',
     'model_deprecation_warning',
+    'serializable',
     'set_verbosity',
     'show_deprecation_warning',
     'show_help_with_pager',
     'SuppressedDeprecationWarning',
+    'to_json',
     'uni_str',
 ]
 
@@ -543,6 +547,55 @@ def model_deprecation_warning(model):
         ".format(model, deprecated_models[model])
         text = get_wrapped_text(text)
         warnings.warn('\n' + text)
+
+
+def serializable(data):
+    """Make data serializable for JSON.
+
+    Parameters
+    ----------
+    data : str, int, float, SLILiteral, list, tuple, dict, ndarray
+
+    Returns
+    -------
+    result : str, int, float, list, dict
+
+    """
+
+    if isinstance(data, kernel.SLILiteral):
+        result = data.name
+
+    elif isinstance(data, numpy.ndarray):
+        result = data.tolist()
+
+    elif type(data) in [list, tuple]:
+        result = [serializable(d) for d in data]
+
+    elif isinstance(data, dict):
+        result = dict([(key, serializable(value)) for key, value in data.items()])
+
+    else:
+        result = data
+
+    return result
+
+
+def to_json(data):
+    """Serialize data to JSON.
+
+    Parameters
+    ----------
+    data : str, int, float, SLILiteral, list, tuple, dict, ndarray
+
+    Returns
+    -------
+    data_json : str
+        JSON format of the data
+    """
+
+    data_serializable = serializable(data)
+    data_json = json.dumps(data_serializable)
+    return data_json
 
 
 class SuppressedDeprecationWarning(object):

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -270,7 +270,7 @@ def SetStatus(nodes, params, val=None):
 
 
 @check_stack
-def GetStatus(nodes, keys=None):
+def GetStatus(nodes, keys=None, output=''):
     """Return the parameter dictionaries of nodes or connections.
 
     If `keys` is given, a ``list`` of values is returned instead. `keys` may
@@ -286,6 +286,9 @@ def GetStatus(nodes, keys=None):
         ``string`` or a ``list`` of strings naming model properties.
         `GetDefaults` then returns a single value or a ``list`` of values
         belonging to the keys given.
+    output : str, optional
+        Whether the returned data should be in a selected format
+        (``output='json'``). Default is ''.
 
     Returns
     -------
@@ -297,6 +300,8 @@ def GetStatus(nodes, keys=None):
     list :
         If keys is a ``list`` of strings, a ``list`` of corrsponding default
         parameters is returned.
+    str :
+        If `output` is `json`, returns parameters in JSON format.
 
     Raises
     ------
@@ -332,5 +337,9 @@ def GetStatus(nodes, keys=None):
         sps(nodes)
 
     sr(cmd)
+    result = spp()
 
-    return spp()
+    if output == 'json':
+        result = to_json(result)
+
+    return result

--- a/pynest/nest/lib/hl_api_models.py
+++ b/pynest/nest/lib/hl_api_models.py
@@ -137,7 +137,7 @@ def SetDefaults(model, params, val=None):
 
 
 @check_stack
-def GetDefaults(model, keys=None):
+def GetDefaults(model, keys=None, output=''):
     """Return default parameters of the given model, specified by a string.
 
     Parameters
@@ -148,6 +148,9 @@ def GetDefaults(model, keys=None):
         String or a list of strings naming model properties. `GetDefaults` then
         returns a single value or a list of values belonging to the keys
         given.
+    output : str, optional
+        Whether the returned data should be in a format
+        (``output='json'``). Default is ''.
 
     Returns
     -------
@@ -158,6 +161,8 @@ def GetDefaults(model, keys=None):
     list
         If keys is a list of strings, a list of corrsponding default parameters
         is returned.
+    str :
+        If `output` is `json`, returns parameters in JSON format.
 
     Raises
     ------
@@ -190,7 +195,12 @@ def GetDefaults(model, keys=None):
         raise TypeError("keys should be either a string or an iterable")
 
     sr(cmd)
-    return spp()
+    result = spp()
+
+    if output == 'json':
+        result = to_json(result)
+
+    return result
 
 
 @check_stack

--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -47,6 +47,7 @@ from . import test_events
 from . import test_facetshw_stdp
 from . import test_getconnections
 from . import test_helper_functions
+from . import test_json
 from . import test_labeled_synapses
 from . import test_mc_neuron
 from . import test_networks
@@ -101,6 +102,7 @@ def suite():
     suite.addTest(test_facetshw_stdp.suite())
     suite.addTest(test_getconnections.suite())
     suite.addTest(test_helper_functions.suite())
+    suite.addTest(test_json.suite())
     suite.addTest(test_labeled_synapses.suite())
     suite.addTest(test_mc_neuron.suite())
     suite.addTest(test_networks.suite())

--- a/pynest/nest/tests/test_json.py
+++ b/pynest/nest/tests/test_json.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# test_json.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test if json output work properly
+"""
+
+import unittest
+import nest
+
+
+@nest.ll_api.check_stack
+class StatusTestCase(unittest.TestCase):
+    """Tests of data in JSON format"""
+
+    def test_GetDefaults_JSON(self):
+        """JSON data of GetDefaults"""
+
+        # sli_neuron does not work under PyNEST
+        models = (m for m in nest.Models() if m != 'sli_neuron')
+
+        for m in models:
+            d_json = nest.GetDefaults(m, output='json')
+            self.assertIsInstance(d_json, str)
+
+            d = nest.GetDefaults(m)
+            d_json = nest.hl_api.to_json(d)
+            self.assertIsInstance(d_json, str)
+
+    def test_GetKernelStatus_JSON(self):
+        """JSON data of KernelStatus"""
+
+        d = nest.GetKernelStatus()
+        d_json = nest.hl_api.to_json(d)
+        self.assertIsInstance(d_json, str)
+
+    def test_GetStatus_JSON(self):
+        """JSON data of GetStatus"""
+
+        # sli_neuron does not work under PyNEST
+        models = (m for m in nest.Models('nodes') if m != 'sli_neuron')
+
+        for m in models:
+            nest.ResetKernel()
+            n = nest.Create(m)
+            d_json = nest.GetStatus(n, output='json')
+            self.assertIsInstance(d_json, str)
+
+
+def suite():
+    suite = unittest.makeSuite(StatusTestCase, 'test')
+    return suite
+
+
+def run():
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
This PR provides serialized output in GetStatus and GetDefaults when the output argument is 'json'.
It is related to https://github.com/compneuronmbu/nest-simulator/pull/7 but for NEST 2.

Here, an example code.
```
import nest
import json
d = nest.GetDefaults('iaf_psc_alpha', output='json')
d_json = json.dumps(d)
```