### PR TITLE
Check recorder type_id instead of model name in plotting modules

### DIFF
--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -185,7 +185,9 @@ def from_device(detec, plot_lid=False, **kwargs):
     ------
     nest.kernel.NESTError
     """
-    if not nest.GetStatus(detec)[0]["model"] == "spike_detector":
+    
+    type_id = nest.GetDefaults(nest.GetStatus(detec, 'model')[0], 'type_id')
+    if not type_id.name == "spike_detector":
         raise nest.kernel.NESTError("Please provide a spike_detector.")
 
     if nest.GetStatus(detec, "to_memory")[0]:

--- a/pynest/nest/voltage_trace.py
+++ b/pynest/nest/voltage_trace.py
@@ -152,10 +152,11 @@ def from_device(detec, neurons=None, title=None, grayscale=False,
     if len(detec) > 1:
         raise nest.kernel.NESTError("Please provide a single voltmeter.")
 
-    if not nest.GetStatus(detec)[0]['model'] in ('voltmeter', 'multimeter'):
+    type_id = nest.GetDefaults(nest.GetStatus(detec, 'model')[0], 'type_id')
+    if not type_id.name in ('voltmeter', 'multimeter'):
         raise nest.kernel.NESTError("Please provide a voltmeter or a \
             multimeter measuring V_m.")
-    elif nest.GetStatus(detec)[0]['model'] == 'multimeter':
+    elif type_id.name == 'multimeter':
         if "V_m" not in nest.GetStatus(detec, "record_from")[0]:
             raise nest.kernel.NESTError("Please provide a multimeter \
                 measuring V_m.")


### PR DESCRIPTION
This PR fixes the issue, that copied model of any recorder has another model name. Thus, the plotting would produce error output for copied recorder model.

As an example:

```
...
nest.CopyModel('spike_detector', 'new_model')
sd = nest.Create('new_model')
...
nest.raster_plot.from_device(sd) 
```
The variable sd contains ID of a copied model of spike detector but not spike detector itself.
