### PR TITLE
Correcting documentation on current input in precise neurons (fixes #226).

### DIFF
--- a/precise/iaf_psc_alpha_canon.h
+++ b/precise/iaf_psc_alpha_canon.h
@@ -71,24 +71,6 @@ application, the canonical application may provide superior overall
 performance given an accuracy goal; see [1] for details.  Subthreshold
 dynamics are integrated using exact integration between events [2].
 
-Remarks:
-
-The iaf_psc_delta_canon neuron does not accept CurrentEvent connections.
-This is because the present method for transmitting CurrentEvents in
-NEST (sending the current to be applied) is not compatible with off-grid
-currents, if more than one CurrentEvent-connection exists. Once CurrentEvents
-are changed to transmit change-of-current-strength, this problem will
-disappear and the canonical neuron will also be able to handle CurrentEvents.
-For now, the only way to inject a current is the built-in current I_e.
-
-Please note that this node is capable of sending precise spike times
-to target nodes (on-grid spike time plus offset). If this node is
-connected to a spike_detector, the property "precise_times" of the
-spike_detector has to be set to true in order to record the offsets
-in addition to the on-grid spike times.
-
-A further improvement of precise simulation is implemented in iaf_psc_exp_ps
-based on [3].
 
 Parameters:
 
@@ -109,10 +91,23 @@ Interpol_Order  int - Interpolation order for spike time:
 
 Remarks:
 
+This model transmits precise spike times to target nodes (on-grid spike
+time and offset). If this node is connected to a spike_detector, the
+property "precise_times" of the spike_detector has to be set to true in
+order to record the offsets in addition to the on-grid spike times.
+
+The iaf_psc_delta_canon neuron accepts connections transmitting
+CurrentEvents. These events transmit stepwise-constant currents which
+can only change at on-grid times.
+
 If tau_m is very close to tau_syn, the model will numerically behave as
 if tau_m is equal to tau_syn, to avoid numerical instabilities.
 For details, please see IAF_Neruons_Singularity.ipynb in
 the NEST source code (docs/model_details).
+
+A further improvement of precise simulation is implemented in iaf_psc_exp_ps
+based on [3].
+
 
 References:
 

--- a/precise/iaf_psc_alpha_presc.h
+++ b/precise/iaf_psc_alpha_presc.h
@@ -80,11 +80,14 @@ Interpol_Order  int - Interpolation order for spike time:
 
 Remarks:
 
-Please note that this node is capable of sending precise spike times
-to target nodes (on-grid spike time plus offset). If this node is
-connected to a spike_detector, the property "precise_times" of the
-spike_detector has to be set to true in order to record the offsets
-in addition to the on-grid spike times.
+This model transmits precise spike times to target nodes (on-grid spike
+time and offset). If this node is connected to a spike_detector, the
+property "precise_times" of the spike_detector has to be set to true in
+order to record the offsets in addition to the on-grid spike times.
+
+The iaf_psc_delta_canon neuron accepts connections transmitting
+CurrentEvents. These events transmit stepwise-constant currents which
+can only change at on-grid times.
 
 If tau_m is very close to tau_syn, the model will numerically behave
 as if tau_m is equal to tau_syn, to avoid numerical instabilities.

--- a/precise/iaf_psc_delta_canon.h
+++ b/precise/iaf_psc_delta_canon.h
@@ -88,34 +88,6 @@ of the nest simulation kernel because it is at the same time complex
 enough to exhibit non-trivial dynamics and simple enough compute
 relevant measures analytically.
 
-Remarks:
-
-The iaf_psc_delta_canon neuron accepts CurrentEvent connections.
-However, the present method for transmitting CurrentEvents in
-NEST (sending the current to be applied) is not compatible with off-grid
-currents, if more than one CurrentEvent-connection exists. Once CurrentEvents
-are changed to transmit change-of-current-strength, this problem will
-disappear and the canonical neuron will also be able to handle CurrentEvents.
-
-The present implementation uses individual variables for the
-components of the state vector and the non-zero matrix elements of
-the propagator.  Because the propagator is a lower triangular matrix
-no full matrix multiplication needs to be carried out and the
-computation can be done "in place" i.e. no temporary state vector
-object is required.
-
-The template support of recent C++ compilers enables a more succinct
-formulation without loss of runtime performance already at minimal
-optimization levels. A future version of iaf_psc_delta_canon will probably
-address the problem of efficient usage of appropriate vector and
-matrix objects.
-
-Please note that this node is capable of sending precise spike times
-to target nodes (on-grid spike time plus offset). If this node is
-connected to a spike_detector, the property "precise_times" of the
-spike_detector has to be set to true in order to record the offsets
-in addition to the on-grid spike times.
-
 Parameters:
 
 The following parameters can be set in the status dictionary.
@@ -132,6 +104,17 @@ V_min      double - Absolute lower value for the membrane potential in mV.
 
 refractory_input bool - If true, do not discard input during
 refractory period. Default: false.
+
+Remarks:
+
+This model transmits precise spike times to target nodes (on-grid spike
+time and offset). If this node is connected to a spike_detector, the
+property "precise_times" of the spike_detector has to be set to true in
+order to record the offsets in addition to the on-grid spike times.
+
+The iaf_psc_delta_canon neuron accepts connections transmitting
+CurrentEvents. These events transmit stepwise-constant currents which
+can only change at on-grid times.
 
 References:
 

--- a/precise/iaf_psc_exp_ps.h
+++ b/precise/iaf_psc_exp_ps.h
@@ -88,11 +88,14 @@ V_reset       double - Reset value for the membrane potential in mV.
 
 Remarks:
 
-Please note that this node is capable of sending precise spike times
-to target nodes (on-grid spike time plus offset). If this node is
-connected to a spike_detector, the property "precise_times" of the
-spike_detector has to be set to true in order to record the offsets
-in addition to the on-grid spike times.
+This model transmits precise spike times to target nodes (on-grid spike
+time and offset). If this node is connected to a spike_detector, the
+property "precise_times" of the spike_detector has to be set to true in
+order to record the offsets in addition to the on-grid spike times.
+
+The iaf_psc_delta_canon neuron accepts connections transmitting
+CurrentEvents. These events transmit stepwise-constant currents which
+can only change at on-grid times.
 
 If tau_m is very close to tau_syn_ex or tau_syn_in, the model
 will numerically behave as if tau_m is equal to tau_syn_ex or

--- a/precise/iaf_psc_exp_ps_lossless.h
+++ b/precise/iaf_psc_exp_ps_lossless.h
@@ -75,14 +75,23 @@ Parameters:
   V_min         double - Absolute lower value for the membrane potential.
   V_reset       double - Reset value for the membrane potential.
 
-Note: In the current implementation, tau_syn_ex and tau_syn_in must be equal.
-  This is because the state space would be 3-dimensional otherwise, which
-  makes the detection of threshold crossing more difficult [1].
-  Support for different time constants may be added in the future, see issue
-  #921.
-
 Remarks:
-  @todo Implement current input in consistent way.
+
+This model transmits precise spike times to target nodes (on-grid spike
+time and offset). If this node is connected to a spike_detector, the
+property "precise_times" of the spike_detector has to be set to true in
+order to record the offsets in addition to the on-grid spike times.
+
+The iaf_psc_delta_canon neuron accepts connections transmitting
+CurrentEvents. These events transmit stepwise-constant currents which
+can only change at on-grid times.
+
+In the current implementation, tau_syn_ex and tau_syn_in must be equal.
+This is because the state space would be 3-dimensional otherwise, which
+makes the detection of threshold crossing more difficult [1].
+Support for different time constants may be added in the future,
+see issue #921.
+
 
 References:
 [1] Krishnan J, Porta Mana P, Helias M, Diesmann M and Di Napoli E


### PR DESCRIPTION
Besides providing correct information on handling of current input, this PR also removes some outdated and very technical comments, and ensures that Remarks always come after the Parameters section.

This PR solves #226.