### PR TITLE
Fix logical error in elseif-statements in connect functions

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -464,6 +464,18 @@ nest::ConnectionManager::connect( const index sgid,
   {
     connect_from_device_( *source, *target, target_thread, syn_id, params, delay, weight );
   }
+  // globally receiving devices, e.g. volume transmitter
+  else if ( not target->has_proxies() and not target->local_receiver() )
+  {
+    // we do not allow to connect a device to a global receiver at the moment
+    if ( not source->has_proxies() )
+    {
+      throw IllegalConnection( "We do not allow to connect a device to a global receiver at the moment" );
+      return;
+    }
+    target = kernel().node_manager.get_node( target->get_gid(), tid );
+    connect_( *source, *target, sgid, tid, syn_id, params, delay, weight );
+  }
   // normal devices -> normal devices
   else if ( not source->has_proxies() and not target->has_proxies() )
   {
@@ -475,17 +487,6 @@ nest::ConnectionManager::connect( const index sgid,
     {
       connect_from_device_( *source, *target, suggested_thread, syn_id, params, delay, weight );
     }
-  }
-  // globally receiving devices, e.g. volume transmitter
-  else if ( not target->has_proxies() and not target->local_receiver() )
-  {
-    // we do not allow to connect a device to a global receiver at the moment
-    if ( not source->has_proxies() )
-    {
-      return;
-    }
-    target = kernel().node_manager.get_node( target->get_gid(), tid );
-    connect_( *source, *target, sgid, tid, syn_id, params, delay, weight );
   }
   else
   {
@@ -547,6 +548,18 @@ nest::ConnectionManager::connect( const index sgid,
   {
     connect_from_device_( *source, *target, target_thread, syn_id, params );
   }
+  // globally receiving devices, e.g. volume transmitter
+  else if ( not target->has_proxies() and not target->local_receiver() )
+  {
+    // we do not allow to connect a device to a global receiver at the moment
+    if ( not source->has_proxies() )
+    {
+      throw IllegalConnection( "We do not allow to connect a device to a global receiver at the moment" );
+      return false;
+    }
+    target = kernel().node_manager.get_node( tgid, tid );
+    connect_( *source, *target, sgid, tid, syn_id, params );
+  }
   // normal devices -> normal devices
   else if ( not source->has_proxies() and not target->has_proxies() )
   {
@@ -557,17 +570,6 @@ nest::ConnectionManager::connect( const index sgid,
     {
       connect_from_device_( *source, *target, suggested_thread, syn_id, params );
     }
-  }
-  // globally receiving devices, e.g. volume transmitter
-  else if ( not target->has_proxies() and not target->local_receiver() )
-  {
-    // we do not allow to connect a device to a global receiver at the moment
-    if ( not source->has_proxies() )
-    {
-      return false;
-    }
-    target = kernel().node_manager.get_node( tgid, tid );
-    connect_( *source, *target, sgid, tid, syn_id, params );
   }
   else
   {

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -471,7 +471,6 @@ nest::ConnectionManager::connect( const index sgid,
     if ( not source->has_proxies() )
     {
       throw IllegalConnection( "We do not allow to connect a device to a global receiver at the moment" );
-      return;
     }
     target = kernel().node_manager.get_node( target->get_gid(), tid );
     connect_( *source, *target, sgid, tid, syn_id, params, delay, weight );
@@ -555,7 +554,6 @@ nest::ConnectionManager::connect( const index sgid,
     if ( not source->has_proxies() )
     {
       throw IllegalConnection( "We do not allow to connect a device to a global receiver at the moment" );
-      return false;
     }
     target = kernel().node_manager.get_node( tgid, tid );
     connect_( *source, *target, sgid, tid, syn_id, params );

--- a/testsuite/regressiontests/issue-1242.sli
+++ b/testsuite/regressiontests/issue-1242.sli
@@ -40,7 +40,7 @@ FirstVersion: July 2019
 
 M_ERROR setverbosity
 
-% Check if such a connections results in an exception
+% Check if such a connection results in an exception
 {
   ResetKernel
 

--- a/testsuite/regressiontests/issue-1242.sli
+++ b/testsuite/regressiontests/issue-1242.sli
@@ -1,0 +1,53 @@
+/*
+ *  issue-1242.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1242
+
+Synopsis: (issue-1242) run -> NEST exits if test fails
+
+Description:
+Tests that a connection from a node without proxies to 
+a node without proxies that has global targets throws an error
+(instead of failing silently or resulting in inconsistent results).
+
+Author: Jan Hahne
+FirstVersion: July 2019
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+% Check if such a connections results in an exception
+{
+  ResetKernel
+
+  /spike_generator Create /sg Set
+  /volume_transmitter Create /vt Set
+  [sg] [vt] Connect
+}
+fail_or_die
+
+endusing


### PR DESCRIPTION
Issue #1242 is a symptom of this logical error in the elseif-state in the connect functions in `connection_manager.cpp`. Currently the case `not source->has_proxies() and not target->has_proxies()` is handled before the case `not target->has_proxies() and not target->local_receiver()` which has a subcase `if ( not source->has_proxies() )` which therefore is not reachable.

This results in wrong behavior in a case where `not source->has_proxies() and not target->has_proxies() and not target->local_receiver()` holds (as for example in the reproducer of #1242). In addition a source code comment indicates that this case is not implemented at all at the moment. Therefore this PR also adds  a `throw IllegalConnection` here, to prevent a silent error where the connect call is executed without creating any connection.