### PR TITLE
Make MPI errors fatal

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -114,7 +114,7 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
 
   // MPI errors are not detected systematically on all MPI operations.
   // Therefore make them fatal to avoid proceeding past MPI errors.
-  MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
+  MPI_Comm_set_errhandler( MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL );
 
   MPI_Comm_size( comm, &num_processes_ );
   MPI_Comm_rank( comm, &rank_ );

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -112,6 +112,10 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
 #endif /* #ifdef HAVE_MUSIC */
   }
 
+  // MPI errors are not detected systematically on all MPI operations.
+  // Therefore make them fatal to avoid proceeding past MPI errors.
+  MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
+
   MPI_Comm_size( comm, &num_processes_ );
   MPI_Comm_rank( comm, &rank_ );
 


### PR DESCRIPTION
Currently, NEST does not systematically check the error status of MPI function calls, so NEST might proceed past MPI errors.

This PR ensures that MPI will treat any errors occurring in MPI routines as fatal. 