### PR TITLE
Introduce time-driven spiking connections

### DIFF
--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -115,6 +115,7 @@ set( models_sources
     step_rate_generator.h step_rate_generator.cpp
     tanh_rate.h tanh_rate.cpp
     threshold_lin_rate.h threshold_lin_rate.cpp
+    time_driven_static_connection.h
     tsodyks2_connection.h
     tsodyks_connection.h
     tsodyks_connection_hom.h tsodyks_connection_hom.cpp

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -136,6 +136,7 @@
 #include "spike_dilutor.h"
 #include "static_connection.h"
 #include "static_connection_hom_w.h"
+#include "time_driven_static_connection.h"
 #include "stdp_connection.h"
 #include "stdp_connection_facetshw_hom.h"
 #include "stdp_connection_facetshw_hom_impl.h"
@@ -485,6 +486,20 @@ ModelsModule::init( SLIInterpreter* )
     .model_manager
     .register_connection_model< StaticConnectionHomW< TargetIdentifierIndex > >(
       "static_synapse_hom_w_hpc" );
+
+  /** @BeginDocumentation
+      Name: time_driven_static_synapse - Synapse type for time-driven static
+     connections.
+      SeeAlso: static_synapse
+  */
+  kernel()
+    .model_manager
+    .register_secondary_connection_model< TimeDrivenStaticConnection< TargetIdentifierPtrRport > >(
+      "time_driven_static_synapse",
+      /*has_delay=*/true,
+      /*requires_symmetric=*/false,
+      /*supports_wfr=*/false );
+
 
   /** @BeginDocumentation
      Name: gap_junction - Connection model for gap junctions.

--- a/models/time_driven_static_connection.h
+++ b/models/time_driven_static_connection.h
@@ -1,0 +1,161 @@
+/*
+ *  time_driven_static_connection.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#ifndef TIME_DRIVEN_STATIC_CONNECTION_H
+#define TIME_DRIVEN_STATIC_CONNECTION_H
+
+/* @BeginDocumentation
+   Name: time_driven_static_synapse - Synapse type for time-driven static
+   connections.
+
+   Description:
+
+   For efficiency reasons spiking connections in NEST are only updated on every
+   presynaptic spike, making it difficult to implement time-driven plasticity
+   rules. This model implements a simple approach to time-driven synapse
+   updates: the framework for continuous interactions is used to communicate
+   spikes. This causes this model to be updated in every time step.
+
+   The event received by the synapse contains a buffer of length h / dt in which
+   non-zero values indicate a spike. For simplicity this static synapse model
+   forwards the entire TimeDrivenSpikeEvent to the receiving node where the
+   buffer is unpacked. To compute updates in dt steps in the synapse object, the
+   event should instead be unpacked in `send()` and a SpikeEvent in every dt
+   step should be forwarded to the receiving node.
+
+   time_driven_static_synapse does not support any kind of plasticity. It simply
+   stores the parameters target, weight, delay and receiver port for each
+   connection.
+
+   FirstVersion: April 2019
+
+   Author: Jakob Jordan
+
+   Transmits: TimeDrivenSpikeEvent
+
+   SeeAlso: static_synapse
+*/
+
+// Includes from nestkernel:
+#include "connection.h"
+
+namespace nest
+{
+template < typename targetidentifierT >
+class TimeDrivenStaticConnection : public Connection< targetidentifierT >
+{
+
+public:
+  // this line determines which common properties to use
+  typedef CommonSynapseProperties CommonPropertiesType;
+
+  typedef Connection< targetidentifierT > ConnectionBase;
+  typedef TimeDrivenSpikeEvent EventType;
+
+  /**
+   * Default Constructor.
+   * Sets default values for all parameters. Needed by GenericConnectorModel.
+   */
+  TimeDrivenStaticConnection()
+    : ConnectionBase()
+    , weight_( 1.0 )
+  {
+  }
+
+  // Explicitly declare all methods inherited from the dependent base
+  // ConnectionBase.
+  // This avoids explicit name prefixes in all places these functions are used.
+  // Since ConnectionBase depends on the template parameter, they are not
+  // automatically
+  // found in the base class.
+  using ConnectionBase::get_delay_steps;
+  using ConnectionBase::get_rport;
+  using ConnectionBase::get_target;
+
+  void
+  check_connection( Node& s,
+    Node& t,
+    rport receptor_type,
+    const CommonPropertiesType& )
+  {
+    EventType ge;
+
+    s.sends_secondary_event( ge );
+    ge.set_sender( s );
+    Connection< targetidentifierT >::target_.set_rport(
+      t.handles_test_event( ge, receptor_type ) );
+    Connection< targetidentifierT >::target_.set_target( &t );
+  }
+
+  /**
+   * Send an event to the receiver of this connection.
+   * \param e The event to send
+   * \param p The port under which this connection is stored in the Connector.
+   */
+  void
+  send( Event& e, thread t, const CommonSynapseProperties& )
+  {
+    e.set_weight( weight_ );
+    e.set_delay_steps( get_delay_steps() );
+    e.set_receiver( *get_target( t ) );
+    e.set_rport( get_rport() );
+    e();
+  }
+
+  void get_status( DictionaryDatum& d ) const;
+
+  void set_status( const DictionaryDatum& d, ConnectorModel& cm );
+
+  void
+  set_weight( double w )
+  {
+    weight_ = w;
+  }
+
+private:
+  double weight_; //!< connection weight
+};
+
+template < typename targetidentifierT >
+void
+TimeDrivenStaticConnection< targetidentifierT >::get_status(
+  DictionaryDatum& d ) const
+{
+  ConnectionBase::get_status( d );
+  def< double >( d, names::weight, weight_ );
+  def< long >( d, names::size_of, sizeof( *this ) );
+}
+
+template < typename targetidentifierT >
+void
+TimeDrivenStaticConnection< targetidentifierT >::set_status(
+  const DictionaryDatum& d,
+  ConnectorModel& cm )
+{
+  ConnectionBase::set_status( d, cm );
+  updateValue< double >( d, names::weight, weight_ );
+}
+
+} // namespace
+
+#endif /* #ifndef TIME_DRIVEN_STATIC_CONNECTION_H */

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -120,6 +120,11 @@ void DiffusionConnectionEvent::operator()()
 {
   receiver_->handle( *this );
 }
+
+void TimeDrivenSpikeEvent::operator()()
+{
+  receiver_->handle( *this );
+}
 }
 
 nest::index

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -1199,6 +1199,18 @@ public:
   weight get_diffusion_factor() const;
 };
 
+class TimeDrivenSpikeEvent
+  : public DataSecondaryEvent< unsigned int, TimeDrivenSpikeEvent >
+{
+public:
+  TimeDrivenSpikeEvent()
+  {
+  }
+
+  void operator()();
+  TimeDrivenSpikeEvent* clone() const;
+};
+
 template < typename DataType, typename Subclass >
 inline DataType
 DataSecondaryEvent< DataType, Subclass >::get_coeffvalue(
@@ -1254,6 +1266,12 @@ inline weight
 DiffusionConnectionEvent::get_diffusion_factor() const
 {
   return diffusion_factor_;
+}
+
+inline TimeDrivenSpikeEvent*
+TimeDrivenSpikeEvent::clone() const
+{
+  return new TimeDrivenSpikeEvent( *this );
 }
 
 //*************************************************************

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -85,6 +85,8 @@ public:
 
   void sends_secondary_event( DelayedRateConnectionEvent& re );
 
+  void sends_secondary_event( TimeDrivenSpikeEvent& re );
+
   Node const& get_prototype() const;
 
   void set_model_id( int );
@@ -225,6 +227,13 @@ template < typename ElementT >
 inline void
 GenericModel< ElementT >::sends_secondary_event(
   DelayedRateConnectionEvent& re )
+{
+  return proto_.sends_secondary_event( re );
+}
+
+template < typename ElementT >
+inline void
+GenericModel< ElementT >::sends_secondary_event( TimeDrivenSpikeEvent& re )
 {
   return proto_.sends_secondary_event( re );
 }

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -158,6 +158,7 @@ public:
     InstantaneousRateConnectionEvent& re ) = 0;
   virtual void sends_secondary_event( DiffusionConnectionEvent& de ) = 0;
   virtual void sends_secondary_event( DelayedRateConnectionEvent& re ) = 0;
+  virtual void sends_secondary_event( TimeDrivenSpikeEvent& re ) = 0;
 
   /**
    * Check what type of signal this model is sending.

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -472,6 +472,7 @@ const Name tics_per_step( "tics_per_step" );
 const Name time( "time" );
 const Name time_collocate( "time_collocate" );
 const Name time_communicate( "time_communicate" );
+const Name time_driven( "time_driven" );
 const Name time_in_steps( "time_in_steps" );
 const Name times( "times" );
 const Name to_accumulator( "to_accumulator" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -491,6 +491,7 @@ extern const Name tics_per_step;
 extern const Name time;
 extern const Name time_collocate;
 extern const Name time_communicate;
+extern const Name time_driven;
 extern const Name time_in_steps;
 extern const Name times;
 extern const Name to_accumulator;

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -385,6 +385,12 @@ Node::handle( DelayedRateConnectionEvent& )
   throw UnexpectedEvent();
 }
 
+void
+Node::handle( TimeDrivenSpikeEvent& )
+{
+  throw UnexpectedEvent();
+}
+
 port
 Node::handles_test_event( InstantaneousRateConnectionEvent&, rport )
 {
@@ -401,6 +407,13 @@ Node::handles_test_event( DiffusionConnectionEvent&, rport )
 
 port
 Node::handles_test_event( DelayedRateConnectionEvent&, rport )
+{
+  throw IllegalConnection();
+  return invalid_port_;
+}
+
+port
+Node::handles_test_event( TimeDrivenSpikeEvent&, rport )
 {
   throw IllegalConnection();
   return invalid_port_;
@@ -424,6 +437,11 @@ Node::sends_secondary_event( DelayedRateConnectionEvent& )
   throw IllegalConnection();
 }
 
+void
+Node::sends_secondary_event( TimeDrivenSpikeEvent& )
+{
+  throw IllegalConnection();
+}
 
 double
 Node::get_LTD_value( double )

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -435,6 +435,7 @@ public:
     rport receptor_type );
   virtual port handles_test_event( DelayedRateConnectionEvent&,
     rport receptor_type );
+  virtual port handles_test_event( TimeDrivenSpikeEvent&, rport receptor_type );
 
   /**
    * Required to check, if source neuron may send a SecondaryEvent.
@@ -471,6 +472,8 @@ public:
    * @throws IllegalConnection
    */
   virtual void sends_secondary_event( DelayedRateConnectionEvent& re );
+
+  virtual void sends_secondary_event( TimeDrivenSpikeEvent& e );
 
   /**
    * Register a STDP connection
@@ -585,6 +588,8 @@ public:
    * @throws UnexpectedEvent
    */
   virtual void handle( DelayedRateConnectionEvent& e );
+
+  virtual void handle( TimeDrivenSpikeEvent& e );
 
   /**
    * @defgroup SP_functions Structural Plasticity in NEST.

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -903,6 +903,8 @@ NodeManager::check_wfr_use()
     kernel().connection_manager.get_min_delay() );
   DiffusionConnectionEvent::set_coeff_length(
     kernel().connection_manager.get_min_delay() );
+  TimeDrivenSpikeEvent::set_coeff_length(
+    kernel().connection_manager.get_min_delay() );
 }
 
 void

--- a/nestkernel/proxynode.cpp
+++ b/nestkernel/proxynode.cpp
@@ -90,6 +90,14 @@ proxynode::sends_secondary_event( DelayedRateConnectionEvent& re )
     ->sends_secondary_event( re );
 }
 
+void
+proxynode::sends_secondary_event( TimeDrivenSpikeEvent& re )
+{
+  kernel()
+    .model_manager.get_model( get_model_id() )
+    ->sends_secondary_event( re );
+}
+
 /**
  * @returns type of signal this node produces
  * used in check_connection to only connect neurons which send / receive

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -91,6 +91,8 @@ public:
 
   void sends_secondary_event( DelayedRateConnectionEvent& );
 
+  void sends_secondary_event( TimeDrivenSpikeEvent& );
+
   void
   handle( SpikeEvent& )
   {

--- a/pynest/nest/tests/test_all.py
+++ b/pynest/nest/tests/test_all.py
@@ -47,6 +47,7 @@ from . import test_events
 from . import test_facetshw_stdp
 from . import test_getconnections
 from . import test_helper_functions
+from . import test_iaf_psc_exp_time_driven
 from . import test_json
 from . import test_labeled_synapses
 from . import test_mc_neuron
@@ -102,6 +103,7 @@ def suite():
     suite.addTest(test_facetshw_stdp.suite())
     suite.addTest(test_getconnections.suite())
     suite.addTest(test_helper_functions.suite())
+    suite.addTest(test_iaf_psc_exp_time_driven.suite())
     suite.addTest(test_json.suite())
     suite.addTest(test_labeled_synapses.suite())
     suite.addTest(test_mc_neuron.suite())

--- a/pynest/nest/tests/test_iaf_psc_exp_time_driven.py
+++ b/pynest/nest/tests/test_iaf_psc_exp_time_driven.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# test_iaf_psc_exp_time_driven.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import nest
+import numpy as np
+
+
+class TestIafPSCExpTimeDrivenNeuron(unittest.TestCase):
+
+    def test_valid_and_invalid_connections(self):
+        nest.ResetKernel()
+        n1 = nest.Create('iaf_psc_exp', 1, {'time_driven': False})
+        n2 = nest.Create('iaf_psc_exp', 1, {'time_driven': False})
+        nest.Connect(n1, n2, syn_spec={'model': 'static_synapse'})
+        with self.assertRaises(nest.kernel.NESTError):
+            nest.Connect(n1, n2, syn_spec={
+                         'model': 'time_driven_static_synapse'})
+
+        nest.ResetKernel()
+        n1 = nest.Create('iaf_psc_exp', 1, {'time_driven': False})
+        n2 = nest.Create('iaf_psc_exp', 1, {'time_driven': True})
+        nest.Connect(n1, n2, syn_spec={'model': 'static_synapse'})
+        with self.assertRaises(nest.kernel.NESTError):
+            nest.Connect(n1, n2, syn_spec={
+                         'model': 'time_driven_static_synapse'})
+
+        nest.ResetKernel()
+        n1 = nest.Create('iaf_psc_exp', 1, {'time_driven': True})
+        n2 = nest.Create('iaf_psc_exp', 1, {'time_driven': False})
+        nest.Connect(n1, n2, syn_spec={'model': 'static_synapse'})
+        nest.Connect(n1, n2, syn_spec={'model': 'time_driven_static_synapse'})
+
+        nest.ResetKernel()
+        n1 = nest.Create('iaf_psc_exp', 1, {'time_driven': True})
+        n2 = nest.Create('iaf_psc_exp', 1, {'time_driven': True})
+        nest.Connect(n1, n2, syn_spec={'model': 'static_synapse'})
+        nest.Connect(n1, n2, syn_spec={'model': 'time_driven_static_synapse'})
+
+    def sim(self, time_driven):
+        nest.ResetKernel()
+        nest.SetKernelStatus({'rng_seeds': [1], 'resolution': 0.1})
+
+        n1 = nest.Create('iaf_psc_exp', 1, {
+                         'time_driven': time_driven, 'I_e': 1000.})
+        n2 = nest.Create('iaf_psc_exp', 1, {
+                         'time_driven': time_driven, 'I_e': 350.})
+
+        sd = nest.Create('spike_detector')
+        m = nest.Create('multimeter', 1, {'record_from': ['V_m']})
+
+        if time_driven:
+            syn_model = 'time_driven_static_synapse'
+        else:
+            syn_model = 'static_synapse'
+
+        nest.Connect(n1, n2, syn_spec={'model': syn_model, 'weight': 100.})
+        nest.Connect(n2, sd)
+        nest.Connect(m, n2)
+
+        nest.Simulate(500.)
+
+        data_sd = nest.GetStatus(sd, 'events')[0]
+        data_m = nest.GetStatus(m, 'events')[0]
+
+        res = {}
+        res['spike_times'] = data_sd['times']
+        res['V_m'] = data_m['V_m']
+
+        return res
+
+    def test_compare_to_event_driven(self):
+
+        res_event_driven = self.sim(time_driven=False)
+        res_time_driven = self.sim(time_driven=True)
+
+        self.assertTrue(np.allclose(
+            res_event_driven['V_m'], res_time_driven['V_m']))
+        self.assertTrue(np.allclose(
+            res_event_driven['spike_times'], res_time_driven['spike_times']))
+
+
+def suite():
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestIafPSCExpTimeDrivenNeuron)
+    return suite
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestIafPSCExpTimeDrivenNeuron)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/pynest/nest/tests/test_labeled_synapses.py
+++ b/pynest/nest/tests/test_labeled_synapses.py
@@ -59,6 +59,11 @@ class LabeledSynapsesTestCase(unittest.TestCase):
             'clopath_synapse_lbl'
         ]
 
+        self.time_driven_spiking_connections = [
+            'time_driven_static_synapse',
+            'time_driven_static_synapse_lbl'
+        ]
+
         # create neurons that accept all synapse connections (especially gap
         # junctions)... hh_psc_alpha_gap is only available with GSL, hence the
         # skipIf above
@@ -75,6 +80,10 @@ class LabeledSynapsesTestCase(unittest.TestCase):
         # in case of the clopath stdp synapse use the a supported model instead
         if syn_model in self.clopath_connections:
             neurons = nest.Create("hh_psc_alpha_clopath", 5)
+
+        # in case of time-driven spiking connections use a supported model instead
+        if syn_model in self.time_driven_spiking_connections:
+            neurons = nest.Create("iaf_psc_exp", 5, {'time_driven': True})
 
         return neurons
 

--- a/pynest/nest/tests/test_sp/test_disconnect.py
+++ b/pynest/nest/tests/test_sp/test_disconnect.py
@@ -61,7 +61,9 @@ class TestDisconnectSingle(unittest.TestCase):
             'diffusion_connection',
             'diffusion_connection_lbl',
             'clopath_synapse',
-            'clopath_synapse_lbl'
+            'clopath_synapse_lbl',
+            'time_driven_static_synapse',
+            'time_driven_static_synapse_lbl'
         ]
 
     def test_synapse_deletion_one_to_one_no_sp(self):

--- a/pynest/nest/tests/test_sp/test_disconnect_multiple.py
+++ b/pynest/nest/tests/test_sp/test_disconnect_multiple.py
@@ -44,7 +44,9 @@ class TestDisconnect(unittest.TestCase):
             'rate_connection_delayed',
             'rate_connection_delayed_lbl',
             'clopath_synapse',
-            'clopath_synapse_lbl'
+            'clopath_synapse_lbl',
+            'time_driven_static_synapse',
+            'time_driven_static_synapse_lbl'
         ]
 
     def test_multiple_synapse_deletion_all_to_all(self):


### PR DESCRIPTION
While the event-driven simulation method for synapse updates makes NEST very efficient, it is often non-trivial to formulate an given plasticity rule involving multiple factors in an event-driven algorithm. To support fast prototyping in NEST a time-driven-update mode for synapses would hence be of great value.

This PR implements a simple approach to time-driven synapse updates: the framework for continuous interactions is used to communicate spikes. This results in the corresponding synapses being updated in every time step. As a proof of concept the `iaf_psc_exp` neuron now can be connected via a new `time_diven_static_connection`, which results in identical dynamics as the matching event-driven implementation. For this model both event- and time-driven connections can be used within the same simulation.

Since the technical side is straightforward, I think the decision of accepting this PR is rather a question of how useful this is estimated to be vs. the increase in loc.
I suggest @heplesser @janhahne @suku248 as reviewers, @clinssen may be interested with regards to NESTML.

