### PR TITLE
Fix uninitialized variable in iaf_psc_exp

### DIFF
--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -83,6 +83,7 @@ nest::iaf_psc_exp::Parameters_::Parameters_()
 
 nest::iaf_psc_exp::State_::State_()
   : i_0_( 0.0 )
+  , i_1_( 0.0 )
   , i_syn_ex_( 0.0 )
   , i_syn_in_( 0.0 )
   , V_m_( 0.0 )


### PR DESCRIPTION
Not initializing the presynaptic stepwise constant input current `i_1_` can have disastrous consequences when the memory is not zero by chance as its initial value is directly used (https://github.com/nest/nest-simulator/blob/master/models/iaf_psc_exp.cpp#L339).