### PR TITLE
Fix show version issue 

### DIFF
--- a/cmake/NestVersionInfo.cmake
+++ b/cmake/NestVersionInfo.cmake
@@ -32,27 +32,29 @@
 
 
 macro(get_version_info)
-   execute_process(
-        COMMAND "git" "rev-parse" "--short" "HEAD"
-        OUTPUT_VARIABLE NEST_VERSION_GITHASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    )
+	if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+	   execute_process(
+			COMMAND "git" "rev-parse" "--short" "HEAD"
+			OUTPUT_VARIABLE NEST_VERSION_GITHASH
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+		)
 
-    execute_process(
-        COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD"
-        OUTPUT_VARIABLE NEST_VERSION_BRANCH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    )
+		execute_process(
+			COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD"
+			OUTPUT_VARIABLE NEST_VERSION_BRANCH
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+		)
 
-    if (NEST_VERSION_SUFFIX)
-        set(versionsuffix "-${NEST_VERSION_SUFFIX}")
-    endif()
+		if (NEST_VERSION_SUFFIX)
+			set(versionsuffix "-${NEST_VERSION_SUFFIX}")
+		endif()
 
-    if (NEST_VERSION_GITHASH)
-        set(githash "@${NEST_VERSION_GITHASH}")
-    endif()
+		if (NEST_VERSION_GITHASH)
+			set(githash "@${NEST_VERSION_GITHASH}")
+		endif()
+	endif()
 
     if (NOT NEST_VERSION_BRANCH)
         set(NEST_VERSION_BRANCH "UNKNOWN")

--- a/cmake/NestVersionInfo.cmake
+++ b/cmake/NestVersionInfo.cmake
@@ -33,12 +33,12 @@
 
 macro(get_version_info)
     if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-       execute_process(
-           COMMAND "git" "rev-parse" "--short" "HEAD"
-           OUTPUT_VARIABLE NEST_VERSION_GITHASH
-           OUTPUT_STRIP_TRAILING_WHITESPACE
-           WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-       )
+        execute_process(
+            COMMAND "git" "rev-parse" "--short" "HEAD"
+            OUTPUT_VARIABLE NEST_VERSION_GITHASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        )
 
         execute_process(
             COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD"

--- a/cmake/NestVersionInfo.cmake
+++ b/cmake/NestVersionInfo.cmake
@@ -32,29 +32,29 @@
 
 
 macro(get_version_info)
-	if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-	   execute_process(
-			COMMAND "git" "rev-parse" "--short" "HEAD"
-			OUTPUT_VARIABLE NEST_VERSION_GITHASH
-			OUTPUT_STRIP_TRAILING_WHITESPACE
-			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-		)
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+       execute_process(
+           COMMAND "git" "rev-parse" "--short" "HEAD"
+           OUTPUT_VARIABLE NEST_VERSION_GITHASH
+           OUTPUT_STRIP_TRAILING_WHITESPACE
+           WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+       )
 
-		execute_process(
-			COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD"
-			OUTPUT_VARIABLE NEST_VERSION_BRANCH
-			OUTPUT_STRIP_TRAILING_WHITESPACE
-			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-		)
+        execute_process(
+            COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD"
+            OUTPUT_VARIABLE NEST_VERSION_BRANCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        )
 
-		if (NEST_VERSION_SUFFIX)
-			set(versionsuffix "-${NEST_VERSION_SUFFIX}")
-		endif()
+        if (NEST_VERSION_SUFFIX)
+            set(versionsuffix "-${NEST_VERSION_SUFFIX}")
+        endif()
 
-		if (NEST_VERSION_GITHASH)
-			set(githash "@${NEST_VERSION_GITHASH}")
-		endif()
-	endif()
+        if (NEST_VERSION_GITHASH)
+            set(githash "@${NEST_VERSION_GITHASH}")
+        endif()
+    endif()
 
     if (NOT NEST_VERSION_BRANCH)
         set(NEST_VERSION_BRANCH "UNKNOWN")

--- a/cmake/NestVersionInfo.cmake
+++ b/cmake/NestVersionInfo.cmake
@@ -32,6 +32,7 @@
 
 
 macro(get_version_info)
+
     if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
         execute_process(
             COMMAND "git" "rev-parse" "--short" "HEAD"


### PR DESCRIPTION
The problem:
If you are inside the folder structure of a git repository and you install NEST within this repository from the source download files (e.g. v2.18.0.tar.gz), the hash of the last commit of the git repository will be displayed as the NEST version number instead of the version of the download package .
This also happens within the conda forge packages.

The solution:
It is checked if there is a .`git` folder inside the source folder. Only then it tries to create the version from the git information. If the folder does not exist, the given version information (UNKNOWN, nest-2.18 ...) is used.

This pull request fixes #1347 .