### PR TITLE
Provide guidelines to writing to mailing list in documentation

### DIFF
--- a/doc/community.rst
+++ b/doc/community.rst
@@ -1,3 +1,5 @@
+.. _nest_community:
+
 NEST Community
 ===============
 
@@ -12,8 +14,7 @@ time allows.
 
 By subscribing to the mailing list you will also get notified of all NEST related events!
 
-For more information, subscription instructions and access to the archives,
-please visit https://www.nest-initiative.org/mailinglist/.
+Before submitting a question, please take a look at our :doc:`guidelines for the NEST mailing list <contribute/mailing_list_guidelines>`.
 
 Open video meeting for users and developers
 --------------------------------------------

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -2,7 +2,7 @@ Contributing to NEST
 ====================
 
 NEST draws its strength from the many people that use and improve it. We
-are happy to consider your contributions (e.g. own models, bug or
+are happy to consider your contributions (e.g., new models, bug or
 documentation fixes) for addition to the official version of NEST.
 
 Report bugs and request features
@@ -29,4 +29,7 @@ If you have a Python example network to contribute, please refer to our template
 :doc:`templates_styleguides/example_template`
 
 
+Have a question?
+------------------
 
+If you want to get in contact with us, see our :ref:`nest_community` page for ways you can reach us.

--- a/doc/contribute/mailing_list_guidelines.rst
+++ b/doc/contribute/mailing_list_guidelines.rst
@@ -1,0 +1,43 @@
+Guidelines for contributing to the mailing list
+=================================================
+
+To ensure community members provide accurate and quick responses to questions on the mailing list,
+please follow the guidelines below:
+
+
+#. Write an informative subject to your email regarding your question or problem.
+
+#. **DO NOT** copy and paste lengthy log or error output without context.
+
+   Remember you are addressing human beings, and we do not have time to read through pages of logs, especially if we don't understand
+   what you want.
+
+#. Provide us with
+
+   * a short description of what you want to accomplish with NEST and why.
+   * an example script, code snippet, or equation, if applicable.
+   * relevant publications related to your question, if applicable.
+   * if you are having problems,
+
+      * the steps you took that lead to the problem.
+      * the specific error messages you get.
+      * relevant system and version information (e.g.,  Ubuntu 18.04/ NEST 2.18 installed using Conda).
+
+#. Keep topics separate.
+
+   It's better to write multiple emails each with it's own topic thread than
+   to try to ask several diverse questions in one email. Some of your questions may get overlooked if
+   there is just too much information to read through.
+
+----
+
+**Feel free to contribute to the conversation!**
+
+The purpose of the mailing list
+is to share ideas and solutions. We encourage all our users to provide their
+knowledge and experience to those seeking advice.
+
+`Access the mailing list here <https://www.nest-initiative.org/mailinglist/>`_
+------------------------------------------------------------------------------------
+
+


### PR DESCRIPTION
This PR resolves #1364 

I've added a page to the docs that states what we expect from people who have questions on the mailing list. 

See sample output here: https://nest-test.readthedocs.io/en/mailing_list_guidelines/contribute/mailing_list_guidelines.html

Should we provide link from GitHub or other place?