### PR TITLE
Add support for sending secondary events to and from devices

### DIFF
--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -186,8 +186,7 @@ iaf_psc_exp_multisynapse::Parameters_::set( const DictionaryDatum& d )
       }
       if ( tau_syn_[ i ] == Tau_ )
       {
-        throw BadProperty(
-          "Membrane and synapse time constant(s) must differ. See note in documentation." );
+        throw BadProperty( "Membrane and synapse time constant(s) must differ. See note in documentation." );
       }
     }
   }

--- a/models/step_rate_generator.h
+++ b/models/step_rate_generator.h
@@ -101,6 +101,12 @@ public:
   step_rate_generator();
   step_rate_generator( const step_rate_generator& );
 
+  bool
+  has_proxies() const
+  {
+    return false;
+  }
+
   // port send_test_event( Node&, rport, synindex, bool );
   void
   sends_secondary_event( DelayedRateConnectionEvent& )

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -252,6 +252,7 @@ public:
    * Send event e to all device targets of source source_gid
    */
   void send_to_devices( const thread tid, const index source_gid, Event& e );
+  void send_to_devices( const thread tid, const index source_gid, SecondaryEvent& e );
 
   /**
    * Send event e to all targets of source device ldid (local device id)

--- a/nestkernel/connection_manager_impl.h
+++ b/nestkernel/connection_manager_impl.h
@@ -57,6 +57,13 @@ ConnectionManager::send_to_devices( const thread tid, const index source_gid, Ev
 }
 
 inline void
+ConnectionManager::send_to_devices( const thread tid, const index source_gid, SecondaryEvent& e )
+{
+  target_table_devices_.send_to_device(
+    tid, source_gid, e, kernel().model_manager.get_synapse_prototypes( tid ) );
+}
+
+inline void
 ConnectionManager::send_from_device( const thread tid, const index ldid, Event& e )
 {
   target_table_devices_.send_from_device( tid, ldid, e, kernel().model_manager.get_synapse_prototypes( tid ) );

--- a/nestkernel/connection_manager_impl.h
+++ b/nestkernel/connection_manager_impl.h
@@ -59,8 +59,7 @@ ConnectionManager::send_to_devices( const thread tid, const index source_gid, Ev
 inline void
 ConnectionManager::send_to_devices( const thread tid, const index source_gid, SecondaryEvent& e )
 {
-  target_table_devices_.send_to_device(
-    tid, source_gid, e, kernel().model_manager.get_synapse_prototypes( tid ) );
+  target_table_devices_.send_to_device( tid, source_gid, e, kernel().model_manager.get_synapse_prototypes( tid ) );
 }
 
 inline void

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -81,7 +81,7 @@ public:
   /**
    * Send a secondary event remote.
    */
-  void send_secondary( const Node& source, SecondaryEvent& e );
+  void send_secondary( Node& source, SecondaryEvent& e );
 
   /**
    * Send event e to all targets of node source on thread t
@@ -349,6 +349,7 @@ private:
    */
   template < class EventT >
   void send_local_( Node& source, EventT& e, const long lag );
+  void send_local_( Node& source, SecondaryEvent& e, const long lag );
 
   //--------------------------------------------------//
 

--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -149,7 +149,7 @@ EventDeliveryManager::send_secondary( Node& source, SecondaryEvent& e )
     // considered.
     const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
     for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin(); cit != supported_syn_ids.end();
-	++cit )
+          ++cit )
     {
       const std::vector< size_t >& positions =
         kernel().connection_manager.get_secondary_send_buffer_positions( tid, lid, *cit );
@@ -159,15 +159,14 @@ EventDeliveryManager::send_secondary( Node& source, SecondaryEvent& e )
         std::vector< unsigned int >::iterator it = send_buffer_secondary_events_.begin() + positions[ i ];
         e >> it;
       }
-
     }
     kernel().connection_manager.send_to_devices( tid, source_gid, e );
   }
   else
   {
-    send_local_( source, e, 0 );  // need to pass lag (last argument), but not
-                                  // used in template specialization, so pass
-                                  // zero as dummy value
+    send_local_( source, e, 0 ); // need to pass lag (last argument), but not
+                                 // used in template specialization, so pass
+                                 // zero as dummy value
   }
 }
 

--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -44,6 +44,17 @@ EventDeliveryManager::send_local_( Node& source, EventT& e, const long lag )
   kernel().connection_manager.send_from_device( t, ldid, e );
 }
 
+inline void
+EventDeliveryManager::send_local_( Node& source, SecondaryEvent& e, const long )
+{
+  assert( not source.has_proxies() );
+  e.set_stamp( kernel().simulation_manager.get_slice_origin() + Time::step( 1 ) );
+  e.set_sender( source );
+  const thread t = source.get_thread();
+  const index ldid = source.get_local_device_id();
+  kernel().connection_manager.send_from_device( t, ldid, e );
+}
+
 template < class EventT >
 inline void
 EventDeliveryManager::send( Node& source, EventT& e, const long lag )
@@ -124,25 +135,39 @@ EventDeliveryManager::send_off_grid_remote( thread tid, SpikeEvent& e, const lon
 }
 
 inline void
-EventDeliveryManager::send_secondary( const Node& source, SecondaryEvent& e )
+EventDeliveryManager::send_secondary( Node& source, SecondaryEvent& e )
 {
   const thread tid = kernel().vp_manager.get_thread_id();
-  const index lid = kernel().vp_manager.gid_to_lid( source.get_gid() );
+  const index source_gid = source.get_gid();
+  const index lid = kernel().vp_manager.gid_to_lid( source_gid );
 
-  // We need to consider every synapse type this event supports to
-  // make sure also labeled and connection created by CopyModel are
-  // considered.
-  const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
-  for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin(); cit != supported_syn_ids.end(); ++cit )
+  if ( source.has_proxies() )
   {
-    const std::vector< size_t >& positions =
-      kernel().connection_manager.get_secondary_send_buffer_positions( tid, lid, *cit );
 
-    for ( size_t i = 0; i < positions.size(); ++i )
+    // We need to consider every synapse type this event supports to
+    // make sure also labeled and connection created by CopyModel are
+    // considered.
+    const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
+    for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin(); cit != supported_syn_ids.end();
+	++cit )
     {
-      std::vector< unsigned int >::iterator it = send_buffer_secondary_events_.begin() + positions[ i ];
-      e >> it;
+      const std::vector< size_t >& positions =
+        kernel().connection_manager.get_secondary_send_buffer_positions( tid, lid, *cit );
+
+      for ( size_t i = 0; i < positions.size(); ++i )
+      {
+        std::vector< unsigned int >::iterator it = send_buffer_secondary_events_.begin() + positions[ i ];
+        e >> it;
+      }
+
     }
+    kernel().connection_manager.send_to_devices( tid, source_gid, e );
+  }
+  else
+  {
+    send_local_( source, e, 0 );  // need to pass lag (last argument), but not
+                                  // used in template specialization, so pass
+                                  // zero as dummy value
   }
 }
 

--- a/nestkernel/target_table_devices.h
+++ b/nestkernel/target_table_devices.h
@@ -104,8 +104,8 @@ public:
    * Sends a spike event to all targets of the source neuron.
    */
   void send_to_device( const thread tid, const index s_gid, Event& e, const std::vector< ConnectorModel* >& cm );
-  void send_to_device( const thread tid, const index s_gid, SecondaryEvent& e,
-                       const std::vector< ConnectorModel* >& cm );
+  void
+  send_to_device( const thread tid, const index s_gid, SecondaryEvent& e, const std::vector< ConnectorModel* >& cm );
 
   /**
    * Sends a spike event to all targets of the source device.

--- a/nestkernel/target_table_devices.h
+++ b/nestkernel/target_table_devices.h
@@ -104,6 +104,8 @@ public:
    * Sends a spike event to all targets of the source neuron.
    */
   void send_to_device( const thread tid, const index s_gid, Event& e, const std::vector< ConnectorModel* >& cm );
+  void send_to_device( const thread tid, const index s_gid, SecondaryEvent& e,
+                       const std::vector< ConnectorModel* >& cm );
 
   /**
    * Sends a spike event to all targets of the source device.

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -91,14 +91,14 @@ nest::TargetTableDevices::send_to_device( const thread tid,
 }
 
 inline void
-nest::TargetTableDevices::send_to_device( const thread tid, const index source_gid, SecondaryEvent& e,
+nest::TargetTableDevices::send_to_device( const thread tid,
+  const index source_gid,
+  SecondaryEvent& e,
   const std::vector< ConnectorModel* >& cm )
 {
   const index lid = kernel().vp_manager.gid_to_lid( source_gid );
   const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
-  for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin();
-        cit != supported_syn_ids.end();
-        ++cit )
+  for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin(); cit != supported_syn_ids.end(); ++cit )
   {
     if ( target_to_devices_[ tid ][ lid ][ *cit ] != NULL )
     {

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -34,14 +34,14 @@
 inline void
 nest::TargetTableDevices::add_connection_to_device( Node& source,
   Node& target,
-  const index s_gid,
+  const index source_gid,
   const thread tid,
   const synindex syn_id,
   const DictionaryDatum& p,
   const double d,
   const double w )
 {
-  const index lid = kernel().vp_manager.gid_to_lid( s_gid );
+  const index lid = kernel().vp_manager.gid_to_lid( source_gid );
   assert( lid < target_to_devices_[ tid ].size() );
   assert( syn_id < target_to_devices_[ tid ][ lid ].size() );
 
@@ -74,11 +74,11 @@ nest::TargetTableDevices::add_connection_from_device( Node& source,
 
 inline void
 nest::TargetTableDevices::send_to_device( const thread tid,
-  const index s_gid,
+  const index source_gid,
   Event& e,
   const std::vector< ConnectorModel* >& cm )
 {
-  const index lid = kernel().vp_manager.gid_to_lid( s_gid );
+  const index lid = kernel().vp_manager.gid_to_lid( source_gid );
   for ( std::vector< ConnectorBase* >::iterator it = target_to_devices_[ tid ][ lid ].begin();
         it != target_to_devices_[ tid ][ lid ].end();
         ++it )
@@ -86,6 +86,23 @@ nest::TargetTableDevices::send_to_device( const thread tid,
     if ( *it != NULL )
     {
       ( *it )->send_to_all( tid, cm, e );
+    }
+  }
+}
+
+inline void
+nest::TargetTableDevices::send_to_device( const thread tid, const index source_gid, SecondaryEvent& e,
+  const std::vector< ConnectorModel* >& cm )
+{
+  const index lid = kernel().vp_manager.gid_to_lid( source_gid );
+  const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
+  for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin();
+        cit != supported_syn_ids.end();
+        ++cit )
+  {
+    if ( target_to_devices_[ tid ][ lid ][ *cit ] != NULL )
+    {
+      target_to_devices_[ tid ][ lid ][ *cit ]->send_to_all( tid, cm, e );
     }
   }
 }

--- a/testsuite/cpptests/test_streamers.h
+++ b/testsuite/cpptests/test_streamers.h
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_SUITE( test_streamers )
 BOOST_AUTO_TEST_CASE( test_int )
 {
   std::ostringstream s;
-  const std::vector<int> x = {2, 3, 4, 5};
+  const std::vector< int > x = { 2, 3, 4, 5 };
 
   s << x;
 


### PR DESCRIPTION
So far, secondary events could only be exchanged between neurons. This PR adds the necessary changes to make sure that secondary events can be sent to/received from devices.

I suggest @janhahne @suku248 as reviewers

branches off from #1243, so should be merged after