### PR TITLE
Update links to model directory in docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,19 +26,19 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
 
 **Have an idea of the type of model you need?**
-    Click on one of the images to access our model directory:
+    Click on one of the images to access our :doc:`model directory <models/index>`:
 
 .. raw:: html
 
  <embed>
 
- <a href="models/neurons/index.html">
+ <a href="models/neurons.html">
     <img src="_static/img/neuron.png" alt="Neuron Models" style="width:150px;height:150px;border:0;">
   </a>
-  <a href="models/synapses/index.html">
+  <a href="models/synapses.html">
     <img src="_static/img/synapse1.png" alt="Synapse Models" style="width:150px;height:150px;border:0;">
   </a>
-  <a href="models/devices/index.html">
+  <a href="models/devices.html">
     <img src="_static/img/oscilloscope.png" alt="Devices" style="width:150px;height:150px;border:0;">
   </a>
   </embed>

--- a/doc/models/devices.rst
+++ b/doc/models/devices.rst
@@ -1,6 +1,7 @@
 All devices
 ==============================
 
+Back to :doc:`model directory <../models/index>`
 
 .. doxygengroup:: Devices
    :content-only:

--- a/doc/models/neurons.rst
+++ b/doc/models/neurons.rst
@@ -1,6 +1,8 @@
 All neuron models
 ==============================
 
+Back to :doc:`model directory <../models/index>`
+
 .. doxygengroup:: Neurons
    :content-only:
 

--- a/doc/models/synapses.rst
+++ b/doc/models/synapses.rst
@@ -1,6 +1,7 @@
 All synapse models
 ================================
 
+Back to :doc:`model directory <../models/index>`
 
 .. doxygengroup:: Synapses
    :content-only:


### PR DESCRIPTION
This PR is a follow-up to #1143 that just updates the links to the model directory in the docs main page.