### PR TITLE
Add PyNEST function to synchronize MPI processes

### DIFF
--- a/pynest/nest/lib/hl_api_parallel_computing.py
+++ b/pynest/nest/lib/hl_api_parallel_computing.py
@@ -32,6 +32,7 @@ __all__ = [
     'Rank',
     'SetAcceptableLatency',
     'SetMaxBuffered',
+    'SyncProcesses',
 ]
 
 
@@ -105,3 +106,10 @@ def SetMaxBuffered(port_name, size):
     sps(kernel.SLILiteral(port_name))
     sps(size)
     sr("SetMaxBuffered")
+
+@check_stack
+def SyncProcesses():
+    """Synchronize all MPI processes.
+    """
+
+    sr("SyncProcesses")


### PR DESCRIPTION
The SLI function `SyncProcesses` blocks until all processes have reached the function, and is used to debug MPI issues. This PR adds a PyNEST binding. 

The PyNEST function is accessible from the `hl_api` submodule, i.e. as `nest.hl_api.SyncProcesses()`, to not encourage users to control MPI on the Python level.