### PR TITLE
Remove the remaining markdown config in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,10 +41,7 @@ import pip
 import subprocess
 
 # import shlex
-# import recommonmark
 
-from recommonmark.parser import CommonMarkParser
-from recommonmark.transform import AutoStructify
 from subprocess import check_output, CalledProcessError
 from mock import Mock as MagicMock
 
@@ -55,30 +52,8 @@ sys.path.insert(0, os.path.abspath('./..'))
 sys.path.insert(0, os.path.abspath('./../topology'))
 sys.path.insert(0, os.path.abspath('./../pynest/nest'))
 
-source_suffix = ['.rst', '.md']
-source_parsers = {
-    '.md': CommonMarkParser
-}
+source_suffix = ['.rst']
 
-# -- Checking for pandoc --------------------------------------------------
-
-try:
-    print(check_output(['pandoc', '--version']))
-except CalledProcessError:
-    print("No pandoc on %s" % os.environ['PATH'])
-
-
-for dirpath, dirnames, files in os.walk(os.path.dirname(__file__)):
-    for f in files:
-        if f.endswith('.md'):
-            ff = os.path.join(dirpath, f)
-            print(ff)
-            fb = os.path.basename(f)[:-3]
-            print(fb)
-            fo = fb + ".rst"
-            args = ['pandoc', ff, '-o', fo]
-            # check_output(args)
-            # check_output(args)
 
 # -- General configuration ------------------------------------------------
 
@@ -91,7 +66,7 @@ for dirpath, dirnames, files in os.walk(os.path.dirname(__file__)):
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
-            return MagicMock()
+        return MagicMock()
 
 
 MOCK_MODULES = ['numpy', 'scipy', 'matplotlib', 'matplotlib.pyplot', 'pandas']
@@ -100,21 +75,6 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
-# extensions = [
-#    'sphinx.ext.autodoc',
-#    'sphinx.ext.napoleon',
-#    'sphinx.ext.autosummary',
-#    'sphinx.ext.doctest',
-#    'sphinx.ext.intersphinx',
-#    'sphinx.ext.todo',
-#    'sphinx.ext.coverage',
-#    'sphinx.ext.mathjax',
-#    'sphinx_gallery.gen_gallery',
-# ]
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -229,17 +189,9 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 
 def setup(app):
-    # app.add_stylesheet('css/my_styles.css')
     app.add_stylesheet('css/custom.css')
     app.add_stylesheet('css/pygments.css')
     app.add_javascript("js/custom.js")
-    app.add_config_value('recommonmark_config', {
-            'auto_toc_tree_section': 'Contents',
-            'enable_inline_math': True,
-            'enable_auto_doc_ref': True,
-            'enable_eval_rst': True
-            }, True)
-    app.add_transform(AutoStructify)
 
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/doc/tutorials/videos/index.rst
+++ b/doc/tutorials/videos/index.rst
@@ -4,4 +4,4 @@ Video Tutorial Series
 .. toctree::
    :maxdepth: 1
 
-   one_neuron.md
+   one_neuron

--- a/doc/tutorials/videos/one_neuron.md
+++ b/doc/tutorials/videos/one_neuron.md
@@ -1,7 +1,0 @@
-# Introduction to NEST: Simulating a single neuron
- 
-
-<video width="640" controls poster="https://www.nest-simulator.org/downloads/screenshot_membranepot_video.png" >
-  <source src="https://www.nest-simulator.org/downloads/DEMO_oneneuron_screencast.mp4" type="video/mp4">
-Your browser does not support the video tag.
-</video>

--- a/doc/tutorials/videos/one_neuron.rst
+++ b/doc/tutorials/videos/one_neuron.rst
@@ -1,0 +1,10 @@
+Introduction to NEST: Simulating a single neuron
+==================================================
+
+
+.. raw:: html
+
+    <video width="640" controls poster="https://www.nest-simulator.org/downloads/screenshot_membranepot_video.png" >
+      <source src="https://www.nest-simulator.org/downloads/DEMO_oneneuron_screencast.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+    </video>


### PR DESCRIPTION
This PR just cleans up the conf.py file by removing all the references to recommonmark or markdown, which is no longer needed.
The video file was also changed from md to rst.