### PR TITLE
Hike minimum required CMake to 3.12 and add support for OpenMP with Apple Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>
 
-cmake_minimum_required( VERSION 3.12 )
+# Version range from minimum required (3.12 for macOS OpenMP)
+# up to newest version tested, see https://cliutils.gitlab.io/modern-cmake/chapters/basics.html
+cmake_minimum_required( VERSION 3.12...3.16 )
 
 # add cmake modules: for all `include(...)` first look here
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>
 
-cmake_minimum_required( VERSION 3.1 )
+cmake_minimum_required( VERSION 3.12 )
 
 # add cmake modules: for all `include(...)` first look here
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -437,7 +437,7 @@ function( NEST_PROCESS_WITH_OPENMP )
   if ( with-openmp )
     if ( NOT "${with-openmp}" STREQUAL "ON" )
       message( STATUS "Set OpenMP argument: ${with-openmp}")
-      # set variablesin this scope
+      # set variables in this scope
       set( OPENMP_FOUND ON )
       set( OpenMP_C_FLAGS "${with-openmp}" )
       set( OpenMP_CXX_FLAGS "${with-openmp}" )
@@ -456,6 +456,13 @@ function( NEST_PROCESS_WITH_OPENMP )
       message( FATAL_ERROR "CMake can not find OpenMP." )
     endif ()
   endif ()
+
+  # Provide a dummy OpenMP::OpenMP_CXX if no OpenMP or if flags explicitly
+  # given. Needed to avoid problems where OpenMP::OpenMP_CXX is used.
+  if ( NOT TARGET OpenMP::OpenMP_CXX )
+    add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
+  endif()
+ 
 endfunction()
 
 function( NEST_PROCESS_WITH_MPI )

--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -55,10 +55,11 @@ endif ()
 
 target_link_libraries( nest
     nestutil nestkernel random sli_lib sli_readline
-    ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} )
+    ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} OpenMP::OpenMP_CXX )
 
 target_link_libraries( nest_lib
-    nestutil nestkernel random sli_lib ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} )
+    nestutil nestkernel random sli_lib ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} 
+    OpenMP::OpenMP_CXX )
 
 target_include_directories( nest PRIVATE
     ${PROJECT_BINARY_DIR}/nest

--- a/sli/CMakeLists.txt
+++ b/sli/CMakeLists.txt
@@ -84,7 +84,7 @@ set( sli_sources
     )
 
 add_library( sli_lib ${sli_sources} )
-target_link_libraries( sli_lib nestutil )
+target_link_libraries( sli_lib nestutil OpenMP::OpenMP_CXX )
 
 # Make a separate target for linking against readline, so that
 # pynestkernel does not need to link against readline and make
@@ -92,11 +92,11 @@ target_link_libraries( sli_lib nestutil )
 # pull request for more information:
 # https://github.com/nest/nest-simulator/pull/323
 add_library( sli_readline gnureadline.cc gnureadline.h )
-target_link_libraries( sli_readline sli_lib nestutil ${READLINE_LIBRARIES} )
+target_link_libraries( sli_readline sli_lib nestutil ${READLINE_LIBRARIES} OpenMP::OpenMP_CXX )
 
 # add the executable
 add_executable( sli puresli.cc )
-target_link_libraries( sli sli_lib sli_readline ${GSL_LIBRARIES} )
+target_link_libraries( sli sli_lib sli_readline ${GSL_LIBRARIES} OpenMP::OpenMP_CXX )
 
 target_include_directories( sli PRIVATE
     ${PROJECT_SOURCE_DIR}/libnestutil


### PR DESCRIPTION
This PR fixes #1326 by hiking the minimum CMake requirement to version 3.12. It also

- Uses the CMake version-range syntax to specify that it has been tested with up to 3.16
(https://cliutils.gitlab.io/modern-cmake/chapters/basics.html)

- Adds support for building NEST with Apple Clang and OpenMP using new 3.12 features (https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html)

Note that building with Apple Clang on macOS in combination with Anaconda Python with MKL will lead to library conflicts in PyNEST (`Initializing libiomp5.dylib, but found libomp.dylib already initialized`).