### PR TITLE
Skip deployment in Travis CI testsuite when not running a build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,12 +169,15 @@ script:
      fi
 
 before_deploy:
-   - cd $TRAVIS_BUILD_DIR/build
-   - tar -zcvf reports.tar.gz ./reports
-   - tar -zcvf docs.tar.gz $TRAVIS_BUILD_DIR/result/share/doc/nest/*.*
-   - mkdir -p $TRAVIS_BUILD_DIR/build/artefacts_upload
-   - mv docs.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
-   - mv reports.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
+   - |
+     if [ "$xRUN_BUILD_AND_TESTSUITE" = "1" ]; then
+         cd $TRAVIS_BUILD_DIR/build
+         tar -zcvf reports.tar.gz ./reports
+         tar -zcvf docs.tar.gz $TRAVIS_BUILD_DIR/result/share/doc/nest/*.*
+         mkdir -p $TRAVIS_BUILD_DIR/build/artefacts_upload
+         mv docs.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
+         mv reports.tar.gz $TRAVIS_BUILD_DIR/build/artefacts_upload
+     fi
 
 # S3 Deployment (Uploading the Travis CI build artefacts to Amazon S3).
 deploy:


### PR DESCRIPTION
This did not show up as an error in the previous PR updating the Travis CI suite (#1267) because the deployment step is always skipped on forks.