### PR TITLE
Fix misuse of outdated variable that led to an impossible condition

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -649,7 +649,6 @@ EventDeliveryManager::collocate_target_data_buffers_( const thread tid,
   const AssignedRanks& assigned_ranks,
   SendBufferPosition& send_buffer_position )
 {
-  unsigned int num_target_data_written = 0;
   thread source_rank;
   TargetData next_target_data;
   bool valid_next_target_data;
@@ -679,7 +678,7 @@ EventDeliveryManager::collocate_target_data_buffers_( const thread tid,
       tid, assigned_ranks.begin, assigned_ranks.end, source_rank, next_target_data );
     if ( valid_next_target_data ) // add valid entry to MPI buffer
     {
-      if ( send_buffer_position.idx( source_rank ) == send_buffer_position.end( source_rank ) )
+      if ( send_buffer_position.is_chunk_filled( source_rank ) )
       {
         // entry does not fit in this part of the MPI buffer any more,
         // so we need to reject it
@@ -691,8 +690,7 @@ EventDeliveryManager::collocate_target_data_buffers_( const thread tid,
         // we have just rejected an entry, so source table can not be
         // fully read
         is_source_table_read = false;
-        if ( num_target_data_written
-          == ( send_buffer_position.send_recv_count_per_rank * assigned_ranks.size ) ) // buffer is full
+        if ( send_buffer_position.are_all_chunks_filled() ) // buffer is full
         {
           return is_source_table_read;
         }


### PR DESCRIPTION
This removes a local counter used as an exit condition for a while true loop that was never increased. It is replaced by using the correct functions of send_buffer_positions. While this should not lead to any bugs, it potentially slows down construction of the presynaptic infrastructure quite severely.

Discovered during a code review session with @suku248 @diesmann @heplesser 