### PR TITLE
Make multimeter and voltmeter class names lower case

### DIFF
--- a/doc/guides/analog_recording_with_multimeter.rst
+++ b/doc/guides/analog_recording_with_multimeter.rst
@@ -4,7 +4,7 @@ Analog recording with multimeter
 As of r89xx, NEST replaces a range of analog recording devices, such as
 voltmeter, conductancemeter and aeif\_w\_meter with a universal
 *multimeter*, which can record all analog quantities a model neuron
-makes available for recording. Multimeter works essentially as the
+makes available for recording. The multimeter works essentially as the
 old-style voltmeter, but with a few changes:
 
 -  The ``/recordables`` list of a neuron model will tell you which
@@ -105,7 +105,7 @@ examples set:
 
 Here is the result:
 
-.. figure:: _static/img/MultimeterExample.png
-   :alt: MultimeterExample
+.. figure:: ../_static/img/multimeter_example.png
+   :alt: multimeter_example
 
-   MultimeterExample
+   Example for using the multimeter

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -257,7 +257,7 @@ ModelsModule::init( SLIInterpreter* )
   kernel().model_manager.register_node_model< spike_detector >( "spike_detector" );
   kernel().model_manager.register_node_model< weight_recorder >( "weight_recorder" );
   kernel().model_manager.register_node_model< spin_detector >( "spin_detector" );
-  kernel().model_manager.register_node_model< Multimeter >( "multimeter" );
+  kernel().model_manager.register_node_model< multimeter >( "multimeter" );
   kernel().model_manager.register_node_model< correlation_detector >( "correlation_detector" );
   kernel().model_manager.register_node_model< correlomatrix_detector >( "correlomatrix_detector" );
   kernel().model_manager.register_node_model< correlospinmatrix_detector >( "correlospinmatrix_detector" );
@@ -335,7 +335,7 @@ ModelsModule::init( SLIInterpreter* )
   ad.push_back( LiteralDatum( names::V_m.toString() ) );
   ( *vmdict )[ names::record_from ] = ad;
   const Name name = "voltmeter";
-  kernel().model_manager.register_preconf_node_model< Multimeter >( name, vmdict, false );
+  kernel().model_manager.register_preconf_node_model< multimeter >( name, vmdict, false );
 
 #ifdef HAVE_GSL
   kernel().model_manager.register_node_model< iaf_chxk_2008 >( "iaf_chxk_2008" );

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -282,7 +282,7 @@ ModelsModule::init( SLIInterpreter* )
   /withgid are set, respectively.
 
   Accumulator mode:
-  Voltmeter can operate in accumulator mode. In this case, values for all
+  A voltmeter can operate in accumulator mode. In this case, values for all
   recorded variables are added across all recorded nodes (but kept separate in
   time). This can be useful to record average membrane potential in a
   population.

--- a/models/multimeter.cpp
+++ b/models/multimeter.cpp
@@ -27,7 +27,7 @@
 
 namespace nest
 {
-Multimeter::Multimeter()
+multimeter::multimeter()
   : DeviceNode()
   , device_( *this, RecordingDevice::MULTIMETER, "dat", true, true )
   , P_()
@@ -37,7 +37,7 @@ Multimeter::Multimeter()
 {
 }
 
-Multimeter::Multimeter( const Multimeter& n )
+multimeter::multimeter( const multimeter& n )
   : DeviceNode( n )
   , device_( *this, n.device_ )
   , P_( n.P_ )
@@ -48,7 +48,7 @@ Multimeter::Multimeter( const Multimeter& n )
 }
 
 port
-Multimeter::send_test_event( Node& target, rport receptor_type, synindex, bool )
+multimeter::send_test_event( Node& target, rport receptor_type, synindex, bool )
 {
   DataLoggingRequest e( P_.interval_, P_.offset_, P_.record_from_ );
   e.set_sender( *this );
@@ -60,14 +60,14 @@ Multimeter::send_test_event( Node& target, rport receptor_type, synindex, bool )
   return p;
 }
 
-nest::Multimeter::Parameters_::Parameters_()
+nest::multimeter::Parameters_::Parameters_()
   : interval_( Time::ms( 1.0 ) )
   , offset_( Time::ms( 0. ) )
   , record_from_()
 {
 }
 
-nest::Multimeter::Parameters_::Parameters_( const Parameters_& p )
+nest::multimeter::Parameters_::Parameters_( const Parameters_& p )
   : interval_( p.interval_ )
   , offset_( p.offset_ )
   , record_from_( p.record_from_ )
@@ -75,13 +75,13 @@ nest::Multimeter::Parameters_::Parameters_( const Parameters_& p )
   interval_.calibrate();
 }
 
-nest::Multimeter::Buffers_::Buffers_()
+nest::multimeter::Buffers_::Buffers_()
   : has_targets_( false )
 {
 }
 
 void
-nest::Multimeter::Parameters_::get( DictionaryDatum& d ) const
+nest::multimeter::Parameters_::get( DictionaryDatum& d ) const
 {
   ( *d )[ names::interval ] = interval_.get_ms();
   ( *d )[ names::offset ] = offset_.get_ms();
@@ -94,7 +94,7 @@ nest::Multimeter::Parameters_::get( DictionaryDatum& d ) const
 }
 
 void
-nest::Multimeter::Parameters_::set( const DictionaryDatum& d, const Buffers_& b )
+nest::multimeter::Parameters_::set( const DictionaryDatum& d, const Buffers_& b )
 {
   if ( b.has_targets_
     && ( d->known( names::interval ) || d->known( names::offset ) || d->known( names::record_from ) ) )
@@ -160,21 +160,21 @@ nest::Multimeter::Parameters_::set( const DictionaryDatum& d, const Buffers_& b 
 }
 
 void
-Multimeter::init_state_( const Node& np )
+multimeter::init_state_( const Node& np )
 {
-  const Multimeter& asd = dynamic_cast< const Multimeter& >( np );
+  const multimeter& asd = dynamic_cast< const multimeter& >( np );
   device_.init_state( asd.device_ );
   S_.data_.clear();
 }
 
 void
-Multimeter::init_buffers_()
+multimeter::init_buffers_()
 {
   device_.init_buffers();
 }
 
 void
-Multimeter::calibrate()
+multimeter::calibrate()
 {
   device_.calibrate();
   V_.new_request_ = false;
@@ -182,19 +182,19 @@ Multimeter::calibrate()
 }
 
 void
-Multimeter::post_run_cleanup()
+multimeter::post_run_cleanup()
 {
   device_.post_run_cleanup();
 }
 
 void
-Multimeter::finalize()
+multimeter::finalize()
 {
   device_.finalize();
 }
 
 void
-Multimeter::update( Time const& origin, const long from, const long )
+multimeter::update( Time const& origin, const long from, const long )
 {
   /* There is nothing to request during the first time slice.
      For each subsequent slice, we collect all data generated during the
@@ -224,7 +224,7 @@ Multimeter::update( Time const& origin, const long from, const long )
 }
 
 void
-Multimeter::handle( DataLoggingReply& reply )
+multimeter::handle( DataLoggingReply& reply )
 {
   // easy access to relevant information
   DataLoggingReply::Container const& info = reply.get_info();
@@ -300,7 +300,7 @@ Multimeter::handle( DataLoggingReply& reply )
 }
 
 void
-Multimeter::print_value_( const std::vector< double >& values )
+multimeter::print_value_( const std::vector< double >& values )
 {
   if ( values.size() < 1 )
   {
@@ -317,7 +317,7 @@ Multimeter::print_value_( const std::vector< double >& values )
 
 
 void
-Multimeter::add_data_( DictionaryDatum& d ) const
+multimeter::add_data_( DictionaryDatum& d ) const
 {
   // re-organize data into one vector per recorded variable
   for ( size_t v = 0; v < P_.record_from_.size(); ++v )
@@ -341,7 +341,7 @@ Multimeter::add_data_( DictionaryDatum& d ) const
 }
 
 bool
-Multimeter::is_active( Time const& T ) const
+multimeter::is_active( Time const& T ) const
 {
   const long stamp = T.get_steps();
 

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -72,7 +72,7 @@ same name as the /recordable. If /withtime is set, times are given in the
 /times vector in /events.
 
 Accumulator mode:
-Multimeter can operate in accumulator mode. In this case, values for all
+A multimeter can operate in accumulator mode. In this case, values for all
 recorded variables are added across all recorded nodes (but kept separate in
 time). This can be useful to record average membrane potential in a population.
 
@@ -143,15 +143,15 @@ Author: Hans Ekkehard Plesser, Barna Zajzon (added offset support March 2017)
 
 SeeAlso: Device, RecordingDevice
 */
-class Multimeter : public DeviceNode
+class multimeter : public DeviceNode
 {
 
 public:
-  Multimeter();
-  Multimeter( const Multimeter& );
+  multimeter();
+  multimeter( const multimeter& );
 
   /**
-   * @note Multimeters never have proxies, since they must
+   * @note multimeters never have proxies, since they must
    *       sample their targets through local communication.
    */
   bool
@@ -276,7 +276,7 @@ private:
      * processed. This flag is set to true by update() before dispatching the
      * DataLoggingRequest event and is reset to false by handle() as soon as the
      * first DataLoggingReply has been handled. This is needed when the
-     * Multimeter is running in accumulator mode.
+     * multimeter is running in accumulator mode.
      */
     bool new_request_;
 
@@ -299,7 +299,7 @@ private:
 
 
 inline void
-nest::Multimeter::get_status( DictionaryDatum& d ) const
+nest::multimeter::get_status( DictionaryDatum& d ) const
 {
   // get the data from the device
   device_.get_status( d );
@@ -324,13 +324,13 @@ nest::Multimeter::get_status( DictionaryDatum& d ) const
 }
 
 inline void
-nest::Multimeter::set_status( const DictionaryDatum& d )
+nest::multimeter::set_status( const DictionaryDatum& d )
 {
-  // protect Multimeter from being frozen
+  // protect multimeter from being frozen
   bool freeze = false;
   if ( updateValue< bool >( d, names::frozen, freeze ) && freeze )
   {
-    throw BadProperty( "Multimeter cannot be frozen." );
+    throw BadProperty( "multimeter cannot be frozen." );
   }
 
   Parameters_ ptmp = P_;
@@ -344,7 +344,7 @@ nest::Multimeter::set_status( const DictionaryDatum& d )
 }
 
 inline SignalType
-nest::Multimeter::sends_signal() const
+nest::multimeter::sends_signal() const
 {
   return ALL;
 }

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -20,10 +20,6 @@
  *
  */
 
-/*
- *  Multimeter support by Yury V. Zaytsev.
- */
-
 #include "pp_pop_psc_delta.h"
 
 // C++ includes:

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -20,10 +20,6 @@
  *
  */
 
-/*
- *  Multimeter support by Yury V. Zaytsev.
- */
-
 /* pp_psc_delta is a stochastically spiking neuron where the potential jumps on
  * each spike arrival.
  */

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -231,7 +231,7 @@ namespace nest
  *       init_buffers() merely closes the stream if close_on_reset_ is true.
  *
  *  @todo Some aspects of RecordingDevice behavior depend on the type of device:
- *        Multimeter needs to have its data cleared on n_events==0 and provides
+ *        multimeter needs to have its data cleared on n_events==0 and provides
  *        an accumulator mode which is administered by RecordingDevice. To tell
  *        recording device about this deviating behavior, we mark the type of
  *        "owning device" with an enum flag on construction. This is not very

--- a/nestkernel/universal_data_logger.h
+++ b/nestkernel/universal_data_logger.h
@@ -165,8 +165,8 @@ public:
 
 private:
   /**
-   * Single data logger, serving one Multimeter.
-   * For each Multimeter connected to a node, one DataLogger_ instance is
+   * Single data logger, serving one multimeter.
+   * For each multimeter connected to a node, one DataLogger_ instance is
    * created. The UniversalDataLogger forwards all requests to the correct
    * DataLogger_ based on the rport of the request.
    */
@@ -431,8 +431,8 @@ public:
 
 private:
   /**
-   * Single data logger, serving one Multimeter.
-   * For each Multimeter connected to a node, one DataLogger_ instance is
+   * Single data logger, serving one multimeter.
+   * For each multimeter connected to a node, one DataLogger_ instance is
    * created. The UniversalDataLogger forwards all requests to the correct
    * DataLogger_ based on the rport of the request.
    */

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -63,10 +63,10 @@ per second.
 References
 ~~~~~~~~~~~~
 
-.. [1] Morrison A, Aertsen A, Diesmann M (2007). Spike-timing-dependent plasticity in balanced random
-       networks. Neural Comput 19(6):1437-67
-.. [2] Helias et al (2012). Supercomputers ready for use as discovery machines for
-       neuroscience. Front. Neuroinform. 6:26
+.. [1] Morrison A, Aertsen A, Diesmann M (2007). Spike-timing-dependent
+       plasticity in balanced random networks. Neural Comput 19(6):1437-67
+.. [2] Helias et al (2012). Supercomputers ready for use as discovery machines
+       for neuroscience. Front. Neuroinform. 6:26
 .. [3] Kunkel et al (2014). Spiking network simulation code for petascale
        computers. Front. Neuroinform. 8:78
 
@@ -83,7 +83,6 @@ import nest.raster_plot
 
 M_INFO = 10
 M_ERROR = 30
-
 
 
 ###############################################################################
@@ -103,7 +102,6 @@ params = {
     'path_name': '.',       # path where all files will have to be written
     'log_file': 'log',      # naming scheme for the log files
 }
-
 
 
 def convert_synapse_weight(tau_m, tau_syn, C_m):
@@ -137,7 +135,6 @@ def convert_synapse_weight(tau_m, tau_syn, C_m):
 tau_syn = 0.32582722403722841
 
 
-
 brunel_params = {
     'NE': int(9000 * params['scale']),  # number of excitatory neurons
     'NI': int(2250 * params['scale']),  # number of inhibitory neurons
@@ -160,10 +157,10 @@ brunel_params = {
         'V_m': 5.7  # mean value of membrane potential
     },
 
-###############################################################################
-# Note that Kunkel et al. (2014) report different values. The values
-# in the paper were used for the benchmarks on K, the values given
-# here were used for the benchmark on JUQUEEN.
+    ####################################################################
+    # Note that Kunkel et al. (2014) report different values. The values
+    # in the paper were used for the benchmarks on K, the values given
+    # here were used for the benchmark on JUQUEEN.
 
     'randomize_Vm': True,
     'mean_potential': 5.7,
@@ -191,6 +188,7 @@ brunel_params = {
 
 ###############################################################################
 # Function Section
+
 
 def build_network(logger):
     """Builds the network including setting of simulation and neuron
@@ -438,6 +436,7 @@ def get_local_nodes(nodes):
         else:
             i += 1
 
+
 class Logger(object):
     """Logger context manager used to properly log memory and timing
     information from network simulations.
@@ -479,6 +478,7 @@ class Logger(object):
     def __exit__(self, exc_type, exc_val, traceback):
         if nest.Rank() < self.max_rank_log:
             self.f.close()
+
 
 if __name__ == '__main__':
     run_simulation()

--- a/pynest/examples/multimeter_file.py
+++ b/pynest/examples/multimeter_file.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Multimeter to file example
---------------------------
+Example of multimeter recording to file
+---------------------------------------
 
 This file demonstrates recording from an ``iaf_cond_alpha`` neuron using a
 multimeter and writing data to file.

--- a/pynest/examples/rate_neuron_dm.py
+++ b/pynest/examples/rate_neuron_dm.py
@@ -38,9 +38,10 @@ import nest
 import pylab
 import numpy
 
-#####################################################################################
-# First,the function ``build_network`` is defined to build the network and
-# return the handles of two decision units and the ``multimeter``
+##########################################################################
+# First,the function ``build_network`` is defined to build the network
+# and return the handles of two decision units and the ``multimeter``
+
 
 def build_network(sigma, dt):
     nest.ResetKernel()
@@ -62,23 +63,24 @@ def build_network(sigma, dt):
     return D1, D2, mm
 
 
-#####################################################################################
+###########################################################################
 # The function ``build_network`` takes the noise parameter sigma
 # and the time resolution as arguments.
-# First, the Kernel is reset and the ``use_wfr`` (waveform-relaxation) is set to
-# false while the resolution is set to the specified value `dt`.
-# Two rate neurons with linear activation functions are created and the
-# handle is stored in the variables `D1` and `D2`. The output of both decision
-# units is rectified at zero.
-# The two decisions units are coupled via mutual inhibition.
-# Next the multimeter is created and the handle stored in mm and the option
-# ``record_from`` is set. The multimeter is then connected to the two units
-# in order to 'observe' them.  The ``Connect`` function takes the handles as input.
+# First, the Kernel is reset and the ``use_wfr`` (waveform-relaxation)
+# is set to false while the resolution is set to the specified value
+# `dt`.  Two rate neurons with linear activation functions are created
+# and the handle is stored in the variables `D1` and `D2`. The output
+# of both decision units is rectified at zero.  The two decisions
+# units are coupled via mutual inhibition.  Next the multimeter is
+# created and the handle stored in mm and the option ``record_from``
+# is set. The multimeter is then connected to the two units in order
+# to 'observe' them.  The ``Connect`` function takes the handles as
+# input.
 
-##################################################################################
-# The decision making process is simulated for three different levels of noise
-# and three differences in evidence for a given decision. The activity of both
-# decision units is plotted for each scenario.
+###########################################################################
+# The decision making process is simulated for three different levels
+# of noise and three differences in evidence for a given decision. The
+# activity of both decision units is plotted for each scenario.
 
 fig_size = [14, 8]
 fig_rows = 3

--- a/pynest/examples/rate_neuron_dm.py
+++ b/pynest/examples/rate_neuron_dm.py
@@ -40,7 +40,7 @@ import numpy
 
 #####################################################################################
 # First,the function ``build_network`` is defined to build the network and
-# return the handles of two decision units and the ``Multimeter``
+# return the handles of two decision units and the ``multimeter``
 
 def build_network(sigma, dt):
     nest.ResetKernel()

--- a/pynest/examples/sinusoidal_gamma_generator.py
+++ b/pynest/examples/sinusoidal_gamma_generator.py
@@ -61,7 +61,7 @@ nest.SetKernelStatus({'resolution': 0.01})
 ###############################################################################
 # Then we create two instances of the ``sinusoidal_gamma_generator`` with two
 # different orders of the underlying gamma process using ``Create``. Moreover,
-# we create devices to record firing rates (``Multimeter``) and spikes
+# we create devices to record firing rates (``multimeter``) and spikes
 # (``spike_detector``) and connect them to the generators using ``Connect``.
 
 

--- a/pynest/examples/sinusoidal_poisson_generator.py
+++ b/pynest/examples/sinusoidal_poisson_generator.py
@@ -50,7 +50,7 @@ nest.ResetKernel()   # in case we run the script multiple times from iPython
 ####################################################################################
 # We create two instances of the ``sinusoidal_poisson_generator`` with two
 # different parameter sets using ``Create``. Moreover, we create devices to
-# record firing rates (``Multimeter``) and spikes (``spike_detector``) and connect
+# record firing rates (``multimeter``) and spikes (``spike_detector``) and connect
 # them to the generators using ``Connect``.
 
 

--- a/pynest/examples/testiaf.py
+++ b/pynest/examples/testiaf.py
@@ -71,10 +71,10 @@ def build_network(dt):
 # therefore, times are given in the times vector in events. Now the
 # ``spike_detector`` is created and its handle is stored in sd.
 #
-# Voltmeter and spikedetector are then connected to the neuron. The ``Connect``
-# function takes the handles as input.  The voltmeter is connected to the
-# neuron and the neuron to the spikedetector because the neuron sends spikes
-# to the detector and the voltmeter 'observes' the neuron.
+# The voltmeter and spike detector are then connected to the neuron. The
+# ``Connect`` function takes the handles as input.  The voltmeter is connected
+# to the neuron and the neuron to the spikedetector because the neuron sends
+# spikes to the detector and the voltmeter 'observes' the neuron.
 
 ###############################################################################
 # The neuron is simulated for three different resolutions and then the

--- a/pynest/examples/testiaf.py
+++ b/pynest/examples/testiaf.py
@@ -61,6 +61,7 @@ def build_network(dt):
 
     return vm, sd
 
+
 ###############################################################################
 # The function ``build_network`` takes the resolution as argument.
 # First the Kernel is reset and the number of threads is set to zero as well
@@ -116,5 +117,3 @@ for dt in [0.1, 0.5, 1.0]:
     pylab.legend(loc=3)
     pylab.xlabel("time (ms)")
     pylab.ylabel("V_m (mV)")
-
-

--- a/pynest/nest/voltage_trace.py
+++ b/pynest/nest/voltage_trace.py
@@ -153,7 +153,7 @@ def from_device(detec, neurons=None, title=None, grayscale=False,
         raise nest.kernel.NESTError("Please provide a single voltmeter.")
 
     type_id = nest.GetDefaults(nest.GetStatus(detec, 'model')[0], 'type_id')
-    if not type_id.name in ('voltmeter', 'multimeter'):
+    if type_id.name not in ('voltmeter', 'multimeter'):
         raise nest.kernel.NESTError("Please provide a voltmeter or a \
             multimeter measuring V_m.")
     elif type_id.name == 'multimeter':

--- a/pynest/nest/voltage_trace.py
+++ b/pynest/nest/voltage_trace.py
@@ -128,12 +128,12 @@ def from_file(fname, title=None, grayscale=False):
 def from_device(detec, neurons=None, title=None, grayscale=False,
                 timeunit="ms"):
     """Plot the membrane potential of a set of neurons recorded by
-    the given Voltmeter or multimeter.
+    the given voltmeter or multimeter.
 
     Parameters
     ----------
     detec : list
-        Global id of Voltmeter or multimeter in a list, e.g. [1]
+        Global id of voltmeter or multimeter in a list, e.g. [1]
     neurons : list, optional
         Indices of of neurons to plot
     title : str, optional
@@ -228,7 +228,7 @@ def _from_memory(detec):
     """Get voltage traces from memory.
     ----------
     detec : list
-        Global id of Voltmeter or multimeter
+        Global id of voltmeter or multimeter
     """
     import array
 

--- a/pynest/nest/voltage_trace.py
+++ b/pynest/nest/voltage_trace.py
@@ -128,12 +128,12 @@ def from_file(fname, title=None, grayscale=False):
 def from_device(detec, neurons=None, title=None, grayscale=False,
                 timeunit="ms"):
     """Plot the membrane potential of a set of neurons recorded by
-    the given Voltmeter or Multimeter.
+    the given Voltmeter or multimeter.
 
     Parameters
     ----------
     detec : list
-        Global id of Voltmeter or Multimeter in a list, e.g. [1]
+        Global id of Voltmeter or multimeter in a list, e.g. [1]
     neurons : list, optional
         Indices of of neurons to plot
     title : str, optional
@@ -228,7 +228,7 @@ def _from_memory(detec):
     """Get voltage traces from memory.
     ----------
     detec : list
-        Global id of Voltmeter or Multimeter
+        Global id of Voltmeter or multimeter
     """
     import array
 

--- a/testsuite/regressiontests/ticket-349.sli
+++ b/testsuite/regressiontests/ticket-349.sli
@@ -96,7 +96,7 @@ skip_if_without_gsl
 
 } pass_or_die
 
-% Third test: connect Multimeter with empty list, then simulate. Must not crash.
+% Third test: connect multimeter with empty list, then simulate. Must not crash.
 {
   ResetKernel
 

--- a/testsuite/unittests/test_voltmeter_reset.sli
+++ b/testsuite/unittests/test_voltmeter_reset.sli
@@ -27,10 +27,10 @@ Name: testsuite::test_voltmeter_reset - test if resetting works on voltmeter
 Synopsis: (test_voltmeter_reset) run -> dies if assertion fails
 
 Description:
-	Voltmeter records from iaf_psc_alpha to memory, checks if proper number
-	of data points is acquired, deleted on reset, and recorded again on
-	further simulation. This test ascertains that also data stored in the
-	derived recorder class, not only in RecordingDevice, is reset.
+  The voltmeter records from iaf_psc_alpha to memory, checks if proper number
+  of data points is acquired, deleted on reset, and recorded again on further
+ simulation. This test ascertains that also data stored in the derived recorder
+ class, not only in RecordingDevice, is reset.
 
 Author: August 2008, Plesser
 SeeAlso: multimeter, testsuite::test_spike_det_reset

--- a/testsuite/unittests/test_voltmeter_reset.sli
+++ b/testsuite/unittests/test_voltmeter_reset.sli
@@ -29,8 +29,8 @@ Synopsis: (test_voltmeter_reset) run -> dies if assertion fails
 Description:
   The voltmeter records from iaf_psc_alpha to memory, checks if proper number
   of data points is acquired, deleted on reset, and recorded again on further
- simulation. This test ascertains that also data stored in the derived recorder
- class, not only in RecordingDevice, is reset.
+  simulation. This test ascertains that also data stored in the derived recorder
+  class, not only in RecordingDevice, is reset.
 
 Author: August 2008, Plesser
 SeeAlso: multimeter, testsuite::test_spike_det_reset


### PR DESCRIPTION
This is done for making the models more consistent with all other models, the name of the C++ class and the registered model, and to make it easier to auto-generate and cross-link documentation.