### PR TITLE
Communication via compressed spikes

### DIFF
--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -42,6 +42,7 @@ nest::ArchivingNode::ArchivingNode()
   , tau_minus_triplet_( 110.0 )
   , tau_minus_triplet_inv_( 1. / tau_minus_triplet_ )
   , max_delay_( 0 )
+  , trace_( 0.0 )
   , last_spike_( -1.0 )
 {
 }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -620,17 +620,40 @@ EventDeliveryManager::deliver_events_( const thread tid, const std::vector< Spik
     {
       const SpikeDataT& spike_data = recv_buffer[ rank * send_recv_count_spike_data_per_rank + i ];
 
-      if ( spike_data.get_tid() == tid )
+      se.set_stamp( prepared_timestamps[ spike_data.get_lag() ] );
+      se.set_offset( spike_data.get_offset() );
+
+      if ( not kernel().connection_manager.use_compressed_spikes() )
       {
-        se.set_stamp( prepared_timestamps[ spike_data.get_lag() ] );
-        se.set_offset( spike_data.get_offset() );
+        if ( spike_data.get_tid() == tid )
+        {
+          const index syn_id = spike_data.get_syn_id();
+          const index lcid = spike_data.get_lcid();
+          const index source_node_id = kernel().connection_manager.get_source_node_id( tid, syn_id, lcid );
+          se.set_sender_node_id( source_node_id );
 
+          kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
+        }
+      }
+      else
+      {
         const index syn_id = spike_data.get_syn_id();
-        const index lcid = spike_data.get_lcid();
-        const index source_node_id = kernel().connection_manager.get_source_node_id( tid, syn_id, lcid );
-        se.set_sender_node_id( source_node_id );
+        // for compressed spikes lcid holds the index in the
+        // compressed_spike_data structure
+        const index idx = spike_data.get_lcid();
+        const std::vector< SpikeData >& compressed_spike_data =
+          kernel().connection_manager.get_compressed_spike_data( syn_id, idx );
+        for ( auto it = compressed_spike_data.cbegin(); it != compressed_spike_data.cend(); ++it )
+        {
+          if ( it->get_tid() == tid )
+          {
+            const index lcid = it->get_lcid();
+            const index source_node_id = kernel().connection_manager.get_source_node_id( tid, syn_id, lcid );
+            se.set_sender_node_id( source_node_id );
 
-        kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
+            kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
+          }
+        }
       }
 
       // break if this was the last valid entry from this rank

--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -542,6 +542,7 @@ const Name u_bar_minus( "u_bar_minus" );
 const Name u_bar_plus( "u_bar_plus" );
 const Name u_ref_squared( "u_ref_squared" );
 const Name upper_right( "upper_right" );
+const Name use_compressed_spikes( "use_compressed_spikes" );
 const Name use_wfr( "use_wfr" );
 
 const Name V_T( "V_T" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -566,6 +566,7 @@ extern const Name u_bar_minus;
 extern const Name u_bar_plus;
 extern const Name u_ref_squared;
 extern const Name upper_right;
+extern const Name use_compressed_spikes;
 extern const Name use_wfr;
 
 extern const Name V_T;

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -713,6 +713,7 @@ nest::SimulationManager::update_connection_infrastructure( const thread tid )
 
   kernel().connection_manager.restructure_connection_tables( tid );
   kernel().connection_manager.sort_connections( tid );
+  kernel().connection_manager.collect_compressed_spike_data( tid );
 
 #pragma omp barrier // wait for all threads to finish sorting
 
@@ -761,6 +762,12 @@ nest::SimulationManager::update_connection_infrastructure( const thread tid )
   if ( kernel().connection_manager.secondary_connections_exist() )
   {
     kernel().connection_manager.compress_secondary_send_buffer_pos( tid );
+  }
+
+#pragma omp barrier
+  if ( kernel().connection_manager.use_compressed_spikes() )
+  {
+    kernel().connection_manager.clear_compressed_spike_data_map( tid );
   }
 
 #pragma omp single

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -49,12 +49,16 @@ nest::SourceTable::initialize()
   saved_entry_point_.initialize( num_threads, false );
   current_positions_.resize( num_threads );
   saved_positions_.resize( num_threads );
+  compressible_sources_.resize( num_threads );
+  compressed_spike_data_map_.resize( num_threads );
 
 #pragma omp parallel
   {
     const thread tid = kernel().vp_manager.get_thread_id();
     sources_[ tid ].resize( 0 );
     resize_sources( tid );
+    compressible_sources_[ tid ].resize( 0 );
+    compressed_spike_data_map_[ tid ].resize( 0 );
   } // of omp parallel
 }
 
@@ -66,12 +70,16 @@ nest::SourceTable::finalize()
     if ( is_cleared_[ tid ].is_false() )
     {
       clear( tid );
+      compressible_sources_[ tid ].clear();
+      compressed_spike_data_map_[ tid ].clear();
     }
   }
 
   sources_.clear();
   current_positions_.clear();
   saved_positions_.clear();
+  compressible_sources_.clear();
+  compressed_spike_data_map_.clear();
 }
 
 bool
@@ -305,7 +313,7 @@ nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& c
     and local_sources[ previous_lcid ].get_node_id() == current_source.get_node_id() );
 }
 
-void
+bool
 nest::SourceTable::populate_target_data_fields_( const SourceTablePosition& current_position,
   const Source& current_source,
   const thread source_rank,
@@ -323,10 +331,36 @@ nest::SourceTable::populate_target_data_fields_( const SourceTablePosition& curr
     next_target_data.set_is_primary( true );
 
     TargetDataFields& target_fields = next_target_data.target_data;
-    // we store the thread index of the source table, not our own tid!
-    target_fields.set_tid( current_position.tid );
     target_fields.set_syn_id( current_position.syn_id );
-    target_fields.set_lcid( current_position.lcid );
+    if ( kernel().connection_manager.use_compressed_spikes() )
+    {
+      // WARNING: we set the tid field here to zero just to make sure
+      // it has a defined value; however, this value is _not_ used
+      // anywhere when using compressed spikes
+      target_fields.set_tid( 0 );
+      auto it_idx = compressed_spike_data_map_.at( current_position.tid )
+                      .at( current_position.syn_id )
+                      .find( current_source.get_node_id() );
+      if ( it_idx != compressed_spike_data_map_.at( current_position.tid ).at( current_position.syn_id ).end() )
+      {
+        // WARNING: no matter how tempting, do not try to remove this
+        // entry from the compressed_spike_data_map_; if the MPI buffer
+        // is already full, this entry will need to be communicated the
+        // next MPI comm round, which, naturally, is not possible if it
+        // has been removed
+        target_fields.set_lcid( it_idx->second );
+      }
+      else // another thread is responsible for communicating this compressed source
+      {
+        return false;
+      }
+    }
+    else
+    {
+      // we store the thread index of the source table, not our own tid!
+      target_fields.set_tid( current_position.tid );
+      target_fields.set_lcid( current_position.lcid );
+    }
   }
   else // secondary connection, e.g., gap junctions
   {
@@ -343,6 +377,8 @@ nest::SourceTable::populate_target_data_fields_( const SourceTablePosition& curr
     secondary_fields.set_recv_buffer_pos( relative_recv_buffer_pos );
     secondary_fields.set_syn_id( current_position.syn_id );
   }
+
+  return true;
 }
 
 bool
@@ -399,12 +435,117 @@ nest::SourceTable::get_next_target_data( const thread tid,
     // set the source rank
     source_rank = kernel().mpi_manager.get_process_id_of_node_id( current_source.get_node_id() );
 
-    populate_target_data_fields_( current_position, current_source, source_rank, next_target_data );
+    if ( not populate_target_data_fields_( current_position, current_source, source_rank, next_target_data ) )
+    {
+      current_position.decrease();
+      continue;
+    }
 
     // we are about to return a valid entry, so mark it as processed
     current_source.set_processed( true );
 
     current_position.decrease();
     return true; // found a valid entry
+  }
+}
+
+void
+nest::SourceTable::resize_compressible_sources()
+{
+  for ( thread tid = 0; tid < static_cast< thread >( compressible_sources_.size() ); ++tid )
+  {
+    compressible_sources_[ tid ].clear();
+    compressible_sources_[ tid ].resize(
+      kernel().model_manager.get_num_synapse_prototypes(), std::map< index, SpikeData >() );
+  }
+}
+
+void
+nest::SourceTable::collect_compressible_sources( const thread tid )
+{
+  for ( synindex syn_id = 0; syn_id < sources_[ tid ].size(); ++syn_id )
+  {
+    index lcid = 0;
+    auto& syn_sources = sources_[ tid ][ syn_id ];
+    while ( lcid < syn_sources.size() )
+    {
+      const index old_source_node_id = syn_sources[ lcid ].get_node_id();
+      const std::pair< index, SpikeData > source_node_id_to_spike_data =
+        std::make_pair( old_source_node_id, SpikeData( tid, syn_id, lcid, 0 ) );
+      compressible_sources_[ tid ][ syn_id ].insert( source_node_id_to_spike_data );
+
+      // find next source with different node_id (assumes sorted sources)
+      ++lcid;
+      while ( ( lcid < syn_sources.size() ) and ( syn_sources[ lcid ].get_node_id() == old_source_node_id ) )
+      {
+        ++lcid;
+      }
+    }
+  }
+}
+
+void
+nest::SourceTable::fill_compressed_spike_data(
+  std::vector< std::vector< std::vector< SpikeData > > >& compressed_spike_data )
+{
+  compressed_spike_data.clear();
+  compressed_spike_data.resize( kernel().model_manager.get_num_synapse_prototypes() );
+
+  for ( thread tid = 0; tid < static_cast< thread >( compressible_sources_.size() ); ++tid )
+  {
+    compressed_spike_data_map_[ tid ].clear();
+    compressed_spike_data_map_[ tid ].resize(
+      kernel().model_manager.get_num_synapse_prototypes(), std::map< index, size_t >() );
+  }
+
+  // pseudo-random thread selector to balance memory usage across
+  // threads of compressed_spike_data_map_
+  size_t thread_idx = 0;
+
+  // for each local thread and each synapse type we will populate this
+  // vector with spike data containing information about all process
+  // local targets
+  std::vector< SpikeData > spike_data;
+
+  for ( thread tid = 0; tid < static_cast< thread >( compressible_sources_.size() ); ++tid )
+  {
+    for ( synindex syn_id = 0; syn_id < compressible_sources_[ tid ].size(); ++syn_id )
+    {
+      for ( auto it = compressible_sources_[ tid ][ syn_id ].begin();
+            it != compressible_sources_[ tid ][ syn_id ].end(); )
+      {
+        spike_data.clear();
+
+        // add target position on this thread
+        spike_data.push_back( it->second );
+
+        // add target positions on all other threads
+        for ( thread other_tid = tid + 1; other_tid < static_cast< thread >( compressible_sources_.size() );
+              ++other_tid )
+        {
+          auto other_it = compressible_sources_[ other_tid ][ syn_id ].find( it->first );
+          if ( other_it != compressible_sources_[ other_tid ][ syn_id ].end() )
+          {
+            spike_data.push_back( other_it->second );
+            compressible_sources_[ other_tid ][ syn_id ].erase( other_it );
+          }
+        }
+
+        // WARNING: store source-node-id -> process-global-synapse
+        // association in compressed_spike_data_map on a
+        // pseudo-randomly selected thread which houses targets for
+        // this source; this tries to balance memory usage of this
+        // data structure across threads
+        const thread responsible_tid = spike_data[ thread_idx % spike_data.size() ].get_tid();
+        ++thread_idx;
+
+        compressed_spike_data_map_[ responsible_tid ][ syn_id ].insert(
+          std::make_pair( it->first, compressed_spike_data[ syn_id ].size() ) );
+        compressed_spike_data[ syn_id ].push_back( spike_data );
+
+        it = compressible_sources_[ tid ][ syn_id ].erase( it );
+      }
+      compressible_sources_[ tid ][ syn_id ].clear();
+    }
   }
 }

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -312,6 +312,11 @@ def SetKernelStatus(params):
         Defines the time interval in ms at which the structural plasticity
         manager will make changes in the structure of the network (creation
         and deletion of plastic synapses)
+    use_compressed_spikes : bool
+        Whether to use spike compression; if a neuron has targets on
+        multiple threads of a process, this switch makes sure that only
+        a single packet is sent to the process instead of one packet per
+        target thread; requires sort_connections_by_source = true
 
 
     Output

--- a/pynest/nest/tests/test_spatial/test_basics.py
+++ b/pynest/nest/tests/test_spatial/test_basics.py
@@ -39,17 +39,17 @@ class BasicsTestCase(unittest.TestCase):
         """Creating a single layer."""
         shape = [5, 4]
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=shape))
-        self.assertEqual(len(l), shape[0]*shape[1])
+        layer = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=shape))
+        self.assertEqual(len(layer), shape[0] * shape[1])
 
     def test_create_layer_with_param(self):
         """Creating a layer with parameters."""
         shape = [5, 4]
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha',
-                        params={'V_m': -55.0},
-                        positions=nest.spatial.grid(shape=shape))
-        layer_vm = l.get('V_m')
+        layer = nest.Create('iaf_psc_alpha',
+                            params={'V_m': -55.0},
+                            positions=nest.spatial.grid(shape=shape))
+        layer_vm = layer.get('V_m')
         for vm in layer_vm:
             self.assertEqual(vm, -55.0)
 
@@ -57,20 +57,20 @@ class BasicsTestCase(unittest.TestCase):
         """Check if GetPosition returns proper positions."""
         pos = ((1.0, 0.0), (0.0, 1.0), (3.5, 1.5))
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha', positions=nest.spatial.free(pos))
+        layer = nest.Create('iaf_psc_alpha', positions=nest.spatial.free(pos))
 
         # GetPosition of single node
-        nodepos_exp = nest.GetPosition(l[:1])
+        nodepos_exp = nest.GetPosition(layer[:1])
         self.assertEqual(nodepos_exp, pos[0])
 
-        nodepos_exp = nest.GetPosition(l[-1:])
+        nodepos_exp = nest.GetPosition(layer[-1:])
         self.assertEqual(nodepos_exp, pos[-1])
 
-        nodepos_exp = nest.GetPosition(l[1:2])
+        nodepos_exp = nest.GetPosition(layer[1:2])
         self.assertEqual(nodepos_exp, pos[1])
 
         # GetPosition of all the nodes in the layer
-        nodepos_exp = nest.GetPosition(l)
+        nodepos_exp = nest.GetPosition(layer)
 
         for npe, npr in zip(nodepos_exp, pos):
             self.assertEqual(npe, npr)
@@ -78,7 +78,7 @@ class BasicsTestCase(unittest.TestCase):
         self.assertEqual(pos, nodepos_exp)
 
         # GetPosition on some of the node IDs
-        nodepos_exp = nest.GetPosition(l[:2])
+        nodepos_exp = nest.GetPosition(layer[:2])
         self.assertEqual(nodepos_exp, (pos[0], pos[1]))
 
     @unittest.skipIf(not HAVE_NUMPY, 'NumPy package is not available')
@@ -86,29 +86,29 @@ class BasicsTestCase(unittest.TestCase):
         """Interface check on displacement calculations."""
         lshape = [5, 4]
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=lshape))
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=lshape))
 
         # node IDs -> node IDs, all displacements must be zero here
-        d = nest.Displacement(l, l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Displacement(layer, layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all(dd == (0., 0.) for dd in d))
 
         # single node ID -> node IDs
-        d = nest.Displacement(l[:1], l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Displacement(layer[:1], layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all(len(dd) == 2 for dd in d))
 
         # node IDs -> single node ID
-        d = nest.Displacement(l, l[:1])
-        self.assertEqual(len(d), len(l))
+        d = nest.Displacement(layer, layer[:1])
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all(len(dd) == 2 for dd in d))
 
         # Displacement between node ID 1 and 6. They are on the same y-axis, and
         # directly next to each other on the x-axis, so the displacement on
         # x-axis should be approximately -dx, while the displacement on the
         # y-axis should be 0.
-        d = nest.Displacement(l[:1], l[4:5])
+        d = nest.Displacement(layer[:1], layer[4:5])
         dx = 1. / lshape[0]
         self.assertAlmostEqual(d[0][0], -dx, 3)
         self.assertEqual(d[0][1], 0.0)
@@ -117,21 +117,21 @@ class BasicsTestCase(unittest.TestCase):
         # directly next to each other on the y-axis, so the displacement on
         # x-axis should be 0, while the displacement on the y-axis should be
         # approximately dy.
-        d = nest.Displacement(l[:1], l[1:2])
+        d = nest.Displacement(layer[:1], layer[1:2])
         dy = 1. / lshape[1]
         self.assertEqual(d[0][0], 0.0)
         self.assertAlmostEqual(d[0][1], dy, 3)
 
         # Test that we get correct results if to_arg and from_arg are from two
         # different layers
-        l2 = nest.Create('iaf_psc_alpha',
-                         positions=nest.spatial.grid(shape=lshape))
-        d = nest.Displacement(l[:1], l2[4:5])
+        layer2 = nest.Create('iaf_psc_alpha',
+                             positions=nest.spatial.grid(shape=lshape))
+        d = nest.Displacement(layer[:1], layer2[4:5])
         dx = 1. / lshape[0]
         self.assertAlmostEqual(d[0][0], -dx, 3)
         self.assertEqual(d[0][1], 0.0)
 
-        d = nest.Displacement(l[:1], l2[1:2])
+        d = nest.Displacement(layer[:1], layer2[1:2])
         dy = 1. / lshape[1]
         self.assertEqual(d[0][0], 0.0)
         self.assertAlmostEqual(d[0][1], dy, 3)
@@ -139,21 +139,21 @@ class BasicsTestCase(unittest.TestCase):
         # Test that an error is thrown if to_arg and from_arg have different
         # size.
         with self.assertRaises(ValueError):
-            d = nest.Displacement(l[1:3], l[2:7])
+            d = nest.Displacement(layer[1:3], layer[2:7])
 
         # position -> node IDs
-        d = nest.Displacement([(0.0, 0.0)], l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Displacement([(0.0, 0.0)], layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all(len(dd) == 2 for dd in d))
 
         # position -> node IDs
-        d = nest.Displacement(np.array([0.0, 0.0]), l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Displacement(np.array([0.0, 0.0]), layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all(len(dd) == 2 for dd in d))
 
         # positions -> node IDs
-        d = nest.Displacement([np.array([0.0, 0.0])] * len(l), l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Displacement([np.array([0.0, 0.0])] * len(layer), layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all(len(dd) == 2 for dd in d))
 
     @unittest.skipIf(not HAVE_NUMPY, 'NumPy package is not available')
@@ -161,84 +161,84 @@ class BasicsTestCase(unittest.TestCase):
         """Interface check on distance calculations."""
         lshape = [5, 4]
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=lshape))
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=lshape))
 
         # node IDs -> node IDs, all displacements must be zero here
-        d = nest.Distance(l, l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Distance(layer, layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all([dd == 0. for dd in d]))
 
         # single node ID -> node IDs
-        d = nest.Distance(l[:1], l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Distance(layer[:1], layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all([isinstance(dd, float) for dd in d]))
         self.assertTrue(all([dd >= 0. for dd in d]))
 
         # node IDs -> single node ID
-        d = nest.Distance(l, l[:1])
-        self.assertEqual(len(d), len(l))
+        d = nest.Distance(layer, layer[:1])
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all([isinstance(dd, float) for dd in d]))
         self.assertTrue(all([dd >= 0. for dd in d]))
 
         # Distance between node ID 1 and 6. They are on the same y-axis, and
         # directly next to each other on the x-axis, so the distance should be
         # approximately dx. The same is true for distance between node ID 6 and 1.
-        d = nest.Distance(l[:1], l[4:5])
+        d = nest.Distance(layer[:1], layer[4:5])
         dx = 1. / lshape[0]
         self.assertAlmostEqual(d[0], dx, 3)
 
-        d = nest.Distance(l[4:5], l[:1])
+        d = nest.Distance(layer[4:5], layer[:1])
         self.assertAlmostEqual(d[0], dx, 3)
 
         # Distance between node ID 1 and 2. They are on the same x-axis, and
         # directly next to each other on the y-axis, so the distance should be
         # approximately dy. The same is true for distance between node ID 2 and 1.
-        d = nest.Distance(l[:1], l[1:2])
+        d = nest.Distance(layer[:1], layer[1:2])
         dy = 1. / lshape[1]
         self.assertAlmostEqual(d[0], dy, 3)
 
-        d = nest.Distance(l[1:2], l[:1])
+        d = nest.Distance(layer[1:2], layer[:1])
         self.assertAlmostEqual(d[0], dy, 3)
 
         # Test that we get correct results if to_arg and from_arg are from two
         # different layers
-        l2 = nest.Create('iaf_psc_alpha',
-                         positions=nest.spatial.grid(shape=lshape))
-        d = nest.Distance(l[:1], l2[4:5])
+        layer2 = nest.Create('iaf_psc_alpha',
+                             positions=nest.spatial.grid(shape=lshape))
+        d = nest.Distance(layer[:1], layer2[4:5])
         dx = 1. / lshape[0]
         self.assertAlmostEqual(d[0], dx, 3)
 
-        d = nest.Distance(l[4:5], l2[:1])
+        d = nest.Distance(layer[4:5], layer2[:1])
         self.assertAlmostEqual(d[0], dx, 3)
 
-        d = nest.Distance(l[:1], l2[1:2])
+        d = nest.Distance(layer[:1], layer2[1:2])
         dy = 1. / lshape[1]
         self.assertAlmostEqual(d[0], dy, 3)
 
-        d = nest.Distance(l[1:2], l2[:1])
+        d = nest.Distance(layer[1:2], layer2[:1])
         self.assertAlmostEqual(d[0], dy, 3)
 
         # Test that an error is thrown if to_arg and from_arg have different
         # size.
         with self.assertRaises(ValueError):
-            d = nest.Distance(l[1:3], l[2:7])
+            d = nest.Distance(layer[1:3], layer[2:7])
 
         # position -> node IDs
-        d = nest.Distance([[0.0, 0.0], ], l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Distance([[0.0, 0.0], ], layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all([isinstance(dd, float) for dd in d]))
         self.assertTrue(all([dd >= 0. for dd in d]))
 
         # position -> node IDs
-        d = nest.Distance(np.array([0.0, 0.0]), l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Distance(np.array([0.0, 0.0]), layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all([isinstance(dd, float) for dd in d]))
         self.assertTrue(all([dd >= 0. for dd in d]))
 
         # positions -> node IDs
-        d = nest.Distance([np.array([0.0, 0.0])] * len(l), l)
-        self.assertEqual(len(d), len(l))
+        d = nest.Distance([np.array([0.0, 0.0])] * len(layer), layer)
+        self.assertEqual(len(d), len(layer))
         self.assertTrue(all([isinstance(dd, float) for dd in d]))
         self.assertTrue(all([dd >= 0. for dd in d]))
 
@@ -248,35 +248,35 @@ class BasicsTestCase(unittest.TestCase):
            This function is Py only, so we also need to check results."""
         # nodes at [-1,0,1]x[-1,0,1], column-wise
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=[3, 3], extent=(3., 3.)))
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=[3, 3], extent=(3., 3.)))
 
         # single location at center
-        n = nest.FindNearestElement(l, (0., 0.))
-        self.assertEqual(n, l[4])
+        n = nest.FindNearestElement(layer, (0., 0.))
+        self.assertEqual(n, layer[4])
 
         # two locations, one layer
-        n = nest.FindNearestElement(l, ((0., 0.), (1., 1.)))
-        self.assertEqual(n[0], l[4])
-        self.assertEqual(n[1], l[6])
+        n = nest.FindNearestElement(layer, ((0., 0.), (1., 1.)))
+        self.assertEqual(n[0], layer[4])
+        self.assertEqual(n[1], layer[6])
 
         # several closest locations, not all
-        n = nest.FindNearestElement(l, (0.5, 0.5))
+        n = nest.FindNearestElement(layer, (0.5, 0.5))
         self.assertEqual(len(n), 1)
         self.assertTrue(n.get('global_id') in nest.NodeCollection((4, 5, 7, 8)))
 
         # several closest locations, all
-        n = nest.FindNearestElement(l, (0.5, 0.5), find_all=True)
+        n = nest.FindNearestElement(layer, (0.5, 0.5), find_all=True)
         self.assertEqual(len(n), 4)
-        self.assertEqual(n[0], l[3])
-        self.assertEqual(n[3], l[7])
+        self.assertEqual(n[0], layer[3])
+        self.assertEqual(n[3], layer[7])
 
         # complex case
-        n = nest.FindNearestElement(l, ((0., 0.), (0.5, 0.5)),
+        n = nest.FindNearestElement(layer, ((0., 0.), (0.5, 0.5)),
                                     find_all=True)
         self.assertEqual(len(n), 2)
-        self.assertEqual(n[0], [l[4]])
-        self.assertEqual(n[1], [l[3], l[4], l[6], l[7]])
+        self.assertEqual(n[0], [layer[4]])
+        self.assertEqual(n[1], [layer[3], layer[4], layer[6], layer[7]])
 
     @unittest.skipIf(not HAVE_NUMPY, 'NumPy package is not available')
     def test_GetCenterElement(self):
@@ -284,12 +284,12 @@ class BasicsTestCase(unittest.TestCase):
            This function is Py only, so we also need to check results."""
         # nodes at [-1,0,1]x[-1,0,1], column-wise
         nest.ResetKernel()
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=[3, 3], extent=(2., 2.)))
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=[3, 3], extent=(2., 2.)))
 
         # single layer
-        n = nest.FindCenterElement(l)
-        self.assertEqual(n, l[4:5])
+        n = nest.FindCenterElement(layer)
+        self.assertEqual(n, layer[4:5])
 
         # new layer
         l2 = nest.Create('iaf_psc_alpha',
@@ -307,40 +307,40 @@ class BasicsTestCase(unittest.TestCase):
         nest.ResetKernel()
         nest.SetKernelStatus({'sort_connections_by_source': False, 'use_compressed_spikes': False})
 
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=[3, 3],
-                                                    extent=(2., 2.),
-                                                    edge_wrap=True))
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=[3, 3],
+                                                        extent=(2., 2.),
+                                                        edge_wrap=True))
 
-        # connect l -> l
-        nest.Connect(l, l, cdict, sdict)
+        # connect layer -> layer
+        nest.Connect(layer, layer, cdict, sdict)
 
-        t = nest.GetTargetNodes(l[0], l)
+        t = nest.GetTargetNodes(layer[0], layer)
         self.assertEqual(len(t), 1)
 
-        t = nest.GetTargetNodes(l, l)
-        self.assertEqual(len(t), len(l))
+        t = nest.GetTargetNodes(layer, layer)
+        self.assertEqual(len(t), len(layer))
         # 2x2 mask -> four targets
         self.assertTrue(all([len(g) == 4 for g in t]))
 
-        t = nest.GetTargetNodes(l, l, syn_model='static_synapse')
-        self.assertEqual(len(t), len(l))
+        t = nest.GetTargetNodes(layer, layer, syn_model='static_synapse')
+        self.assertEqual(len(t), len(layer))
         self.assertTrue(all([len(g) == 0 for g in t]))  # no static syns
 
-        t = nest.GetTargetNodes(l, l, syn_model='stdp_synapse')
-        self.assertEqual(len(t), len(l))
+        t = nest.GetTargetNodes(layer, layer, syn_model='stdp_synapse')
+        self.assertEqual(len(t), len(layer))
         self.assertTrue(
             all([len(g) == 4 for g in t]))  # 2x2 mask  -> four targets
 
-        t = nest.GetTargetNodes(l[0], l)
+        t = nest.GetTargetNodes(layer[0], layer)
         self.assertEqual(len(t), 1)
         self.assertEqual(t[0], nest.NodeCollection([1, 2, 4, 5]))
 
-        t = nest.GetTargetNodes(l[4], l)
+        t = nest.GetTargetNodes(layer[4], layer)
         self.assertEqual(len(t), 1)
         self.assertEqual(t[0], nest.NodeCollection([5, 6, 8, 9]))
 
-        t = nest.GetTargetNodes(l[8], l)
+        t = nest.GetTargetNodes(layer[8], layer)
         self.assertEqual(len(t), 1)
         self.assertEqual(t[0], nest.NodeCollection([1, 3, 7, 9]))
 
@@ -354,14 +354,14 @@ class BasicsTestCase(unittest.TestCase):
 
         nest.SetKernelStatus({'sort_connections_by_source': False, 'use_compressed_spikes': False})
 
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=[1, 1],
-                                                    extent=(1., 1.),
-                                                    edge_wrap=False))
-        nest.Connect(l, l, cdict, sdict)
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=[1, 1],
+                                                        extent=(1., 1.),
+                                                        edge_wrap=False))
+        nest.Connect(layer, layer, cdict, sdict)
 
         # Simple test with one node ID in the layer, should be placed in the origin
-        p = nest.GetTargetPositions(l, l)
+        p = nest.GetTargetPositions(layer, layer)
         self.assertTrue(p, [[(0.0, 0.0)]])
 
         # Test positions on a grid, we can calculate what they should be
@@ -372,18 +372,18 @@ class BasicsTestCase(unittest.TestCase):
         y_extent = 1.
         shape = [3, 3]
 
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.grid(shape=shape,
-                                                    extent=[x_extent, y_extent],
-                                                    edge_wrap=False))
-        nest.Connect(l, l, cdict, sdict)
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=shape,
+                                                        extent=[x_extent, y_extent],
+                                                        edge_wrap=False))
+        nest.Connect(layer, layer, cdict, sdict)
 
-        p = nest.GetTargetPositions(l[:1], l)
+        p = nest.GetTargetPositions(layer[:1], layer)
         self.assertEqual(len(p), 1)
         self.assertTrue(all([len(pp) == 2 for pp in p[0]]))
 
-        p = nest.GetTargetPositions(l, l)
-        self.assertEqual(len(p), len(l))
+        p = nest.GetTargetPositions(layer, layer)
+        self.assertEqual(len(p), len(layer))
 
         dx = x_extent / shape[0]
         dy = y_extent / shape[1]
@@ -406,12 +406,12 @@ class BasicsTestCase(unittest.TestCase):
 
         positions = [(np.random.uniform(-0.5, 0.5),
                       np.random.uniform(-0.5, 0.5)) for _ in range(50)]
-        l = nest.Create('iaf_psc_alpha',
-                        positions=nest.spatial.free(positions,
-                                                    edge_wrap=False))
-        nest.Connect(l, l, cdict, sdict)
+        layer = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.free(positions,
+                                                        edge_wrap=False))
+        nest.Connect(layer, layer, cdict, sdict)
 
-        p = nest.GetTargetPositions(l[:1], l)
+        p = nest.GetTargetPositions(layer[:1], layer)
 
         for indx in range(len(p[0])):
             self.assertAlmostEqual(positions[indx][0], p[0][indx][0])

--- a/pynest/nest/tests/test_spatial/test_basics.py
+++ b/pynest/nest/tests/test_spatial/test_basics.py
@@ -305,7 +305,7 @@ class BasicsTestCase(unittest.TestCase):
                  'mask': {'grid': {'shape': [2, 2]}}}
         sdict = {'synapse_model': 'stdp_synapse'}
         nest.ResetKernel()
-        nest.SetKernelStatus({'sort_connections_by_source': False})
+        nest.SetKernelStatus({'sort_connections_by_source': False, 'use_compressed_spikes': False})
 
         l = nest.Create('iaf_psc_alpha',
                         positions=nest.spatial.grid(shape=[3, 3],
@@ -352,7 +352,7 @@ class BasicsTestCase(unittest.TestCase):
                  'p': 1.}
         sdict = {'synapse_model': 'stdp_synapse'}
 
-        nest.SetKernelStatus({'sort_connections_by_source': False})
+        nest.SetKernelStatus({'sort_connections_by_source': False, 'use_compressed_spikes': False})
 
         l = nest.Create('iaf_psc_alpha',
                         positions=nest.spatial.grid(shape=[1, 1],
@@ -366,7 +366,7 @@ class BasicsTestCase(unittest.TestCase):
 
         # Test positions on a grid, we can calculate what they should be
         nest.ResetKernel()
-        nest.SetKernelStatus({'sort_connections_by_source': False})
+        nest.SetKernelStatus({'sort_connections_by_source': False, 'use_compressed_spikes': False})
 
         x_extent = 1.
         y_extent = 1.
@@ -402,7 +402,7 @@ class BasicsTestCase(unittest.TestCase):
         # Test that we get correct positions when we send in a positions array
         # when creating the layer
         nest.ResetKernel()
-        nest.SetKernelStatus({'sort_connections_by_source': False})
+        nest.SetKernelStatus({'sort_connections_by_source': False, 'use_compressed_spikes': False})
 
         positions = [(np.random.uniform(-0.5, 0.5),
                       np.random.uniform(-0.5, 0.5)) for _ in range(50)]

--- a/testsuite/unittests/test_connect_after_simulate.sli
+++ b/testsuite/unittests/test_connect_after_simulate.sli
@@ -54,7 +54,7 @@ M_ERROR setverbosity
 
   /neurons /iaf_psc_alpha 10 Create def
 
-  << /sort_connections_by_source sort_connections >> SetKernelStatus
+  << /sort_connections_by_source sort_connections /use_compressed_spikes sort_connections >> SetKernelStatus
   neurons neurons << /rule /fixed_indegree /indegree 2 >> << >> Connect
 
   /connections_before << >> GetConnections def
@@ -64,7 +64,7 @@ M_ERROR setverbosity
 
   % switch from sort to no-sort or vice versa
   % and create more connections and check again
-  << /sort_connections_by_source sort_connections not >> SetKernelStatus
+  << /sort_connections_by_source sort_connections not /use_compressed_spikes sort_connections not >> SetKernelStatus
   neurons neurons << /rule /fixed_indegree /indegree 2 >> << >> Connect
 
   /connections_before << >> GetConnections def
@@ -81,7 +81,7 @@ forall
 
   ResetKernel
 
-  << /sort_connections_by_source sort_connections >> SetKernelStatus
+  << /sort_connections_by_source sort_connections /use_compressed_spikes sort_connections >> SetKernelStatus
 
   /neuron /iaf_psc_delta << /I_e 500. >> Create def
   /parrot /parrot_neuron Create def

--- a/testsuite/unittests/test_free_mask_circ_anchor_00.sli
+++ b/testsuite/unittests/test_free_mask_circ_anchor_00.sli
@@ -242,7 +242,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_circ_anchor_01.sli
+++ b/testsuite/unittests/test_free_mask_circ_anchor_01.sli
@@ -231,7 +231,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_circ_anchor_10.sli
+++ b/testsuite/unittests/test_free_mask_circ_anchor_10.sli
@@ -265,7 +265,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_circ_anchor_11.sli
+++ b/testsuite/unittests/test_free_mask_circ_anchor_11.sli
@@ -265,7 +265,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_donut_anchor_00.sli
+++ b/testsuite/unittests/test_free_mask_donut_anchor_00.sli
@@ -216,7 +216,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_donut_anchor_01.sli
+++ b/testsuite/unittests/test_free_mask_donut_anchor_01.sli
@@ -211,7 +211,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_donut_anchor_10.sli
+++ b/testsuite/unittests/test_free_mask_donut_anchor_10.sli
@@ -239,7 +239,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_donut_anchor_11.sli
+++ b/testsuite/unittests/test_free_mask_donut_anchor_11.sli
@@ -241,7 +241,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_rect_00.sli
+++ b/testsuite/unittests/test_free_mask_rect_00.sli
@@ -244,7 +244,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_rect_01.sli
+++ b/testsuite/unittests/test_free_mask_rect_01.sli
@@ -226,7 +226,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_rect_11.sli
+++ b/testsuite/unittests/test_free_mask_rect_11.sli
@@ -269,7 +269,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_free_mask_rect_13.sli
+++ b/testsuite/unittests/test_free_mask_rect_13.sli
@@ -355,7 +355,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_circ_anchor_00.sli
+++ b/testsuite/unittests/test_reg_mask_circ_anchor_00.sli
@@ -234,7 +234,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_circ_anchor_01.sli
+++ b/testsuite/unittests/test_reg_mask_circ_anchor_01.sli
@@ -223,7 +223,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_circ_anchor_10.sli
+++ b/testsuite/unittests/test_reg_mask_circ_anchor_10.sli
@@ -257,7 +257,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_circ_anchor_11.sli
+++ b/testsuite/unittests/test_reg_mask_circ_anchor_11.sli
@@ -258,7 +258,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_donut_anchor_00.sli
+++ b/testsuite/unittests/test_reg_mask_donut_anchor_00.sli
@@ -208,7 +208,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_donut_anchor_01.sli
+++ b/testsuite/unittests/test_reg_mask_donut_anchor_01.sli
@@ -203,7 +203,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_donut_anchor_10.sli
+++ b/testsuite/unittests/test_reg_mask_donut_anchor_10.sli
@@ -231,7 +231,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_donut_anchor_11.sli
+++ b/testsuite/unittests/test_reg_mask_donut_anchor_11.sli
@@ -233,7 +233,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_00.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_00.sli
@@ -235,7 +235,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_01.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_01.sli
@@ -236,7 +236,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_02.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_02.sli
@@ -208,7 +208,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_03.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_03.sli
@@ -239,7 +239,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_04.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_04.sli
@@ -202,7 +202,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_05.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_05.sli
@@ -129,7 +129,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_06.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_06.sli
@@ -293,7 +293,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_10.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_10.sli
@@ -271,7 +271,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_11.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_11.sli
@@ -271,7 +271,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_13.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_13.sli
@@ -271,7 +271,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_grid_anchor_15.sli
+++ b/testsuite/unittests/test_reg_mask_grid_anchor_15.sli
@@ -286,7 +286,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_rect_00.sli
+++ b/testsuite/unittests/test_reg_mask_rect_00.sli
@@ -238,7 +238,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_rect_01.sli
+++ b/testsuite/unittests/test_reg_mask_rect_01.sli
@@ -241,7 +241,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_rect_02.sli
+++ b/testsuite/unittests/test_reg_mask_rect_02.sli
@@ -236,7 +236,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_rect_10.sli
+++ b/testsuite/unittests/test_reg_mask_rect_10.sli
@@ -280,7 +280,7 @@ def
 ResetKernel
 
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_reg_mask_rect_11.sli
+++ b/testsuite/unittests/test_reg_mask_rect_11.sli
@@ -282,7 +282,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 /sources src_layer CreateLayer def
 /targets tgt_layer CreateLayer def

--- a/testsuite/unittests/test_weight_delay.sli
+++ b/testsuite/unittests/test_weight_delay.sli
@@ -194,7 +194,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 userdict /resolution known { << /resolution resolution >> SetKernelStatus } if
 

--- a/testsuite/unittests/test_weight_delay_free.sli
+++ b/testsuite/unittests/test_weight_delay_free.sli
@@ -196,7 +196,7 @@ def
 
 ResetKernel
 
-<< /sort_connections_by_source false >> SetKernelStatus
+<< /sort_connections_by_source false /use_compressed_spikes false >> SetKernelStatus
 
 userdict /resolution known { << /resolution resolution >> SetKernelStatus } if
 


### PR DESCRIPTION
In the current ("5g") communication scheme if a neuron has multiple targets on different threads of a target process, spikes for all different threads are generated on the presynaptic side and send to the postsynaptic side via MPI. For example for 48threads, a neuron with targets on all threads will generate 48spikes presynaptically. This leads to unnecessarily large MPI buffers for massively multihreaded simulations (buffer sizes scale ~ #threads per process).

By introducing an additional postsynaptic data structure and the concept of a "compressed spike" this PR modifies the communication infrastructure such that this redundancy is avoided. A neuron with targets on all threads of a process hence only needs to send a single spike which is then multiplexed on the postsynaptic side, significantly reducing the load on the communication network. Initial benchmarks show significant improvements over 5g on specific benchmark instances with many threads (measured and reported by @jarsi @jhnnsnk ).
The current implementation relies on heuristics to select the connections which qualify for using compressed spikes, these should be critically reviewed.

@jhnnsnk @terhorstd 