### PR TITLE
Fix typo in doc - random_numbers

### DIFF
--- a/doc/guides/random_numbers.rst
+++ b/doc/guides/random_numbers.rst
@@ -518,6 +518,6 @@ check with ``diff``:
     diff 41 44
 
 These commands should not generate any output. Obviously, this test
-checks only a necessary, by no means a sufficient condition for a
-correct simulation (Oh yes, do make sure that these directories contain
-data! Nothing easier that to pass a diff-test on empty dirs.)
+checks only a necessary, but by no means sufficient condition for a
+correct simulation. (Oh yes, do make sure that these directories contain
+data! Nothing easier than to pass a diff-test on empty dirs.)


### PR DESCRIPTION
Fixes type (that -> than), and makes a sentence easier to read by a minor edit of the subclause.