### PR TITLE
Add support for rate data in MUSIC proxies

### DIFF
--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -79,6 +79,8 @@ set( models_sources
     music_cont_out_proxy.h music_cont_out_proxy.cpp
     music_event_in_proxy.h music_event_in_proxy.cpp
     music_event_out_proxy.h music_event_out_proxy.cpp
+    music_rate_in_proxy.h music_rate_in_proxy.cpp
+    music_rate_out_proxy.h music_rate_out_proxy.cpp
     music_message_in_proxy.h music_message_in_proxy.cpp
     noise_generator.h noise_generator.cpp
     parrot_neuron.h parrot_neuron.cpp

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -166,6 +166,8 @@
 #include "music_cont_in_proxy.h"
 #include "music_cont_out_proxy.h"
 #include "music_message_in_proxy.h"
+#include "music_rate_in_proxy.h"
+#include "music_rate_out_proxy.h"
 #endif
 
 namespace nest
@@ -378,6 +380,8 @@ ModelsModule::init( SLIInterpreter* )
   kernel().model_manager.register_node_model< music_cont_in_proxy >( "music_cont_in_proxy" );
   kernel().model_manager.register_node_model< music_cont_out_proxy >( "music_cont_out_proxy" );
   kernel().model_manager.register_node_model< music_message_in_proxy >( "music_message_in_proxy" );
+  kernel().model_manager.register_node_model< music_rate_in_proxy >( "music_rate_in_proxy" );
+  kernel().model_manager.register_node_model< music_rate_out_proxy >( "music_rate_out_proxy" );
 #endif
 
   // register synapses

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -149,7 +149,7 @@ nest::music_rate_in_proxy::get_status( DictionaryDatum& d ) const
   P_.get( d );
   S_.get( d );
 
-  // TODO  ( *d )[ "data" ] = DoubleVectorDatum( new std::vector< double >( B_.data_ ) );
+  ( *d )[ names::data ] = DoubleVectorDatum( new std::vector< double >( B_.data_ ) );
 }
 
 void

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -76,7 +76,7 @@ nest::music_rate_in_proxy::Parameters_::set( const DictionaryDatum& d, State_& s
   //  if(d->known(names::port_name) && s.registered_)
   //    throw MUSICPortAlreadyPublished(get_name(), P_.port_name_);
 
-  if ( !s.registered_ )
+  if ( not s.registered_ )
   {
     updateValue< string >( d, names::port_name, port_name_ );
     updateValue< long >( d, names::music_channel, channel_ );
@@ -136,7 +136,7 @@ void
 nest::music_rate_in_proxy::calibrate()
 {
   // only publish the port once
-  if ( !S_.registered_ )
+  if ( not S_.registered_ )
   {
     kernel().music_manager.register_music_rate_in_proxy( P_.port_name_, P_.channel_, this );
     S_.registered_ = true;

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -1,0 +1,183 @@
+/*
+ *  music_rate_in_proxy.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "music_rate_in_proxy.h"
+
+#ifdef HAVE_MUSIC
+
+// Includes from sli:
+#include "arraydatum.h"
+#include "dict.h"
+#include "dictutils.h"
+#include "doubledatum.h"
+#include "integerdatum.h"
+
+// Includes from libnestutil:
+#include "compose.hpp"
+#include "logging.h"
+
+// Includes from nestkernel:
+#include "kernel_manager.h"
+
+/* ----------------------------------------------------------------
+ * Default constructors defining default parameters and state
+ * ---------------------------------------------------------------- */
+
+nest::music_rate_in_proxy::Parameters_::Parameters_()
+  : port_name_( "rate_in" )
+  , channel_( 0 )
+{
+}
+
+nest::music_rate_in_proxy::Parameters_::Parameters_( const Parameters_& op )
+  : port_name_( op.port_name_ )
+  , channel_( op.channel_ )
+{
+}
+
+nest::music_rate_in_proxy::State_::State_()
+  : registered_( false )
+{
+}
+
+/* ----------------------------------------------------------------
+ * Parameter extraction and manipulation functions
+ * ---------------------------------------------------------------- */
+
+void
+nest::music_rate_in_proxy::Parameters_::get( DictionaryDatum& d ) const
+{
+  ( *d )[ names::port_name ] = port_name_;
+}
+
+void
+nest::music_rate_in_proxy::Parameters_::set( const DictionaryDatum& d, State_& s )
+{
+  // TODO: This is not possible, as P_ does not know about get_name()
+  //  if(d->known(names::port_name) && s.registered_)
+  //    throw MUSICPortAlreadyPublished(get_name(), P_.port_name_);
+
+  if ( !s.registered_ )
+  {
+    updateValue< string >( d, names::port_name, port_name_ );
+    updateValue< long >( d, names::music_channel, channel_ );
+  }
+}
+
+void
+nest::music_rate_in_proxy::State_::get( DictionaryDatum& d ) const
+{
+  ( *d )[ names::registered ] = registered_;
+}
+
+void
+nest::music_rate_in_proxy::State_::set( const DictionaryDatum&, const Parameters_& )
+{
+}
+
+
+/* ----------------------------------------------------------------
+ * Default and copy constructor for node
+ * ---------------------------------------------------------------- */
+
+nest::music_rate_in_proxy::music_rate_in_proxy()
+  : DeviceNode()
+  , P_()
+  , S_()
+{
+}
+
+nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
+  : DeviceNode( n )
+  , P_( n.P_ )
+  , S_( n.S_ )
+{
+  kernel().music_manager.register_music_in_port( P_.port_name_, true );
+}
+
+
+/* ----------------------------------------------------------------
+ * Node initialization functions
+ * ---------------------------------------------------------------- */
+
+void
+nest::music_rate_in_proxy::init_state_( const Node& proto )
+{
+  const music_rate_in_proxy& pr = downcast< music_rate_in_proxy >( proto );
+
+  S_ = pr.S_;
+}
+
+void
+nest::music_rate_in_proxy::init_buffers_()
+{
+}
+
+void
+nest::music_rate_in_proxy::calibrate()
+{
+  // only publish the port once
+  if ( !S_.registered_ )
+  {
+    kernel().music_manager.register_music_rate_in_proxy( P_.port_name_, P_.channel_, this );
+    S_.registered_ = true;
+  }
+}
+
+void
+nest::music_rate_in_proxy::get_status( DictionaryDatum& d ) const
+{
+  P_.get( d );
+  S_.get( d );
+
+  // TODO  ( *d )[ "data" ] = DoubleVectorDatum( new std::vector< double >( B_.data_ ) );
+}
+
+void
+nest::music_rate_in_proxy::set_status( const DictionaryDatum& d )
+{
+  Parameters_ ptmp = P_; // temporary copy in case of errors
+  ptmp.set( d, S_ );     // throws if BadProperty
+
+  State_ stmp = S_;
+  stmp.set( d, P_ ); // throws if BadProperty
+
+  // if we get here, temporaries contain consistent set of properties
+  kernel().music_manager.register_music_in_port( ptmp.port_name_ );
+  kernel().music_manager.unregister_music_in_port( P_.port_name_ );
+  P_ = ptmp;
+  S_ = stmp;
+}
+
+void
+nest::music_rate_in_proxy::update( Time const& origin, const long from, const long to )
+{
+}
+
+void
+nest::music_rate_in_proxy::handle( InstantaneousRateConnectionEvent& e )
+{
+  kernel().event_delivery_manager.send_secondary( *this, e );
+}
+
+
+#endif

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -47,15 +47,15 @@
 
 /*BeginDocumentation
 
-Name: music_rate_in_proxy - A device which receives continuous data from MUSIC.
+Name: music_rate_in_proxy - A device which receives rate data from MUSIC.
 
 Description:
-A music_rate_in_proxy can be used to receive continuous data from
+A music_rate_in_proxy can be used to receive rate data from
 remote MUSIC applications in NEST.
 
 It uses the MUSIC library to receive the data from other applications.
 The music_rate_in_proxy represents a complete port to which MUSIC can
-connect and send data. The music_rate_in_proxy can queried using
+connect and send data. The music_rate_in_proxy can be queried using
 GetStatus to retrieve the messages.
 
 Parameters:
@@ -75,19 +75,18 @@ Examples:
 10 Simulate
 mcip GetStatus /data get /gaze_directions Set
 
-Author: Jochen Martin Eppler
-FirstVersion: July 2010
+Author: Philipp Weidel, Jakob Jordan
+FirstVersion: June 2019
 Availability: Only when compiled with MUSIC
 
-SeeAlso: music_event_out_proxy, music_event_in_proxy, music_message_in_proxy
+SeeAlso: music_rate_out_proxy, music_cont_in_proxy
 */
 
 namespace nest
 {
 /**
- * Emit spikes at times received from another application via a
- * MUSIC port. The timestamps of the events also contain offsets,
- * which makes it also useful for precise spikes.
+ * Emit rate at times received from another application via a
+ * MUSIC port.
  */
 class music_rate_in_proxy : public DeviceNode
 {

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -1,0 +1,195 @@
+/*
+ *  music_rate_in_proxy.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MUSIC_RATE_IN_PROXY_H
+#define MUSIC_RATE_IN_PROXY_H
+
+// Generated includes:
+#include "config.h"
+
+#ifdef HAVE_MUSIC
+
+// C includes:
+#include <mpi.h>
+
+// C++ includes:
+#include <vector>
+
+// External includes:
+#include <music.hh>
+
+// Includes from nestkernel:
+#include "device_node.h"
+#include "nest_types.h"
+#include "node.h"
+
+// Includes from sli:
+#include "arraydatum.h"
+
+/*BeginDocumentation
+
+Name: music_rate_in_proxy - A device which receives continuous data from MUSIC.
+
+Description:
+A music_rate_in_proxy can be used to receive continuous data from
+remote MUSIC applications in NEST.
+
+It uses the MUSIC library to receive the data from other applications.
+The music_rate_in_proxy represents a complete port to which MUSIC can
+connect and send data. The music_rate_in_proxy can queried using
+GetStatus to retrieve the messages.
+
+Parameters:
+The following properties are available in the status dictionary:
+
+port_name      - The name of the MUSIC input port to listen to (default:
+                 rate_in)
+port_width     - The width of the MUSIC input port
+data           - The data received on the port as vector of doubles
+published      - A bool indicating if the port has been already published
+                 with MUSIC
+
+The parameter port_name can be set using SetStatus.
+
+Examples:
+/music_rate_in_proxy Create /mcip Set
+10 Simulate
+mcip GetStatus /data get /gaze_directions Set
+
+Author: Jochen Martin Eppler
+FirstVersion: July 2010
+Availability: Only when compiled with MUSIC
+
+SeeAlso: music_event_out_proxy, music_event_in_proxy, music_message_in_proxy
+*/
+
+namespace nest
+{
+/**
+ * Emit spikes at times received from another application via a
+ * MUSIC port. The timestamps of the events also contain offsets,
+ * which makes it also useful for precise spikes.
+ */
+class music_rate_in_proxy : public DeviceNode
+{
+
+public:
+  music_rate_in_proxy();
+  music_rate_in_proxy( const music_rate_in_proxy& );
+
+  bool
+  has_proxies() const
+  {
+    return false;
+  }
+  bool
+  one_node_per_process() const
+  {
+    return true;
+  }
+
+  /**
+   * Import sets of overloaded virtual functions.
+   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
+   * Hiding
+   */
+  using Node::handle;
+  using Node::handles_test_event;
+
+  void handle( InstantaneousRateConnectionEvent& );
+
+  void get_status( DictionaryDatum& ) const;
+  void set_status( const DictionaryDatum& );
+
+  using Node::sends_secondary_event;
+  void
+  sends_secondary_event( InstantaneousRateConnectionEvent& )
+  {
+  }
+  void
+  sends_secondary_event( DelayedRateConnectionEvent& )
+  {
+  }
+
+private:
+  void init_state_( const Node& );
+  void init_buffers_();
+  void calibrate();
+
+  void update( Time const&, const long, const long );
+
+  // ------------------------------------------------------------
+
+  struct State_;
+
+  struct Parameters_
+  {
+    std::string port_name_; //!< the name of MUSIC port to connect to
+    int channel_;           //!< the MUSIC channel of the port
+
+    Parameters_();                     //!< Sets default parameter values
+    Parameters_( const Parameters_& ); //!< Recalibrate all times
+
+    void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
+    void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary
+  };
+
+  // ------------------------------------------------------------
+
+  struct State_
+  {
+    bool registered_; //!< indicates whether this node has been published already
+                      //!< with MUSIC
+
+    State_(); //!< Sets default state value
+
+    void get( DictionaryDatum& ) const; //!< Store current values in dictionary
+    //! Set values from dictionary
+    void set( const DictionaryDatum&, const Parameters_& );
+  };
+
+  // ------------------------------------------------------------
+
+  struct Buffers_
+  {
+    double data_;
+  };
+
+  // ------------------------------------------------------------
+
+  struct Variables_
+  {
+  };
+
+  // ------------------------------------------------------------
+
+  Parameters_ P_;
+  State_ S_;
+  Buffers_ B_;
+  Variables_ V_;
+};
+
+} // namespace
+
+#endif
+
+#endif /* #ifndef MUSIC_RATE_IN_PROXY_H */

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -28,9 +28,6 @@
 
 #ifdef HAVE_MUSIC
 
-// C includes:
-#include <mpi.h>
-
 // C++ includes:
 #include <vector>
 

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -1,0 +1,240 @@
+/*
+ *  music_rate_out_proxy.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "music_rate_out_proxy.h"
+
+#ifdef HAVE_MUSIC
+
+// C++ includes:
+#include <numeric>
+
+// Includes from sli:
+#include "arraydatum.h"
+#include "dict.h"
+#include "dictutils.h"
+#include "doubledatum.h"
+#include "integerdatum.h"
+
+// Includes from libnestutil:
+#include "compose.hpp"
+#include "logging.h"
+
+// Includes from nestkernel:
+#include "kernel_manager.h"
+
+/* ----------------------------------------------------------------
+ * Default constructors defining default parameters and state
+ * ---------------------------------------------------------------- */
+
+nest::music_rate_out_proxy::Parameters_::Parameters_()
+  : port_name_( "rate_out" )
+{
+}
+
+nest::music_rate_out_proxy::Parameters_::Parameters_( const Parameters_& op )
+  : port_name_( op.port_name_ )
+{
+}
+
+nest::music_rate_out_proxy::State_::State_()
+  : published_( false )
+  , port_width_( -1 )
+{
+}
+
+nest::music_rate_out_proxy::Buffers_::Buffers_()
+  : data_()
+{
+}
+
+nest::music_rate_out_proxy::Buffers_::Buffers_( const Buffers_& b )
+  : data_( b.data_ )
+{
+}
+
+/* ----------------------------------------------------------------
+ * Parameter extraction and manipulation functions
+ * ---------------------------------------------------------------- */
+
+void
+nest::music_rate_out_proxy::Parameters_::get( DictionaryDatum& d ) const
+{
+  ( *d )[ names::port_name ] = port_name_;
+}
+
+void
+nest::music_rate_out_proxy::Parameters_::set( const DictionaryDatum& d, State_& s )
+{
+  // TODO: This is not possible, as P_ does not know about get_name()
+  //  if(d->known(names::port_name) && s.published_)
+  //    throw MUSICPortAlreadyPublished(get_name(), P_.port_name_);
+
+  if ( !s.published_ )
+    updateValue< string >( d, names::port_name, port_name_ );
+}
+
+void
+nest::music_rate_out_proxy::State_::get( DictionaryDatum& d ) const
+{
+  ( *d )[ names::published ] = published_;
+  ( *d )[ names::port_width ] = port_width_;
+}
+
+void
+nest::music_rate_out_proxy::State_::set( const DictionaryDatum&, const Parameters_& )
+{
+}
+
+
+/* ----------------------------------------------------------------
+ * Default and copy constructor for node
+ * ---------------------------------------------------------------- */
+
+nest::music_rate_out_proxy::music_rate_out_proxy()
+  : DeviceNode()
+  , P_()
+  , S_()
+{
+}
+
+nest::music_rate_out_proxy::music_rate_out_proxy( const music_rate_out_proxy& n )
+  : DeviceNode( n )
+  , P_( n.P_ )
+  , S_( n.S_ )
+{
+}
+
+nest::music_rate_out_proxy::~music_rate_out_proxy()
+{
+  if ( S_.published_ )
+  {
+    delete V_.MP_;
+  }
+}
+
+void
+nest::music_rate_out_proxy::init_state_( const Node& /* np */ )
+{
+  // const music_rate_out_proxy& sd = dynamic_cast<const
+  // music_rate_out_proxy&>(np);
+}
+
+void
+nest::music_rate_out_proxy::init_buffers_()
+{
+}
+
+void
+nest::music_rate_out_proxy::calibrate()
+{
+  // only publish the output port once,
+  if ( !S_.published_ )
+  {
+    MUSIC::Setup* s = kernel().music_manager.get_music_setup();
+    if ( s == 0 )
+      throw MUSICSimulationHasRun( "" );
+
+    V_.MP_ = s->publishContOutput( P_.port_name_ );
+
+    if ( !V_.MP_->isConnected() )
+      throw MUSICPortUnconnected( "", P_.port_name_ );
+
+    if ( !V_.MP_->hasWidth() )
+      throw MUSICPortHasNoWidth( "", P_.port_name_ );
+
+    S_.port_width_ = V_.MP_->width();
+
+    // check, if there are connections to receiver ports, which are
+    // beyond the width of the port
+    std::vector< MUSIC::GlobalIndex >::const_iterator it;
+    for ( it = V_.index_map_.begin(); it != V_.index_map_.end(); ++it )
+      if ( *it > S_.port_width_ )
+        throw UnknownReceptorType( *it, get_name() );
+
+    // Allocate memory
+    B_.data_.resize( S_.port_width_ );
+
+
+    MUSIC::ArrayData* dmap =
+      new MUSIC::ArrayData( static_cast< void* >( &( B_.data_.front() ) ), MPI::DOUBLE, 0, S_.port_width_ );
+
+
+    // Setup an array map
+    V_.MP_->map( dmap, 1 );
+
+    S_.published_ = true;
+
+
+    std::string msg = String::compose( "Mapping MUSIC output port '%1' with width=%2.", P_.port_name_, S_.port_width_ );
+    LOG( M_INFO, "MusicRateHandler::publish_port()", msg.c_str() );
+  }
+}
+
+void
+nest::music_rate_out_proxy::get_status( DictionaryDatum& d ) const
+{
+  P_.get( d );
+  S_.get( d );
+
+  ( *d )[ names::connection_count ] = V_.index_map_.size();
+
+  // make a copy, since MUSIC uses int instead of long int
+  std::vector< long >* pInd_map_long = new std::vector< long >( V_.index_map_.size() );
+  std::copy< std::vector< MUSIC::GlobalIndex >::const_iterator, std::vector< long >::iterator >(
+    V_.index_map_.begin(), V_.index_map_.end(), pInd_map_long->begin() );
+
+  ( *d )[ names::index_map ] = IntVectorDatum( pInd_map_long );
+}
+
+void
+nest::music_rate_out_proxy::set_status( const DictionaryDatum& d )
+{
+  Parameters_ ptmp = P_; // temporary copy in case of errors
+  ptmp.set( d, S_ );     // throws if BadProperty
+
+  State_ stmp = S_;
+  stmp.set( d, P_ ); // throws if BadProperty
+
+  // if we get here, temporaries contain consistent set of properties
+  P_ = ptmp;
+  S_ = stmp;
+}
+
+void
+nest::music_rate_out_proxy::handle( InstantaneousRateConnectionEvent& e )
+{
+
+  // propagate last rate in min delay interval to MUSIC port; we can not use
+  // e.end() - 1 since the iterator is defined in terms of unsigned ints, not
+  // the event DataType; instead we forward iterate using e.get_coeffvalue and
+  // overwrite the element in data_ for every dt step
+  const long receiver_port = e.get_rport();
+
+  std::vector< unsigned int >::iterator it = e.begin();
+  // The call to get_coeffvalue( it ) in this loop also advances the iterator it
+  while ( it != e.end() )
+  {
+    B_.data_[ receiver_port ] = e.get_coeffvalue( it );
+  }
+}
+
+#endif

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -136,8 +136,6 @@ nest::music_rate_out_proxy::~music_rate_out_proxy()
 void
 nest::music_rate_out_proxy::init_state_( const Node& /* np */ )
 {
-  // const music_rate_out_proxy& sd = dynamic_cast<const
-  // music_rate_out_proxy&>(np);
 }
 
 void

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -88,8 +88,10 @@ nest::music_rate_out_proxy::Parameters_::set( const DictionaryDatum& d, State_& 
   //  if(d->known(names::port_name) && s.published_)
   //    throw MUSICPortAlreadyPublished(get_name(), P_.port_name_);
 
-  if ( !s.published_ )
+  if ( not s.published_ )
+  {
     updateValue< string >( d, names::port_name, port_name_ );
+  }
 }
 
 void
@@ -147,19 +149,26 @@ void
 nest::music_rate_out_proxy::calibrate()
 {
   // only publish the output port once,
-  if ( !S_.published_ )
+  if ( not S_.published_ )
   {
     MUSIC::Setup* s = kernel().music_manager.get_music_setup();
+
     if ( s == 0 )
+    {
       throw MUSICSimulationHasRun( "" );
+    }
 
     V_.MP_ = s->publishContOutput( P_.port_name_ );
 
-    if ( !V_.MP_->isConnected() )
+    if ( not V_.MP_->isConnected() )
+    {
       throw MUSICPortUnconnected( "", P_.port_name_ );
+    }
 
-    if ( !V_.MP_->hasWidth() )
+    if ( not V_.MP_->hasWidth() )
+    {
       throw MUSICPortHasNoWidth( "", P_.port_name_ );
+    }
 
     S_.port_width_ = V_.MP_->width();
 
@@ -167,8 +176,12 @@ nest::music_rate_out_proxy::calibrate()
     // beyond the width of the port
     std::vector< MUSIC::GlobalIndex >::const_iterator it;
     for ( it = V_.index_map_.begin(); it != V_.index_map_.end(); ++it )
+    {
       if ( *it > S_.port_width_ )
+      {
         throw UnknownReceptorType( *it, get_name() );
+      }
+    }
 
     // Allocate memory
     B_.data_.resize( S_.port_width_ );

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -191,10 +191,14 @@ music_rate_out_proxy::handles_test_event( InstantaneousRateConnectionEvent&, rpo
   // number to the local index of this connection the local index
   // equals the number of connection
 
-  if ( !S_.published_ )
+  if ( not S_.published_ )
+  {
     V_.index_map_.push_back( static_cast< int >( receptor_type ) );
+  }
   else
+  {
     throw MUSICPortAlreadyPublished( "", P_.port_name_ );
+  }
 
   return receptor_type;
 }

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -43,11 +43,11 @@
 
 /* BeginDocumentation
 
-Name: music_rate_out_proxy - Device to forward spikes to remote applications
+Name: music_rate_out_proxy - Device to forward rates to remote applications
                               using MUSIC.
 
 Description:
-A music_rate_out_proxy is used to send spikes to a remote application that
+A music_rate_out_proxy is used to send rates to a remote application that
 also uses MUSIC.
 
 The music_rate_out_proxy represents a complete MUSIC rate output
@@ -72,11 +72,11 @@ Examples:
 /music_rate_out_proxy Create /meop Set
 n meop << /music_channel 2 >> Connect
 
-Author: Moritz Helias, Jochen Martin Eppler
-FirstVersion: March 2009
+Author: Philipp Weidel, Jakob Jordan
+FirstVersion: June 2019
 Availability: Only when compiled with MUSIC
 
-SeeAlso: music_rate_in_proxy, music_cont_in_proxy, music_message_in_proxy
+SeeAlso: music_rate_in_proxy, music_cont_out_proxy
 */
 
 namespace nest

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -1,0 +1,206 @@
+/*
+ *  music_rate_out_proxy.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MUSIC_RATE_OUT_PROXY_H
+#define MUSIC_RATE_OUT_PROXY_H
+
+// Generated includes:
+#include "config.h"
+
+#ifdef HAVE_MUSIC
+
+// C++ includes:
+#include <vector>
+
+// External includes:
+#include <music.hh>
+
+// Includes from nestkernel:
+#include "device_node.h"
+#include "event.h"
+#include "exceptions.h"
+#include "nest_types.h"
+#include "node.h"
+
+/* BeginDocumentation
+
+Name: music_rate_out_proxy - Device to forward spikes to remote applications
+                              using MUSIC.
+
+Description:
+A music_rate_out_proxy is used to send spikes to a remote application that
+also uses MUSIC.
+
+The music_rate_out_proxy represents a complete MUSIC rate output
+port. The channel on the port to which a source node forwards its
+events is determined during connection setup by using the parameter
+music_channel of the connection. The name of the port is set via
+SetStatus (see Parameters section below).
+
+Parameters:
+The following properties are available in the status dictionary:
+
+port_name      - The name of the MUSIC output_port to forward events to
+                 (default: rate_out)
+port_width     - The width of the MUSIC input port
+published      - A bool indicating if the port has been already published
+                 with MUSIC
+
+The parameter port_name can be set using SetStatus.
+
+Examples:
+/iaf_psc_alpha Create /n Set
+/music_rate_out_proxy Create /meop Set
+n meop << /music_channel 2 >> Connect
+
+Author: Moritz Helias, Jochen Martin Eppler
+FirstVersion: March 2009
+Availability: Only when compiled with MUSIC
+
+SeeAlso: music_rate_in_proxy, music_cont_in_proxy, music_message_in_proxy
+*/
+
+namespace nest
+{
+class music_rate_out_proxy : public DeviceNode
+{
+
+public:
+  music_rate_out_proxy();
+  music_rate_out_proxy( const music_rate_out_proxy& );
+  ~music_rate_out_proxy();
+
+  bool
+  has_proxies() const
+  {
+    return false;
+  }
+  bool
+  local_receiver() const
+  {
+    return true;
+  }
+  bool
+  one_node_per_process() const
+  {
+    return true;
+  }
+
+  /**
+   * Import sets of overloaded virtual functions.
+   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
+   * Hiding
+   */
+  using Node::handle;
+  using Node::handles_test_event;
+
+  void handle( InstantaneousRateConnectionEvent& );
+
+  port handles_test_event( InstantaneousRateConnectionEvent&, rport );
+
+  void get_status( DictionaryDatum& ) const;
+  void set_status( const DictionaryDatum& );
+
+private:
+  void init_state_( Node const& );
+  void init_buffers_();
+  void calibrate();
+
+  void
+  update( Time const&, const long, const long )
+  {
+  }
+
+  // ------------------------------------------------------------
+
+  struct State_;
+
+  struct Parameters_
+  {
+    std::string port_name_; //!< the name of MUSIC port to connect to
+
+    Parameters_();                     //!< Sets default parameter values
+    Parameters_( const Parameters_& ); //!< Recalibrate all times
+
+    void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
+    void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary
+  };
+
+  // ------------------------------------------------------------
+
+  struct State_
+  {
+    bool published_; //!< indicates whether this node has been published already
+                     //!< with MUSIC
+    int port_width_; //!< the width of the MUSIC port
+
+    State_(); //!< Sets default state value
+
+    void get( DictionaryDatum& ) const; //!< Store current values in dictionary
+    //!< Set values from dictionary
+    void set( const DictionaryDatum&, const Parameters_& );
+  };
+
+  // ------------------------------------------------------------
+
+  struct Variables_
+  {
+    MUSIC::ContOutputPort* MP_; //!< The MUSIC rate port for output of spikes
+    std::vector< MUSIC::GlobalIndex > index_map_;
+  };
+
+  struct Buffers_
+  {
+    Buffers_();                  //!< Initializes default buffer
+    Buffers_( const Buffers_& ); //!< Copy constructor for the data buffer
+    std::vector< double > data_; //!< Recorded data
+  };
+
+  // ------------------------------------------------------------
+
+  Parameters_ P_;
+  State_ S_;
+  Variables_ V_;
+  Buffers_ B_;
+};
+
+inline port
+music_rate_out_proxy::handles_test_event( InstantaneousRateConnectionEvent&, rport receptor_type )
+{
+  // receptor_type i is mapped to channel i of the MUSIC port so we
+  // have to generate the index map here, that assigns the channel
+  // number to the local index of this connection the local index
+  // equals the number of connection
+
+  if ( !S_.published_ )
+    V_.index_map_.push_back( static_cast< int >( receptor_type ) );
+  else
+    throw MUSICPortAlreadyPublished( "", P_.port_name_ );
+
+  return receptor_type;
+}
+
+} // namespace
+
+#endif /* #ifndef MUSIC_RATE_OUT_PROXY_H */
+
+#endif

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -66,6 +66,7 @@ set( nestkernel_sources
     conn_builder.h conn_builder_impl.h conn_builder.cpp
     conn_builder_factory.h
     music_event_handler.h music_event_handler.cpp
+    music_rate_in_handler.h music_rate_in_handler.cpp
     music_manager.cpp music_manager.h
     nest.h nest.cpp
     synaptic_element.h synaptic_element.cpp

--- a/nestkernel/music_event_handler.cpp
+++ b/nestkernel/music_event_handler.cpp
@@ -73,7 +73,7 @@ MusicEventHandler::~MusicEventHandler()
 void
 MusicEventHandler::register_channel( int channel, nest::Node* mp )
 {
-  if ( channel >= channelmap_.size() )
+  if ( static_cast< size_t >( channel ) >= channelmap_.size() )
   {
     // all entries not explicitly set will be 0
     channelmap_.resize( channel + 1, 0 );

--- a/nestkernel/music_manager.cpp
+++ b/nestkernel/music_manager.cpp
@@ -199,13 +199,30 @@ void
 MUSICManager::register_music_event_in_proxy( std::string portname, int channel, nest::Node* mp )
 {
   std::map< std::string, MusicEventHandler >::iterator it;
-  it = music_in_portmap_.find( portname );
-  if ( it == music_in_portmap_.end() )
+  it = music_event_in_portmap_.find( portname );
+  if ( it == music_event_in_portmap_.end() )
   {
     MusicEventHandler tmp(
       portname, music_in_portlist_[ portname ].acceptable_latency, music_in_portlist_[ portname ].max_buffered );
     tmp.register_channel( channel, mp );
-    music_in_portmap_[ portname ] = tmp;
+    music_event_in_portmap_[ portname ] = tmp;
+  }
+  else
+  {
+    it->second.register_channel( channel, mp );
+  }
+}
+
+void
+MUSICManager::register_music_rate_in_proxy( std::string portname, int channel, nest::Node* mp )
+{
+  std::map< std::string, MusicRateInHandler >::iterator it;
+  it = music_rate_in_portmap_.find( portname );
+  if ( it == music_rate_in_portmap_.end() )
+  {
+    MusicRateInHandler tmp( portname );
+    tmp.register_channel( channel, mp );
+    music_rate_in_portmap_[ portname ] = tmp;
   }
   else
   {
@@ -246,8 +263,16 @@ MUSICManager::set_music_in_port_max_buffered( std::string portname, int maxbuffe
 void
 MUSICManager::publish_music_in_ports_()
 {
-  std::map< std::string, MusicEventHandler >::iterator it;
-  for ( it = music_in_portmap_.begin(); it != music_in_portmap_.end(); ++it )
+  for ( std::map< std::string, MusicEventHandler >::iterator it = music_event_in_portmap_.begin();
+        it != music_event_in_portmap_.end();
+        ++it )
+  {
+    it->second.publish_port();
+  }
+
+  for ( std::map< std::string, MusicRateInHandler >::iterator it = music_rate_in_portmap_.begin();
+        it != music_rate_in_portmap_.end();
+        ++it )
   {
     it->second.publish_port();
   }
@@ -256,8 +281,16 @@ MUSICManager::publish_music_in_ports_()
 void
 MUSICManager::update_music_event_handlers( Time const& origin, const long from, const long to )
 {
-  std::map< std::string, MusicEventHandler >::iterator it;
-  for ( it = music_in_portmap_.begin(); it != music_in_portmap_.end(); ++it )
+  for ( std::map< std::string, MusicEventHandler >::iterator it = music_event_in_portmap_.begin();
+        it != music_event_in_portmap_.end();
+        ++it )
+  {
+    it->second.update( origin, from, to );
+  }
+
+  for ( std::map< std::string, MusicRateInHandler >::iterator it = music_rate_in_portmap_.begin();
+        it != music_rate_in_portmap_.end();
+        ++it )
   {
     it->second.update( origin, from, to );
   }

--- a/nestkernel/music_manager.h
+++ b/nestkernel/music_manager.h
@@ -39,6 +39,7 @@
 
 #ifdef HAVE_MUSIC
 #include "music_event_handler.h"
+#include "music_rate_in_handler.h"
 #endif
 
 /*
@@ -66,7 +67,7 @@ Linked Data Structures:
 
 struct MusicPortData
 std::map< std::string, MusicPortData > music_in_portlist_;
-std::map< std::string, MusicEventHandler > music_in_portmap_;
+std::map< std::string, MusicEventHandler > music_event_in_portmap_;
  */
 
 namespace nest
@@ -137,6 +138,14 @@ public:
   void register_music_event_in_proxy( std::string portname, int channel, nest::Node* mp );
 
   /**
+   * Register a node (of type music_input_proxy) with a given MUSIC
+   * port (portname) and a specific channel. The proxy will be
+   * notified, if a MUSIC event is being received on the respective
+   * channel and port.
+   */
+  void register_music_rate_in_proxy( std::string portname, int channel, nest::Node* mp );
+
+  /**
    * Set the acceptable latency (latency) for a music input port (portname).
    */
   void set_music_in_port_acceptable_latency( std::string portname, double latency );
@@ -183,7 +192,8 @@ public:
    * The mapping between MUSIC input ports identified by portname
    * and the corresponding MUSIC event handler.
    */
-  std::map< std::string, MusicEventHandler > music_in_portmap_;
+  std::map< std::string, MusicEventHandler > music_event_in_portmap_;
+  std::map< std::string, MusicRateInHandler > music_rate_in_portmap_;
 
   /**
    * Publish all MUSIC input ports that were registered using

--- a/nestkernel/music_rate_in_handler.cpp
+++ b/nestkernel/music_rate_in_handler.cpp
@@ -54,7 +54,9 @@ MusicRateInHandler::~MusicRateInHandler()
   if ( published_ )
   {
     if ( MP_ != 0 )
+    {
       delete MP_;
+    }
   }
 }
 
@@ -68,7 +70,9 @@ MusicRateInHandler::register_channel( int channel, nest::Node* mp )
   }
 
   if ( channelmap_[ channel ] != 0 )
+  {
     throw MUSICChannelAlreadyMapped( "MusicRateInHandler", port_name_, channel );
+  }
 
   channelmap_[ channel ] = mp;
 }
@@ -87,12 +91,12 @@ MusicRateInHandler::publish_port()
 
     MP_ = s->publishContInput( port_name_ );
 
-    if ( !MP_->isConnected() )
+    if ( not MP_->isConnected() )
     {
       throw MUSICPortUnconnected( "", port_name_ );
     }
 
-    if ( !MP_->hasWidth() )
+    if ( not MP_->hasWidth() )
     {
       throw MUSICPortHasNoWidth( "", port_name_ );
     }

--- a/nestkernel/music_rate_in_handler.cpp
+++ b/nestkernel/music_rate_in_handler.cpp
@@ -1,0 +1,141 @@
+/*
+ *  music_rate_in_handler.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "music_rate_in_handler.h"
+
+#ifdef HAVE_MUSIC
+
+// Includes from libnestutil:
+#include "compose.hpp"
+#include "logging.h"
+
+// Includes from nestkernel:
+#include "event.h"
+#include "kernel_manager.h"
+#include "nest_types.h"
+
+namespace nest
+{
+MusicRateInHandler::MusicRateInHandler()
+  : MP_( 0 )
+  , published_( false )
+  , port_name_( "" )
+{
+}
+
+MusicRateInHandler::MusicRateInHandler( std::string portname )
+  : MP_( 0 )
+  , published_( false )
+  , port_name_( portname )
+{
+}
+
+MusicRateInHandler::~MusicRateInHandler()
+{
+  if ( published_ )
+  {
+    if ( MP_ != 0 )
+      delete MP_;
+  }
+}
+
+void
+MusicRateInHandler::register_channel( int channel, nest::Node* mp )
+{
+  if ( static_cast< size_t >( channel ) >= channelmap_.size() )
+  {
+    // all entries not explicitly set will be 0
+    channelmap_.resize( channel + 1, 0 );
+  }
+
+  if ( channelmap_[ channel ] != 0 )
+    throw MUSICChannelAlreadyMapped( "MusicRateInHandler", port_name_, channel );
+
+  channelmap_[ channel ] = mp;
+}
+
+void
+MusicRateInHandler::publish_port()
+{
+
+  if ( not published_ )
+  {
+    MUSIC::Setup* s = kernel().music_manager.get_music_setup();
+    if ( s == 0 )
+    {
+      throw MUSICSimulationHasRun( "" );
+    }
+
+    MP_ = s->publishContInput( port_name_ );
+
+    if ( !MP_->isConnected() )
+    {
+      throw MUSICPortUnconnected( "", port_name_ );
+    }
+
+    if ( !MP_->hasWidth() )
+    {
+      throw MUSICPortHasNoWidth( "", port_name_ );
+    }
+
+    port_width_ = MP_->width();
+
+    data_ = std::vector< double >( port_width_ );
+
+    for ( std::vector< double >::iterator it = data_.begin(); it != data_.end(); ++it )
+    {
+      *it = 0;
+    }
+
+    MUSIC::ArrayData data_map( static_cast< void* >( &( data_[ 0 ] ) ), MPI::DOUBLE, 0, port_width_ );
+
+    MP_->map( &data_map );
+    published_ = true;
+
+    std::string msg = String::compose( "Mapping MUSIC input port '%1' with width=%2.", port_name_, port_width_ );
+    LOG( M_INFO, "music_rate_in_handler::publish_port()", msg.c_str() );
+  }
+}
+
+
+void
+MusicRateInHandler::update( Time const& origin, const long from, const long to )
+{
+  const size_t buffer_size = kernel().connection_manager.get_min_delay();
+  std::vector< double > new_rates( buffer_size, 0.0 );
+
+  for ( size_t channel = 0; channel < channelmap_.size(); ++channel )
+  {
+    if ( channelmap_[ channel ] != 0 )
+    {
+      std::fill( new_rates.begin(), new_rates.end(), data_[ channel ] );
+
+      InstantaneousRateConnectionEvent rate_event;
+      rate_event.set_coeffarray( new_rates );
+      channelmap_[ channel ]->handle( rate_event );
+    }
+  }
+}
+
+} // namespace nest
+
+#endif // #ifdef HAVE_MUSIC

--- a/nestkernel/music_rate_in_handler.h
+++ b/nestkernel/music_rate_in_handler.h
@@ -1,0 +1,88 @@
+/*
+ *  music_rate_in_handler.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MUSIC_RATE_IN_HANDLER
+#define MUSIC_RATE_IN_HANDLER
+
+// Generated includes:
+#include "config.h"
+
+#ifdef HAVE_MUSIC
+
+// C++ includes:
+#include <music.hh>
+#include <queue>
+
+// Includes from nestkernel:
+#include "nest_types.h"
+#include "node.h"
+
+
+namespace nest
+{
+
+/**
+ * RateIn handler for all events of a MUSIC port received on this process.
+ */
+class MusicRateInHandler
+{
+public:
+  MusicRateInHandler();
+  MusicRateInHandler( std::string portname );
+
+  virtual ~MusicRateInHandler();
+
+  /**
+   * Register a new node to a specific channel on this port.
+   */
+  void register_channel( int channel, nest::Node* mp );
+
+  /**
+   * Publish the MUSIC port.
+   * This method has to be called once before the first simulation to
+   * tell MUSIC which channels lie on which processor.
+   */
+  void publish_port();
+
+  /**
+   * This function is called by the scheduler and delivers the queued
+   * events to the target music_in_proxies.
+   */
+  void update( Time const&, const long, const long );
+
+private:
+  MUSIC::ContInputPort* MP_;   //!< The MUSIC rate port for input of data
+  std::vector< double > data_; //!< The buffer for incoming data
+
+  bool published_;
+  std::string port_name_;
+
+  int port_width_; //!< the width of the MUSIC port
+  //! Maps channel number to music_rate_in_proxy
+  std::vector< nest::Node* > channelmap_;
+};
+
+} // namespace nest
+
+#endif // HAVE_MUSIC
+
+#endif // MUSIC_RATE_IN_HANDLER

--- a/testsuite/regressiontests/issue-77.sli
+++ b/testsuite/regressiontests/issue-77.sli
@@ -82,6 +82,8 @@ M_ERROR setverbosity
              /music_message_in_proxy      % MUSIC port
              /music_cont_out_proxy        % MUSIC port
              /music_cont_in_proxy         % MUSIC port
+             /music_rate_out_proxy        % MUSIC port
+             /music_rate_in_proxy         % MUSIC port
            ] def    
 
 % The following models require connections to rport 1 or other specific parameters:

--- a/testsuite/unittests/test_neurons_handle_multiplicity.sli
+++ b/testsuite/unittests/test_neurons_handle_multiplicity.sli
@@ -70,6 +70,8 @@ M_ERROR setverbosity
              /music_cont_out_proxy        % music device
              /music_message_in_proxy      % music device
              /music_message_out_proxy     % music device
+             /music_rate_in_proxy      % music device
+             /music_rate_out_proxy     % music device
            ] def    
 
 % The following models require connections to rport 1:

--- a/testsuite/unittests/test_neurons_handle_multiplicity.sli
+++ b/testsuite/unittests/test_neurons_handle_multiplicity.sli
@@ -70,8 +70,8 @@ M_ERROR setverbosity
              /music_cont_out_proxy        % music device
              /music_message_in_proxy      % music device
              /music_message_out_proxy     % music device
-             /music_rate_in_proxy      % music device
-             /music_rate_out_proxy     % music device
+             /music_rate_in_proxy         % music device
+             /music_rate_out_proxy        % music device
            ] def    
 
 % The following models require connections to rport 1:


### PR DESCRIPTION
Despite rate models being available for quite some time now, MUSIC support for rates was missing. This PR adds MUSIC proxies that allow communication from rates (continuous data) between a running simulation and other processes.

I suggest @mdjurfeldt and @janhahne as reviewers

branches off from #1244, so should be merged after