### PR TITLE
Clean the build process for the NEST Debian packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,12 @@
 nest (2.18.0+1SNAPSHOT-0ubuntu1ppa1) unstable; urgency=low
 
   * NEST daily builds of master in 'ppa:nest-simulator/nest-nightly'
+  * Build without MUSIC and libneurosim
+
+ -- Steffen Graber <s.graber@fz-juelich.de>  Wed, 17 Oct 2019 10:20:16 +0000
+
+nest (2.18.0+1SNAPSHOT-0ubuntu1ppa1) unstable; urgency=low
+
+  * NEST daily builds of master in 'ppa:nest-simulator/nest-nightly'
 
  -- Steffen Graber <s.graber@fz-juelich.de>  Wed, 17 Jul 2019 06:50:16 +0000

--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,7 @@ Build-Depends: cmake, debhelper (>= 9), autotools-dev,
 	software-properties-common, build-essential, autoconf, python3,
 	libltdl-dev, libreadline-dev, libncurses-dev, libgsl-dev, openmpi-bin,
 	python3-dev, libopenmpi-dev, libgomp1, libomp-dev, libibverbs-dev, libpcre3, libpcre3-dev, jq,
-	libmusic1v5, music-bin, libmusic-dev, python3-numpy, python3-pandas,
-	python3-scipy,python3-matplotlib, python3-setuptools, python3-tk,
+	python3-numpy, python3-pandas, python3-scipy,python3-matplotlib, python3-setuptools, python3-tk,
 	python3-pydot, cython3, libtool
 Standards-Version: 4.1.1
 
@@ -16,8 +15,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python3, libltdl-dev,
 	libreadline-dev, libncurses-dev, libgsl-dev, openmpi-bin,
 	python3-dev, libopenmpi-dev, libgomp1, libomp-dev, libibverbs-dev, libpcre3, libpcre3-dev, jq,
-	libmusic1v5, music-bin, libmusic-dev, python3-numpy, python3-pandas,
-	python3-scipy, python3-matplotlib, python3-setuptools, python3-pydot, python3-tk,
+	python3-numpy, python3-pandas, python3-scipy, python3-matplotlib, python3-setuptools, python3-pydot, python3-tk,
 	cython3
 Description: NEST is a simulator for networks of spiking neurons.
  NEST is a simulation system for large networks of biologically realistic

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: cmake, debhelper (>= 9), autotools-dev,
 	software-properties-common, build-essential, autoconf, python3,
 	libltdl-dev, libreadline-dev, libncurses-dev, libgsl-dev, openmpi-bin,
 	python3-dev, libopenmpi-dev, libgomp1, libomp-dev, libibverbs-dev, libpcre3, libpcre3-dev, jq,
-	python3-numpy, python3-pandas, python3-scipy,python3-matplotlib, python3-setuptools, python3-tk,
+	python3-numpy, python3-pandas, python3-scipy,python3-matplotlib, python3-mpi4py, python3-setuptools, python3-tk,
 	python3-pydot, cython3, libtool
 Standards-Version: 4.1.1
 
@@ -15,8 +15,8 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python3, libltdl-dev,
 	libreadline-dev, libncurses-dev, libgsl-dev, openmpi-bin,
 	python3-dev, libopenmpi-dev, libgomp1, libomp-dev, libibverbs-dev, libpcre3, libpcre3-dev, jq,
-	python3-numpy, python3-pandas, python3-scipy, python3-matplotlib, python3-setuptools, python3-pydot, python3-tk,
-	cython3
+	python3-numpy, python3-pandas, python3-scipy, python3-matplotlib, python3-mpi4py, python3-setuptools,
+	python3-pydot, python3-tk, cython3
 Description: NEST is a simulator for networks of spiking neurons.
  NEST is a simulation system for large networks of biologically realistic
  point-neurons and neurons with a small number of electrical compartments.

--- a/debian/rules
+++ b/debian/rules
@@ -8,11 +8,9 @@ INSTALLDIR = \/$(BUILDDIR)\/$(PACKAGEVERSION)\/$(DESTDIR)
 
 CMAKE_FLAGS = -DCMAKE_INSTALL_PREFIX:PATH=$(DESTDIR)/usr -Dwith-python=3 -DCMAKE_INSTALL_LIBDIR:PATH=lib
 CMAKE_FLAGS += -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
-CMAKE_FLAGS += -Dwith-mpi:BOOL=On
-CMAKE_FLAGS += -Dwith-openmp:BOOL=On
-CMAKE_FLAGS += -Dwith-gsl:BOOL=On /usr/local/lib
-# CMAKE_FLAGS += -Dwith-libneurosim:BOOL=On /usr/local/lib
-# CMAKE_FLAGS += -Dwith-music=On /usr/lib
+CMAKE_FLAGS += -Dwith-mpi=ON
+CMAKE_FLAGS += -Dwith-openmp=ON
+CMAKE_FLAGS += -Dwith-gsl=ON -Dwith-ltdl=ON -Dwith-readline=ON
 
 %:
 	LC_ALL=en_US.UTF-8 dh ${@} --with python3 --builddirectory=$(BUILDDIR)

--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,8 @@ CMAKE_FLAGS += -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
 CMAKE_FLAGS += -Dwith-mpi:BOOL=On
 CMAKE_FLAGS += -Dwith-openmp:BOOL=On
 CMAKE_FLAGS += -Dwith-gsl:BOOL=On /usr/local/lib
-CMAKE_FLAGS += -Dwith-libneurosim:BOOL=On /usr/local/lib
-CMAKE_FLAGS += -Dwith-music=On /usr/lib
+# CMAKE_FLAGS += -Dwith-libneurosim:BOOL=On /usr/local/lib
+# CMAKE_FLAGS += -Dwith-music=On /usr/lib
 
 %:
 	LC_ALL=en_US.UTF-8 dh ${@} --with python3 --builddirectory=$(BUILDDIR)

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
Among other things, this PR removes MUSIC and libneuerosim from the cmake command. This simplifies the build process and allows Launchpad to automatically create installation packages from Ubuntu Xenial to the latest (comming) Eoan.
First test versions can be installed in this way:

```
sudo add-apt-repository ppa:nest-simulator/nest-nightly
sudo apt-get update
sudo apt-get install nest
```
