### PR TITLE
Add getattr/setattr to GIDCollection

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -568,16 +568,12 @@ class GIDCollection(object):
         return self.get(attr)
 
     def __setattr__(self, attr, value):
-        # check whether the attribute is a node property; need to manually
-        # exclude _datum since without it, get() does not work and we can not
-        # check whether attr is a node property
-        if attr != '_datum':
-            if attr in self.get().keys():
-                self.set({attr: value})
-                return  # if we have set the property in NEST, we are done
-
-        super().__setattr__(attr, value)  # if attr is not a node property,
-                                          # store it as regular attribute
+        # `_datum` is the only property of GIDCollection that should not be
+        # interpreted as a property of the model
+        if attr == '_datum':
+            super().__setattr__(attr, value)
+        else:
+            self.set({attr: value})
 
 
 class ConnectomeIterator(object):

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -564,6 +564,21 @@ class GIDCollection(object):
         """
         return self.tolist().index(gid)
 
+    def __getattr__(self, attr):
+        return self.get(attr)
+
+    def __setattr__(self, attr, value):
+        # check whether the attribute is a node property; need to manually
+        # exclude _datum since without it, get() does not work and we can not
+        # check whether attr is a node property
+        if attr != '_datum':
+            if attr in self.get().keys():
+                self.set({attr: value})
+                return  # if we have set the property in NEST, we are done
+
+        super().__setattr__(attr, value)  # if attr is not a node property,
+                                          # store it as regular attribute
+
 
 class ConnectomeIterator(object):
     """


### PR DESCRIPTION
Defining `__getattr__` and `__setattr__` allows more pythonic access of node properties:
```python
import nest

nodes = nest.Create('iaf_psc_alpha', 10)

print('V_m', nodes.V_m)
nodes.V_m = np.random.normal(-60., 1., 10)
print('V_m', nodes.V_m)
```

@hakonsbm 

edit: here's a more interesting example
```python
import matplotlib.pyplot as plt
import nest

nodes = nest.Create('iaf_psc_alpha', 10)
nodes.V_m = np.random.normal(-60., 1., 10)
nodes.I_e = 376.

m = nest.Create('multimeter')
m.record_from = ('V_m',)

nest.Connect(m, nodes[0])

nest.Simulate(100.)

plt.plot(m.events['times'], m.events['V_m'])
plt.show()
```