### PR TITLE
Fix nest_vars in case of undefined PYTHONPATH

### DIFF
--- a/extras/nest_vars.sh.in
+++ b/extras/nest_vars.sh.in
@@ -15,6 +15,7 @@ export NEST_MODULE_PATH=$NEST_INSTALL_DIR/@CMAKE_INSTALL_LIBDIR@/nest
 # The path where the PyNEST bindings are installed.
 export NEST_PYTHON_PREFIX=$NEST_INSTALL_DIR/@PYEXECDIR@
 
+# Prepend NEST to PYTHONPATH in a safe way even if PYTHONPATH is undefined
 export PYTHONPATH=$NEST_PYTHON_PREFIX${PYTHONPATH:+:$PYTHONPATH}
 
 # Make nest / sli /... executables visible.

--- a/extras/nest_vars.sh.in
+++ b/extras/nest_vars.sh.in
@@ -14,7 +14,8 @@ export NEST_MODULE_PATH=$NEST_INSTALL_DIR/@CMAKE_INSTALL_LIBDIR@/nest
 
 # The path where the PyNEST bindings are installed.
 export NEST_PYTHON_PREFIX=$NEST_INSTALL_DIR/@PYEXECDIR@
-export PYTHONPATH=$NEST_PYTHON_PREFIX:$PYTHONPATH
+
+export PYTHONPATH=$NEST_PYTHON_PREFIX${PYTHONPATH:+:$PYTHONPATH}
 
 # Make nest / sli /... executables visible.
 export PATH=$NEST_INSTALL_DIR/bin:$PATH


### PR DESCRIPTION
In a shell with the "-e" option set, the `source nest_vars.sh` fails with "undefined variable PYTHONPATH". Without this option the default substitute with empty string leaves a stray `:` at the end, which is not intended.

This PR changes this to only be `$NEST_PYTHON_PREFIX` without the trailing colon.