### PR TITLE
Fixed normalization factor for iaf_cond_beta

### DIFF
--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -373,9 +373,33 @@ nest::iaf_cond_beta::get_normalisation_factor( double tau_rise,
   double tau_decay )
 {
   // Factor used to normalise the synaptic conductance such that
-  //
-
-  return 1.0 / ( tau_decay * tau_rise );
+  // incoming spike causes a peak conductance of 1 nS.
+  // The denominator (denom1) that appears in the expression of the peak time
+  // is computed here to check that it is != 0
+  // another denominator denom2 appears in the expression of the
+  // normalization factor g0
+  // Both denom1 and denom2 are null if tau_decay = tau_rise, but they
+  // can also be null if tau_decay and tau_rise are not equal but very
+  // close to each other, due to the numerical precision limits.
+  // In such case the beta function reduces to the alpha function,
+  // and the normalization factor for the alpha function should be used.
+  double denom1 = tau_decay - tau_rise;
+  double normalisation_factor = 0;
+  if ( std::abs( denom1 ) > std::numeric_limits< double >::epsilon() )
+  // if rise time != decay time use beta function
+  {
+    // peak time
+    const double t_p =
+      tau_decay * tau_rise * std::log( tau_decay / tau_rise ) / denom1;
+    // another denominator is computed here to check that it is != 0
+    double denom2 = std::exp( -t_p / tau_decay ) - std::exp( -t_p / tau_rise );
+    normalisation_factor = ( 1. / tau_rise - 1. / tau_decay ) / denom2;
+  }
+  else // if rise time == decay time use alpha function
+  {
+    normalisation_factor = 1. * numerics::e / tau_decay;
+  }
+  return normalisation_factor;
 }
 
 void

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -383,21 +383,26 @@ nest::iaf_cond_beta::get_normalisation_factor( double tau_rise,
   // close to each other, due to the numerical precision limits.
   // In such case the beta function reduces to the alpha function,
   // and the normalization factor for the alpha function should be used.
-  double denom1 = tau_decay - tau_rise;
+  const double denom1 = tau_decay - tau_rise;
+  double denom2 = 0;
   double normalisation_factor = 0;
   if ( std::abs( denom1 ) > std::numeric_limits< double >::epsilon() )
-  // if rise time != decay time use beta function
   {
     // peak time
     const double t_p =
       tau_decay * tau_rise * std::log( tau_decay / tau_rise ) / denom1;
     // another denominator is computed here to check that it is != 0
-    double denom2 = std::exp( -t_p / tau_decay ) - std::exp( -t_p / tau_rise );
-    normalisation_factor = ( 1. / tau_rise - 1. / tau_decay ) / denom2;
+    denom2 = std::exp( -t_p / tau_decay ) - std::exp( -t_p / tau_rise );
   }
-  else // if rise time == decay time use alpha function
+  if ( std::abs( denom2 ) < std::numeric_limits< double >::epsilon() )
   {
+    // if rise time == decay time use alpha function
     normalisation_factor = 1. * numerics::e / tau_decay;
+  }
+  else
+  {
+    // if rise time != decay time use beta function
+    normalisation_factor = ( 1. / tau_rise - 1. / tau_decay ) / denom2;
   }
   return normalisation_factor;
 }


### PR DESCRIPTION
Per @pablomc88's comment on [https://github.com/nest/nest-simulator/pull/1038](PR1038), the synaptic conductance should be normalized to have a peak amplitude of 1 nS as it is with other neuron models such as `ht_neuron`. I have made the necessary changes to iaf_cond_beta.cpp and tested them in nest to ensure they are working correctly.