### PR TITLE
Remove spurious brackets from code example in tutorial

### DIFF
--- a/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -401,8 +401,8 @@ the synaptic model.
 
     syn_dict_ex = {"weight": 1.2}
     syn_dict_in = {"weight": -2.0}
-    nest.Connect([noise_ex], neuron, syn_spec=syn_dict_ex)
-    nest.Connect([noise_in], neuron, syn_spec=syn_dict_in)
+    nest.Connect(noise_ex, neuron, syn_spec=syn_dict_ex)
+    nest.Connect(noise_in, neuron, syn_spec=syn_dict_in)
 
 
 .. _vm_one_neuron_noise:


### PR DESCRIPTION
This is a tiny PR that removes two brackets in the documentation so that the example will run without issuing an error.

This fixes #1269.