### PR TITLE
Fix GetConnections to correctly get connections where the target is a global receiving device

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1091,7 +1091,11 @@ nest::ConnectionManager::split_to_neuron_device_vectors_( const thread tid,
   for ( size_t t_id = 0; t_id < gid_token_array->size(); ++t_id )
   {
     const index gid = gid_token_array->get( t_id );
-    if ( kernel().node_manager.get_node( gid, tid )->has_proxies() )
+    const auto node = kernel().node_manager.get_node( gid, tid );
+    // Normal neuron nodes have proxies. Globally receiving devices, e.g. volume transmitter, don't have a local
+    // receiver, but are connected in the same way as normal neuron nodes. Therefore they have to be treated as such
+    // here.
+    if ( node->has_proxies() or not node->local_receiver() )
     {
       neuron_gids.push_back( gid );
     }

--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -53,6 +53,38 @@ class GetConnectionsTestCase(unittest.TestCase):
         c4 = nest.GetConnections()
         self.assertEqual(c1, c4)
 
+    def test_GetConnectionsTargetModels(self):
+        """GetConnections iterating models for target"""
+        for model in nest.Models():
+            alpha = nest.Create('iaf_psc_alpha')
+            try:
+                other = nest.Create(model)
+                nest.Connect(alpha, other)
+            except nest.kernel.NESTError:
+                # If we can't create a node with this model, or connect
+                # to a node of this model, we ignore it.
+                continue
+            conns = nest.GetConnections(alpha, other)
+            self.assertEqual(
+                len(conns), 1,
+                'Failed to get connection with target model {}'.format(model))
+
+    def test_GetConnectionsSourceModels(self):
+        """GetConnections iterating models for source"""
+        for model in nest.Models():
+            alpha = nest.Create('iaf_psc_alpha')
+            try:
+                other = nest.Create(model)
+                nest.Connect(other, alpha)
+            except nest.kernel.NESTError:
+                # If we can't create a node with this model, or connect
+                # to a node of this model, we ignore it.
+                continue
+            conns = nest.GetConnections(other, alpha)
+            self.assertEqual(
+                len(conns), 1,
+                'Failed to get connection with source model {}'.format(model))
+
 
 def suite():
 


### PR DESCRIPTION
Fixes an issue with GetConnections, where it would not get the connection if the specified target is a global receiving device. 

In jakobj#104, to improve the performance of GetConnections, targets are split into vectors containing neurons and devices. However, even though the global receiving device target is a device, it is connected in the same way as a normal neuron node. This means that the connection is never added to `TargetTableDevices`, and the connection isn't found.

This PR changes the splitting function to put global receiving devices in the neuron vector, which allows GetConnections to correctly get the connections. Two tests are also added, checking that GetConnections with specified source and target always gets the connection.

Fixes #1190.