### PR TITLE
Update parallel computing docs regarding configuration

### DIFF
--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -67,6 +67,16 @@ in a scenario with two processes with two threads each.
  real node free on remote processes).
 
 
+.. note::
+
+ The status dictionary of each node (i.e. neuron or device) contains
+ three entries that are related to parallel computing:
+
+ *  *local* (boolean): indicating if the node exists on the local process or not
+ *  *thread* (integer): id of the local thread the node is assigned to
+ *  *vp* (integer): id of the virtual process the node is assigned to
+
+
 Neuron distribution
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -102,16 +112,6 @@ analog recordings from the ``multimeter`` have ``dat`` as file extension.
 
 The ``label`` and ``file_extension`` of a recording device can be set like any
 other parameter of a node using ``SetStatus``.
-
-.. note::
-
- The status dictionary of each node (i.e. neuron or device) contains
- three entries that are related to parallel computing:
-
- *  *local* (boolean): indicating if the node exists on the local process or not
- *  *thread* (integer): id of the local thread the node is assigned to
- *  *vp* (integer): id of the virtual process the node is assigned to
-
 
 Spike exchange and synapse update
 ------------------------------------

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -113,19 +113,7 @@ analog recordings from the ``multimeter`` have ``dat`` as file extension.
 The ``label`` and ``file_extension`` of a recording device can be set like any
 other parameter of a node using ``SetStatus``.
 
-<<<<<<< HEAD
-=======
-.. note::
 
- The status dictionary of each node (i.e. neuron or device) contains
- three entries that are related to parallel computing:
-
- *  *local* (boolean): indicating if the node exists on the local process or not
- *  *thread* (integer): id of the local thread the node is assigned to
- *  *vp* (integer): id of the virtual process the node is assigned to (denoted :math:`id_{vp}` here)
-
-
->>>>>>> 591029d62ba3e725576786d34b18c7d202cd9bc8
 Spike exchange and synapse update
 ------------------------------------
 

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -1,213 +1,227 @@
-Parallel Computing
-==================
+Guide to parallel computing
+==============================
 
-Introduction
-------------
 
-Parallelization is a means to run simulations faster and use the
-capabilities of computer clusters and supercomputers to run large-scale
-simulations.
+.. contents::
+   :local:
 
-Since version 2.0, NEST is capable of running simulations on
-multi-core/-processor machines and computer clusters using two ways of
-parallelization: *thread-parallel simulation* and *distributed
-simulations*. The first is implemented using OpenMP (POSIX threads prior
-to NEST 2.2), while the second is implemented on top of the Message
-Passing Interface (MPI). Both ways of parallelism can be combined in a
-hybrid fashion.
+What is parallelization?
+--------------------------
 
-Using threads allows to take advantage of multi-core and multi-processor
-computers without the need for additional software libraries. Using
-distributed computing allows to draw in more computers and thus enables
-larger simulations, than would fit into the memory of a single machine.
-The following paragraphs describe the facilities for parallel and
-distributed computing in detail.
+Parallelization can improve the efficiency of running large-scale simulations by
+taking advantage of multicore/multiprocessor machines, computer clusters or
+supercomputers. Here we explain how  parallelization is set up in NEST and how you
+can take advantage of it for your simulations.
 
-See `Plesser et al
-(2007) <http://dx.doi.org/10.1007/978-3-540-74466-5_71>`__ for more
-information on NEST parallelization and be sure to check the
+NEST employs two methods for parallelization:
+
+* :ref:`Thread-parallel simulation <multiple_threads>`
+     * uses OpenMP
+     * takes advantage of multicore and multiprocessor computers without
+       the need for additional libraries
+* :ref:`Distributed simulation (or distributed computing) <distributed_computing>`
+     * uses the Message Passing Interface (MPI)
+     * supports simulations over multiple computers
+
+Both methods can be combined within a simulation.
+
+
+See `Plesser et al. (2007) <http://dx.doi.org/10.1007/978-3-540-74466-5_71>`__
+for more information on NEST parallelization and be sure to check the
 documentation on `Random numbers in NEST <random-numbers.md>`__.
 
-**Note:** The NEST simulation kernel assumes that it has full control
-over threads in the NEST process. Combining this with other use of threads
-in the same process that is running the NEST kernel, can lead to unpredictable
-results and **is not supported**. Examples for this would be the use of Python
-threads or multi-threaded modules from within Python.
 
-Concepts and definitions
-------------------------
 
-In order to ease the handling of neuron and synapse distribution with
-both thread and process based parallelization, we use the concept of
-local and remote threads, called *virtual processes*. A virtual process
-(VP) is a thread living in one of NEST's MPI processes. Virtual
-processes are distributed round-robin onto the MPI processes and counted
-continuously over all processes. The concept is visualized in the
-following figure:
+Virtual processes
+--------------------------
+
+We use the concept of local and remote threads, called *virtual processes*.
+A virtual process (VP) is a thread residing in one of NEST's MPI processes.
+For both thread and distributed parallelization, VPs simplify handling of
+neuron  and synapses distributions.
+Virtual processes are distributed round-robin (i.e. each VP is allocated equal
+time slices, without any given a priority) onto the MPI processes and
+counted continuously over all processes.
 
 .. figure:: ../_static/img/Process_vp_thread.png
 
- Basic scheme for counting threads (T), virtual
- processes (VP) and MPI processes (P) in NEST
+ Basic scheme showing how threads (T) and virtual
+ processes (VP) reside in MPI processes (P) in NEST
 
-The status dictionary of each node (i.e. neuron or device) contains
-three entries that are related to parallel computing:
 
--  *local* (boolean): indicating if the node exists on the local process
-   or not
--  *thread* (integer): id of the local thread the node is assigned to
--  *vp* (integer): id of the virtual process the node is assigned to.
 
-Node distribution
-~~~~~~~~~~~~~~~~~
+Node distributions
+--------------------
 
-The distribution of nodes is based on the type of the node. Neurons are
-assigned to one of the virtual processes in a round-robin fashion. On
-all other virtual processes, no object is created (the *proxy* object in
-the figure below is just a conceptual way of keeping the id of the real
-node free on remote processes). The virtual process *idVP* on which a
-neuron with global id *idNode* is allocated is given by *idVP = idNode %
-NVP*, where *NVP* is the total number of virtual processes in the
-simulation.
+The distribution of nodes depends on the type of node.
 
-Devices for the stimulation and observation of the network are
-replicated once on each thread in order to balance the load of the
-different threads and minimize their interaction. Devices thus do not
-have proxies on remote virtual processes.
-
-The node distribution for a small network consisting of
-``spike_generator``, four ``iaf_psc_alpha``\ s, and a ``spike_detector``
-in a scenario with two processes with two threads each is shown in the
-following figure:
+In the figure below, a node distribution for a small network consisting of ``spike_generator``,
+four ``iaf_psc_alpha`` neurons, and a ``spike_detector``
+in a scenario with two processes with two threads each.
 
 .. figure:: ../_static/img/Node_distribution.png
 
  sg=spike\_generator, iaf=iaf\_psc\_alpha, sd=spike\_detector. Numbers to
  the left and right indicate global ids.
+ The *proxy* object in the figure is a conceptual way of keeping the id of the
+ real node free on remote processes).
 
-For recording devices that are configured to record to a file (property
-*to\_file* set to *true*), the distribution also results in multiple
+
+Neuron distribution
+~~~~~~~~~~~~~~~~~~~~
+
+Neurons are assigned to one of the virtual processes in a round-robin fashion.
+On all other virtual processes, no object is created. Proxies ensure the id
+of the real node on a given VP is kept free.
+
+The virtual process `idVP` on which a neuron with global id `idNode` is
+allocated is given by :math:`idVP = idNode %NVP`, where `NVP` is the total
+number of virtual processes in the simulation.
+
+Device Distribution
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Devices are replicated once on each thread in order to balance the load and
+minimize their interaction. Devices thus do not have proxies on remote virtual
+processes.
+
+For recording devices configured to record to a file (property
+`to_file` set to `true`), the distribution results in multiple
 data files, each containing the data from one thread. The files names
 are composed according to the following scheme
 
-::
+.. code-block:: bash
 
     [model|label]-gid-vp.[dat|gdf]
 
-The first part is the name of the model (e.g. ``voltmeter`` or
-``spike_detector``) or, if set, the *label* of the recording device. The
-second part is the global id (GID) of the recording device. The third
-part is the id of the virtual process the recorder is assigned to,
-counted from 0. The extension is ``gdf`` for spike files and ``dat`` for
-analog recordings from the ``multimeter``. The ``label`` and
-``file_extension`` of a recording device can be set like any other
-parameter of a node using ``SetStatus``.
+The first part is the name of the `model` (e.g. ``voltmeter`` or
+``spike_detector``) or, if set, the `label` of the recording device. Next is
+the global id (GID) of the recording device, followed by the id of the VP
+assigned to the recorder. Spike files have the file extension ``gdf`` and
+analog recordings from the ``multimeter`` have ``dat`` as file extension.
 
-Spike exchange and synapse updates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``label`` and ``file_extension`` of a recording device can be set like any
+other parameter of a node using ``SetStatus``.
+
+.. note::
+
+ The status dictionary of each node (i.e. neuron or device) contains
+ three entries that are related to parallel computing:
+
+ *  *local* (boolean): indicating if the node exists on the local process or not
+ *  *thread* (integer): id of the local thread the node is assigned to
+ *  *vp* (integer): id of the virtual process the node is assigned to
+
+
+Spike exchange and synapse update
+------------------------------------
 
 Spike exchange in NEST takes different routes depending on the type of
 the sending and receiving node. There are two distinct cases.
 
-Spikes between neurons are always exchanged through the global spike
-exchange mechanism. Neuron update and spike generation in the source
-neuron and spike delivery to the target neuron may be handled by
-different virtual process in this case. Spike delivery is always handled
-by the virtual process to which the *target* neuron is assigned (see
-property ``vp`` in the status dictionary).
+Spikes between neurons
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spike exchange to or from neurons over connections that either originate
-or terminate at a device (e.g., ``spike_generator -> neuron`` or
-``neuron -> spike_detector``) differs in that it bypasses the global
-spike exchange mechanism. Instead, spikes are delivered locally within
-the virtual process from or to a replica of the device. In this case,
-both the pre- and postsynaptic nodes are handled by the virtual process
-to which the neuron is assigned.
+* Spikes between neurons are always exchanged through the **global spike
+  exchange mechanism**.
+
+* Neuron update and spike generation in the `source neuron` and spike delivery
+  to the `target neuron` may be handled by **different virtual process**.
+
+* But the virtual process assigned to the `target_neuron`, always handles the corresponding spike delivery
+  (see property ``vp`` in the status dictionary).
+
+Spikes between neurons and devices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Spike exchange to or from neurons over connections that either originate
+  or terminate at a device (e.g., ``spike_generator -> neuron`` or
+  ``neuron -> spike_detector``) bypasses the global spike exchange mechanism.
+
+* Spikes are delivered locally within the virtual process from or to a
+  replica of the device. In this case, both the pre- and postsynaptic nodes are
+  handled by the virtual process to which the neuron is assigned.
+
+Synaptic plasticity models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For synapse models supporting plasticity, synapse dynamics in the
 ``Connection`` object are always handled by the virtual process of the
-target node.
+`target node`.
+
+.. _multiple_threads:
 
 Using multiple threads
 ----------------------
 
-Thread-parallelism is compiled into NEST by default and should work on
-all MacOS and Linux machines without additional requirements. In order
-to keep results comparable and reproducible across different machines,
-however, the default mode is that only a single thread is used and
-multi-threading has to be turned on explicitly.
+Thread-parallel simulation is compiled into NEST by default and should work on
+all MacOS and Linux machines without additional requirements.
+
+In order to keep results comparable and reproducible across different machines,
+the **default mode** is set to a **single thread**  and
+**multi-threading** has to be turned on explicitly.
 
 To use multiple threads for the simulation, the desired number of
-threads has to be set *before* any nodes or connections are created. The
+threads has to be set **before** any nodes or connections are created. The
 command for this is
 
-::
+.. code-block:: bash
 
     nest.SetKernelStatus({"local_num_threads": T})
 
-Usually, a good choice for T is the number of processor cores available
-on your machine. In some situations, oversubscribing can yield 20-30%
-improvement in simulation speed. Finding the optimal thread number for a
-specific situation might require a bit of experimenting.
+Usually, a good choice for `T` is the number of processor cores available
+on your machine.
+
+.. note::
+
+ In some situations, `oversubscribing` (i.e., to specify a ``local_num_threads`` that is higher than available cores on your machine)
+ can yield 20-30% improvement in simulation speed. Finding the optimal thread number for a
+ specific situation might require a bit of experimenting.
+
+.. _distributed_computing:
 
 Using distributed computing
----------------------------
+------------------------------
 
 Build requirements
 ~~~~~~~~~~~~~~~~~~
 
-To compile NEST for distributed computing, you need a library
-implementation of MPI on your system. If you are on a cluster, you most
-likely have this already. Note, that in the case of a pre-packaged MPI
-library you will need both, the library and the development packages.
-Please see the `Installation instructions <installation.md>`__ for
-general information on installing NEST. Please be advised that NEST
-should currently only be run in a homogeneous MPI environment. Running
-in a heterogenenous environment can lead to unexpected results or even
-crashes. Please contact the `NEST community <community.md>`__ if you
-require support for exotic setups.
+To compile NEST for distributed computing, you will need
 
-Compilation
-~~~~~~~~~~~
+ * a library implementation of MPI on your system. If you are on a cluster, you
+   most likely have this already.
+ * NEST development packages in the case of pre-packaged MPI library.
 
-If the MPI library and header files are installed to the standard
-directories of the system, it is likely that a simple
+.. note::
 
-::
+  Please be advised that NEST should currently only be run in a homogeneous
+  MPI environment. Running in a heterogenenous environment can lead to
+  unexpected results or even crashes. Please contact the :doc:`NEST community
+  <../contribute/index>` if you require support for exotic setups.
 
-    $NEST_SOURCE_DIR/configure --with-mpi
+Configure
+~~~~~~~~~~~~
 
-will find them (``$NEST_SOURCE_DIR`` is the directory holding the NEST
-sources). If MPI is installed to a non-standard location
-``/path/to/mpi``, the command line looks like this:
+If using the :ref:`standard installation <standard>` instructions
+when calling `cmake`, add the option ``-Dwith-mpi=ON``. The build summary
+should report that MPI is linked.
 
-::
+Please see the :doc:`Installation instructions <../installation/index>` for
+more information on installing NEST.
 
-    $NEST_SOURCE_DIR/configure --with-mpi=/path/to/mpi
 
-In some cases it might be necessary to specify MPI compiler wrappers
-explicitly:
-
-::
-
-    $NEST_SOURCE_DIR/configure CC=mpicc CXX=mpicxx --with-mpi
-
-Additional information concerning MPI on OSX can be found
-`here <installation.md>`__.
-
-Running distributed simulations
+Run distributed simulations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Distributed simulations cannot be run interactively, which means that
-the simulation has to be provided as a script. However, the script does
-not have to be changed compared to the script for serial simulation:
-inter-process communication and node distribution is managed
-transparently inside of NEST.
+Distributed simulations **cannot be run interactively**, which means that
+the simulation has to be provided as a script. However, the script can be the same
+as a script for any simulation. No changes are necessary for distibuted simulation scripts:
+inter-process communication and node distribution is managed transparently inside of NEST.
 
 To distribute a simulation onto 128 processes of a computer cluster, the
-command line to execute looks like this:
+command should look like this
 
-::
+.. code-block:: bash
 
     mpirun -np 128 python simulation.py
 
@@ -224,17 +238,20 @@ information about the MPI application. One example would opening the
 right stimulus file for a specific rank. Therefore, some MPI specific
 commands are available:
 
-| ``NumProcesses``
-| The number of MPI processes in the simulation
+.. glossary::
 
-| ``ProcessorName``
-| The name of the machine. The result might differ on each process.
+ ``NumProcesses``
+     The number of MPI processes in the simulation
 
-| ``Rank``
-| The rank of the MPI process. The result differs on each process.
+ ``ProcessorName``
+     The name of the machine. The result might differ on each process.
 
-| ``SyncProcesses``
-| Synchronize all MPI processes.
+ ``Rank``
+     The rank of the MPI process. The result differs on each process.
+
+ ``SyncProcesses``
+      Synchronize all MPI processes.
+
 
 Reproducibility
 ---------------
@@ -244,8 +261,8 @@ parallelization strategies, the number of virtual processes has to be
 kept constant. A simulation with a specific number of virtual processes
 will always yield the same results, no matter how they are distributed
 over threads and processes, given that the seeds for the random number
-generators of the different virtual processes are the same (see `Random
-numbers in NEST <random-numbers.md>`__).
+generators of the different virtual processes are the same (see :doc:`Random
+numbers in NEST <random_numbers>`).
 
 In order to achieve a constant number of virtual processes, NEST
 provides the property *total\_num\_virtual\_procs* to adapt the number
@@ -257,7 +274,7 @@ The following listing contains a complete simulation script
 neuron receives random input from a ``poisson_generator`` and the spikes
 of all four neurons are recorded to files.
 
-::
+.. code-block:: bash
 
     from nest import *
     SetKernelStatus({"total_num_virtual_procs": 4})
@@ -274,7 +291,7 @@ of all four neurons are recorded to files.
 The script is run three times using different numbers of MPI processes,
 but 4 virtual processes in every run:
 
-::
+.. code-block:: bash
 
     mkdir 4vp_1p; cd 4vp_1p
     mpirun -np 1 python ../simulation.py
@@ -287,10 +304,9 @@ but 4 virtual processes in every run:
     diff 4vp_1p 4vp_4p
 
 Each variant of the experiment produces four data files, one for each
-virtual process (*spike\_detector-6-0.gdf*, *spike\_detector-6-1.gdf*,
-*spike\_detector-6-2.gdf*, and *spike\_detector-6-3.gdf*). Using diff on
+virtual process (*spike_detector-6-0.gdf*, *spike_detector-6-1.gdf*,
+*spike_detector-6-2.gdf*, and *spike_detector-6-3.gdf*). Using diff on
 the three data directories shows that they all contain the same spikes,
 which means that the simulation results are indeed the same
 independently of the details of parallelization.
-
 

--- a/doc/guides/random_numbers.rst
+++ b/doc/guides/random_numbers.rst
@@ -1,3 +1,5 @@
+.. _random_numbers:
+
 Random numbers
 ==============
 

--- a/doc/installation/linux_install.rst
+++ b/doc/installation/linux_install.rst
@@ -1,6 +1,8 @@
 Ubuntu / Debian Installation
 ===============================
 
+.. _standard:
+
 Standard Installation
 ------------------------
 


### PR DESCRIPTION
This PR removes section of text in doc/guides/parallel_computing.rst regarding the outdated NEST_SOURCE_DIR/configure --with-mpi and replaces it with a brief description of using the -Dwith-mpi=ON 

Additionally, some minor fixes to broken links and changes to the text were made to improve clarity. 