### PR TITLE
Fixed creation of inhomogeneous poisson generator with parameters

### DIFF
--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -144,15 +144,19 @@ nest::inhomogeneous_poisson_generator::Parameters_::set(
     throw BadProperty( "Rate times and values must be reset together." );
   }
 
-  // if empty parameters given, return here
+  // if neither times or rates are given, return here
   if ( not( times or rates ) )
   {
     return;
   }
 
-  // from here on we are sure the passed arguments are not empty
   const std::vector< double_t > d_times =
     getValue< std::vector< double_t > >( d->lookup( names::rate_times ) );
+
+  if ( d_times.empty() )
+  {
+    return;
+  }
 
   if ( d_times.size() != rate_values_.size() )
   {

--- a/testsuite/regressiontests/issue-1140.sli
+++ b/testsuite/regressiontests/issue-1140.sli
@@ -37,6 +37,23 @@ FirstVersion: March 2019
 (unittest) run
 /unittest using
 
+M_ERROR setverbosity
+
+% Check if we can set parameters with empty arrays for rate_times
+% and rate_values without causing a segfault.
+{
+  ResetKernel
+
+  /params
+  <<
+    /rate_times []
+    /rate_values []
+  >> def
+  /ipg /inhomogeneous_poisson_generator Create def
+  ipg params SetStatus
+}
+pass_or_die
+
 % Check if parameters on creation are set properly when set implicitly
 % with Create. Create temporarily changes default values, then resets
 % them, which would trigger the issue.

--- a/testsuite/regressiontests/issue-1140.sli
+++ b/testsuite/regressiontests/issue-1140.sli
@@ -1,0 +1,65 @@
+/*
+ *  issue-1140.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1140
+
+Synopsis: (issue-1140) run -> NEST exits if test fails
+
+Description:
+Tests if parameters for inhomogeneous_poisson_generator can be set with empty
+arrays for rate_times and rate_values.
+
+Author: Håkon Mørk
+FirstVersion: March 2019
+*/
+
+(unittest) run
+/unittest using
+
+% Check if parameters on creation are set properly when set implicitly
+% with Create. Create temporarily changes default values, then resets
+% them, which would trigger the issue.
+{
+  ResetKernel
+
+  /params
+  <<
+    /rate_times [ 10.0 110.0 210.0 ]
+    /rate_values [ 400.0 1000.0 200.0 ]
+  >> def
+  /ipg /inhomogeneous_poisson_generator params Create def
+  /status ipg GetStatus def
+
+  true
+  [ /rate_times /rate_values ]
+  {
+    /element Set
+    status element get
+    params element get cv_dv
+    eq
+  } Fold
+}
+assert_or_die
+
+endusing

--- a/testsuite/unittests/test_inhomogeneous_poisson_generator.sli
+++ b/testsuite/unittests/test_inhomogeneous_poisson_generator.sli
@@ -203,27 +203,3 @@ fail_or_die
   >> SetStatus
 }
 fail_or_die
-
-% Test 7
-% Parameters on creation set properly
-{
-  ResetKernel
-
-  /params
-  <<
-    /rate_times [ 10.0 110.0 210.0 ]
-    /rate_values [ 400.0 1000.0 200.0 ]
-  >> def
-  /ipg /inhomogeneous_poisson_generator params Create def
-  /status ipg GetStatus def
-
-  true
-  [ /rate_times /rate_values ]
-  {
-    /element Set
-    status element get
-    params element get cv_dv
-    eq
-  } Fold
-}
-assert_or_die

--- a/testsuite/unittests/test_inhomogeneous_poisson_generator.sli
+++ b/testsuite/unittests/test_inhomogeneous_poisson_generator.sli
@@ -203,3 +203,27 @@ fail_or_die
   >> SetStatus
 }
 fail_or_die
+
+% Test 7
+% Parameters on creation set properly
+{
+  ResetKernel
+
+  /params
+  <<
+    /rate_times [ 10.0 110.0 210.0 ]
+    /rate_values [ 400.0 1000.0 200.0 ]
+  >> def
+  /ipg /inhomogeneous_poisson_generator params Create def
+  /status ipg GetStatus def
+
+  true
+  [ /rate_times /rate_values ]
+  {
+    /element Set
+    status element get
+    params element get cv_dv
+    eq
+  } Fold
+}
+assert_or_die


### PR DESCRIPTION
This PR fixes an issue with the inhomogeneous poisson generator where it could not be created with empty arrays for the `rate_times` and `rate_values` parameters. This is required when creating a node with specified parameters.

Fixes #1140.