### PR TITLE
Ensure number of connections for fixed total number is properly set

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1376,8 +1376,12 @@ nest::FixedTotalNumberBuilder::connect_()
   librandom::BinomialRandomDev bino( grng, 0, 0 );
 #endif
 
-  for ( int k = 0; k < M; k++ )
+  for ( int k = 0; k < M - 1; k++ )
   {
+    if ( N_ == sum_partitions )
+    {
+      break;
+    }
     if ( number_of_targets_on_vp[ k ] > 0 )
     {
       double num_local_targets = static_cast< double >( number_of_targets_on_vp[ k ] );
@@ -1390,6 +1394,9 @@ nest::FixedTotalNumberBuilder::connect_()
     sum_dist += static_cast< double >( number_of_targets_on_vp[ k ] );
     sum_partitions += static_cast< unsigned int >( num_conns_on_vp[ k ] );
   }
+
+  // Number of connections on last process is N_ - connections on other vp's
+  num_conns_on_vp[ M - 1 ] = N_ - sum_partitions;
 
 // end code adapted from gsl 1.8
 

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1376,6 +1376,11 @@ nest::FixedTotalNumberBuilder::connect_()
   librandom::BinomialRandomDev bino( grng, 0, 0 );
 #endif
 
+  // We only go to M - 1 here as we can set the number of connections on the last process manually after having
+  // distributed the number of connections on the other processes. The number of connections on the last process
+  // will then be N_ - connections on other vp's, and this we can set directly without having to go through the
+  // binomial random dev. This will also prevent an error with setting the n value for GSL if we have already
+  // distributed all connections on the previous processes, as we can't have n = 0 for GSL.
   for ( int k = 0; k < M - 1; k++ )
   {
     if ( N_ == sum_partitions )

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1376,13 +1376,10 @@ nest::FixedTotalNumberBuilder::connect_()
   librandom::BinomialRandomDev bino( grng, 0, 0 );
 #endif
 
-  // We only go to M - 1 here as we can set the number of connections on the last process manually after having
-  // distributed the number of connections on the other processes. The number of connections on the last process
-  // will then be N_ - connections on other vp's, and this we can set directly without having to go through the
-  // binomial random dev. This will also prevent an error with setting the n value for GSL if we have already
-  // distributed all connections on the previous processes, as we can't have n = 0 for GSL.
-  for ( int k = 0; k < M - 1; k++ )
+  for ( int k = 0; k < M; k++ )
   {
+    // If we have distributed all connections on the previous processes we exit the loop. It is important to
+    // have this check here, as N - sum_partition is set as n value for GSL, and this must be larger than 0.
     if ( N_ == sum_partitions )
     {
       break;
@@ -1399,9 +1396,6 @@ nest::FixedTotalNumberBuilder::connect_()
     sum_dist += static_cast< double >( number_of_targets_on_vp[ k ] );
     sum_partitions += static_cast< unsigned int >( num_conns_on_vp[ k ] );
   }
-
-  // Number of connections on last process is N_ - connections on other vp's
-  num_conns_on_vp[ M - 1 ] = N_ - sum_partitions;
 
 // end code adapted from gsl 1.8
 

--- a/testsuite/regressiontests/issue-1366.sli
+++ b/testsuite/regressiontests/issue-1366.sli
@@ -1,0 +1,60 @@
+/*
+ *  issue-1366.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1366
+
+Synopsis: (issue-1366) run -> NEST exits if test fails
+
+Description:
+This tests checks that we are able to connect with fixed_total_number equal to 1
+when we have more than 1 virtual process and more than 1 node per process.
+
+Author: Stine Brekke Vennemo
+FirstVersion: December 2019
+*/
+
+(unittest) run
+/unittest using
+
+skip_if_not_threaded
+
+M_ERROR setverbosity
+
+% Check if we are able to connect with fixed_total_number equal to 1
+{
+  ResetKernel
+
+  0 << 
+      /total_num_virtual_procs 4
+    >> SetStatus
+
+  /nodes /iaf_psc_alpha 4 Create def
+
+  [nodes] Range [nodes] Range << /rule /fixed_total_number /N 1 >> Connect
+
+  0 GetStatus /num_connections get 1 eq
+}
+assert_or_die
+
+endusing


### PR DESCRIPTION
This PR fixes #1366.

For `fixed_total_number`, a loop is used to set the number of connections on all processes. This PR checks if all connections have already been distributed, and if so, exits the loop. This way, if we have created all connections on the other processes, we will not get a problem with gsl binomial, and the number of connections on the last processes will automatically be zero (because all is initialized to zero).