### PR TITLE
Update download page for 2.18 and conda-forge

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -9,57 +9,63 @@ NEST is available under the :doc:`GNU General Public License 2 or later <license
 
 If you use NEST for your project, don't forget to :doc:`cite NEST <citing-nest>`!
 
-Download the current version of NEST here:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Current Release NEST 2.16.0 <https://github.com/nest/nest-simulator/archive/v2.16.0.tar.gz>`_
-````````````````````````````````````````````````````````````````````````````````````````````````````
-`Release Notes <https://github.com/nest/nest-simulator/releases/tag/v2.16.0>`_
+NEST as a conda-forge package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+NEST is available as a conda-forge package: you can find the instructions :doc:`on installing NEST with Conda <installation/conda_install>`.
+
+Download NEST source code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also `download the source code of the latest release <https://github.com/nest/nest-simulator/archive/v2.18.0.tar.gz>`_.
 
 
-`Latest developer version <https://github.com/nest/nest-simulator>`_
+Follow the installation instructions for :doc:`Linux <installation/linux_install>` or :doc:`MacOS <installation/mac_install>`.
 
-Download the NEST Live Media for Virtual Machines
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. seealso::
+
+  `Release notes for latest version of NEST <https://github.com/nest/nest-simulator/releases/tag/v2.18.0>`_
+
+`You can also download the latest developer version on GitHub <https://github.com/nest/nest-simulator>`_
+
+Download the NEST live media for virtual machines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Live media is available in the OVA format, and is suitable, for example, for importing into VirtualBox.
 If you run **Windows**, this is the option for you OR if you just want to run NEST without installing it on your computer.
 
-`NEST Live Media 2.14.0 <https://www.nest-simulator.org/downloads/gplreleases/nest-live.ova>`_ (OVA, 2.5G)
-
-`Checksum 2.14.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.14.0.ova.sha512sum>`_
+`NEST live media 2.16.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.16.0.ova>`_
 
 See the :doc:`install instructions for Live Media <installation/livemedia>`
 
-
-Previous Releases
-~~~~~~~~~~~~~~~~~~~
+Previous releases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 We continuously aim to improve NEST and implement features and fix bugs with every new version;
 thus, we strongly encourage our users to use the **most recent version of NEST**. However,
 if you do need an older version you can find `all NEST releases here <https://github.com/nest/nest-simulator/releases/>`_.
+Scroll to bottom of desired release and download the source code.
+
 
 **Older Versions of Live Media**
 
-- Ubuntu 16.04 Live Media with NEST 2.12.0
+- `NEST Live Media 2.14.0 <https://www.nest-simulator.org/downloads/gplreleases/nest-live.ova>`_ (OVA, 2.5G)
 
-    - `Download 2.12.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.12.0.ova>`_
-      (OVA, 3.2G)
+   `Checksum 2.14.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.14.0.ova.sha512sum>`_
 
-    - `Checksum 2.12.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.12.0.ova.sha512sum>`_
-      (sha512sum)
+- `Download 2.12.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.12.0.ova>`_ (OVA, 3.2G)
 
--  Ubuntu 16.04 Live Media with NEST 2.10.0
+   `Checksum 2.12.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.12.0.ova.sha512sum>`_ (sha512sum)
 
-   -  `Download 2.10.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.10.0.ova>`_
-      (OVA, ~3.7G)
 
-   -  `Checksum 2.10.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.10.0.ova.sha512sum>`_
-      (sha512sum)
+-  `Download 2.10.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.10.0.ova>`_
+   (OVA, ~3.7G)
 
-- Ubuntu 15.10 Live Media with NEST 2.8.0
+    `Checksum 2.10.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-16.04_nest-2.10.0.ova.sha512sum>`_
+    (sha512sum)
 
-   -  `Download 2.8.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-15.10_nest-2.8.0.ova>`_
-      (OVA, ~2.5G)
+-  `Download 2.8.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-15.10_nest-2.8.0.ova>`_
+   (OVA, ~2.5G)
 
-   -  `Checksum 2.8.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-15.10_nest-2.8.0.ova.sha512sum>`_
-      (sha512sum)
+    `Checksum 2.8.0 <https://www.nest-simulator.org/downloads/gplreleases/lubuntu-15.10_nest-2.8.0.ova.sha512sum>`_
+    (sha512sum)


### PR DESCRIPTION
This updates the links on the documentation download page for the conda-forge package as well as 2.18

You can see a sample HTML here: https://nest-test.readthedocs.io/en/update_download_page/download.html