### PR TITLE
Check variables of GSL binomial random generator where they are set

### DIFF
--- a/librandom/gsl_binomial_randomdev.cpp
+++ b/librandom/gsl_binomial_randomdev.cpp
@@ -94,8 +94,8 @@ librandom::GSL_BinomialRandomDev::set_p( double p_s )
 void
 librandom::GSL_BinomialRandomDev::set_n( size_t n_s )
 {
-  // gsl_ran_binomial() takes n as an unsigned int, so it cannot be
-  // greater than what an unsigned int can hold.
+  // gsl_ran_binomial() takes n as an unsigned int, so it cannot be greater
+  // than what an unsigned int can hold.
   const auto N_MAX = std::numeric_limits< unsigned int >::max();
   if ( n_s >= N_MAX )
   {

--- a/librandom/gsl_binomial_randomdev.cpp
+++ b/librandom/gsl_binomial_randomdev.cpp
@@ -84,7 +84,10 @@ librandom::GSL_BinomialRandomDev::set_p_n( double p_s, size_t n_s )
 void
 librandom::GSL_BinomialRandomDev::set_p( double p_s )
 {
-  assert( 0.0 <= p_ && p_ <= 1.0 );
+  if ( p_s < 0. or 1. < p_s )
+  {
+    throw BadParameterValue( "gsl_binomial RDV: 0 <= p <= 1 required." );
+  }
   p_ = p_s;
 }
 
@@ -113,17 +116,11 @@ librandom::GSL_BinomialRandomDev::set_status( const DictionaryDatum& d )
 
   long n_new = n_;
   const bool n_updated = updateValue< long >( d, names::n, n_new );
-
-  if ( p_new < 0. || 1. < p_new )
-  {
-    throw BadParameterValue( "gsl_binomial RDV: 0 <= p <= 1 required." );
-  }
-  if ( n_new < 1 )
+  if ( n_new < 1 ) // We must check n_new here in case it is negative
   {
     throw BadParameterValue( "gsl_binomial RDV: n >= 1 required." );
   }
-
-  if ( n_updated || p_updated )
+  if ( n_updated or p_updated )
   {
     set_p_n( p_new, n_new );
   }

--- a/librandom/gsl_binomial_randomdev.cpp
+++ b/librandom/gsl_binomial_randomdev.cpp
@@ -99,7 +99,7 @@ librandom::GSL_BinomialRandomDev::set_n( size_t n_s )
   const auto N_MAX = std::numeric_limits< unsigned int >::max();
   if ( n_s >= N_MAX )
   {
-    throw BadParameterValue( String::compose( "Gsl_binomial RDV: N < %1 required.", static_cast< double >( N_MAX ) ) );
+    throw BadParameterValue( String::compose( "gsl_binomial RDV: N < %1 required.", static_cast< double >( N_MAX ) ) );
   }
   if ( n_s < 1 )
   {

--- a/librandom/gsl_binomial_randomdev.h
+++ b/librandom/gsl_binomial_randomdev.h
@@ -104,9 +104,9 @@ public:
    * p - success probability for single trial
    * n - number of trials
    */
-  void set_p_n( double, unsigned int );
-  void set_p( double );       //!<set p
-  void set_n( unsigned int ); //!<set n
+  void set_p_n( double, size_t );
+  void set_p( double ); //!<set p
+  void set_n( size_t ); //!<set n
 
   /**
    * Import sets of overloaded virtual functions.


### PR DESCRIPTION
In `GSL_BinomialRandomDev`, checks of new `n` and `p` values are now done in the setter methods, to catch erroneous or error-inducing values used when setting `n` and `p` directly without using `GSL_BinomialRandomDev::set_status()`.

Fixes #1298.