### PR TITLE
Fix MPI synchronization problem in presence of very small layers

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -936,6 +936,7 @@ nest::ConnectionManager::data_connect_single( const index source_id,
 bool
 nest::ConnectionManager::data_connect_connectome( const ArrayDatum& connectome )
 {
+  kernel().connection_manager.set_have_connections_changed( true );
   for ( Token* ct = connectome.begin(); ct != connectome.end(); ++ct )
   {
     DictionaryDatum cd = getValue< DictionaryDatum >( *ct );
@@ -964,7 +965,6 @@ nest::ConnectionManager::data_connect_connectome( const ArrayDatum& connectome )
     Node* source_node = kernel().node_manager.get_node( source_gid );
     connect_( *source_node, *target_node, source_gid, thr, syn_id, cd );
   }
-  kernel().connection_manager.set_have_connections_changed( true );
   return true;
 }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -964,6 +964,7 @@ nest::ConnectionManager::data_connect_connectome( const ArrayDatum& connectome )
     Node* source_node = kernel().node_manager.get_node( source_gid );
     connect_( *source_node, *target_node, source_gid, thr, syn_id, cd );
   }
+  kernel().connection_manager.set_have_connections_changed( true );
   return true;
 }
 

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -210,8 +210,8 @@ connect_layers( const index source_gid,
   const index target_gid,
   const DictionaryDatum& connection_dict )
 {
-  kernel().connection_manager.set_have_connections_changed(true);
-  
+  kernel().connection_manager.set_have_connections_changed( true );
+
   AbstractLayer* source = dynamic_cast< AbstractLayer* >(
     kernel().node_manager.get_node( source_gid ) );
   AbstractLayer* target = dynamic_cast< AbstractLayer* >(

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -210,6 +210,8 @@ connect_layers( const index source_gid,
   const index target_gid,
   const DictionaryDatum& connection_dict )
 {
+  kernel().connection_manager.set_have_connections_changed(true);
+  
   AbstractLayer* source = dynamic_cast< AbstractLayer* >(
     kernel().node_manager.get_node( source_gid ) );
   AbstractLayer* target = dynamic_cast< AbstractLayer* >(


### PR DESCRIPTION
When connecting layers on multiple MPI processes, the processes may end up with different values for the bool `ConnectionManager::have_connections_changed_` if not all of the processes actually create connections. This is a problem in cases where updating connection infrastructure only occurs when connections are changed, as `update_connection_infrastructure()` requires MPI communication. Processes then go out of sync.

This is not a problem when connecting normally, as `have_connections_changed_` is set to `true` even if no connections are created. In topology however, `have_connections_changed_` is not set until a connection is made. With this PR it is set to `true` earlier, even if no connections are created.