### PR TITLE
Bug fix in poisson example in part 1 of pynest tutorial

### DIFF
--- a/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
+++ b/extras/userdoc/md/documentation/part-1-neurons-and-simple-neural-networks.md
@@ -337,8 +337,8 @@ to the synaptic model.
 
     syn_dict_ex = {"weight": 1.2}
     syn_dict_in = {"weight": -2.0}
-    nest.Connect([noise_ex], neuron, syn_spec=syn_dict_ex)
-    nest.Connect([noise_in], neuron, syn_spec=syn_dict_in)
+    nest.Connect(noise_ex, neuron, syn_spec=syn_dict_ex)
+    nest.Connect(noise_in, neuron, syn_spec=syn_dict_in)
 
 <table><tr>
 <td style="max-width: 400px;">


### PR DESCRIPTION
http://www.nest-simulator.org/part-1-neurons-and-simple-neural-networks/

Removed brackets around `noise_ex` and `noise_in`: passing those as lists generated following error:

>     NESTError: TypeMismatch in cvgidcollection_ia: Expected datatype: integertype
> Provided datatype: arraytype

Removing the brackets removed the error, and the code worked (Ubuntu 16, Nest 2.16, Python 3.7, iPython 7.2).