### PR TITLE
Fix [-Wsign-compare] warnings when Cythonizing pynestkernel.pyx

### DIFF
--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -623,10 +623,12 @@ cdef inline object sli_datum_to_object(Datum* dat):
 
 cdef inline object sli_array_to_object(ArrayDatum* dat):
 
-    # the size of dat has to be explicitly cast to int to avoid compiler warnings (#1318) during cythonization
+    # the size of dat has to be explicitly cast to int to avoid
+    # compiler warnings (#1318) during cythonization
     cdef tmp = [None] * int(dat.size())
 
-    # i and n have to be cast to size_t (unsigned long int) to avoid compiler warnings (#1318) in the for loop below
+    # i and n have to be cast to size_t (unsigned long int) to avoid
+    # compiler warnings (#1318) in the for loop below
     cdef size_t i, n
     cdef Token* tok = dat.begin()
 

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -623,12 +623,14 @@ cdef inline object sli_datum_to_object(Datum* dat):
 
 cdef inline object sli_array_to_object(ArrayDatum* dat):
 
-    cdef tmp = [None] * dat.size()
+    cdef tmp = [None] * int(dat.size())
 
-    cdef size_t i
+    cdef size_t i, n
     cdef Token* tok = dat.begin()
 
-    for i in range(len(tmp)):
+    n = len(tmp)
+
+    for i in range(n):
         tmp[i] = sli_datum_to_object(tok.datum())
         inc(tok)
 

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -623,8 +623,10 @@ cdef inline object sli_datum_to_object(Datum* dat):
 
 cdef inline object sli_array_to_object(ArrayDatum* dat):
 
+    # the size of dat has to be explicitly cast to int to avoid compiler warnings (#1318) during cythonization
     cdef tmp = [None] * int(dat.size())
 
+    # i and n have to be cast to size_t (unsigned long int) to avoid compiler warnings (#1318) in the for loop below
     cdef size_t i, n
     cdef Token* tok = dat.begin()
 


### PR DESCRIPTION
## Problem

Compiling NEST, when it cythonizes pynestkernel.pyx, the compiler (tested with both gcc 9.1.0 and gcc 8.3.1) generates the following warnings:

```
[100%] Compiling Cython CXX source for pynestkernel...
warning: /home/aantonietti/workspace/nest-simulator/pynest/pynestkernel.pyx:689:10: Unreachable code
warning: /home/aantonietti/workspace/nest-simulator/pynest/pynestkernel.pyx:689:10: Unreachable code
```
Which is an external Cython bug (see #1196) [Won't fix]

And

```
Scanning dependencies of target pynestkernel
[100%] Building CXX object pynest/CMakeFiles/pynestkernel.dir/pynestkernel.cxx.o
/home/aantonietti/workspace/nest-simulator/b/pynest/pynestkernel.cxx: In function ‘PyObject* __pyx_f_12pynestkernel_sli_array_to_object(ArrayDatum*)’:
/home/aantonietti/workspace/nest-simulator/b/pynest/pynestkernel.cxx:11232:35: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
     for (__pyx_temp=0; __pyx_temp < __pyx_v_dat->size(); __pyx_temp++) {
                        ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
/home/aantonietti/workspace/nest-simulator/b/pynest/pynestkernel.cxx:11260:33: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘Py_ssize_t’ {aka ‘long int’} [-Wsign-compare]
   for (__pyx_t_4 = 0; __pyx_t_4 < __pyx_t_2; __pyx_t_4+=1) {
                       ~~~~~~~~~~^~~~~~~~~~~
```
As reported also in #1318 .
## Solution

This PR fixes the two [-Wsign-compare] warning with an explicit cast to `int` of size( ) and of the argument of range( ).

