### PR TITLE
Add include sys/time.h.

### DIFF
--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -23,10 +23,10 @@
 #ifndef SIMULATION_MANAGER_H
 #define SIMULATION_MANAGER_H
 
+#include <sys/time.h>
+
 // C++ includes:
 #include <vector>
-
-#include <sys/time.h>
 
 // Includes from libnestutil:
 #include "manager_interface.h"

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -26,6 +26,8 @@
 // C++ includes:
 #include <vector>
 
+#include <sys/time.h>
+
 // Includes from libnestutil:
 #include "manager_interface.h"
 

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -23,6 +23,7 @@
 #ifndef SIMULATION_MANAGER_H
 #define SIMULATION_MANAGER_H
 
+// C includes:
 #include <sys/time.h>
 
 // C++ includes:


### PR DESCRIPTION
nestkernel/simulation_manager.h needs include sys/time.h for timeval struct.