### PR TITLE
Add documentation on splitting and repeating simulations, and deprecation warning for ResetNetwork

### DIFF
--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -6,11 +6,11 @@ Here you can find detailed look into a variety of topics in NEST.
 .. toctree::
     :maxdepth: 1
 
-    analog_recording_with_multimeter
     connection_management
+    running_simulations
     parallel_computing
     random_numbers
-    scheduling_and_simulation_flow
+    analog_recording_with_multimeter
     simulations_with_gap_junctions
     simulations_with_precise_spike_times
     using_nest_with_music

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -133,13 +133,13 @@ of doing this is to simply loop over ``Simulate()`` calls:
         nest.Simulate(10)
         # extract and analyse data
         
- would run a simulation in 20 rounds of 10 ms. With this solution, NEST takes
- a number of preparatory and cleanup steps for each ``Simulate()`` call. 
- This makes the solution robust and entirely reliable, but comes with a 
- performance cost.
+would run a simulation in 20 rounds of 10 ms. With this solution, NEST takes
+a number of preparatory and cleanup steps for each ``Simulate()`` call. 
+This makes the solution robust and entirely reliable, but comes with a 
+performance cost.
  
- A more efficient solution doing exactly the same thing is
- 
+A more efficient solution doing exactly the same thing is
+
 ::
 
     nest.Prepare()
@@ -148,7 +148,7 @@ of doing this is to simply loop over ``Simulate()`` calls:
         # extract and analyse data
     nest.Cleanup()
      
-For convenience, the `RunManager()` context manager can handle preparation
+For convenience, the ``RunManager()`` context manager can handle preparation
 and cleanup for you:
 
 ::

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -190,4 +190,4 @@ then to build the network anew. If your simulations are rather large and
 you are working on a computer with a job queueing system, it may be most
 efficient to submit individual jobs or a job array to smiulate network 
 instances in parallel; don't forget to use different 
-:doc:`random seeds <random_numbers>`!. 
+:doc:`random seeds <random_numbers>`! 

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -128,6 +128,7 @@ to extract information while the simulation is running. The simplest way
 of doing this is to simply loop over ``Simulate()`` calls:
 
 ::
+
     for _ in range(20):
         nest.Simulate(10)
         # extract and analyse data
@@ -139,17 +140,19 @@ of doing this is to simply loop over ``Simulate()`` calls:
  
  A more efficient solution doing exactly the same thing is
  
- ::
-     nest.Prepare()
-     for _ in range(20):
-         nest.Run(10)
-         # extract and analyse data
-     nest.Cleanup()
+::
+
+    nest.Prepare()
+    for _ in range(20):
+        nest.Run(10)
+        # extract and analyse data
+    nest.Cleanup()
      
 For convenience, the `RunManager()` context manager can handle preparation
 and cleanup for you:
 
 ::
+
     with nest.RunManager():
         for _ in range(20):
             nest.Run(10)
@@ -160,7 +163,7 @@ and cleanup for you:
      ``Run()`` and ``Cleanup()`` in that order
    - You can call ``Run()`` any number of times inside a ``RunManager()`` 
      context or between ``Prepare()`` and ``Cleanup()`` calls
-   - Calling **``SetStatus()``** inside a ``RunManager()`` context or
+   - Calling ``SetStatus()`` inside a ``RunManager()`` context or
      between ``Prepare()`` and ``Cleanup()`` will **lead to unpredictable
      results** 
    - After calling ``Cleanup()``, you need to call ``Prepare()`` again before
@@ -179,7 +182,7 @@ without re-seeding. Unfortunately, **such a reset is not possible in NEST**.
 The ``ResetNetwork()`` function, which is available in NEST 2, but will be
 removed in NEST 3, resets state to default values and deletes spikes that 
 are in the delivery pipeline, but it does not, e.g., reset plastic synapses.
-We therefore **advise against using ``ResetNetwork()``**.
+We therefore **advise against using** ``ResetNetwork()``.
 
 The only reliable way to perform two simulations of a network from exactly
 the same starting point is to restart NEST or to call `ResetKernel()` and
@@ -187,4 +190,4 @@ then to build the network anew. If your simulations are rather large and
 you are working on a computer with a job queueing system, it may be most
 efficient to submit individual jobs or a job array to smiulate network 
 instances in parallel; don't forget to use different 
-:doc:`random seeds </random_numbers>`!. 
+:doc:`random seeds <random_numbers>`!. 

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -708,6 +708,24 @@ def
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+/ResetNetwork
+<< /deprecation_warning true >>
+Options
+
+/ResetNetwork
+{
+  << >> begin
+  /ResetNetwork /deprecation_warning GetOption true eq
+  {
+    (SLI function ResetNetwork is deprecated and will be removed in NEST 3.0.) M_DEPRECATED message
+    /ResetNetwork << /deprecation_warning false >> SetOptions
+  } if
+  
+  ::ResetNetwork
+} bind def
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 /** @BeginDocumentation
    Name: LayoutNetwork - Create a multidimensional network.
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -723,6 +723,10 @@ NestModule::ResetKernelFunction::execute( SLIInterpreter* i ) const
    Name: ResetNetwork - Reset the dynamic state of the network.
    Synopsis: ResetNetwork -> -
    Description:
+
+   ResetNetwork is deprecated as of NEST 2.18 and will be removed in NEST3,
+   because it cannot be implemented in an efficient and consistent way.
+
    ResetNetwork resets the dynamic state of the entire network to its state
    at T=0. The dynamic state comprises typically the membrane potential,
    synaptic currents, buffers holding input that has been delivered, but not
@@ -1739,7 +1743,7 @@ NestModule::init( SLIInterpreter* i )
     "DataConnect_i_D_s", &dataconnect_i_D_sfunction, "NEST 3.0" );
   i->createcommand( "DataConnect_a", &dataconnect_afunction, "NEST 3.0" );
 
-  i->createcommand( "ResetNetwork", &resetnetworkfunction );
+  i->createcommand( "::ResetNetwork", &resetnetworkfunction );
   i->createcommand( "ResetKernel", &resetkernelfunction );
 
   i->createcommand( "MemoryInfo", &memoryinfofunction );

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -724,7 +724,7 @@ NestModule::ResetKernelFunction::execute( SLIInterpreter* i ) const
    Synopsis: ResetNetwork -> -
    Description:
 
-   ResetNetwork is deprecated as of NEST 2.18 and will be removed in NEST3,
+   ResetNetwork is deprecated as of NEST 2.18 and will be removed in NEST 3.0,
    because it cannot be implemented in an efficient and consistent way.
 
    ResetNetwork resets the dynamic state of the entire network to its state

--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -77,7 +77,7 @@ __all__ = [
     'Prepare',
     'Rank',
     'ResetKernel',
-    'ResetNetwork',
+    'ResetNetwork',  # deprecated
     'Run',
     'RunManager',
     'SetAcceptableLatency',

--- a/pynest/nest/import_libs.py
+++ b/pynest/nest/import_libs.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# import_libs.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
 import ast
 import os
 

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -246,7 +246,7 @@ def Connect(pre, post, conn_spec=None, syn_spec=None, model=None):
     if model is not None:
         deprecation_text = "".join([
             "The argument 'model' is there for backward compatibility with ",
-            "the old Connect function and will be removed NEST 3. ",
+            "the old Connect function and will be removed in NEST 3.0. ",
             "Please change the name of the keyword argument from 'model' to ",
             "'syn_spec'. For details, see the documentation ",
             "at:\nhttp://www.nest-simulator.org/connection_management"

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -246,9 +246,9 @@ def Connect(pre, post, conn_spec=None, syn_spec=None, model=None):
     if model is not None:
         deprecation_text = "".join([
             "The argument 'model' is there for backward compatibility with ",
-            "the old Connect function and will be removed in a future",
-            "version of NEST. Please change the name of the keyword argument ",
-            "from 'model' to 'syn_spec'. For details, see the documentation ",
+            "the old Connect function and will be removed NEST 3. ",
+            "Please change the name of the keyword argument from 'model' to ",
+            "'syn_spec'. For details, see the documentation ",
             "at:\nhttp://www.nest-simulator.org/connection_management"
         ])
         show_deprecation_warning("BackwardCompatibilityConnect",

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -64,10 +64,11 @@ __all__ = [
     'uni_str',
 ]
 
-
-# These flags are used to print deprecation warnings only once. The
-# corresponding functions will be removed in a future release of NEST.
-_deprecation_warning = {'BackwardCompatibilityConnect': True, 'subnet': True,
+# These flags are used to print deprecation warnings only once.
+# Only flags for special cases need to be entered here, all flags for
+# deprecated functions will be registered by the @deprecated decorator.
+_deprecation_warning = {'BackwardCompatibilityConnect': True,
+                        'subnet': True,
                         'aeif_cond_alpha_RK5': True}
 
 
@@ -116,9 +117,7 @@ def show_deprecation_warning(func_name, alt_func_name=None, text=None):
             alt_func_name = 'Connect'
         if text is None:
             text = "{0} is deprecated and will be removed in a future \
-            version of NEST.\nPlease use {1} instead!\n\
-            For details, see\
-            http://www.nest-simulator.org/connection_management\
+            version of NEST.\nPlease use {1} instead!\
             ".format(func_name, alt_func_name)
             text = get_wrapped_text(text)
 
@@ -136,7 +135,7 @@ def deprecated(alt_func_name, text=None):
     Parameters
     ----------
     alt_func_name : str, optional
-        Name of the function to use instead
+        Name of the function to use instead, may be em
     text : str, optional
         Text to display instead of standard text
 
@@ -171,7 +170,6 @@ def get_unistring_type():
     if sys.version_info[0] < 3:
         return basestring
     return str
-
 
 uni_str = get_unistring_type()
 

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -135,7 +135,7 @@ def deprecated(alt_func_name, text=None):
     Parameters
     ----------
     alt_func_name : str, optional
-        Name of the function to use instead, may be em
+        Name of the function to use instead, may be empty string
     text : str, optional
         Text to display instead of standard text
 

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -83,7 +83,7 @@ def Run(t):
     `Prepare` must be called before `Run` to calibrate the system, and
     `Cleanup` must be called after `Run` to close files, cleanup handles, and
     so on. After `Cleanup`, `Prepare` can and must be called before more `Run`
-    calls. Any calls to `set_status` between `Prepare` and `Cleanup` have
+    calls. Any calls to `SetStatus` between `Prepare` and `Cleanup` have
     undefined behaviour.
 
     See Also
@@ -102,7 +102,7 @@ def Prepare():
     """Calibrate the system before a `Run` call. Not needed for `Simulate`.
 
     Call before the first `Run` call, or before calling `Run` after changing
-    the system, calling `set_status` or `Cleanup`.
+    the system, calling `SetStatus` or `Cleanup`.
 
     See Also
     --------

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -175,10 +175,6 @@ def ResetKernel():
     are reset. The only exception is that dynamically loaded modules are not
     unloaded. This may change in a future version of NEST.
 
-    See Also
-    --------
-    ResetNetwork
-
     KEYWORDS:
    """
 
@@ -186,8 +182,15 @@ def ResetKernel():
 
 
 @check_stack
+@deprecated('', 'ResetNetwork is deprecated and will be removed in NEST 3.0.')
 def ResetNetwork():
     """Reset all nodes and connections to their original state.
+
+    .. deprecated:: 2.18
+    `ResetNetwork` is deprecated and will be removed in NEST 3.0, because
+    this function is not fully able to reset network and simulator state.
+    The only reliable way to reset state is to call `ResetKernel` and then
+    rebuild the network.
 
     Resets the dynamic state of the entire network to its original state.
     The dynamic state comprises typically the membrane potential,


### PR DESCRIPTION
This also adds a missing copyright header to `import_libs.py`.