### PR TITLE
Avoid segfault when using a weight recorder with a probabilistic synapse

### DIFF
--- a/nestkernel/connector_base_impl.h
+++ b/nestkernel/connector_base_impl.h
@@ -40,7 +40,7 @@ Connector< ConnectionT >::send_weight_event( const thread tid,
 {
   // If the pointer to the receiver node in the event is a null pointer,
   // the event was not sent, and a WeightRecorderEvent is therefore not created.
-  if ( cp.get_weight_recorder() and e.receiver_is_not_null() )
+  if ( cp.get_weight_recorder() and not e.receiver_is_null() )
   {
     // Create new event to record the weight and copy relevant content.
     WeightRecorderEvent wr_e;

--- a/nestkernel/connector_base_impl.h
+++ b/nestkernel/connector_base_impl.h
@@ -38,7 +38,9 @@ Connector< ConnectionT >::send_weight_event( const thread tid,
   Event& e,
   const CommonSynapseProperties& cp )
 {
-  if ( cp.get_weight_recorder() )
+  // If the pointer to the receiver node in the event is a null pointer,
+  // the event was not sent, and a WeightRecorderEvent is therefore not created.
+  if ( cp.get_weight_recorder() and e.receiver_is_not_null() )
   {
     // Create new event to record the weight and copy relevant content.
     WeightRecorderEvent wr_e;
@@ -52,7 +54,7 @@ Connector< ConnectionT >::send_weight_event( const thread tid,
     // Set weight_recorder as receiver
     wr_e.set_receiver( *cp.get_weight_recorder()->get_thread_sibling( tid ) );
     // Put the gid of the postsynaptic node as receiver gid
-    wr_e.set_receiver_gid( e.get_receiver().get_gid() );
+    wr_e.set_receiver_gid( e.get_receiver_gid() );
     wr_e();
   }
 }

--- a/nestkernel/connector_base_impl.h
+++ b/nestkernel/connector_base_impl.h
@@ -38,9 +38,9 @@ Connector< ConnectionT >::send_weight_event( const thread tid,
   Event& e,
   const CommonSynapseProperties& cp )
 {
-  // If the pointer to the receiver node in the event is a null pointer,
+  // If the pointer to the receiver node in the event is invalid,
   // the event was not sent, and a WeightRecorderEvent is therefore not created.
-  if ( cp.get_weight_recorder() and not e.receiver_is_null() )
+  if ( cp.get_weight_recorder() and e.receiver_is_valid() )
   {
     // Create new event to record the weight and copy relevant content.
     WeightRecorderEvent wr_e;

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -259,14 +259,14 @@ public:
   virtual void set_diffusion_factor( weight t ){};
 
   /**
-   * Returns true if the pointer to the sender node is null.
+   * Returns true if the pointer to the sender node is valid.
    */
-  bool sender_is_null() const;
+  bool sender_is_valid() const;
 
   /**
-   * Returns true if the pointer to the receiver node is null.
+   * Returns true if the pointer to the receiver node is valid.
    */
-  bool receiver_is_null() const;
+  bool receiver_is_valid() const;
 
   /**
    * Check integrity of the event.
@@ -1264,21 +1264,21 @@ DiffusionConnectionEvent::get_diffusion_factor() const
 // Inline implementations.
 
 inline bool
-Event::sender_is_null() const
+Event::sender_is_valid() const
 {
-  return sender_ == nullptr;
+  return sender_ != nullptr;
 }
 
 inline bool
-Event::receiver_is_null() const
+Event::receiver_is_valid() const
 {
-  return receiver_ == nullptr;
+  return receiver_ != nullptr;
 }
 
 inline bool
 Event::is_valid() const
 {
-  return ( not sender_is_null() and not receiver_is_null() and ( d_ > 0 ) );
+  return ( sender_is_valid() and receiver_is_valid() and ( d_ > 0 ) );
 }
 
 inline void

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -259,6 +259,16 @@ public:
   virtual void set_diffusion_factor( weight t ){};
 
   /**
+   * Returns true if the pointer to the sender node is not null.
+   */
+  bool sender_is_not_null() const;
+
+  /**
+   * Returns true if the pointer to the receiver node is not null.
+   */
+  bool receiver_is_not_null() const;
+
+  /**
    * Check integrity of the event.
    * This function returns true, if all data, in particular sender
    * and receiver pointers are correctly set.
@@ -1254,9 +1264,21 @@ DiffusionConnectionEvent::get_diffusion_factor() const
 // Inline implementations.
 
 inline bool
+Event::sender_is_not_null() const
+{
+  return sender_ != nullptr;
+}
+
+inline bool
+Event::receiver_is_not_null() const
+{
+  return receiver_ != nullptr;
+}
+
+inline bool
 Event::is_valid() const
 {
-  return ( ( sender_ != NULL ) and ( receiver_ != NULL ) and ( d_ > 0 ) );
+  return ( sender_is_not_null() and receiver_is_not_null() and ( d_ > 0 ) );
 }
 
 inline void

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -261,12 +261,12 @@ public:
   /**
    * Returns true if the pointer to the sender node is not null.
    */
-  bool sender_is_not_null() const;
+  bool sender_is_null() const;
 
   /**
    * Returns true if the pointer to the receiver node is not null.
    */
-  bool receiver_is_not_null() const;
+  bool receiver_is_null() const;
 
   /**
    * Check integrity of the event.
@@ -1264,21 +1264,21 @@ DiffusionConnectionEvent::get_diffusion_factor() const
 // Inline implementations.
 
 inline bool
-Event::sender_is_not_null() const
+Event::sender_is_null() const
 {
-  return sender_ != nullptr;
+  return sender_ == nullptr;
 }
 
 inline bool
-Event::receiver_is_not_null() const
+Event::receiver_is_null() const
 {
-  return receiver_ != nullptr;
+  return receiver_ == nullptr;
 }
 
 inline bool
 Event::is_valid() const
 {
-  return ( sender_is_not_null() and receiver_is_not_null() and ( d_ > 0 ) );
+  return ( not sender_is_null() and not receiver_is_null() and ( d_ > 0 ) );
 }
 
 inline void

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -259,12 +259,12 @@ public:
   virtual void set_diffusion_factor( weight t ){};
 
   /**
-   * Returns true if the pointer to the sender node is not null.
+   * Returns true if the pointer to the sender node is null.
    */
   bool sender_is_null() const;
 
   /**
-   * Returns true if the pointer to the receiver node is not null.
+   * Returns true if the pointer to the receiver node is null.
    */
   bool receiver_is_null() const;
 

--- a/testsuite/regressiontests/issue-1212.sli
+++ b/testsuite/regressiontests/issue-1212.sli
@@ -1,0 +1,63 @@
+/*
+ *  issue-1212.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1212
+
+Synopsis: (issue-1212) run -> NEST exits if test fails
+
+Description:
+This test makes sure that using a weight recorder with a probabilistic
+synapse that drops a spike doesn't result in a segfault.
+
+Author: Håkon Mørk
+FirstVersion: January 2020
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+  /sg /spike_generator << /spike_times [ 10. ] >> Create def
+  /source_parrot /parrot_neuron Create def
+  /target_parrot /parrot_neuron Create def
+  /wr /weight_recorder Create def
+
+  /bernoulli_synapse /bernoulli_synapse_wr << /weight_recorder wr >> CopyModel
+
+  sg source_parrot Connect
+
+  [source_parrot] [target_parrot]
+  << /rule /one_to_one >>
+  << /model /bernoulli_synapse_wr
+     /p_transmit 0.0
+     /weight 1.0 >>
+  Connect
+
+  20. Simulate
+}
+pass_or_die
+
+endusing


### PR DESCRIPTION
This PR fixes an issue caused by using a weight recorder with a probabilistic synapse. If the synapse drops a spike, i.e. the spike is not transmitted, the receiving node of the `Event` object is never set. When the connector then tries to create a `WeightRecorderEvent` from the `Event`, it causes a segfault. The connector now checks that the receiver node is set in the event before it tries to create a `WeightRecorderEvent`.

Fixes #1212.