### PR TITLE
Fix incorrect flag in ProcessOptions.cmake

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -169,7 +169,7 @@ function( NEST_PROCESS_STATIC_LIBRARIES )
       set( CMAKE_FIND_LIBRARY_SUFFIXES ".a;.lib;.dylib;.so" PARENT_SCOPE )
     endif ()
 
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --static" PARENT_SCOPE )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static" PARENT_SCOPE )
 
   else ()
     set( BUILD_SHARED_LIBS ON PARENT_SCOPE )


### PR DESCRIPTION
This PR fixes a typo, an extra dash, and let users make a statically linked NEST binary again.