### PR TITLE
Cleanup for the K computer specific CMake file for v2.18 

### DIFF
--- a/cmake/Platform/Fujitsu-Sparc64.cmake
+++ b/cmake/Platform/Fujitsu-Sparc64.cmake
@@ -26,10 +26,9 @@ set( TRIPLET_VENDOR fujitsu )
 # Set k-computer for main CMakeList.txt
 #
 set( k-computer ON CACHE BOOL "Enable K computer." FORCE )
-# better to build static for K computer
-set( static-libraries ON CACHE BOOL "Build static libraries. [default=no]" FORCE )
 # no readline support on K computer
 set( with-readline OFF CACHE BOOL "Find a readline library [default=ON]. To set a specific readline, set install path." FORCE )
+set( with-ltdl OFF CACHE BOOL "Find a ltdl library [default=ON]. To set a specific ltdl, set install path." FORCE )
 # we obviously want to do mpi on K computer
 set( with-mpi ON CACHE BOOL "Request compilation with MPI; optionally give directory with MPI installation." FORCE )
 
@@ -57,15 +56,9 @@ set( CMAKE_CXX_COMPILER mpiFCCpx CACHE FILEPATH "Override C++ compiler" )
 set( CMAKE_C_COMPILER_ID "Fujitsu" CACHE STRING "Fujitsu C cross-compiler" FORCE )
 set( CMAKE_CXX_COMPILER_ID "Fujitsu" CACHE STRING "Fujitsu C++ cross-compiler" FORCE )
 
-# Set specific OpenMPI variables
-set( MPI_CXX_COMPIER mpiFCCpx )
-set( MPI_CXX_HEADER_DIR "/opt/FJSVtclang/GM-1.2.0-24/include/mpi/fujitsu/" CACHE PATH "Location of the mpi.h header on disk" FORCE )
-#set( MPI_CXX_LIBRARIES "mpi" CACHE STRING "" FORCE )
-#set( MPI_CXX_LINK_FLAGS "-mt -Kident_mpi -lmpi_cxx -lmpi -ltofucom -ltofutop -lm -lnsl -lutil" CACHE STRING "" FORCE )
-
 # Set specific OpenMP variables
 set( OpenMP_C_FLAGS "-Kopenmp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
 set( OpenMP_CXX_FLAGS "-Kopenmp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
 set( OpenMP_C_LIB_NAMES "fjomp" CACHE STRING "libfjomp" FORCE )
 set( OpenMP_CXX_LIB_NAMES "fjomp" CACHE STRING "libfjomp" FORCE )
-set( OpenMP_fjomp_LIBRARY "/opt/FJSVtclang/GM-1.2.0-24/lib64/" CACHE STRING "PATH to fjomp" FORCE )
+set( OpenMP_fjomp_LIBRARY "/opt/FJSVtclang/GM-1.2.0-25/lib64/" CACHE STRING "PATH to fjomp" FORCE )

--- a/cmake/Platform/Fujitsu-Sparc64.cmake
+++ b/cmake/Platform/Fujitsu-Sparc64.cmake
@@ -32,8 +32,6 @@ set( with-ltdl OFF CACHE BOOL "Find a ltdl library [default=ON]. To set a specif
 # we obviously want to do mpi on K computer
 set( with-mpi ON CACHE BOOL "Request compilation with MPI; optionally give directory with MPI installation." FORCE )
 
-set_property( GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE )
-
 #
 # Library prefixes, suffixes, extra libs.
 #
@@ -55,10 +53,3 @@ set( CMAKE_CXX_COMPILER mpiFCCpx CACHE FILEPATH "Override C++ compiler" )
 # Prevent CMake from adding GNU-specific linker flags (-rdynamic)
 set( CMAKE_C_COMPILER_ID "Fujitsu" CACHE STRING "Fujitsu C cross-compiler" FORCE )
 set( CMAKE_CXX_COMPILER_ID "Fujitsu" CACHE STRING "Fujitsu C++ cross-compiler" FORCE )
-
-# Set specific OpenMP variables
-set( OpenMP_C_FLAGS "-Kopenmp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
-set( OpenMP_CXX_FLAGS "-Kopenmp" CACHE STRING "Compiler flag for OpenMP parallelization" FORCE )
-set( OpenMP_C_LIB_NAMES "fjomp" CACHE STRING "libfjomp" FORCE )
-set( OpenMP_CXX_LIB_NAMES "fjomp" CACHE STRING "libfjomp" FORCE )
-set( OpenMP_fjomp_LIBRARY "/opt/FJSVtclang/GM-1.2.0-25/lib64/" CACHE STRING "PATH to fjomp" FORCE )

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -43,11 +43,55 @@
 #include "config.h"
 
 // Neuron models
+#include "aeif_cond_alpha.h"
+#include "aeif_cond_alpha_multisynapse.h"
+#include "aeif_cond_beta_multisynapse.h"
+#include "aeif_cond_alpha_RK5.h"
+#include "aeif_cond_exp.h"
+#include "aeif_psc_alpha.h"
+#include "aeif_psc_exp.h"
+#include "aeif_psc_delta.h"
+#include "aeif_psc_delta_clopath.h"
+#include "amat2_psc_exp.h"
+#include "erfc_neuron.h"
+#include "gauss_rate.h"
+#include "ginzburg_neuron.h"
+#include "hh_cond_exp_traub.h"
+#include "hh_cond_beta_gap_traub.h"
 #include "hh_psc_alpha.h"
 #include "hh_psc_alpha_clopath.h"
 #include "hh_psc_alpha_gap.h"
+#include "ht_neuron.h"
+#include "iaf_chs_2007.h"
+#include "iaf_chxk_2008.h"
+#include "iaf_cond_alpha.h"
+#include "iaf_cond_alpha_mc.h"
+#include "iaf_cond_beta.h"
 #include "iaf_cond_exp.h"
+#include "iaf_cond_exp_sfa_rr.h"
 #include "iaf_psc_alpha.h"
+#include "iaf_psc_alpha_multisynapse.h"
+#include "iaf_psc_delta.h"
+#include "iaf_psc_exp.h"
+#include "iaf_psc_exp_multisynapse.h"
+#include "iaf_tum_2000.h"
+#include "izhikevich.h"
+#include "lin_rate.h"
+#include "tanh_rate.h"
+#include "threshold_lin_rate.h"
+#include "mat2_psc_exp.h"
+#include "mcculloch_pitts_neuron.h"
+#include "parrot_neuron.h"
+#include "pp_pop_psc_delta.h"
+#include "pp_psc_delta.h"
+#include "siegert_neuron.h"
+#include "sigmoid_rate.h"
+#include "sigmoid_rate_gg_1998.h"
+#include "gif_psc_exp.h"
+#include "gif_psc_exp_multisynapse.h"
+#include "gif_cond_exp.h"
+#include "gif_cond_exp_multisynapse.h"
+#include "gif_pop_psc_exp.h"
 
 // Stimulation devices
 #include "ac_generator.h"
@@ -80,11 +124,15 @@
 #include "bernoulli_connection.h"
 #include "clopath_connection.h"
 #include "common_synapse_properties.h"
+#include "cont_delay_connection.h"
 #include "cont_delay_connection_impl.h"
 #include "diffusion_connection.h"
+#include "gap_junction.h"
 #include "ht_connection.h"
 #include "quantal_stp_connection.h"
 #include "quantal_stp_connection_impl.h"
+#include "rate_connection_instantaneous.h"
+#include "rate_connection_delayed.h"
 #include "spike_dilutor.h"
 #include "static_connection.h"
 #include "static_connection_hom_w.h"
@@ -92,8 +140,13 @@
 #include "stdp_connection_facetshw_hom.h"
 #include "stdp_connection_facetshw_hom_impl.h"
 #include "stdp_connection_hom.h"
+#include "stdp_triplet_connection.h"
 #include "stdp_dopa_connection.h"
 #include "stdp_pl_connection_hom.h"
+#include "tsodyks2_connection.h"
+#include "tsodyks_connection.h"
+#include "tsodyks_connection_hom.h"
+#include "vogels_sprekeler_connection.h"
 
 // Includes from nestkernel:
 #include "common_synapse_properties.h"
@@ -144,11 +197,96 @@ ModelsModule::commandstring( void ) const
 void
 ModelsModule::init( SLIInterpreter* )
 {
+  // rate models with input noise
+  kernel().model_manager.register_node_model< gauss_rate_ipn >(
+    "gauss_rate_ipn" );
+  kernel().model_manager.register_node_model< lin_rate_ipn >( "lin_rate_ipn" );
+  kernel().model_manager.register_node_model< sigmoid_rate_ipn >(
+    "sigmoid_rate_ipn" );
+  kernel().model_manager.register_node_model< sigmoid_rate_gg_1998_ipn >(
+    "sigmoid_rate_gg_1998_ipn" );
+  kernel().model_manager.register_node_model< tanh_rate_ipn >(
+    "tanh_rate_ipn" );
+  kernel().model_manager.register_node_model< threshold_lin_rate_ipn >(
+    "threshold_lin_rate_ipn" );
+
+  // rate models with output noise
+  kernel().model_manager.register_node_model< lin_rate_opn >( "lin_rate_opn" );
+  kernel().model_manager.register_node_model< tanh_rate_opn >(
+    "tanh_rate_opn" );
+  kernel().model_manager.register_node_model< threshold_lin_rate_opn >(
+    "threshold_lin_rate_opn" );
+
+  // rate transformer nodes
+  kernel().model_manager.register_node_model< rate_transformer_gauss >(
+    "rate_transformer_gauss" );
+  kernel().model_manager.register_node_model< rate_transformer_lin >(
+    "rate_transformer_lin" );
+  kernel().model_manager.register_node_model< rate_transformer_sigmoid >(
+    "rate_transformer_sigmoid" );
+  kernel()
+    .model_manager.register_node_model< rate_transformer_sigmoid_gg_1998 >(
+      "rate_transformer_sigmoid_gg_1998" );
+  kernel().model_manager.register_node_model< rate_transformer_tanh >(
+    "rate_transformer_tanh" );
+  kernel().model_manager.register_node_model< rate_transformer_threshold_lin >(
+    "rate_transformer_threshold_lin" );
+
+  kernel().model_manager.register_node_model< iaf_chs_2007 >( "iaf_chs_2007" );
   kernel().model_manager.register_node_model< iaf_psc_alpha >(
     "iaf_psc_alpha" );
+  kernel().model_manager.register_node_model< iaf_psc_alpha_multisynapse >(
+    "iaf_psc_alpha_multisynapse" );
+  kernel().model_manager.register_node_model< iaf_psc_delta >(
+    "iaf_psc_delta" );
+  kernel().model_manager.register_node_model< iaf_psc_exp >( "iaf_psc_exp" );
+  kernel().model_manager.register_node_model< iaf_psc_exp_multisynapse >(
+    "iaf_psc_exp_multisynapse" );
+  kernel().model_manager.register_node_model< iaf_tum_2000 >( "iaf_tum_2000" );
+  kernel().model_manager.register_node_model< amat2_psc_exp >(
+    "amat2_psc_exp" );
+  kernel().model_manager.register_node_model< mat2_psc_exp >( "mat2_psc_exp" );
+  kernel().model_manager.register_node_model< parrot_neuron >(
+    "parrot_neuron" );
+  kernel().model_manager.register_node_model< pp_psc_delta >( "pp_psc_delta" );
+  kernel().model_manager.register_node_model< pp_pop_psc_delta >(
+    "pp_pop_psc_delta" );
+  kernel().model_manager.register_node_model< gif_psc_exp >( "gif_psc_exp" );
+  kernel().model_manager.register_node_model< gif_psc_exp_multisynapse >(
+    "gif_psc_exp_multisynapse" );
 
+  kernel().model_manager.register_node_model< ac_generator >( "ac_generator" );
+  kernel().model_manager.register_node_model< dc_generator >( "dc_generator" );
+  kernel().model_manager.register_node_model< spike_generator >(
+    "spike_generator" );
+  kernel().model_manager.register_node_model< inhomogeneous_poisson_generator >(
+    "inhomogeneous_poisson_generator" );
   kernel().model_manager.register_node_model< poisson_generator >(
     "poisson_generator" );
+  kernel().model_manager.register_node_model< pulsepacket_generator >(
+    "pulsepacket_generator" );
+  kernel().model_manager.register_node_model< noise_generator >(
+    "noise_generator" );
+  kernel().model_manager.register_node_model< step_current_generator >(
+    "step_current_generator" );
+  kernel().model_manager.register_node_model< step_rate_generator >(
+    "step_rate_generator" );
+  kernel().model_manager.register_node_model< mip_generator >(
+    "mip_generator" );
+  kernel().model_manager.register_node_model< sinusoidal_poisson_generator >(
+    "sinusoidal_poisson_generator" );
+  kernel().model_manager.register_node_model< ppd_sup_generator >(
+    "ppd_sup_generator" );
+  kernel().model_manager.register_node_model< gamma_sup_generator >(
+    "gamma_sup_generator" );
+  kernel().model_manager.register_node_model< erfc_neuron >( "erfc_neuron" );
+  kernel().model_manager.register_node_model< ginzburg_neuron >(
+    "ginzburg_neuron" );
+  kernel().model_manager.register_node_model< mcculloch_pitts_neuron >(
+    "mcculloch_pitts_neuron" );
+  kernel().model_manager.register_node_model< izhikevich >( "izhikevich" );
+  kernel().model_manager.register_node_model< spike_dilutor >(
+    "spike_dilutor" );
 
   kernel().model_manager.register_node_model< spike_detector >(
     "spike_detector" );
@@ -242,14 +380,59 @@ ModelsModule::init( SLIInterpreter* )
     name, vmdict, false );
 
 #ifdef HAVE_GSL
+  kernel().model_manager.register_node_model< iaf_chxk_2008 >(
+    "iaf_chxk_2008" );
+  kernel().model_manager.register_node_model< iaf_cond_alpha >(
+    "iaf_cond_alpha" );
+  kernel().model_manager.register_node_model< iaf_cond_beta >(
+    "iaf_cond_beta" );
   kernel().model_manager.register_node_model< iaf_cond_exp >( "iaf_cond_exp" );
+  kernel().model_manager.register_node_model< iaf_cond_exp_sfa_rr >(
+    "iaf_cond_exp_sfa_rr" );
+  kernel().model_manager.register_node_model< iaf_cond_alpha_mc >(
+    "iaf_cond_alpha_mc" );
+  kernel().model_manager.register_node_model< hh_cond_beta_gap_traub >(
+    "hh_cond_beta_gap_traub" );
+  kernel().model_manager.register_node_model< hh_psc_alpha >( "hh_psc_alpha" );
+  kernel().model_manager.register_node_model< hh_psc_alpha_clopath >(
+    "hh_psc_alpha_clopath" );
+  kernel().model_manager.register_node_model< hh_psc_alpha_gap >(
+    "hh_psc_alpha_gap" );
+  kernel().model_manager.register_node_model< hh_cond_exp_traub >(
+    "hh_cond_exp_traub" );
+  kernel().model_manager.register_node_model< sinusoidal_gamma_generator >(
+    "sinusoidal_gamma_generator" );
+  kernel().model_manager.register_node_model< gif_cond_exp >( "gif_cond_exp" );
+  kernel().model_manager.register_node_model< gif_cond_exp_multisynapse >(
+    "gif_cond_exp_multisynapse" );
+  kernel().model_manager.register_node_model< gif_pop_psc_exp >(
+    "gif_pop_psc_exp" );
+
+  kernel().model_manager.register_node_model< aeif_psc_delta_clopath >(
+    "aeif_psc_delta_clopath" );
+  kernel().model_manager.register_node_model< aeif_cond_alpha >(
+    "aeif_cond_alpha" );
+  kernel().model_manager.register_node_model< aeif_cond_exp >(
+    "aeif_cond_exp" );
+  kernel().model_manager.register_node_model< aeif_psc_alpha >(
+    "aeif_psc_alpha" );
+  kernel().model_manager.register_node_model< aeif_psc_exp >( "aeif_psc_exp" );
+  kernel().model_manager.register_node_model< aeif_psc_delta >(
+    "aeif_psc_delta" );
+  kernel().model_manager.register_node_model< ht_neuron >( "ht_neuron" );
+  kernel().model_manager.register_node_model< aeif_cond_beta_multisynapse >(
+    "aeif_cond_beta_multisynapse" );
+  kernel().model_manager.register_node_model< aeif_cond_alpha_multisynapse >(
+    "aeif_cond_alpha_multisynapse" );
+  kernel().model_manager.register_node_model< siegert_neuron >(
+    "siegert_neuron" );
 #endif
 
   // This version of the AdEx model does not depend on GSL.
-  //kernel().model_manager.register_node_model< aeif_cond_alpha_RK5 >(
-  //  "aeif_cond_alpha_RK5",
-  //  /*private_model*/ false,
-  //  /*deprecation_info*/ "NEST 3.0" );
+  kernel().model_manager.register_node_model< aeif_cond_alpha_RK5 >(
+    "aeif_cond_alpha_RK5",
+    /*private_model*/ false,
+    /*deprecation_info*/ "NEST 3.0" );
 
 #ifdef HAVE_MUSIC
   //// proxies for inter-application communication using MUSIC
@@ -303,7 +486,41 @@ ModelsModule::init( SLIInterpreter* )
     .register_connection_model< StaticConnectionHomW< TargetIdentifierIndex > >(
       "static_synapse_hom_w_hpc" );
 
-  /* BeginDocumentation
+  /** @BeginDocumentation
+     Name: gap_junction - Connection model for gap junctions.
+     SeeAlso: synapsedict
+  */
+  kernel()
+    .model_manager
+    .register_secondary_connection_model< GapJunction< TargetIdentifierPtrRport > >(
+      "gap_junction",
+      /*has_delay=*/false,
+      /*requires_symmetric=*/true,
+      /*supports_wfr=*/true );
+  kernel()
+    .model_manager
+    .register_secondary_connection_model< RateConnectionInstantaneous< TargetIdentifierPtrRport > >(
+      "rate_connection_instantaneous",
+      /*has_delay=*/false,
+      /*requires_symmetric=*/false,
+      /*supports_wfr=*/true );
+  kernel()
+    .model_manager
+    .register_secondary_connection_model< RateConnectionDelayed< TargetIdentifierPtrRport > >(
+      "rate_connection_delayed",
+      /*has_delay=*/true,
+      /*requires_symmetric=*/false,
+      /*supports_wfr=*/false );
+  kernel()
+    .model_manager
+    .register_secondary_connection_model< DiffusionConnection< TargetIdentifierPtrRport > >(
+      "diffusion_connection",
+      /*has_delay=*/false,
+      /*requires_symmetric=*/false,
+      /*supports_wfr=*/true );
+
+
+  /** @BeginDocumentation
      Name: stdp_synapse_hpc - Variant of stdp_synapse with low memory
      consumption.
      SeeAlso: synapsedict, stdp_synapse, static_synapse_hpc
@@ -338,7 +555,38 @@ ModelsModule::init( SLIInterpreter* )
     .register_connection_model< STDPPLConnectionHom< TargetIdentifierIndex > >(
       "stdp_pl_synapse_hom_hpc" );
 
-  /* BeginDocumentation
+
+  /** @BeginDocumentation
+     Name: stdp_triplet_synapse_hpc - Variant of stdp_triplet_synapse with low
+     memory consumption.
+     SeeAlso: synapsedict, stdp_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< STDPTripletConnection< TargetIdentifierPtrRport > >(
+      "stdp_triplet_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< STDPTripletConnection< TargetIdentifierIndex > >(
+      "stdp_triplet_synapse_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: quantal_stp_synapse_hpc - Variant of quantal_stp_synapse with low
+     memory consumption.
+     SeeAlso: synapsedict, quantal_stp_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< Quantal_StpConnection< TargetIdentifierPtrRport > >(
+      "quantal_stp_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< Quantal_StpConnection< TargetIdentifierIndex > >(
+      "quantal_stp_synapse_hpc" );
+
+
+  /** @BeginDocumentation
      Name: stdp_synapse_hom_hpc - Variant of quantal_stp_synapse with low memory
      consumption.
      SeeAlso: synapsedict, stdp_synapse_hom, static_synapse_hpc
@@ -352,7 +600,126 @@ ModelsModule::init( SLIInterpreter* )
     .register_connection_model< STDPConnectionHom< TargetIdentifierIndex > >(
       "stdp_synapse_hom_hpc" );
 
-  /* BeginDocumentation
+
+  /** @BeginDocumentation
+     Name: stdp_facetshw_synapse_hom_hpc - Variant of stdp_facetshw_synapse_hom
+     with low memory consumption.
+     SeeAlso: synapsedict, stdp_facetshw_synapse_hom, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< STDPFACETSHWConnectionHom< TargetIdentifierPtrRport > >(
+      "stdp_facetshw_synapse_hom" );
+  kernel()
+    .model_manager
+    .register_connection_model< STDPFACETSHWConnectionHom< TargetIdentifierIndex > >(
+      "stdp_facetshw_synapse_hom_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: cont_delay_synapse_hpc - Variant of cont_delay_synapse with low
+     memory consumption.
+     SeeAlso: synapsedict, cont_delay_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< ContDelayConnection< TargetIdentifierPtrRport > >(
+      "cont_delay_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< ContDelayConnection< TargetIdentifierIndex > >(
+      "cont_delay_synapse_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: tsodyks_synapse_hpc - Variant of tsodyks_synapse with low memory
+     consumption.
+     SeeAlso: synapsedict, tsodyks_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< TsodyksConnection< TargetIdentifierPtrRport > >(
+      "tsodyks_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< TsodyksConnection< TargetIdentifierIndex > >(
+      "tsodyks_synapse_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: tsodyks_synapse_hom_hpc - Variant of tsodyks_synapse_hom with low
+     memory consumption.
+     SeeAlso: synapsedict, tsodyks_synapse_hom, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< TsodyksConnectionHom< TargetIdentifierPtrRport > >(
+      "tsodyks_synapse_hom" );
+  kernel()
+    .model_manager
+    .register_connection_model< TsodyksConnectionHom< TargetIdentifierIndex > >(
+      "tsodyks_synapse_hom_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: tsodyks2_synapse_hpc - Variant of tsodyks2_synapse with low memory
+     consumption.
+     SeeAlso: synapsedict, tsodyks2_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< Tsodyks2Connection< TargetIdentifierPtrRport > >(
+      "tsodyks2_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< Tsodyks2Connection< TargetIdentifierIndex > >(
+      "tsodyks2_synapse_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: ht_synapse_hpc - Variant of ht_synapse with low memory consumption.
+     SeeAlso: synapsedict, ht_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< HTConnection< TargetIdentifierPtrRport > >(
+      "ht_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< HTConnection< TargetIdentifierIndex > >(
+      "ht_synapse_hpc" );
+
+
+  /** @BeginDocumentation
+     Name: stdp_dopamine_synapse_hpc - Variant of stdp_dopamine_synapse with low
+     memory consumption.
+     SeeAlso: synapsedict, stdp_dopamine_synapse, static_synapse_hpc
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< STDPDopaConnection< TargetIdentifierPtrRport > >(
+      "stdp_dopamine_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< STDPDopaConnection< TargetIdentifierIndex > >(
+      "stdp_dopamine_synapse_hpc" );
+
+  /** @BeginDocumentation
+     Name: vogels_sprekeler_synapse_hpc - Variant of vogels_sprekeler_synapse
+     with low memory
+     consumption.
+     SeeAlso: synapsedict, vogels_sprekeler_synapse
+  */
+  kernel()
+    .model_manager
+    .register_connection_model< VogelsSprekelerConnection< TargetIdentifierPtrRport > >(
+      "vogels_sprekeler_synapse" );
+  kernel()
+    .model_manager
+    .register_connection_model< VogelsSprekelerConnection< TargetIdentifierIndex > >(
+      "vogels_sprekeler_synapse_hpc" );
+
+  /** @BeginDocumentation
      Name: bernoulli_synapse - Static synapse with stochastic transmission
      SeeAlso: synapsedict, static_synapse, static_synapse_hom_w
   */

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -43,55 +43,11 @@
 #include "config.h"
 
 // Neuron models
-#include "aeif_cond_alpha.h"
-#include "aeif_cond_alpha_multisynapse.h"
-#include "aeif_cond_beta_multisynapse.h"
-#include "aeif_cond_alpha_RK5.h"
-#include "aeif_cond_exp.h"
-#include "aeif_psc_alpha.h"
-#include "aeif_psc_exp.h"
-#include "aeif_psc_delta.h"
-#include "aeif_psc_delta_clopath.h"
-#include "amat2_psc_exp.h"
-#include "erfc_neuron.h"
-#include "gauss_rate.h"
-#include "ginzburg_neuron.h"
-#include "hh_cond_exp_traub.h"
-#include "hh_cond_beta_gap_traub.h"
 #include "hh_psc_alpha.h"
 #include "hh_psc_alpha_clopath.h"
 #include "hh_psc_alpha_gap.h"
-#include "ht_neuron.h"
-#include "iaf_chs_2007.h"
-#include "iaf_chxk_2008.h"
-#include "iaf_cond_alpha.h"
-#include "iaf_cond_alpha_mc.h"
-#include "iaf_cond_beta.h"
 #include "iaf_cond_exp.h"
-#include "iaf_cond_exp_sfa_rr.h"
 #include "iaf_psc_alpha.h"
-#include "iaf_psc_alpha_multisynapse.h"
-#include "iaf_psc_delta.h"
-#include "iaf_psc_exp.h"
-#include "iaf_psc_exp_multisynapse.h"
-#include "iaf_tum_2000.h"
-#include "izhikevich.h"
-#include "lin_rate.h"
-#include "tanh_rate.h"
-#include "threshold_lin_rate.h"
-#include "mat2_psc_exp.h"
-#include "mcculloch_pitts_neuron.h"
-#include "parrot_neuron.h"
-#include "pp_pop_psc_delta.h"
-#include "pp_psc_delta.h"
-#include "siegert_neuron.h"
-#include "sigmoid_rate.h"
-#include "sigmoid_rate_gg_1998.h"
-#include "gif_psc_exp.h"
-#include "gif_psc_exp_multisynapse.h"
-#include "gif_cond_exp.h"
-#include "gif_cond_exp_multisynapse.h"
-#include "gif_pop_psc_exp.h"
 
 // Stimulation devices
 #include "ac_generator.h"
@@ -124,15 +80,11 @@
 #include "bernoulli_connection.h"
 #include "clopath_connection.h"
 #include "common_synapse_properties.h"
-#include "cont_delay_connection.h"
 #include "cont_delay_connection_impl.h"
 #include "diffusion_connection.h"
-#include "gap_junction.h"
 #include "ht_connection.h"
 #include "quantal_stp_connection.h"
 #include "quantal_stp_connection_impl.h"
-#include "rate_connection_instantaneous.h"
-#include "rate_connection_delayed.h"
 #include "spike_dilutor.h"
 #include "static_connection.h"
 #include "static_connection_hom_w.h"
@@ -140,13 +92,8 @@
 #include "stdp_connection_facetshw_hom.h"
 #include "stdp_connection_facetshw_hom_impl.h"
 #include "stdp_connection_hom.h"
-#include "stdp_triplet_connection.h"
 #include "stdp_dopa_connection.h"
 #include "stdp_pl_connection_hom.h"
-#include "tsodyks2_connection.h"
-#include "tsodyks_connection.h"
-#include "tsodyks_connection_hom.h"
-#include "vogels_sprekeler_connection.h"
 
 // Includes from nestkernel:
 #include "common_synapse_properties.h"
@@ -197,96 +144,11 @@ ModelsModule::commandstring( void ) const
 void
 ModelsModule::init( SLIInterpreter* )
 {
-  // rate models with input noise
-  kernel().model_manager.register_node_model< gauss_rate_ipn >(
-    "gauss_rate_ipn" );
-  kernel().model_manager.register_node_model< lin_rate_ipn >( "lin_rate_ipn" );
-  kernel().model_manager.register_node_model< sigmoid_rate_ipn >(
-    "sigmoid_rate_ipn" );
-  kernel().model_manager.register_node_model< sigmoid_rate_gg_1998_ipn >(
-    "sigmoid_rate_gg_1998_ipn" );
-  kernel().model_manager.register_node_model< tanh_rate_ipn >(
-    "tanh_rate_ipn" );
-  kernel().model_manager.register_node_model< threshold_lin_rate_ipn >(
-    "threshold_lin_rate_ipn" );
-
-  // rate models with output noise
-  kernel().model_manager.register_node_model< lin_rate_opn >( "lin_rate_opn" );
-  kernel().model_manager.register_node_model< tanh_rate_opn >(
-    "tanh_rate_opn" );
-  kernel().model_manager.register_node_model< threshold_lin_rate_opn >(
-    "threshold_lin_rate_opn" );
-
-  // rate transformer nodes
-  kernel().model_manager.register_node_model< rate_transformer_gauss >(
-    "rate_transformer_gauss" );
-  kernel().model_manager.register_node_model< rate_transformer_lin >(
-    "rate_transformer_lin" );
-  kernel().model_manager.register_node_model< rate_transformer_sigmoid >(
-    "rate_transformer_sigmoid" );
-  kernel()
-    .model_manager.register_node_model< rate_transformer_sigmoid_gg_1998 >(
-      "rate_transformer_sigmoid_gg_1998" );
-  kernel().model_manager.register_node_model< rate_transformer_tanh >(
-    "rate_transformer_tanh" );
-  kernel().model_manager.register_node_model< rate_transformer_threshold_lin >(
-    "rate_transformer_threshold_lin" );
-
-  kernel().model_manager.register_node_model< iaf_chs_2007 >( "iaf_chs_2007" );
   kernel().model_manager.register_node_model< iaf_psc_alpha >(
     "iaf_psc_alpha" );
-  kernel().model_manager.register_node_model< iaf_psc_alpha_multisynapse >(
-    "iaf_psc_alpha_multisynapse" );
-  kernel().model_manager.register_node_model< iaf_psc_delta >(
-    "iaf_psc_delta" );
-  kernel().model_manager.register_node_model< iaf_psc_exp >( "iaf_psc_exp" );
-  kernel().model_manager.register_node_model< iaf_psc_exp_multisynapse >(
-    "iaf_psc_exp_multisynapse" );
-  kernel().model_manager.register_node_model< iaf_tum_2000 >( "iaf_tum_2000" );
-  kernel().model_manager.register_node_model< amat2_psc_exp >(
-    "amat2_psc_exp" );
-  kernel().model_manager.register_node_model< mat2_psc_exp >( "mat2_psc_exp" );
-  kernel().model_manager.register_node_model< parrot_neuron >(
-    "parrot_neuron" );
-  kernel().model_manager.register_node_model< pp_psc_delta >( "pp_psc_delta" );
-  kernel().model_manager.register_node_model< pp_pop_psc_delta >(
-    "pp_pop_psc_delta" );
-  kernel().model_manager.register_node_model< gif_psc_exp >( "gif_psc_exp" );
-  kernel().model_manager.register_node_model< gif_psc_exp_multisynapse >(
-    "gif_psc_exp_multisynapse" );
 
-  kernel().model_manager.register_node_model< ac_generator >( "ac_generator" );
-  kernel().model_manager.register_node_model< dc_generator >( "dc_generator" );
-  kernel().model_manager.register_node_model< spike_generator >(
-    "spike_generator" );
-  kernel().model_manager.register_node_model< inhomogeneous_poisson_generator >(
-    "inhomogeneous_poisson_generator" );
   kernel().model_manager.register_node_model< poisson_generator >(
     "poisson_generator" );
-  kernel().model_manager.register_node_model< pulsepacket_generator >(
-    "pulsepacket_generator" );
-  kernel().model_manager.register_node_model< noise_generator >(
-    "noise_generator" );
-  kernel().model_manager.register_node_model< step_current_generator >(
-    "step_current_generator" );
-  kernel().model_manager.register_node_model< step_rate_generator >(
-    "step_rate_generator" );
-  kernel().model_manager.register_node_model< mip_generator >(
-    "mip_generator" );
-  kernel().model_manager.register_node_model< sinusoidal_poisson_generator >(
-    "sinusoidal_poisson_generator" );
-  kernel().model_manager.register_node_model< ppd_sup_generator >(
-    "ppd_sup_generator" );
-  kernel().model_manager.register_node_model< gamma_sup_generator >(
-    "gamma_sup_generator" );
-  kernel().model_manager.register_node_model< erfc_neuron >( "erfc_neuron" );
-  kernel().model_manager.register_node_model< ginzburg_neuron >(
-    "ginzburg_neuron" );
-  kernel().model_manager.register_node_model< mcculloch_pitts_neuron >(
-    "mcculloch_pitts_neuron" );
-  kernel().model_manager.register_node_model< izhikevich >( "izhikevich" );
-  kernel().model_manager.register_node_model< spike_dilutor >(
-    "spike_dilutor" );
 
   kernel().model_manager.register_node_model< spike_detector >(
     "spike_detector" );
@@ -380,59 +242,14 @@ ModelsModule::init( SLIInterpreter* )
     name, vmdict, false );
 
 #ifdef HAVE_GSL
-  kernel().model_manager.register_node_model< iaf_chxk_2008 >(
-    "iaf_chxk_2008" );
-  kernel().model_manager.register_node_model< iaf_cond_alpha >(
-    "iaf_cond_alpha" );
-  kernel().model_manager.register_node_model< iaf_cond_beta >(
-    "iaf_cond_beta" );
   kernel().model_manager.register_node_model< iaf_cond_exp >( "iaf_cond_exp" );
-  kernel().model_manager.register_node_model< iaf_cond_exp_sfa_rr >(
-    "iaf_cond_exp_sfa_rr" );
-  kernel().model_manager.register_node_model< iaf_cond_alpha_mc >(
-    "iaf_cond_alpha_mc" );
-  kernel().model_manager.register_node_model< hh_cond_beta_gap_traub >(
-    "hh_cond_beta_gap_traub" );
-  kernel().model_manager.register_node_model< hh_psc_alpha >( "hh_psc_alpha" );
-  kernel().model_manager.register_node_model< hh_psc_alpha_clopath >(
-    "hh_psc_alpha_clopath" );
-  kernel().model_manager.register_node_model< hh_psc_alpha_gap >(
-    "hh_psc_alpha_gap" );
-  kernel().model_manager.register_node_model< hh_cond_exp_traub >(
-    "hh_cond_exp_traub" );
-  kernel().model_manager.register_node_model< sinusoidal_gamma_generator >(
-    "sinusoidal_gamma_generator" );
-  kernel().model_manager.register_node_model< gif_cond_exp >( "gif_cond_exp" );
-  kernel().model_manager.register_node_model< gif_cond_exp_multisynapse >(
-    "gif_cond_exp_multisynapse" );
-  kernel().model_manager.register_node_model< gif_pop_psc_exp >(
-    "gif_pop_psc_exp" );
-
-  kernel().model_manager.register_node_model< aeif_psc_delta_clopath >(
-    "aeif_psc_delta_clopath" );
-  kernel().model_manager.register_node_model< aeif_cond_alpha >(
-    "aeif_cond_alpha" );
-  kernel().model_manager.register_node_model< aeif_cond_exp >(
-    "aeif_cond_exp" );
-  kernel().model_manager.register_node_model< aeif_psc_alpha >(
-    "aeif_psc_alpha" );
-  kernel().model_manager.register_node_model< aeif_psc_exp >( "aeif_psc_exp" );
-  kernel().model_manager.register_node_model< aeif_psc_delta >(
-    "aeif_psc_delta" );
-  kernel().model_manager.register_node_model< ht_neuron >( "ht_neuron" );
-  kernel().model_manager.register_node_model< aeif_cond_beta_multisynapse >(
-    "aeif_cond_beta_multisynapse" );
-  kernel().model_manager.register_node_model< aeif_cond_alpha_multisynapse >(
-    "aeif_cond_alpha_multisynapse" );
-  kernel().model_manager.register_node_model< siegert_neuron >(
-    "siegert_neuron" );
 #endif
 
   // This version of the AdEx model does not depend on GSL.
-  kernel().model_manager.register_node_model< aeif_cond_alpha_RK5 >(
-    "aeif_cond_alpha_RK5",
-    /*private_model*/ false,
-    /*deprecation_info*/ "NEST 3.0" );
+  //kernel().model_manager.register_node_model< aeif_cond_alpha_RK5 >(
+  //  "aeif_cond_alpha_RK5",
+  //  /*private_model*/ false,
+  //  /*deprecation_info*/ "NEST 3.0" );
 
 #ifdef HAVE_MUSIC
   //// proxies for inter-application communication using MUSIC
@@ -486,41 +303,7 @@ ModelsModule::init( SLIInterpreter* )
     .register_connection_model< StaticConnectionHomW< TargetIdentifierIndex > >(
       "static_synapse_hom_w_hpc" );
 
-  /** @BeginDocumentation
-     Name: gap_junction - Connection model for gap junctions.
-     SeeAlso: synapsedict
-  */
-  kernel()
-    .model_manager
-    .register_secondary_connection_model< GapJunction< TargetIdentifierPtrRport > >(
-      "gap_junction",
-      /*has_delay=*/false,
-      /*requires_symmetric=*/true,
-      /*supports_wfr=*/true );
-  kernel()
-    .model_manager
-    .register_secondary_connection_model< RateConnectionInstantaneous< TargetIdentifierPtrRport > >(
-      "rate_connection_instantaneous",
-      /*has_delay=*/false,
-      /*requires_symmetric=*/false,
-      /*supports_wfr=*/true );
-  kernel()
-    .model_manager
-    .register_secondary_connection_model< RateConnectionDelayed< TargetIdentifierPtrRport > >(
-      "rate_connection_delayed",
-      /*has_delay=*/true,
-      /*requires_symmetric=*/false,
-      /*supports_wfr=*/false );
-  kernel()
-    .model_manager
-    .register_secondary_connection_model< DiffusionConnection< TargetIdentifierPtrRport > >(
-      "diffusion_connection",
-      /*has_delay=*/false,
-      /*requires_symmetric=*/false,
-      /*supports_wfr=*/true );
-
-
-  /** @BeginDocumentation
+  /* BeginDocumentation
      Name: stdp_synapse_hpc - Variant of stdp_synapse with low memory
      consumption.
      SeeAlso: synapsedict, stdp_synapse, static_synapse_hpc
@@ -555,38 +338,7 @@ ModelsModule::init( SLIInterpreter* )
     .register_connection_model< STDPPLConnectionHom< TargetIdentifierIndex > >(
       "stdp_pl_synapse_hom_hpc" );
 
-
-  /** @BeginDocumentation
-     Name: stdp_triplet_synapse_hpc - Variant of stdp_triplet_synapse with low
-     memory consumption.
-     SeeAlso: synapsedict, stdp_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< STDPTripletConnection< TargetIdentifierPtrRport > >(
-      "stdp_triplet_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< STDPTripletConnection< TargetIdentifierIndex > >(
-      "stdp_triplet_synapse_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: quantal_stp_synapse_hpc - Variant of quantal_stp_synapse with low
-     memory consumption.
-     SeeAlso: synapsedict, quantal_stp_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< Quantal_StpConnection< TargetIdentifierPtrRport > >(
-      "quantal_stp_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< Quantal_StpConnection< TargetIdentifierIndex > >(
-      "quantal_stp_synapse_hpc" );
-
-
-  /** @BeginDocumentation
+  /* BeginDocumentation
      Name: stdp_synapse_hom_hpc - Variant of quantal_stp_synapse with low memory
      consumption.
      SeeAlso: synapsedict, stdp_synapse_hom, static_synapse_hpc
@@ -600,126 +352,7 @@ ModelsModule::init( SLIInterpreter* )
     .register_connection_model< STDPConnectionHom< TargetIdentifierIndex > >(
       "stdp_synapse_hom_hpc" );
 
-
-  /** @BeginDocumentation
-     Name: stdp_facetshw_synapse_hom_hpc - Variant of stdp_facetshw_synapse_hom
-     with low memory consumption.
-     SeeAlso: synapsedict, stdp_facetshw_synapse_hom, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< STDPFACETSHWConnectionHom< TargetIdentifierPtrRport > >(
-      "stdp_facetshw_synapse_hom" );
-  kernel()
-    .model_manager
-    .register_connection_model< STDPFACETSHWConnectionHom< TargetIdentifierIndex > >(
-      "stdp_facetshw_synapse_hom_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: cont_delay_synapse_hpc - Variant of cont_delay_synapse with low
-     memory consumption.
-     SeeAlso: synapsedict, cont_delay_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< ContDelayConnection< TargetIdentifierPtrRport > >(
-      "cont_delay_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< ContDelayConnection< TargetIdentifierIndex > >(
-      "cont_delay_synapse_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: tsodyks_synapse_hpc - Variant of tsodyks_synapse with low memory
-     consumption.
-     SeeAlso: synapsedict, tsodyks_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< TsodyksConnection< TargetIdentifierPtrRport > >(
-      "tsodyks_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< TsodyksConnection< TargetIdentifierIndex > >(
-      "tsodyks_synapse_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: tsodyks_synapse_hom_hpc - Variant of tsodyks_synapse_hom with low
-     memory consumption.
-     SeeAlso: synapsedict, tsodyks_synapse_hom, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< TsodyksConnectionHom< TargetIdentifierPtrRport > >(
-      "tsodyks_synapse_hom" );
-  kernel()
-    .model_manager
-    .register_connection_model< TsodyksConnectionHom< TargetIdentifierIndex > >(
-      "tsodyks_synapse_hom_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: tsodyks2_synapse_hpc - Variant of tsodyks2_synapse with low memory
-     consumption.
-     SeeAlso: synapsedict, tsodyks2_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< Tsodyks2Connection< TargetIdentifierPtrRport > >(
-      "tsodyks2_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< Tsodyks2Connection< TargetIdentifierIndex > >(
-      "tsodyks2_synapse_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: ht_synapse_hpc - Variant of ht_synapse with low memory consumption.
-     SeeAlso: synapsedict, ht_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< HTConnection< TargetIdentifierPtrRport > >(
-      "ht_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< HTConnection< TargetIdentifierIndex > >(
-      "ht_synapse_hpc" );
-
-
-  /** @BeginDocumentation
-     Name: stdp_dopamine_synapse_hpc - Variant of stdp_dopamine_synapse with low
-     memory consumption.
-     SeeAlso: synapsedict, stdp_dopamine_synapse, static_synapse_hpc
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< STDPDopaConnection< TargetIdentifierPtrRport > >(
-      "stdp_dopamine_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< STDPDopaConnection< TargetIdentifierIndex > >(
-      "stdp_dopamine_synapse_hpc" );
-
-  /** @BeginDocumentation
-     Name: vogels_sprekeler_synapse_hpc - Variant of vogels_sprekeler_synapse
-     with low memory
-     consumption.
-     SeeAlso: synapsedict, vogels_sprekeler_synapse
-  */
-  kernel()
-    .model_manager
-    .register_connection_model< VogelsSprekelerConnection< TargetIdentifierPtrRport > >(
-      "vogels_sprekeler_synapse" );
-  kernel()
-    .model_manager
-    .register_connection_model< VogelsSprekelerConnection< TargetIdentifierIndex > >(
-      "vogels_sprekeler_synapse_hpc" );
-
-  /** @BeginDocumentation
+  /* BeginDocumentation
      Name: bernoulli_synapse - Static synapse with stochastic transmission
      SeeAlso: synapsedict, static_synapse, static_synapse_hom_w
   */


### PR DESCRIPTION
In the latest FCC for K computer, static builds are not supported, so remove the line static-libraries to ON. Also, remove hard-coded MPI-related variables.

Suggested reviewers, @heplesser , @jarsi , @suku248 .