### PR TITLE
Restore PyNEST functions to top level modules

### DIFF
--- a/doc/model_details/test_post_trace.ipynb
+++ b/doc/model_details/test_post_trace.ipynb
@@ -68,7 +68,7 @@
     "        print(\"Post spike times: [\"\n",
     "              + \", \".join([str(t) for t in post_spike_times]) + \"]\")\n",
     "\n",
-    "    nest.hl_api.set_verbosity(\"M_WARNING\")\n",
+    "    nest.set_verbosity(\"M_WARNING\")\n",
     "\n",
     "    nest.ResetKernel()\n",
     "    nest.SetKernelStatus({'resolution': resolution})\n",

--- a/pynest/examples/CampbellSiegert.py
+++ b/pynest/examples/CampbellSiegert.py
@@ -163,7 +163,7 @@ r = 1. / (t_ref * ms + tau_m * ms * tmpsum)
 # and compare the theoretical result to the empirical value.
 
 nest.ResetKernel()
-nest.hl_api.set_verbosity('M_WARNING')
+nest.set_verbosity('M_WARNING')
 neurondict = {'V_th': V_th, 'tau_m': tau_m, 'tau_syn_ex': tau_syn_ex,
               'tau_syn_in': tau_syn_in, 'C_m': C_m, 'E_L': E_L, 't_ref': t_ref,
               'V_m': E_L, 'V_reset': E_L}

--- a/pynest/examples/balancedneuron.py
+++ b/pynest/examples/balancedneuron.py
@@ -61,7 +61,7 @@ import nest.voltage_trace
 # suppress info messages.
 
 
-nest.hl_api.set_verbosity("M_WARNING")
+nest.set_verbosity("M_WARNING")
 nest.ResetKernel()
 
 ###############################################################################

--- a/pynest/examples/brunel_alpha_evolution_strategies.py
+++ b/pynest/examples/brunel_alpha_evolution_strategies.py
@@ -232,7 +232,7 @@ def simulate(parameters):
     p_rate = 1000.0 * nu_ex * CE
 
     nest.ResetKernel()
-    nest.hl_api.set_verbosity('M_FATAL')
+    nest.set_verbosity('M_FATAL')
 
     nest.SetKernelStatus({'rng_seeds': [parameters['seed']],
                           'resolution': parameters['dt']})

--- a/pynest/examples/gif_pop_psc_exp.py
+++ b/pynest/examples/gif_pop_psc_exp.py
@@ -121,7 +121,7 @@ tau_in = 6.  # in ms
 # neurons), we can build the populations using the NEST model
 # gif_pop_psc_exp:
 
-nest.hl_api.set_verbosity("M_WARNING")
+nest.set_verbosity("M_WARNING")
 nest.ResetKernel()
 nest.SetKernelStatus(
     {'resolution': dt, 'print_time': True, 'local_num_threads': 1})

--- a/pynest/examples/hh_phaseplane.py
+++ b/pynest/examples/hh_phaseplane.py
@@ -68,7 +68,7 @@ num_v_steps = len(V_vec)
 num_n_steps = len(n_vec)
 
 nest.ResetKernel()
-nest.hl_api.set_verbosity('M_ERROR')
+nest.set_verbosity('M_ERROR')
 
 nest.SetKernelStatus({'resolution': dt})
 neuron = nest.Create('hh_psc_alpha')

--- a/pynest/examples/hh_psc_alpha.py
+++ b/pynest/examples/hh_psc_alpha.py
@@ -44,7 +44,7 @@ import nest
 import numpy as np
 import matplotlib.pyplot as plt
 
-nest.hl_api.set_verbosity('M_WARNING')
+nest.set_verbosity('M_WARNING')
 nest.ResetKernel()
 
 simtime = 1000

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -355,7 +355,7 @@ def run_simulation():
     with Logger(params['log_file']) as logger:
 
         nest.ResetKernel()
-        nest.hl_api.set_verbosity(M_INFO)
+        nest.set_verbosity(M_INFO)
 
         logger.log(str(memory_thisjob()) + ' # virt_mem_0')
 

--- a/pynest/examples/if_curve.py
+++ b/pynest/examples/if_curve.py
@@ -145,7 +145,7 @@ class IF_curve():
         self.i_range = numpy.arange(*i_mean)
         self.std_range = numpy.arange(*i_std)
         self.rate = numpy.zeros((self.i_range.size, self.std_range.size))
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         for n, i in enumerate(self.i_range):
             print('I  =  {0}'.format(i))
             for m, std in enumerate(self.std_range):

--- a/pynest/examples/intrinsic_currents_spiking.py
+++ b/pynest/examples/intrinsic_currents_spiking.py
@@ -62,7 +62,7 @@ import matplotlib.pyplot as plt
 # Additionally, we set the verbosity using `set_verbosity` to suppress info
 # messages. We also reset the kernel to be sure to start with a clean NEST.
 
-nest.hl_api.set_verbosity("M_WARNING")
+nest.set_verbosity("M_WARNING")
 nest.ResetKernel()
 
 ###############################################################################

--- a/pynest/examples/intrinsic_currents_subthreshold.py
+++ b/pynest/examples/intrinsic_currents_subthreshold.py
@@ -60,7 +60,7 @@ import matplotlib.pyplot as plt
 # Additionally, we set the verbosity using `set_verbosity` to suppress info
 # messages. We also reset the kernel to be sure to start with a clean NEST.
 
-nest.hl_api.set_verbosity("M_WARNING")
+nest.set_verbosity("M_WARNING")
 nest.ResetKernel()
 
 ###############################################################################

--- a/pynest/examples/one_neuron.py
+++ b/pynest/examples/one_neuron.py
@@ -37,7 +37,7 @@ and records its membrane potential.
 
 import nest
 import nest.voltage_trace
-nest.hl_api.set_verbosity("M_WARNING")
+nest.set_verbosity("M_WARNING")
 nest.ResetKernel()
 # Second, the nodes (neurons and devices) are created using `Create()`.
 # We store the returned handles in variables for later reference.

--- a/pynest/examples/pulsepacket.py
+++ b/pynest/examples/pulsepacket.py
@@ -192,7 +192,7 @@ t_U = (convolution_resolution * numpy.linspace(-l / 2., l / 2., l) +
 
 nest.ResetKernel()
 nest.SetStatus([0], [{'resolution': simulation_resolution}])
-nest.hl_api.set_verbosity("M_WARNING")
+nest.set_verbosity("M_WARNING")
 
 
 ###############################################################################

--- a/pynest/examples/structural_plasticity.py
+++ b/pynest/examples/structural_plasticity.py
@@ -144,7 +144,7 @@ class StructralPlasticityExample:
 
     def prepare_simulation(self):
         nest.ResetKernel()
-        nest.hl_api.set_verbosity('M_ERROR')
+        nest.set_verbosity('M_ERROR')
         '''
         We set global kernel parameters. Here we define the resolution
         for the simulation, which is also the time resolution for the update

--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -75,6 +75,7 @@ __all__ = [
     'Models',
     'NumProcesses',
     'Prepare',
+    'PrintNetwork',  # deprecated
     'Rank',
     'ResetKernel',
     'ResetNetwork',
@@ -88,8 +89,11 @@ __all__ = [
     'SetStructuralPlasticityStatus',
     'Simulate',
     'authors',
+    'get_verbosity',
     'help',
     'helpdesk',
+    'message',
+    'set_verbosity',
     'sysinfo',
     'version',
 ]

--- a/pynest/nest/tests/test_clopath_synapse.py
+++ b/pynest/nest/tests/test_clopath_synapse.py
@@ -38,7 +38,7 @@ class ClopathSynapseTestCase(unittest.TestCase):
     def test_ConnectNeuronsWithClopathSynapse(self):
         """Ensures that the restriction to supported neuron models works."""
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
 
         # Specify supported models
         supported_models = [
@@ -73,7 +73,7 @@ class ClopathSynapseTestCase(unittest.TestCase):
     def test_SynapseDepressionFacilitation(self):
         """Ensure that depression and facilitation work correctly"""
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
 
         # This is done using the spike pairing experiment of
         # Clopath et al. 2010. First we specify the parameters
@@ -192,7 +192,7 @@ class ClopathSynapseTestCase(unittest.TestCase):
     def test_SynapseFunctionWithAeifModel(self):
         """Ensure that spikes are properly processed"""
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # Create neurons and devices

--- a/pynest/nest/tests/test_connect_parameters.py
+++ b/pynest/nest/tests/test_connect_parameters.py
@@ -66,14 +66,14 @@ class TestParams(unittest.TestCase):
             N2 = self.N2
         self.pop1 = hf.nest.Create('iaf_psc_alpha', N1)
         self.pop2 = hf.nest.Create('iaf_psc_alpha', N2)
-        hf.nest.hl_api.set_verbosity('M_FATAL')
+        hf.nest.set_verbosity('M_FATAL')
         hf.nest.Connect(self.pop1, self.pop2, conn_dict, syn_dict)
 
     def setUpNetworkOnePop(self, conn_dict=None, syn_dict=None, N=None):
         if N is None:
             N = self.N1
         self.pop = hf.nest.Create('iaf_psc_alpha', N)
-        hf.nest.hl_api.set_verbosity('M_FATAL')
+        hf.nest.set_verbosity('M_FATAL')
         hf.nest.Connect(self.pop, self.pop, conn_dict, syn_dict)
 
     def testWeightSetting(self):

--- a/pynest/nest/tests/test_current_recording_generators.py
+++ b/pynest/nest/tests/test_current_recording_generators.py
@@ -39,7 +39,7 @@ class CurrentRecordingGeneratorTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # setting up the neuron and the generators

--- a/pynest/nest/tests/test_erfc_neuron.py
+++ b/pynest/nest/tests/test_erfc_neuron.py
@@ -83,7 +83,7 @@ class ErfcNeuronTheoryTestCase(unittest.TestCase):
 
     def build_and_connect_nodes(self, sigma, theta):
         """ sets up an erfc neuron and spin detector. """
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         self.neuron = nest.Create('erfc_neuron', 1,

--- a/pynest/nest/tests/test_helper_functions.py
+++ b/pynest/nest/tests/test_helper_functions.py
@@ -26,7 +26,7 @@ import nest
 class TestHelperFunctions(unittest.TestCase):
 
     def test_get_verbosity(self):
-        verbosity = nest.hl_api.get_verbosity()
+        verbosity = nest.get_verbosity()
         self.assertTrue(isinstance(verbosity, int))
 
     def test_set_verbosity(self):
@@ -41,8 +41,8 @@ class TestHelperFunctions(unittest.TestCase):
                   ('M_QUIET', 100)
                   ]
         for level, code in levels:
-            nest.hl_api.set_verbosity(level)
-            verbosity = nest.hl_api.get_verbosity()
+            nest.set_verbosity(level)
+            verbosity = nest.get_verbosity()
             self.assertEqual(verbosity, code)
 
 

--- a/pynest/nest/tests/test_parrot_neuron.py
+++ b/pynest/nest/tests/test_parrot_neuron.py
@@ -32,7 +32,7 @@ class ParrotNeuronTestCase(unittest.TestCase):
     """Check parrot_neuron spike repetition properties"""
 
     def setUp(self):
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # set up source spike generator, as well as parrot neurons
@@ -129,7 +129,7 @@ class ParrotNeuronPoissonTestCase(unittest.TestCase):
         assert spikes_expected - 3 * spikes_std > 10. * t_sim / h, \
             "Internal inconsistency: too few spikes."
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus({'resolution': h,
                               'grng_seed': 123,
@@ -166,7 +166,7 @@ class ParrotNeuronSTDPTestCase(unittest.TestCase):
         """Set up a network with pre-post spike pairings
         with t_post - t_pre = dt"""
 
-        nest.hl_api.set_verbosity("M_WARNING")
+        nest.set_verbosity("M_WARNING")
         nest.ResetKernel()
 
         # set pre and postsynaptic spike times

--- a/pynest/nest/tests/test_parrot_neuron_ps.py
+++ b/pynest/nest/tests/test_parrot_neuron_ps.py
@@ -41,7 +41,7 @@ class ParrotNeuronPSTestCase(unittest.TestCase):
     """Check parrot_neuron spike repetition properties"""
 
     def setUp(self):
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # set up source spike generator, as well as parrot neurons
@@ -143,7 +143,7 @@ class ParrotNeuronPSPoissonTestCase(unittest.TestCase):
         assert spikes_expected - 3 * spikes_std > 10. * t_sim / h, \
             "Internal inconsistency: too few spikes."
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus({'resolution': h,
                               'grng_seed': 123,
@@ -180,7 +180,7 @@ class ParrotNeuronPSSTDPTestCase(unittest.TestCase):
         """Set up a network with pre-post spike pairings with
         t_post - t_pre = dt"""
 
-        nest.hl_api.set_verbosity("M_WARNING")
+        nest.set_verbosity("M_WARNING")
         nest.ResetKernel()
 
         # set pre and postsynaptic spike times

--- a/pynest/nest/tests/test_quantal_stp_synapse.py
+++ b/pynest/nest/tests/test_quantal_stp_synapse.py
@@ -33,7 +33,7 @@ class QuantalSTPSynapseTestCase(unittest.TestCase):
     def test_QuantalSTPSynapse(self):
         """Compare quantal_stp_synapse with its deterministic equivalent"""
         nest.ResetKernel()
-        nest.hl_api.set_verbosity(100)
+        nest.set_verbosity(100)
         n_syn = 12  # number of synapses in a connection
         n_trials = 50  # number of measurement trials
 

--- a/pynest/nest/tests/test_rate_copy_model.py
+++ b/pynest/nest/tests/test_rate_copy_model.py
@@ -43,7 +43,7 @@ class RateCopyModelTestCase(unittest.TestCase):
         simtime = 100.
         dt = 0.001
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus(
             {'resolution': dt, 'use_wfr': True, 'print_time': False})

--- a/pynest/nest/tests/test_rate_instantaneous_and_delayed.py
+++ b/pynest/nest/tests/test_rate_instantaneous_and_delayed.py
@@ -44,7 +44,7 @@ class RateInstantaneousAndDelayedTestCase(unittest.TestCase):
         simtime = 100.
         dt = 0.001
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus(
             {'resolution': dt, 'use_wfr': True, 'print_time': False})

--- a/pynest/nest/tests/test_rate_neuron.py
+++ b/pynest/nest/tests/test_rate_neuron.py
@@ -47,7 +47,7 @@ class RateNeuronTestCase(unittest.TestCase):
         self.dt = 0.1
         self.tstart = 10. * self.neuron_params['tau']
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus(
             {'resolution': self.dt, 'use_wfr': False, 'print_time': True})

--- a/pynest/nest/tests/test_rate_neuron_communication.py
+++ b/pynest/nest/tests/test_rate_neuron_communication.py
@@ -55,7 +55,7 @@ class RateNeuronCommunicationTestCase(unittest.TestCase):
         self.simtime = 100.
         self.dt = 0.1
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus(
             {'resolution': self.dt, 'use_wfr': True, 'print_time': True})

--- a/pynest/nest/tests/test_siegert_neuron.py
+++ b/pynest/nest/tests/test_siegert_neuron.py
@@ -54,7 +54,7 @@ class SiegertNeuronTestCase(unittest.TestCase):
         self.dt = 0.1
         self.start = 200.
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus(
             {'resolution': self.dt, 'use_wfr': False, 'print_time': True})

--- a/pynest/nest/tests/test_sp/mpitest_issue_578_sp.py
+++ b/pynest/nest/tests/test_sp/mpitest_issue_578_sp.py
@@ -34,7 +34,7 @@ class TestIssue578():
 
     def test_targets(self):
         nest.ResetKernel()
-        nest.hl_api.set_verbosity('M_ALL')
+        nest.set_verbosity('M_ALL')
         # Testing with 2 MPI processes
         nest.SetKernelStatus(
             {

--- a/pynest/nest/tests/test_sp/test_all.py
+++ b/pynest/nest/tests/test_sp/test_all.py
@@ -61,6 +61,6 @@ def suite():
     return test_suite
 
 if __name__ == "__main__":
-    nest.hl_api.set_verbosity('M_WARNING')
+    nest.set_verbosity('M_WARNING')
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite())

--- a/pynest/nest/tests/test_sp/test_disconnect.py
+++ b/pynest/nest/tests/test_sp/test_disconnect.py
@@ -40,7 +40,7 @@ class TestDisconnectSingle(unittest.TestCase):
 
     def setUp(self):
         nest.ResetKernel()
-        nest.hl_api.set_verbosity('M_ERROR')
+        nest.set_verbosity('M_ERROR')
         self.num_procs = 1
         if mpi_test:
             self.comm = MPI.COMM_WORLD

--- a/pynest/nest/tests/test_sp/test_disconnect_multiple.py
+++ b/pynest/nest/tests/test_sp/test_disconnect_multiple.py
@@ -29,7 +29,7 @@ class TestDisconnect(unittest.TestCase):
 
     def setUp(self):
         nest.ResetKernel()
-        nest.hl_api.set_verbosity('M_ERROR')
+        nest.set_verbosity('M_ERROR')
         self.exclude_synapse_model = [
             'stdp_dopamine_synapse',
             'stdp_dopamine_synapse_lbl',

--- a/pynest/nest/tests/test_sp/test_enable_multithread.py
+++ b/pynest/nest/tests/test_sp/test_enable_multithread.py
@@ -38,7 +38,7 @@ class TestEnableMultithread(unittest.TestCase):
 
     def setUp(self):
         nest.ResetKernel()
-        nest.hl_api.set_verbosity('M_ERROR')
+        nest.set_verbosity('M_ERROR')
 
     def test_enable_multithread(self):
 

--- a/pynest/nest/tests/test_sp/test_growth_curves.py
+++ b/pynest/nest/tests/test_sp/test_growth_curves.py
@@ -270,7 +270,7 @@ class TestGrowthCurve(unittest.TestCase):
         nest.ResetKernel()
         nest.SetKernelStatus({"total_num_virtual_procs": 4})
         nest.ResetNetwork()
-        nest.hl_api.set_verbosity('M_DEBUG')
+        nest.set_verbosity('M_DEBUG')
 
         self.sim_time = 10000
         self.sim_step = 100

--- a/pynest/nest/tests/test_sp/test_sp_manager.py
+++ b/pynest/nest/tests/test_sp/test_sp_manager.py
@@ -30,7 +30,7 @@ class TestStructuralPlasticityManager(unittest.TestCase):
 
     def setUp(self):
         nest.ResetKernel()
-        nest.hl_api.set_verbosity('M_INFO')
+        nest.set_verbosity('M_INFO')
         self.exclude_synapse_model = [
             'stdp_dopamine_synapse',
             'stdp_dopamine_synapse_lbl',

--- a/pynest/nest/tests/test_stdp_multiplicity.py
+++ b/pynest/nest/tests/test_stdp_multiplicity.py
@@ -108,7 +108,7 @@ class StdpSpikeMultiplicity(unittest.TestCase):
         # k spikes will be emitted at these two times
         pre_spike_times_base = [100., 200.]
 
-        nest.hl_api.set_verbosity("M_WARNING")
+        nest.set_verbosity("M_WARNING")
 
         post_weights = {'parrot': [], 'parrot_ps': []}
 

--- a/pynest/nest/tests/test_stdp_triplet_synapse.py
+++ b/pynest/nest/tests/test_stdp_triplet_synapse.py
@@ -32,7 +32,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
     """Check stdp_triplet_connection model properties."""
 
     def setUp(self):
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # settings
@@ -298,7 +298,7 @@ class STDPTripletConnectionTestCase(unittest.TestCase):
 class STDPTripletInhTestCase(STDPTripletConnectionTestCase):
 
     def setUp(self):
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # settings

--- a/pynest/nest/tests/test_step_rate_generator.py
+++ b/pynest/nest/tests/test_step_rate_generator.py
@@ -36,7 +36,7 @@ class StepRateGeneratorTestCase(unittest.TestCase):
 
         rates = np.array([400.0, 1000.0, 200.0])
 
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
         nest.SetKernelStatus(
             {'resolution': 0.1, 'use_wfr': False, 'print_time': False})

--- a/pynest/nest/tests/test_vogels_sprekeler_synapse.py
+++ b/pynest/nest/tests/test_vogels_sprekeler_synapse.py
@@ -33,7 +33,7 @@ class VogelsSprekelerConnectionTestCase(unittest.TestCase):
 
     def setUp(self):
         """Set up the test."""
-        nest.hl_api.set_verbosity('M_WARNING')
+        nest.set_verbosity('M_WARNING')
         nest.ResetKernel()
 
         # settings

--- a/testsuite/regressiontests/issue-1034.py
+++ b/testsuite/regressiontests/issue-1034.py
@@ -56,7 +56,7 @@ class PostTraceTester(object):
     def run_post_trace_test_nest_(self,
                                   show_all_nest_trace_samples=False):
 
-        nest.hl_api.set_verbosity("M_WARNING")
+        nest.set_verbosity("M_WARNING")
 
         nest.ResetKernel()
         nest.SetKernelStatus({'resolution': self.resolution_})

--- a/topology/examples/conncomp.py
+++ b/topology/examples/conncomp.py
@@ -38,7 +38,7 @@ pylab.ion()
 
 
 nest.ResetKernel()
-nest.hl_api.set_verbosity('M_WARNING')
+nest.set_verbosity('M_WARNING')
 
 # create two test layers
 nest.CopyModel('iaf_psc_alpha', 'pyr')

--- a/topology/examples/conncon_sources.py
+++ b/topology/examples/conncon_sources.py
@@ -38,7 +38,7 @@ pylab.ion()
 
 
 nest.ResetKernel()
-nest.hl_api.set_verbosity('M_WARNING')
+nest.set_verbosity('M_WARNING')
 
 # create two test layers
 a = topo.CreateLayer({'columns': 30, 'rows': 30, 'extent': [3.0, 3.0],

--- a/topology/examples/ctx_2n.py
+++ b/topology/examples/ctx_2n.py
@@ -48,11 +48,11 @@ ctx = topo.CreateLayer({'columns': 4, 'rows': 3,
                         'extent': [2.0, 1.5],
                         'elements': ['pyr', 'in']})
 
-nest.hl_api.PrintNetwork()
+nest.PrintNetwork()
 
-nest.hl_api.PrintNetwork(2)
+nest.PrintNetwork(2)
 
-nest.hl_api.PrintNetwork(2, ctx)
+nest.PrintNetwork(2, ctx)
 
 # ctx_leaves is a work-around until NEST 3.0 is released
 ctx_leaves = nest.hl_api.GetLeaves(ctx)[0]

--- a/topology/examples/grid_iaf.py
+++ b/topology/examples/grid_iaf.py
@@ -40,9 +40,9 @@ l1 = topo.CreateLayer({'columns': 4, 'rows': 3,
                        'extent': [2.0, 1.5],
                        'elements': 'iaf_psc_alpha'})
 
-nest.hl_api.PrintNetwork()
-nest.hl_api.PrintNetwork(2)
-nest.hl_api.PrintNetwork(2, l1)
+nest.PrintNetwork()
+nest.PrintNetwork(2)
+nest.PrintNetwork(2, l1)
 
 topo.PlotLayer(l1, nodesize=50)
 

--- a/topology/examples/grid_iaf_irr.py
+++ b/topology/examples/grid_iaf_irr.py
@@ -45,9 +45,9 @@ l1 = topo.CreateLayer({'extent': [2., 1.5],
                        'positions': pos,
                        'elements': 'iaf_psc_alpha'})
 
-nest.hl_api.PrintNetwork()
-nest.hl_api.PrintNetwork(2)
-nest.hl_api.PrintNetwork(2, l1)
+nest.PrintNetwork()
+nest.PrintNetwork(2)
+nest.PrintNetwork(2, l1)
 
 topo.PlotLayer(l1, nodesize=50)
 

--- a/topology/examples/hill_tononi_Vp.py
+++ b/topology/examples/hill_tononi_Vp.py
@@ -452,7 +452,7 @@ populations = (retina, Tp, Rp, Vp_h, Vp_v)
 # ! ----------
 
 # ! We can now look at the network using `PrintNetwork`:
-nest.hl_api.PrintNetwork()
+nest.PrintNetwork()
 
 # ! We can also try to plot a single layer in a network. For
 # ! simplicity, we use Rp, which has only a single neuron per position.


### PR DESCRIPTION
This PR restores some functions (PrintNetwork, message, get_verbosity, set_verbosity) to top level modules in PyNEST.

Fixes #1141.