### PR TITLE
Add decorator that can wrap pynest functions to accept plain GIDs

### DIFF
--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -107,6 +107,7 @@ def GetConnections(source=None, target=None, synapse_model=None,
     return spp()
 
 
+@possibly_promote_plain_gid_to_iterable(0, 1)
 @check_stack
 def Connect(pre, post, conn_spec=None, syn_spec=None, model=None):
     """

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -202,6 +202,7 @@ def message(level, sender, text):
     sr('message')
 
 
+@possibly_promote_plain_gid_to_iterable(0)
 @check_stack
 def SetStatus(nodes, params, val=None):
     """Set parameters of nodes or connections.
@@ -269,6 +270,7 @@ def SetStatus(nodes, params, val=None):
     sr('Transpose { arrayload pop SetStatus } forall')
 
 
+@possibly_promote_plain_gid_to_iterable(0, demote_output=True)
 @check_stack
 def GetStatus(nodes, keys=None, output=''):
     """Return the parameter dictionaries of nodes or connections.


### PR DESCRIPTION
Are your tired of littering your beautiful pynest code with superfluous square brackets?
```python
n = nest.Create('iaf_psc_delta', 2)
nest.SetStatus([n[0]], {'I_e': 400.})
nest.Connect([n[0]], [n[1]])
```
That doesn't look very nice!
Fear no more, now you can provide plain GIDs to pynest functions!
```python
n = nest.Create('iaf_psc_delta', 2)
nest.SetStatus(n[0], {'I_e': 400.})
nest.Connect(n[0], n[1])
```
Much better!

In all seriousness, I feel like this feature existed before but was removed for consistency? I think that for good reasons one can depart from consistency (only arrays!), as long as the departure is intuitive. I would argue that this is the case here.

I've not decorated all functions yet as I first wanted to hear your thoughts @heplesser @suku248 @jougs @stinebuu @hakonsbm 