### PR TITLE
Fix broken PyNEST, remove traces of ResumeSimulation

### DIFF
--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -71,7 +71,6 @@ __all__ = [
     'Rank',
     'ResetKernel',
     'ResetNetwork',
-    'ResumeSimulation',
     'Run',
     'RunManager',
     'SetAcceptableLatency',

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -38,7 +38,6 @@ __all__ = [
     'Prepare',
     'ResetKernel',
     'ResetNetwork',
-    'ResumeSimulation',
     'Run',
     'RunManager',
     'SetKernelStatus',


### PR DESCRIPTION
PRs #1094 and #1058 have been worked on simultaneously. With #1058 we provide explicit indices to all  PyNEST functions in `__all__`, but as #1094 removed `ResumeSimulation`, PyNEST now breaks because `ResumeSimulation` is not found.