### PR TITLE
Fix cppcheck in Travis CI testsuite

### DIFF
--- a/extras/static_code_analysis.sh
+++ b/extras/static_code_analysis.sh
@@ -171,7 +171,7 @@ for f in $FILE_NAMES; do
       # CPPCHECK
       if $PERFORM_CPPCHECK; then
         print_msg "MSGBLD0150: " "Running CPPCHECK ...: $f"
-        $CPPCHECK --enable=all --inconclusive --std=c++03 --suppress=missingIncludeSystem $f > ${f_base}_cppcheck.txt 2>&1
+        $CPPCHECK --enable=all --std=c++11 --suppress=missingIncludeSystem $f > ${f_base}_cppcheck.txt 2>&1
         # Remove the header, the first line.
         tail -n +2 "${f_base}_cppcheck.txt" > "${f_base}_cppcheck.tmp" && mv "${f_base}_cppcheck.tmp" "${f_base}_cppcheck.txt"
         if [ -s "${f_base}_cppcheck.txt" ]; then

--- a/extras/static_code_analysis.sh
+++ b/extras/static_code_analysis.sh
@@ -218,7 +218,7 @@ for f in $FILE_NAMES; do
       fi
 
       # Add the file to the list of files with format errors.
-      if $vera_failed || $cppcheck_failed || $clang_format_failed; then
+      if (! $IGNORE_MSG_VERA && $vera_failed) || (! $IGNORE_MSG_CPPCHECK && $cppcheck_failed) || (! $IGNORE_MSG_CLANG_FORMAT && $clang_format_failed); then
         c_files_with_errors="$c_files_with_errors $f"
       fi
       ;;


### PR DESCRIPTION
Update C++ standard to C++11, because the old was giving syntax errors on the enum class.

Do not throw "inconclusive" warnings, as there seem to be many non-consequential ones (has this option been discussed before?)

Fixes #1303.