### PR TITLE
Simplify dynamic import of PyNEST submodules

### DIFF
--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -41,7 +41,7 @@ def _import_libs(mod_file, mod_dict, path,
       level: relative level (1 is relative to path, 2 is ../path, ...)
              (default 1)
       """
-                 
+
     import ast
     import os
 

--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -23,51 +23,7 @@
 High-level API of PyNEST Module
 """
 
-# We search through the subdirectory "lib" of the "nest" module
-# directory and import the content of all Python files therein into
-# the global namespace. This makes the API functions of PyNEST itself
-# and those of extra modules available to the user.
-
-
-def _import_libs(mod_file, mod_dict, path,
-                 prefix=None, ignore=frozenset(), level=1):
-    """
-    _import_libs: construct a relative import of all modules
-      mod_file: name of calling module file (__file__)
-      mod_dict: globals() of calling module
-      path: relative path to check for modules
-      prefix: string for import prefix (defaults to path)
-      ignore: set of import names ($prefix.$name) to not import
-      level: relative level (1 is relative to path, 2 is ../path, ...)
-             (default 1)
-      """
-
-    import ast
-    import os
-
-    if prefix is None:
-        prefix = path
-
-    # from .$prefix.$x import *
-    # relative to mod_file which is the filename from which mod_dict was read
-    # where $x.py is all files ./$path/*.py not starting with __
-    libdir = os.path.join(os.path.dirname(mod_file), path)
-    for name in os.listdir(libdir):
-        if not name.endswith(".py") or name.startswith('__'):
-            continue  # not a regular python module
-
-        pkg_name = "{}.{}".format(prefix, name[:-3])
-        if pkg_name in ignore:
-            continue  # this package is not to be imported dynamically
-
-        # construct from .pkg_name import * ; this is the old 'exec(string)'
-        names = [ast.alias(name='*', asname=None)]
-        body = [ast.ImportFrom(module=pkg_name, names=names, level=level)]
-        module = ast.fix_missing_locations(ast.Module(body=body))
-
-        code = compile(module, mod_file, 'exec')
-        exec(code, mod_dict, mod_dict)
-
+import .import_libs as _il
 
 #############################
 # insert static imports here
@@ -81,7 +37,7 @@ _ignore_modules = set()
 # then do
 #   `from .libs.$X import *`
 # for every module in ./libs/$X.py that is left
-_import_libs(__file__, globals(), 'lib', ignore=_ignore_modules)
+_il.import_libs(__file__, globals(), 'lib', ignore=_ignore_modules)
 ############################
 
 # With '__all__' we provide an explicit index of the package. Without any

--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -23,7 +23,7 @@
 High-level API of PyNEST Module
 """
 
-import .import_libs as _il
+from . import import_libs as _il
 
 #############################
 # insert static imports here

--- a/pynest/nest/import_libs.py
+++ b/pynest/nest/import_libs.py
@@ -1,0 +1,53 @@
+import ast
+import os
+
+
+# We search through the subdirectory "lib" of the "nest" module
+# directory and import the content of all Python files therein into
+# the global namespace. This makes the API functions of PyNEST itself
+# and those of extra modules available to the user.
+
+
+def import_libs(mod_file, mod_dict, path,
+                prefix=None, ignore=frozenset(), level=1):
+    """Construct a relative import of all modules
+
+    Parameters
+    __________
+    mod_file: str
+      name of calling module file (__file__)
+    mod_dict: dict
+      globals() of calling module
+    path: str
+      relative path to check for modules
+    prefix: str
+      import prefix (defaults to path)
+    ignore: set/dict
+      set of import names ($prefix.$name) to not import
+    level: int
+        relative level (1 is relative to path, 2 is ../path, ...)
+        (default 1)
+    """
+
+    if prefix is None:
+        prefix = path
+
+    # from .$prefix.$x import *
+    # relative to mod_file which is the filename from which mod_dict was read
+    # where $x.py is all files ./$path/*.py not starting with __
+    libdir = os.path.join(os.path.dirname(mod_file), path)
+    for name in os.listdir(libdir):
+        if not name.endswith(".py") or name.startswith('__'):
+            continue  # not a regular python module
+
+        pkg_name = "{}.{}".format(prefix, name[:-3])
+        if pkg_name in ignore:
+            continue  # this package is not to be imported dynamically
+
+        # construct from .pkg_name import *
+        names = [ast.alias(name='*', asname=None)]
+        body = [ast.ImportFrom(module=pkg_name, names=names, level=level)]
+        module = ast.fix_missing_locations(ast.Module(body=body))
+
+        code = compile(module, mod_file, 'exec')
+        exec(code, mod_dict, mod_dict)


### PR DESCRIPTION
Feature/dynamic import #1150

Since @jougs liked the brevity of the old solution, I shrunk this as much as possible -- instead of doing module member transfers by hand, it recreates the old exec, but using an ast.

The advantage of this over `exec('string')` is that you won't get weird errors for garbage filenames in the directory (and the code can be simply re-used elsewhere)

For example, with the old string approach, if a file were dropped with the name of `'lib/x a .py` your error would be an unclear syntax error -- you can make arbitrarily bad 'file names' that could do anything, given sufficient uncleveriness.