### PR TITLE
Remove spurious thread_local_connectors update.

### DIFF
--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -262,12 +262,10 @@ public:
     C_[ lcid ].set_status( dict, static_cast< GenericConnectorModel< ConnectionT >& >( cm ) );
   }
 
-
-  Connector< ConnectionT >&
+  void
   push_back( const ConnectionT& c )
   {
     C_.push_back( c );
-    return *this;
   }
 
   void

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -276,11 +276,8 @@ GenericConnectorModel< ConnectionT >::add_connection_( Node& src,
 
   assert( connector != 0 );
 
-  // TODO: simplify: push_back should not return anything
   Connector< ConnectionT >* vc = static_cast< Connector< ConnectionT >* >( connector );
-  connector = &vc->push_back( connection );
-
-  thread_local_connectors[ syn_id ] = connector;
+  vc->push_back( connection );
 }
 
 } // namespace nest


### PR DESCRIPTION
Fix a TODO by making sure push_back on connections does not return anything.

This change was originally part of #1276, but as it is not really relevant for that PR, I have taken it out and made a separate PR.