### PR TITLE
Remove pylab for plotting

### DIFF
--- a/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -130,7 +130,6 @@ ids of all the created neurons, in this case only one, which we store in
 a variable called ``neuron``.
 
 ::
-
     import pylab
     import nest
     neuron = nest.Create("iaf_psc_alpha")


### PR DESCRIPTION
**Description of problem:**
Importing pylab for plotting caused problems for me. I received the following error: 
`AttributeError: module 'pylab' has no attribute 'figure'`. pip installing pylab or uninstalling it in my conda environment does not solve the problem. What did work for me is just installing matplotlib to `import matplotlib.pyplot as plt` and use `plt.figure()` instead to plot the graphs instead. 

**Version-Release or Git commit:**
git version 2.20.1 (Apple Git-117)

**How reproducible: (Always/Sometimes/Unsure)**
Always

**Steps to Reproduce:**
1. Following all steps for tutorial 1
2. Go to section "Extracting and plotting data from devices"
3. Do `pylab.figure(1)`

**More information**

Script that can be run without pylab:

```
from sklearn.svm import LinearSVC
from scipy.special import erf

import nest
import matplotlib.pyplot as plt

neuron = nest.Create("iaf_psc_alpha") # create integrate and fire neuron

nest.GetStatus(neuron, "I_e") # value of the constant background current 
nest.GetStatus(neuron, ["V_reset", "V_th"]) 

nest.SetStatus(neuron, {"I_e": 376.0})
# Next we create a multimeter, a device we can use to record the membrane voltage of a neuron over time.
multimeter = nest.Create("multimeter")
nest.SetStatus(multimeter, {"withtime":True, "record_from":["V_m"]})

# create spikedetector
spikedetector = nest.Create("spike_detector",
                params={"withgid": True, "withtime": True})

nest.Connect(multimeter, neuron)
nest.Connect(neuron, spikedetector)

nest.Simulate(1000.0)

dmm = nest.GetStatus(multimeter)[0] # select one node, we get back one dictionary
Vms = dmm["events"]["V_m"]
ts = dmm["events"]["times"]

plt.figure(1)
plt.plot(ts, Vms)

```

