### PR TITLE
Changed EnableStructuralPlasticity documentation to address issue #571

### DIFF
--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -1623,6 +1623,9 @@ NestModule::GetStructuralPlasticityStatus_DFunction::execute( SLIInterpreter* i 
 /**
  * Enable Structural Plasticity within the simulation. This means, allowing
  * dynamic rewiring of the network based on mean electrical activity.
+ * Please note that in the current implementation of structural plasticity
+ * spikes could be delivered via connections that were not present at the 
+ * time of the spike in some cases.
  * @param i
  */
 void

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -1621,11 +1621,11 @@ NestModule::GetStructuralPlasticityStatus_DFunction::execute( SLIInterpreter* i 
 }
 
 /**
- * Enable Structural Plasticity within the simulation. This means, allowing
+ * Enable Structural Plasticity within the simulation. This allows
  * dynamic rewiring of the network based on mean electrical activity.
- * Please note that in the current implementation of structural plasticity
- * spikes could be delivered via connections that were not present at the 
- * time of the spike in some cases.
+ * Please note that, in the current implementation of structural plasticity,
+ * spikes could occasionally be delivered via connections that were not present
+ * at the time of the spike.
  * @param i
  */
 void


### PR DESCRIPTION
This PR addresses issue #571 by adding additional documentation to the EnableStructuralPlasticity function about the possibility of having spikes delivered via connections that were not present at the time of the spike. Further non-trivial work would need to be done in order to completely remove this possibility.