### PR TITLE
Replace iaf_neuron by iaf_psc_alpha in MUSIC tutorial

### DIFF
--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -17,7 +17,7 @@ configuration file:
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
 
-    neurons = nest.Create('iaf_neuron', 2, [{'I_e': 400.0}, {'I_e': 405.0}])
+    neurons = nest.Create('iaf_psc_alpha', 2, [{'I_e': 400.0}, {'I_e': 405.0}])
 
     music_out = nest.Create('music_event_out_proxy', 1,
         params = {'port_name':'p_out'})
@@ -40,7 +40,7 @@ and one with 405mA, just so they will respond differently. If you use
 ipython to work interactively, you can check their current status
 dictionary with ``nest.GetStatus(neurons)``. The definitive
 documentation for NEST nodes is the header file, in this case
-``models/iaf_neuron.h`` in the NEST source.
+``models/iaf_psc_alpha.h`` in the NEST source.
 
 We create a single ``music_event_out_proxy`` for our
 output on line 8, and set the port name. We loop over all the neurons on


### PR DESCRIPTION
This is only a very small change to the documentation.
In the example, the obsolete `iaf_neuron` is replaced by `iaf_psc_alpha`. (Compare PR #526) 
With this I was able to reproduce the example.