### PR TITLE
Work-around for device compile.

### DIFF
--- a/libnestutil/numerics.cpp
+++ b/libnestutil/numerics.cpp
@@ -51,6 +51,7 @@
 
 #if defined( HAVE_STD_NAN )
 #include <cmath>
+#define NAN (0.0f/ 0.0f)
 #elif defined( HAVE_NAN )
 #include <math.h>
 #endif

--- a/libnestutil/numerics.h
+++ b/libnestutil/numerics.h
@@ -37,6 +37,11 @@
 
 #if defined( HAVE_STD_ISNAN )
 #include <cmath>
+#ifdef __NVPTX__
+#define NAN (0.0f/ 0.0f)
+typedef double double_t;
+#include <cmath>
+#endif
 #elif defined( HAVE_ISNAN )
 #include <math.h>
 #endif


### PR DESCRIPTION
Recent upstream Clang does not compile NEST if -fopenmp and -fopenmp-targets flags are supplied. Per upstream, they're working on a fix, but in the meantime, I am proposing this be merged.