### PR TITLE
Fix poisson generator ps

### DIFF
--- a/precise/poisson_generator_ps.cpp
+++ b/precise/poisson_generator_ps.cpp
@@ -45,6 +45,7 @@
 nest::poisson_generator_ps::Parameters_::Parameters_()
   : rate_( 0.0 )      // Hz
   , dead_time_( 0.0 ) // ms
+  , rate_changed_( false )
   , num_targets_( 0 )
 {
 }
@@ -70,7 +71,9 @@ nest::poisson_generator_ps::Parameters_::set( const DictionaryDatum& d )
     throw BadProperty( "The dead time cannot be negative." );
   }
 
-  updateValue< double >( d, names::rate, rate_ );
+  // Change of rate has to be flagged to let the event_hook handle the
+  // interval from the rate change to the first subsequent spike.
+  rate_changed_ = updateValue< double >( d, names::rate, rate_ );
 
   if ( rate_ < 0.0 )
   {
@@ -223,7 +226,7 @@ nest::poisson_generator_ps::event_hook( DSSpikeEvent& e )
   // introduce nextspk as a shorthand
   Buffers_::SpikeTime& nextspk = B_.next_spike_[ prt ];
 
-  if ( nextspk.first.is_neg_inf() )
+  if ( nextspk.first.is_neg_inf() or P_.rate_changed_ )
   {
     // need to initialize relative to t_min_active_
     // first spike is drawn from backward recurrence time to initialize the
@@ -255,6 +258,7 @@ nest::poisson_generator_ps::event_hook( DSSpikeEvent& e )
     nextspk.first = Time::ms_stamp( spike_offset );
     nextspk.second = nextspk.first.get_ms() - spike_offset;
     nextspk.first += V_.t_min_active_;
+    P_.rate_changed_ = false;
   }
 
   // as long as there are spikes in active period, emit and redraw

--- a/precise/poisson_generator_ps.h
+++ b/precise/poisson_generator_ps.h
@@ -125,6 +125,7 @@ private:
   {
     double rate_;      //!< process rate [Hz]
     double dead_time_; //!< dead time [ms]
+    bool rate_changed_; //!< flag for rate change
 
     /**
      * Number of targets.

--- a/testsuite/regressiontests/issue-1278-1279.sli
+++ b/testsuite/regressiontests/issue-1278-1279.sli
@@ -1,0 +1,72 @@
+/*
+ *  issue-1278-1279.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1278-1279
+
+Synopsis: (issue-1278-1279) run -> NEST exits if test fails
+
+Description:
+Tests that poisson_generator_ps handles changing the rate, and
+if it properly applies the new rate.
+
+Author: Håkon Mørk
+FirstVersion: September 2019
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+    ResetKernel
+
+    /p /poisson_generator_ps << /rate 10. >> Create def
+    /n /parrot_neuron_ps Create def
+    /sd /spike_detector Create def
+
+    p n Connect
+    n sd Connect
+
+    1000 Simulate
+    /first_spikes sd GetStatus /n_events get def
+    sd << /n_events 0 >> SetStatus
+    p << /rate 0. >> SetStatus
+
+    1000 Simulate
+    /second_spikes sd GetStatus /n_events get def
+    sd << /n_events 0 >> SetStatus
+    p << /rate 100. >> SetStatus
+
+    1000 Simulate
+    /third_spikes sd GetStatus /n_events get def
+
+    first_spikes 5 gt first_spikes 15 lt and
+    second_spikes 0 eq
+    third_spikes 50 gt third_spikes 150 lt and
+    and and
+}
+assert_or_die
+
+endusing


### PR DESCRIPTION
Adds a `P::rate_changed_` flag to `poisson_generator_ps` which lets the `event_hook()` handle the interval from the rate change to the first subsequent spike. This makes sure that the generator model correctly handles rate changes. A regeressiontest is also added.

Fixes #1278 
Fixes #1279 