### PR TITLE
Add links to the new NEST virtual machine

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -62,8 +62,17 @@ The VM image of NEST is available in the OVA format, and is suitable, for exampl
 If you run **Windows**, this is the option for you OR if you just want to run NEST without installing it on your computer.
 After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 
+* Download the |link-preova|\ |version|\ |link-postova|
 
-* Download the `latest release of the NEST VM image <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.20.0.ova>`_
+.. |link-preova| raw:: html
+
+    <a href="https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-
+
+.. |link-postova|  raw:: html
+
+     .ova">latest release of the NEST VM image</a>
+
+* Download the `NEST Live Media 2.20.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.20.0.ova>`_
 
 * After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 

--- a/doc/download.rst
+++ b/doc/download.rst
@@ -38,8 +38,8 @@ Download the source code
 
 .. seealso::
 
-   Previous versions and associated release notes can be found a
-   https://github.com/nest/nest-simulator/releases/
+   Previous versions and associated release notes can be found at
+   `<https://github.com/nest/nest-simulator/releases/>`_
 
 .. _download_livemedia:
 

--- a/doc/download.rst
+++ b/doc/download.rst
@@ -25,13 +25,13 @@ If you use NEST for your project, don't forget to :doc:`cite NEST <citing-nest>`
 Download the source code
 -------------------------
 
-* If you are compiling NEST from source, you can download the latest release here `<https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
+* If you are compiling NEST from source, you can download the latest release `here <https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
 
 * Then, follow the installation instructions for :doc:`Linux <installation/linux_install>` or :doc:`macOS <installation/mac_install>`.
 
 * Get the `source code of the latest release <https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
 
-* Get the release notes here `<https://github.com/nest/nest-simulator/releases/tag/v2.20.0>`_.
+* Get the release notes `here <https://github.com/nest/nest-simulator/releases/tag/v2.20.0>`_.
 
 * You can also test out the `latest developer version <https://github.com/nest/nest-simulator>`_ from GitHub.
 

--- a/doc/download.rst
+++ b/doc/download.rst
@@ -25,34 +25,20 @@ If you use NEST for your project, don't forget to :doc:`cite NEST <citing-nest>`
 Download the source code
 -------------------------
 
-* If you are compiling NEST from source, you can |link-pre|\ |version|\ |link-post|
-
-.. |link-pre| raw:: html
-
-    <a href="https://github.com/nest/nest-simulator/archive/v
-
-.. |link-post| raw:: html
-
-    .tar.gz">download the latest release here</a>
+* If you are compiling NEST from source, you can download the latest release here `<https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
 
 * Then, follow the installation instructions for :doc:`Linux <installation/linux_install>` or :doc:`macOS <installation/mac_install>`.
 
- |link-pregit|\ |version|\ |link-postgit|
-
-.. |link-pregit| raw:: html
-
 * Get the `source code of the latest release <https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
 
-.. |link-postgit| raw:: html
-
-    ">Get the release notes here</a>
+* Get the release notes here `<https://github.com/nest/nest-simulator/releases/tag/v2.20.0>`_.
 
 * You can also test out the `latest developer version <https://github.com/nest/nest-simulator>`_ from GitHub.
 
 
 .. seealso::
 
-   Previous versions and associated release notes can be found at
+   Previous versions and associated release notes can be found a
    https://github.com/nest/nest-simulator/releases/
 
 .. _download_livemedia:
@@ -65,16 +51,7 @@ If you run **Windows**, this is the option for you OR if you just want to run NE
 After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 
 
-* Download the |link-preova|\ |version|\ |link-postova|
-
-.. |link-preova| raw:: html
-
-    <a href="https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-
-
-.. |link-postova|  raw:: html
-
-     .ova">latest release of the NEST VM image</a>
-
+* Download the `latest release of the NEST VM image <https://nest-simulator.org/downloads/gplreleases/NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova>`_
 * After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 
 

--- a/doc/download.rst
+++ b/doc/download.rst
@@ -33,7 +33,7 @@ Download the source code
 
 .. |link-post| raw:: html
 
-    .tar.gz">download the latest release here</a>
+    .tar.gz">download the latest release here</a>.
 
 * Then, follow the installation instructions for :doc:`Linux <installation/linux_install>` or :doc:`macOS <installation/mac_install>`. |link-pregit|\ |version|\ |link-postgit|
 
@@ -43,9 +43,7 @@ Download the source code
 
 .. |link-postgit| raw:: html
 
-    ">Get the release notes here</a>
-
-* Get the `source code of the latest release <https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
+    ">Get the release notes here</a>.
 
 * You can also test out the `latest developer version <https://github.com/nest/nest-simulator>`_ from GitHub.
 

--- a/doc/download.rst
+++ b/doc/download.rst
@@ -25,13 +25,27 @@ If you use NEST for your project, don't forget to :doc:`cite NEST <citing-nest>`
 Download the source code
 -------------------------
 
-* If you are compiling NEST from source, you can download the latest release `here <https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
+* If you are compiling NEST from source, you can |link-pre|\ |version|\ |link-post|
 
-* Then, follow the installation instructions for :doc:`Linux <installation/linux_install>` or :doc:`macOS <installation/mac_install>`.
+.. |link-pre| raw:: html
+
+    <a href="https://github.com/nest/nest-simulator/archive/v
+
+.. |link-post| raw:: html
+
+    .tar.gz">download the latest release here</a>
+
+* Then, follow the installation instructions for :doc:`Linux <installation/linux_install>` or :doc:`macOS <installation/mac_install>`. |link-pregit|\ |version|\ |link-postgit|
+
+.. |link-pregit| raw:: html
+
+    <a href="https://github.com/nest/nest-simulator/releases/tag/v
+
+.. |link-postgit| raw:: html
+
+    ">Get the release notes here</a>
 
 * Get the `source code of the latest release <https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz>`_.
-
-* Get the release notes `here <https://github.com/nest/nest-simulator/releases/tag/v2.20.0>`_.
 
 * You can also test out the `latest developer version <https://github.com/nest/nest-simulator>`_ from GitHub.
 
@@ -39,7 +53,7 @@ Download the source code
 .. seealso::
 
    Previous versions and associated release notes can be found at
-   `<https://github.com/nest/nest-simulator/releases/>`_
+   https://github.com/nest/nest-simulator/releases/
 
 .. _download_livemedia:
 
@@ -51,7 +65,8 @@ If you run **Windows**, this is the option for you OR if you just want to run NE
 After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 
 
-* Download the `latest release of the NEST VM image <https://nest-simulator.org/downloads/gplreleases/NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova>`_
+* Download the `latest release of the NEST VM image <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.20.0.ova>`_
+
 * After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 
 

--- a/doc/installation/livemedia.rst
+++ b/doc/installation/livemedia.rst
@@ -47,6 +47,7 @@ Notes
 
 * To install Guest Additions, select **Devices** > **Insert Guest Additions CD image...**  (top left of the VirtualBox Window). Then, open a terminal (Ctrl+Alt+t), go to "/media/nest/VBOXADDITIONS.../" and run "sudo bash VboxLinuxAdditions.run".
 
-* To set the correct language layout for your keyboard (e.g., from "US" to "DE"), you can use the program "lxkeymap", which you start by typing "lxkeymap" in the terminal.
+* To set the correct language layout for your keyboard (e.g., from "US" to "DE"), open a terminal and type: "sudo dpkg-reconfigure keyboard-configuration". Reboot now.
+
 
 

--- a/doc/installation/livemedia.rst
+++ b/doc/installation/livemedia.rst
@@ -47,7 +47,7 @@ Notes
 
 * To install Guest Additions, select **Devices** > **Insert Guest Additions CD image...**  (top left of the VirtualBox Window). Then, open a terminal (Ctrl+Alt+t), go to "/media/nest/VBOXADDITIONS.../" and run "sudo bash VboxLinuxAdditions.run".
 
-* To set the correct language layout for your keyboard (e.g., from "US" to "DE"), open a terminal and type: "sudo dpkg-reconfigure keyboard-configuration". Reboot now.
+* To set the correct language layout for your keyboard (e.g., from "US" to "DE"), open a terminal and type: "sudo dpkg-reconfigure keyboard-configuration". After setting the correct keyboard map you have to reboot the system to activate the changes.
 
 
 

--- a/doc/installation/livemedia.rst
+++ b/doc/installation/livemedia.rst
@@ -28,9 +28,9 @@ Windows users can follow instructions on the website (see above).
 NEST image setup
 ------------------
 
-* Download the `NEST live medium <https://www.nest-simulator.org/downloads/gplreleases/nest-live.ova>`_
+* Download the `NEST live medium <https://www.nest-simulator.org/downloads/gplreleases/NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova>`_
 
-* Start Virtual Box and import the virtual machine image "lubuntu-16.04_nest-2.XX.0.ova" (**File** > **Import Appliance**)
+* Start Virtual Box and import the virtual machine image "NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova" (**File** > **Import Appliance**)
 
 * Once imported, you can run the NEST image
 


### PR DESCRIPTION
There is now a new virtual machine with NEST 2.20.0.
https://nest-simulator.org/downloads/gplreleases/NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova
With Brian2, Jupyter Notebook, LFPy, MUSIC, neo, NEST, NESTML, NEURON and PyNN.