### PR TITLE
Moving to Python3.x on OsX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
     - stage: OsX
       os: osx
       osx_image: xcode10.3 # Python 3.7.4 running on macOS 10.14.4
-      language: shell # 'language: python' is an error on Travis CI macOS
+      language: shell #  # language 'python' result in errors on macOS
       env: xTHREADING=1 xMPI=0 xGSL=1 xLIBNEUROSIM=0 xLTDL=1 xREADLINE=1 xPYTHON=1 xMUSIC=0 xSTATIC_ANALYSIS=0 xRUN_BUILD_AND_TESTSUITE=1 CACHE_NAME=JOB   # Without MUSIC, MPI and Libneurosim
     
 #https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ before_install:
            brew --version
            brew update
            brew info python
-           export PATH="/usr/local/opt/python/libexec/bin:$PATH" #To use homebrew's python, add the directory in the PATH.
+           export PATH="/usr/local/opt/python/libexec/bin:$PATH"  # To use homebrew's Python
            brew tap brewsci/science
            brew tap brewsci/bio
            brew install coreutils gsl open-mpi automake autoconf libtool

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
     - stage: OsX
       os: osx
       osx_image: xcode10.3 # Python 3.7.4 running on macOS 10.14.4
-      language: shell #  # language 'python' result in errors on macOS
+      language: shell # language 'python' result in errors on macOS
       env: xTHREADING=1 xMPI=0 xGSL=1 xLIBNEUROSIM=0 xLTDL=1 xREADLINE=1 xPYTHON=1 xMUSIC=0 xSTATIC_ANALYSIS=0 xRUN_BUILD_AND_TESTSUITE=1 CACHE_NAME=JOB   # Without MUSIC, MPI and Libneurosim
     
 #https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ jobs:
       env: MATRIX_EVAL="CC=clang-7 && CXX=clang++-7" xRUN_BUILD_AND_TESTSUITE=1
     - stage: OsX
       os: osx
-      osx_image: xcode10.2
-      language: generic
+      osx_image: xcode10.3 # Python 3.7.4 running on macOS 10.14.4
+      language: shell # 'language: python' is an error on Travis CI macOS
       env: xTHREADING=1 xMPI=0 xGSL=1 xLIBNEUROSIM=0 xLTDL=1 xREADLINE=1 xPYTHON=1 xMUSIC=0 xSTATIC_ANALYSIS=0 xRUN_BUILD_AND_TESTSUITE=1 CACHE_NAME=JOB   # Without MUSIC, MPI and Libneurosim
     
 #https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
@@ -150,6 +150,8 @@ before_install:
          if [ "$TRAVIS_OS_NAME" = "osx" ]; then
            brew --version
            brew update
+           brew info python
+           export PATH="/usr/local/opt/python/libexec/bin:$PATH" #To use homebrew's python, add the directory in the PATH.
            brew tap brewsci/science
            brew tap brewsci/bio
            brew install coreutils gsl open-mpi automake autoconf libtool
@@ -160,8 +162,10 @@ before_install:
            brew leaves
            brew cask list
          fi
-         pip install --upgrade pip
-         pip install --upgrade setuptools
+         if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+           pip install --upgrade pip setuptools
+         fi
+         
          # Installing additional packages using pip as they only have
          # outdated versions in the Travis package whitelist.
          # terminaltables is required by parse_travis_log.py to create

--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -57,7 +57,7 @@ if [ "$xPYTHON" = "1" ] ; then
       CONFIGURE_PYTHON="-DPYTHON_LIBRARY=/opt/python/3.6.7/lib/libpython3.6m.so -DPYTHON_INCLUDE_DIR=/opt/python/3.6.7/include/python3.6m/"
    fi
    if [[ $OSTYPE = darwin* ]]; then
-      CONFIGURE_PYTHON="-DPYTHON_LIBRARY=/usr/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/include/python2.7"
+      CONFIGURE_PYTHON="-DPYTHON_LIBRARY=/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/include//python3.7m/"
    fi
 else
     CONFIGURE_PYTHON="-Dwith-python=OFF"


### PR DESCRIPTION
At the moment OsX build uses Python2.x. This PR will fix one of the task in #1313 and  #1325