### PR TITLE
Fix broken internal links in doc/guides

### DIFF
--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -53,8 +53,7 @@ given as a string defining the synapse model (default:
 (``Connect(pre, post, syn_spec=syn_spec_dict)``), the conn\_spec can be
 omitted in the call to connect and 'all\_to\_all' is assumed as the
 default. The exact usage of the synapse dictionary is described in
-`Synapse
-Specification <connection-management.md#synapse-specification>`__.
+:ref:`synapse-spec`.
 
 Connection Rules
 ----------------
@@ -191,13 +190,14 @@ Example:
     conn_dict = {'rule': 'pairwise_bernoulli', 'p': p}
     Connect(A, B, conn_dict)
 
+.. _synapse-spec:
+
 Synapse Specification
 ~~~~~~~~~~~~~~~~~~~~~
 
 The synapse properties can be given as a string or a dictionary. The
 string can be the name of a pre-defined synapse which can be found in
-the synapsedict (see `Synapse
-Types <connection-management.md#synapse-types>`__) or a manually defined
+the synapsedict (see  :ref:`synapse-types`) or a manually defined
 synapse via ``CopyModel()``.
 
 Example:
@@ -222,8 +222,7 @@ types, as long as they agree with the connection routine ('rule').
 
 **Scalar** parameters must be given as floats except for the
 'receptor\_type' which has to be initialized as an integer. For more
-information on the receptor type see `Receptor
-Types <connection-management.md#synapse-types>`__ .
+information on the receptor type see :ref:`receptor-types`.
 
 Example:
 
@@ -301,7 +300,7 @@ Example:
 specifying the 'distribution' and the distribution-specific parameters,
 whose specification is optional.
 
-Available distributions are given in the rdevdict, the most common ones
+Available distributions are given in the ``rdevdict``, the most common ones
 are:
 
 Distributions Keys 'normal' 'mu', 'sigma' 'normal\_clipped' 'mu',
@@ -353,8 +352,8 @@ parameters it needs to be defined in two steps:
                }
     Connect(A, B, syn_spec=syn_dict)
 
-For further information on the distributions see `Random numbers in
-NEST <random-numbers.md>`__.
+For further information on the distributions see :doc:`Random numbers in
+NEST <random_numbers>`.
 
 Old Connection Routines
 -----------------------
@@ -529,6 +528,8 @@ receptive field structures and much more! See `Topological
 Connections <http://www.nest-simulator.org/wp-content/uploads/2015/04/Topology_UserManual.pdf>`__
 for more information.
 
+.. _receptor-types:
+
 Receptor Types
 --------------
 
@@ -572,6 +573,8 @@ post-synaptic node.
 The code block above connects a standard integrate-and-fire neuron to a
 somatic excitatory receptor of a multi-compartment integrate-and-fire
 neuron model. The result is illustrated in the figure.
+
+.. _synapse-types:
 
 Synapse Types
 -------------

--- a/doc/guides/random_numbers.rst
+++ b/doc/guides/random_numbers.rst
@@ -40,18 +40,19 @@ N}. Random *deviate* generators, on the other hand, provide random
 numbers drawn from a range of distributions, such as the normal or
 binomial distributions. In most cases, you will be using random deviate
 generators. They are in particular used to initialize properties during
-network construction, as described in the sections `Changes in NEST
-2.4 <random-numbers.md#changes-in-random-number-generation-in-nest-2.4>`__
-and `Examples <random-numbers.md#examples>`__ below.
+network construction, as described in the sections :ref:`changes-nest>`
+and :ref:`examples-rng` below.
+
+.. _changes-nest:
 
 Changes in random number generation in NEST 2.4
 -----------------------------------------------
 
 Random deviate generation has become significantly more powerful in NEST
 2.4, to fully support randomization of connections parameters offered by
-the revised ``Connect`` function, as described in `Connection
-Management <connection-management.md>`__ and illustrated by the
-`examples <random-numbers.md#examples>`__ below. We have also made minor
+the revised ``Connect`` function, as described in :doc:`Connection
+Management <connection_management>` and illustrated by the
+:ref:`examples-rng` below. We have also made minor
 changes to make to achieve greater similarity between NEST, PyNN, and
 NumPy. For most users, these changes only add new features. Only
 existing scripts using
@@ -359,6 +360,9 @@ The following happens here:
 
 -  This array is then passed to the ``/rngs`` status variable of the
    kernel. This variable is invisible as well.
+
+
+.. _examples-rng:
 
 Examples
 --------

--- a/doc/guides/scheduling_and_simulation_flow.rst
+++ b/doc/guides/scheduling_and_simulation_flow.rst
@@ -115,7 +115,7 @@ end of the interval* during which the threshold was crossed.
 
 NEST also has a some models that determine the precise time of the
 threshold crossing during the interval. Please see the documentation on
-`precise spike time neurons <simulations-with-precise-spike-times.md>`__
+:doc:`precise spike time neurons <simulations_with_precise_spike_time>`
 for details about neuron update in continuous time and the
-`documentation on connection management <connection-management.md>`__
+:doc:`documentation on connection management <connection_management>`
 for how to set the delay when creating synapses.

--- a/doc/guides/simulations_with_precise_spike_times.rst
+++ b/doc/guides/simulations_with_precise_spike_times.rst
@@ -2,8 +2,8 @@ Simulations with precise spike times
 ====================================
 
 The simulation resolution *h* and the minimum synaptic transmission
-delay *dmin* define the two major time intervals of the `scheduling and
-simulation flow of NEST <scheduling-and-simulation-flow.md>`__: neurons
+delay *dmin* define the two major time intervals of the :doc:`scheduling and
+simulation flow of NEST <scheduling_and_simulation_flow>`: neurons
 update their state variables in steps of *h*, whereas spikes are
 communicated and delivered to their targets in steps of *dmin*, where
 *dmin* is a multiple of *h*.
@@ -43,7 +43,7 @@ to update its state variables for each substep.
 
 .. figure:: ../_static/img/precise1-300x175.png
 
- Propagation of membrane potential in case of off-grid spiking. 
+ Propagation of membrane potential in case of off-grid spiking.
  Dashed red line indicates precise time of threshold crossing.
 
 If after an update the membrane potential is above the firing threshold,

--- a/doc/guides/using_nest_with_music.rst
+++ b/doc/guides/using_nest_with_music.rst
@@ -331,7 +331,7 @@ where w is the width of the port. The MUSIC configuration file
     from.cont_out -> to.cont_in [10]
 
 The receiving side is again implemented using a
-`PyNEST <introduction-to-pynest.md>`__ script (``conttest.py``).
+:doc:`PyNEST <../tutorials/index>` script (``conttest.py``).
 We first import the NEST and create an instance of the
 ``music_cont_in_proxy``. we set the name of the port
 it listens on to ``msgdata``. We then simulate the network in

--- a/doc/guides/using_nest_with_music.rst
+++ b/doc/guides/using_nest_with_music.rst
@@ -207,7 +207,9 @@ time stamps. For this example, we use the data file, ``messages0.dat``:
     0.3     Hello
     0.7     !
 
-.. note:: In MUSIC, the default unit for time is seconds for the specification
+.. note::
+
+  In MUSIC, the default unit for time is seconds for the specification
   of times, while NEST uses miliseconds.
 
 The script that sets up the receiving side (``msgtest.py``)


### PR DESCRIPTION
This PR fixes some broken links in the doc/guides that still had markdown format.  The links have been updated, so they now follow restructured text format and work properly.