### PR TITLE
Improve information given by error messages typically triggered by Connect

### DIFF
--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -345,7 +345,7 @@ Connection< targetidentifierT >::check_connection_( Node& dummy_target,
   // each bit in the signal type as a collection of individual flags
   if ( not( source.sends_signal() & target.receives_signal() ) )
   {
-    throw IllegalConnection();
+    throw IllegalConnection( "Source and target neuron are not compatible (e.g., spiking vs binary neuron)." );
   }
 
   target_.set_target( &target );

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -208,17 +208,28 @@ nest::BadDelay::message() const
 std::string
 nest::UnexpectedEvent::message() const
 {
-  return "Node cannot handle received event.";
+  if ( msg_.empty() )
+  {
+    return std::string(
+      "Target node cannot handle input event.\n"
+      "    A common cause for this is an attempt to connect recording devices incorrectly.\n"
+      "    Note that detectors such as spike detectors must be connected as\n\n"
+      "        nest.Connect(neurons, spike_det)\n\n"
+      "    while meters such as voltmeters must be connected as\n\n"
+      "        nest.Connect(meter, neurons) " );
+  }
+  else
+  {
+    return "UnexpectedEvent: " + msg_;
+  }
 }
 
 std::string
 nest::UnsupportedEvent::message() const
 {
   return std::string(
-    "The current synapse type does not support the event type of the "
-    "sender.\n"
-    "       A common reason for this is a dynamic synapse between a "
-    "device and a neuron." );
+    "The current synapse type does not support the event type of the sender.\n"
+    "    A common cause for this is a plastic synapse between a device and a neuron." );
 }
 
 std::string

--- a/nestkernel/exceptions.h
+++ b/nestkernel/exceptions.h
@@ -507,12 +507,22 @@ public:
   {
   }
 
+  UnexpectedEvent( std::string msg )
+    : KernelException( "UnexpectedEvent" )
+    , msg_( msg )
+  {
+  }
+
   ~UnexpectedEvent() throw()
   {
   }
 
   std::string message() const;
+
+private:
+  std::string msg_;
 };
+
 
 /**
  * Exception to be thrown by a Connection object if

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -208,7 +208,7 @@ Node::set_status_base( const DictionaryDatum& dict )
 bool
 Node::wfr_update( Time const&, const long, const long )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "Waveform relaxation not supported." );
 }
 
 /**
@@ -217,7 +217,8 @@ Node::wfr_update( Time const&, const long, const long )
 port
 Node::send_test_event( Node&, rport, synindex, bool )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent(
+    "Source node does not send output. Note that detectors need to be connected as Connect(neuron, detector)." );
 }
 
 /**
@@ -227,7 +228,7 @@ Node::send_test_event( Node&, rport, synindex, bool )
 void
 Node::register_stdp_connection( double, double )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node does not support STDP synapses." );
 }
 
 /**
@@ -239,55 +240,57 @@ Node::register_stdp_connection( double, double )
 void
 Node::handle( SpikeEvent& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle spike input." );
 }
 
 port
 Node::handles_test_event( SpikeEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection(
+    "The target node or synapse model does not support spike input.\n"
+    "  Note that volt/multimeters must be connected as Connect(meter, neuron)." );
 }
 
 void
 Node::handle( WeightRecorderEvent& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle weight recorder events." );
 }
 
 port
 Node::handles_test_event( WeightRecorderEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support weight recorder events." );
 }
 
 void
 Node::handle( RateEvent& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle rate input." );
 }
 
 port
 Node::handles_test_event( RateEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support rate input." );
 }
 
 void
 Node::handle( CurrentEvent& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle current input." );
 }
 
 port
 Node::handles_test_event( CurrentEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support current input." );
 }
 
 void
 Node::handle( DataLoggingRequest& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle data logging requests." );
 }
 
 port
@@ -307,13 +310,13 @@ Node::handle( DataLoggingReply& )
 void
 Node::handle( ConductanceEvent& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle conductance input." );
 }
 
 port
 Node::handles_test_event( ConductanceEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support conductance input." );
 }
 
 void
@@ -347,77 +350,77 @@ Node::handles_test_event( DSCurrentEvent&, rport )
 void
 Node::handle( GapJunctionEvent& )
 {
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle gap junction input." );
 }
 
 port
 Node::handles_test_event( GapJunctionEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support gap junction input." );
   return invalid_port_;
 }
 
 void
 Node::sends_secondary_event( GapJunctionEvent& )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The source node does not support gap junction output." );
 }
 
 void
 Node::handle( InstantaneousRateConnectionEvent& )
 {
-  throw UnexpectedEvent();
-}
-
-void
-Node::handle( DiffusionConnectionEvent& )
-{
-  throw UnexpectedEvent();
-}
-
-void
-Node::handle( DelayedRateConnectionEvent& )
-{
-  throw UnexpectedEvent();
+  throw UnexpectedEvent( "The target node does not handle instantaneous rate input." );
 }
 
 port
 Node::handles_test_event( InstantaneousRateConnectionEvent&, rport )
 {
-  throw IllegalConnection();
-  return invalid_port_;
-}
-
-port
-Node::handles_test_event( DiffusionConnectionEvent&, rport )
-{
-  throw IllegalConnection();
-  return invalid_port_;
-}
-
-port
-Node::handles_test_event( DelayedRateConnectionEvent&, rport )
-{
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support instantaneous rate input." );
   return invalid_port_;
 }
 
 void
 Node::sends_secondary_event( InstantaneousRateConnectionEvent& )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The source node does not support instantaneous rate output." );
+}
+
+void
+Node::handle( DiffusionConnectionEvent& )
+{
+  throw UnexpectedEvent( "The target node does not handle diffusion input." );
+}
+
+port
+Node::handles_test_event( DiffusionConnectionEvent&, rport )
+{
+  throw IllegalConnection( "The target node or synapse model does not support diffusion input." );
+  return invalid_port_;
 }
 
 void
 Node::sends_secondary_event( DiffusionConnectionEvent& )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The source node does not support diffusion output." );
+}
+
+void
+Node::handle( DelayedRateConnectionEvent& )
+{
+  throw UnexpectedEvent( "The target node does not handle delayed rate input." );
+}
+
+port
+Node::handles_test_event( DelayedRateConnectionEvent&, rport )
+{
+  throw IllegalConnection( "The target node or synapse model does not support delayed rate input." );
+  return invalid_port_;
 }
 
 void
 Node::sends_secondary_event( DelayedRateConnectionEvent& )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The source node does not support delayed rate output." );
 }
 
 


### PR DESCRIPTION
This PR makes some Connect-related error messages more informative, e.g.

```
SLI ] /n /iaf_psc_alpha Create def
SLI ] /v /voltmeter Create def
SLI ] /d /spike_detector Create def
SLI ] n v Connect
Jan 15 15:09:17 Connect_g_g_D_D [Error]: IllegalConnection
    Creation of connection is not possible because:
    The target node or synapse model does not support spike input.
      Note that volt/multimeters must be connected as Connect(meter, neuron).
SLI [4] clear
SLI ] d n Connect
Jan 15 15:09:32 Connect_g_g_D_D [Error]: UnexpectedEvent
    UnexpectedEvent: Source node does not send output. Note that detectors 
    need to be connected as Connect(neuron, detector).
```

It fixes #1339.