### PR TITLE
Update FindLibNeurosim to take Python version into account

### DIFF
--- a/cmake/FindLibNeurosim.cmake
+++ b/cmake/FindLibNeurosim.cmake
@@ -36,10 +36,17 @@ find_library( NEUROSIM_LIBRARY
     HINTS ${LIBNEUROSIM_ROOT}/lib
     )
 
-find_library( PYNEUROSIM_LIBRARY
-    NAMES pyneurosim
-    HINTS ${LIBNEUROSIM_ROOT}/lib
+if ( ${PYTHON_VERSION} VERSION_GREATER "3" )
+    find_library( PYNEUROSIM_LIBRARY
+        NAMES py3neurosim
+        HINTS ${LIBNEUROSIM_ROOT}/lib
     )
+else ()
+    find_library( PYNEUROSIM_LIBRARY
+        NAMES pyneurosim
+        HINTS ${LIBNEUROSIM_ROOT}/lib
+    )
+endif ()
 
 if ( EXISTS "${LIBNEUROSIM_INCLUDE_DIR}/neurosim/version.h" )
   file( STRINGS "${LIBNEUROSIM_INCLUDE_DIR}/neurosim/version.h"


### PR DESCRIPTION
(fixes #1080). I think this change could be fine as it is, but I have several questions the could be answered before merging to avoid complications down the build process: 

how can I validate that python 3 is working in the final build for libneurosim? I'm looking for a simple script like `python -c "import nest;nest.checklibneurosim"`, something that would break if libneurosim was not properly integrated. If `make installcheck` already takes care of that, please let me know. 

I'm thinking about making some dockerimages, that compile different setups to make sure, that setups that are supposed to fail, do fail. The different setups would be:
  - compile nest with python2 and without libneurosim
  - compile nest with python3 and without libneurosim
  - compile nest with python2 and with py2neurosim
  - compile nest with python3 and with py2neurosim (should fail)
  - compile nest with python2 and with py3neurosim (should fail)
  - compile nest with python3 and with py3neurosim

I would just post the dockerfiles as comment in this PR along with their respective outputs. I'm not sure if there would be a better way to validate the results. And I don't know if it would even be worth the hassle, since the changes are rather small to begin with. 

____

on a side-note: yesterday I asked on info@nest-initiative.org where to send the contributors-agreement to. I have not yet received an answer yet. Preferably I'd sent it per email to somewhere; If that's not possible I'd like to sent it to a location in Germany, maybe even close to Karlsruhe. Please let me know where to sent the contributors-agreement