### PR TITLE
Deleting script in profile.d during uninstallation of the NEST .deb package 

### DIFF
--- a/debian/nest.postinst
+++ b/debian/nest.postinst
@@ -4,7 +4,6 @@ rm -f /etc/profile.d/nest-simulator.sh
 touch /etc/profile.d/nest-simulator.sh
 cat >>/etc/profile.d/nest-simulator.sh <<EOF
 #!/bin/sh
-set -e
 . /usr/bin/nest_vars.sh
 EOF
 exit 0

--- a/debian/nest.postrm
+++ b/debian/nest.postrm
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+[ -f /etc/profile.d/nest-simulator.sh ] && rm -f /etc/profile.d/nest-simulator.sh
+exit 0


### PR DESCRIPTION
During the installation of the .deb package with `apt install nest`, a shell script is written to` /etc/profile.d`, which ensures that the correct environment variables are set for NEST every time the system boots.
This file is now removed during the uninstallation of the package with `apt remove nest`.