### PR TITLE
Improve documentation of get_verbosity and set_verbosity in PyNEST 

### DIFF
--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -508,6 +508,13 @@ def show_help_with_pager(hlpobj, pager=None):
 def get_verbosity():
     """Return verbosity level of NEST's messages.
 
+    M_ALL=0,  display all messages
+    M_INFO=10, display information messages and above
+    M_DEPRECATED=18, display deprecation warnings and above
+    M_WARNING=20, display warning messages and above
+    M_ERROR=30, display error messages and above
+    M_FATAL=40, display failure messages and above
+
     Returns
     -------
     int:
@@ -523,6 +530,13 @@ def get_verbosity():
 @check_stack
 def set_verbosity(level):
     """Change verbosity level for NEST's messages.
+
+    M_ALL=0,  display all messages
+    M_INFO=10, display information messages and above
+    M_DEPRECATED=18, display deprecation warnings and above
+    M_WARNING=20, display warning messages and above
+    M_ERROR=30, display error messages and above
+    M_FATAL=40, display failure messages and above
 
     Parameters
     ----------


### PR DESCRIPTION
Text added to PyNEST API to clarify correlation between get and set verbosity.  (get_verbosity returns an int and set_verbosity expects a string)

Fixes #1061 