### PR TITLE
Fix rounding issue when setting small resolution

### DIFF
--- a/libnestutil/numerics.cpp
+++ b/libnestutil/numerics.cpp
@@ -109,3 +109,20 @@ dtruncate( double x )
   std::modf( x, &ip );
   return ip;
 }
+
+bool 
+is_integer( double n )
+{
+  double int_part;
+  double frac_part = std::modf( n, &int_part );
+
+  // Since n > 0 and modf always rounds towards zero, a value of n just below an 
+  // integer will result in frac_part = 0.99999.... . We subtract from 1 in this case. 
+  if ( frac_part > 0.5 )
+  {
+    frac_part = 1 - frac_part;
+  }
+  
+  // factor 4 allows for two bits of rounding error
+  return frac_part < 4 * n * std::numeric_limits<double>::epsilon();
+}

--- a/libnestutil/numerics.cpp
+++ b/libnestutil/numerics.cpp
@@ -110,19 +110,19 @@ dtruncate( double x )
   return ip;
 }
 
-bool 
+bool
 is_integer( double n )
 {
   double int_part;
   double frac_part = std::modf( n, &int_part );
 
-  // Since n > 0 and modf always rounds towards zero, a value of n just below an 
-  // integer will result in frac_part = 0.99999.... . We subtract from 1 in this case. 
+  // Since n > 0 and modf always rounds towards zero, a value of n just below an
+  // integer will result in frac_part = 0.99999.... . We subtract from 1 in this case.
   if ( frac_part > 0.5 )
   {
     frac_part = 1 - frac_part;
   }
-  
+
   // factor 4 allows for two bits of rounding error
-  return frac_part < 4 * n * std::numeric_limits<double>::epsilon();
+  return frac_part < 4 * n * std::numeric_limits< double >::epsilon();
 }

--- a/libnestutil/numerics.h
+++ b/libnestutil/numerics.h
@@ -125,5 +125,10 @@ double dround( double );
  */
 double dtruncate( double );
 
+/**
+ * Returns true if n is integer
+ * @return bool
+ */
+bool is_integer( double );
 
 #endif

--- a/libnestutil/numerics.h
+++ b/libnestutil/numerics.h
@@ -126,7 +126,7 @@ double dround( double );
 double dtruncate( double );
 
 /**
- * Returns true if n is integer
+ * Returns true if n is integer up to rounding error.
  * @return bool
  */
 bool is_integer( double );

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -102,6 +102,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
   TimeConverter time_converter;
 
   double time;
+  double eps = 1e-10;
   if ( updateValue< double >( d, names::time, time ) )
   {
     if ( time != 0.0 )
@@ -176,7 +177,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( std::modf( resd * tics_per_ms, &integer_part ) != 0 )
+      else if ( std::modf( resd * tics_per_ms + eps, &integer_part ) > 2 * eps )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",
@@ -212,7 +213,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( std::modf( resd / Time::get_ms_per_tic(), &integer_part ) != 0 )
+      else if ( std::modf( resd / Time::get_ms_per_tic() + eps, &integer_part ) > 2 * eps )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -177,7 +177,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( !is_integer( resd * tics_per_ms ) )
+      else if ( not is_integer( resd * tics_per_ms ) )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",
@@ -213,7 +213,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( !is_integer( resd / Time::get_ms_per_tic() ) )
+      else if ( not is_integer( resd / Time::get_ms_per_tic() ) )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -30,6 +30,7 @@
 
 // Includes from libnestutil:
 #include "compose.hpp"
+#include "numerics.h"
 
 // Includes from nestkernel:
 #include "connection_manager_impl.h"
@@ -102,7 +103,6 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
   TimeConverter time_converter;
 
   double time;
-  const double RESOLUTION_TOLERANCE = 1e-14;
   if ( updateValue< double >( d, names::time, time ) )
   {
     if ( time != 0.0 )
@@ -177,7 +177,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( std::modf( resd * tics_per_ms + RESOLUTION_TOLERANCE, &integer_part ) > 2 * RESOLUTION_TOLERANCE )
+      else if ( !is_integer( resd * tics_per_ms ) )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",
@@ -213,7 +213,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( std::modf( resd / Time::get_ms_per_tic() + RESOLUTION_TOLERANCE, &integer_part ) > 2 * RESOLUTION_TOLERANCE )
+      else if ( !is_integer( resd / Time::get_ms_per_tic() ) )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -102,7 +102,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
   TimeConverter time_converter;
 
   double time;
-  double eps = 1e-10;
+  const double RESOLUTION_TOLERANCE = 1e-14;
   if ( updateValue< double >( d, names::time, time ) )
   {
     if ( time != 0.0 )
@@ -177,7 +177,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( std::modf( resd * tics_per_ms + eps, &integer_part ) > 2 * eps )
+      else if ( std::modf( resd * tics_per_ms + RESOLUTION_TOLERANCE, &integer_part ) > 2 * RESOLUTION_TOLERANCE )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",
@@ -213,7 +213,7 @@ nest::SimulationManager::set_status( const DictionaryDatum& d )
           "unchanged." );
         throw KernelException();
       }
-      else if ( std::modf( resd / Time::get_ms_per_tic() + eps, &integer_part ) > 2 * eps )
+      else if ( std::modf( resd / Time::get_ms_per_tic() + RESOLUTION_TOLERANCE, &integer_part ) > 2 * RESOLUTION_TOLERANCE )
       {
         LOG( M_ERROR,
           "SimulationManager::set_status",

--- a/testsuite/regressiontests/issue-1305.sli
+++ b/testsuite/regressiontests/issue-1305.sli
@@ -39,25 +39,25 @@ M_ERROR setverbosity
 
 % Test setting valid resolution 
 {
-  ResetKernel
-  
-  0 << /resolution 0.102 /tics_per_ms 1000.0 >> SetStatus
-  0 GetStatus
-  /res {/resolution get} def
-  /delta {res 0.102 sub} def
-  delta 1e-15 leq
+  /target_resolution 0.102 def
 
+  ResetKernel
+  0 << /resolution target_resolution /tics_per_ms 1000.0 >> SetStatus
+  0 /resolution get
+  target_resolution
+  sub abs
+  1e-15 leq
 } assert_or_die
 
 % Test setting invalid resolution 
 {
-  ResetKernel
-  
-  0 << /resolution 0.1002 /tics_per_ms 1000.0 >> SetStatus
-  0 GetStatus
-  /res {/resolution get} def
-  /delta {res 0.1002 sub} def
-  delta 1e-15 leq
+  /target_resolution 0.1002 def
 
+  ResetKernel
+  0 << /resolution target_resolution /tics_per_ms 1000.0 >> SetStatus
+  0 /resolution get
+  target_resolution
+  sub abs
+  1e-15 leq
 } fail_or_die
 

--- a/testsuite/regressiontests/issue-1305.sli
+++ b/testsuite/regressiontests/issue-1305.sli
@@ -1,0 +1,63 @@
+/*
+ *  issue-1305.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/** @BeginDocumentation
+
+Name: testsuite::issue-1305 Ensure that small simulation timesteps can be set without errors.
+
+Synopsis: (issue-1305) run -> NEST exits if test fails
+
+Description:
+This ticket ensures that NEST can set small resolutions and deals with rounding errors correctly.
+
+Author: Philipp Weidel, 2019-12-06 based on material by Hans E Plesser, Jafet Diaz
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+% Test setting valid resolution 
+{
+  ResetKernel
+  
+  0 << /resolution 0.102 /tics_per_ms 1000.0 >> SetStatus
+  0 GetStatus
+  /res {/resolution get} def
+  /delta {res 0.102 sub} def
+  delta 1e-15 leq
+
+} assert_or_die
+
+% Test setting invalid resolution 
+{
+  ResetKernel
+  
+  0 << /resolution 0.1002 /tics_per_ms 1000.0 >> SetStatus
+  0 GetStatus
+  /res {/resolution get} def
+  /delta {res 0.1002 sub} def
+  delta 1e-15 leq
+
+} fail_or_die
+


### PR DESCRIPTION
As described in  #1305 there is a problem setting the resolution to a small numbers.
The origin of this issue is a rounding error and the comparison of `modf` to `0` in `simulation_manager.cpp`.

In this PR I fixed this issue by comparing the the result of `modf` to a small epsilon instead of `0`.
