### PR TITLE
Add initial membrane potential options to microcircuit example

### DIFF
--- a/examples/nest/Potjans_2014/microcircuit.sli
+++ b/examples/nest/Potjans_2014/microcircuit.sli
@@ -56,6 +56,28 @@
             message  % this is written to the output file
         } if 
     } if
+
+    /vm0_type_options <(original) (optimized)> def
+    Vm0_type (original) eq not
+    {
+        Vm0_type (optimized) eq not
+        {
+
+           M_WARNING (CheckParameters)
+           (') Vm0_type join
+           (' is not a valid option, replacing it with ') join
+           vm0_type_options 0 get join
+           ('; Valid options are ') join
+           vm0_type_options 0 get join
+           (' and ') join
+           vm0_type_options 1 get join
+           (') join
+           message
+
+           % reset variable to (original)
+           /Vm0_type vm0_type_options 0 get def
+        } if
+    } if
  
     % number of layers
     /n_layers full_scale_n_neurons length def
@@ -248,8 +270,20 @@
             neuron_subnet GetLocalNodes
             {
                dup /vp get /node_vp Set
-	        << /V_m normal_rdvs node_vp get Random Vm0_std mul Vm0_mean add
-                >> SetStatus
+               Vm0_type (optimized) eq
+               {
+                   <<
+                      /V_m normal_rdvs node_vp get Random
+                      Vm0_std layer_index get population_index get mul
+                      Vm0_mean layer_index get population_index get add
+                   >>
+               }{
+                   <<
+                      /V_m normal_rdvs node_vp get Random
+                      Vm0_std mul Vm0_mean add
+                   >>
+               } ifelse
+               SetStatus
 	    } forall
 	    
 	    population_subnet ChangeSubnet

--- a/examples/nest/Potjans_2014/network_params.sli
+++ b/examples/nest/Potjans_2014/network_params.sli
@@ -101,8 +101,40 @@ def
 /neuron_model /iaf_psc_exp def  % neuron model. For PSP-to-PSC conversion to
                                 % be correct, synapses should be current-based
                                 % with an exponential time course
-/Vm0_mean -58.0 def             % mean of initial membrane potential (mV)
-/Vm0_std 10.0 def               % std of initial membrane potential (mV)
+
+% Initial conditions for the membrane potential, options are:
+% (original): uniform mean and std for all populations
+% (optimized): population-specific mean and std, allowing a reduction of the
+% initial activity burst in the network
+/Vm0_type (optimized) def        % choose either (original) or (optimized)
+Vm0_type (optimized) eq
+{
+    % optimized
+    % mean of initial membrane potential (mV)
+    /Vm0_mean [[-68.28   % 2/3e
+                -63.16]  % 2/3i
+               [-63.33   % 4e
+                -63.45]  % 4i
+               [-63.11   % 5e
+                -61.66]  % 5i
+               [-66.72   % 6e
+                -61.43]] % 6i
+                def
+    % std of initial membrane potential (mV)
+    /Vm0_std  [[5.36     % 2/3e
+                4.57]    % 2/3i
+               [4.74     % 4e
+                4.94]    % 4i
+               [4.94     % 5e
+                4.55]    % 5i
+               [5.46     % 6e
+                4.48]]   % 6i
+                def
+}{
+    % original
+    /Vm0_mean -58.0 def
+    /Vm0_std 10.0 def
+} ifelse
 
 % neuron model parameters
 /model_params  << /tau_m 10.        % membrane time constant (ms)

--- a/examples/nest/Potjans_2014/network_params.sli
+++ b/examples/nest/Potjans_2014/network_params.sli
@@ -106,7 +106,7 @@ def
 % (original): uniform mean and std for all populations
 % (optimized): population-specific mean and std, allowing a reduction of the
 % initial activity burst in the network
-/Vm0_type (optimized) def        % choose either (original) or (optimized)
+/Vm0_type (original) def        % choose either (original) or (optimized)
 Vm0_type (optimized) eq
 {
     % optimized

--- a/pynest/examples/Potjans_2014/network_params.py
+++ b/pynest/examples/Potjans_2014/network_params.py
@@ -200,7 +200,7 @@ net_dict = {
     # 'optimized': population-specific mean and std, allowing a reduction of
     # the initial activity burst in the network.
     # Choose either 'original' or 'optimized'.
-    'V0_type': 'optimized',
+    'V0_type': 'original',
     # Parameters of the neurons.
     'neuron_params': {
         # Membrane potential average for the neurons (in mV).

--- a/pynest/examples/Potjans_2014/network_params.py
+++ b/pynest/examples/Potjans_2014/network_params.py
@@ -195,12 +195,22 @@ net_dict = {
     # Relative standard deviation of the delay of excitatory and
     # inhibitory connections (in relative units).
     'rel_std_delay': 0.5,
+    # Initial conditions for the membrane potential, options are:
+    # 'original': uniform mean and std for all populations.
+    # 'optimized': population-specific mean and std, allowing a reduction of
+    # the initial activity burst in the network.
+    # Choose either 'original' or 'optimized'.
+    'V0_type': 'optimized',
     # Parameters of the neurons.
     'neuron_params': {
         # Membrane potential average for the neurons (in mV).
-        'V0_mean': -58.0,
+        'V0_mean': {'original': -58.0,
+                    'optimized': [-68.28, -63.16, -63.33, -63.45,
+                                  -63.11, -61.66, -66.72, -61.43]},
         # Standard deviation of the average membrane potential (in mV).
-        'V0_sd': 10.0,
+        'V0_sd': {'original': 10.0,
+                  'optimized': [5.36, 4.57, 4.74, 4.94,
+                                4.94, 4.55, 5.46, 4.48]},
         # Reset membrane potential of the neurons (in mV).
         'E_L': -65.0,
         # Threshold potential of the neurons (in mV).


### PR DESCRIPTION
To avoid the transient firing burst and fluctuation in the first 10 ms of simulation, options of optimized initial membrane potentials are added for both sli and pynest microcircuit example code. The optimized membrane potential distributions were measured in the stationary state (100th to 200th ms) for all neuron populations in the model.
In the network parameter file, the user can choose either the original initial values from the previous version, or the optimized initial values. A warning message is printed in the terminal or the log if the user misspells one of the options.

This is the same content as the pull request #1206, which had a wrong git history due to a corrupted rebase. The current pull request has a clean git history.