### PR TITLE
Refactor SendBufferPosition, fail on query with rank outside of range

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -649,7 +649,6 @@ EventDeliveryManager::collocate_target_data_buffers_( const thread tid,
   const AssignedRanks& assigned_ranks,
   SendBufferPosition& send_buffer_position )
 {
-  unsigned int num_target_data_written = 0;
   thread source_rank;
   TargetData next_target_data;
   bool valid_next_target_data;
@@ -679,7 +678,7 @@ EventDeliveryManager::collocate_target_data_buffers_( const thread tid,
       tid, assigned_ranks.begin, assigned_ranks.end, source_rank, next_target_data );
     if ( valid_next_target_data ) // add valid entry to MPI buffer
     {
-      if ( send_buffer_position.idx( source_rank ) == send_buffer_position.end( source_rank ) )
+      if ( send_buffer_position.is_chunk_filled( source_rank ) )
       {
         // entry does not fit in this part of the MPI buffer any more,
         // so we need to reject it
@@ -691,8 +690,7 @@ EventDeliveryManager::collocate_target_data_buffers_( const thread tid,
         // we have just rejected an entry, so source table can not be
         // fully read
         is_source_table_read = false;
-        if ( num_target_data_written
-          == ( send_buffer_position.send_recv_count_per_rank * assigned_ranks.size ) ) // buffer is full
+        if ( send_buffer_position.are_all_chunks_filled() ) // buffer is full
         {
           return is_source_table_read;
         }

--- a/nestkernel/send_buffer_position.h
+++ b/nestkernel/send_buffer_position.h
@@ -41,14 +41,17 @@ namespace nest
 class SendBufferPosition
 {
 private:
+  thread begin_rank_;
+  thread end_rank_;
+  thread size_;
+  thread max_size_;
   size_t num_spike_data_written_;
-  std::vector< unsigned int > idx_;
-  std::vector< unsigned int > begin_;
-  std::vector< unsigned int > end_;
+  size_t send_recv_count_per_rank_;
+  std::vector< thread > idx_;
+  std::vector< thread > begin_;
+  std::vector< thread > end_;
 
   thread rank_to_index_( const thread rank ) const;
-
-  const unsigned int max_size_;
 
 public:
   SendBufferPosition( const AssignedRanks& assigned_ranks, const unsigned int send_recv_count_per_rank );
@@ -83,15 +86,16 @@ public:
   bool are_all_chunks_filled() const;
 
   void increase( const thread rank );
-
-  const unsigned int send_recv_count_per_rank;
 };
 
 inline SendBufferPosition::SendBufferPosition( const AssignedRanks& assigned_ranks,
   const unsigned int send_recv_count_per_rank )
-  : num_spike_data_written_( 0 )
+  : begin_rank_( assigned_ranks.begin )
+  , end_rank_( assigned_ranks.end )
+  , size_( assigned_ranks.size )
   , max_size_( assigned_ranks.max_size )
-  , send_recv_count_per_rank( send_recv_count_per_rank )
+  , num_spike_data_written_( 0 )
+  , send_recv_count_per_rank_( send_recv_count_per_rank )
 {
   idx_.resize( assigned_ranks.size );
   begin_.resize( assigned_ranks.size );
@@ -110,6 +114,8 @@ inline SendBufferPosition::SendBufferPosition( const AssignedRanks& assigned_ran
 inline thread
 SendBufferPosition::rank_to_index_( const thread rank ) const
 {
+  assert( begin_rank_ <= rank );
+  assert( rank < end_rank_ );
   return rank % max_size_;
 }
 
@@ -140,7 +146,7 @@ SendBufferPosition::is_chunk_filled( const thread rank ) const
 inline bool
 SendBufferPosition::are_all_chunks_filled() const
 {
-  return num_spike_data_written_ == send_recv_count_per_rank * idx_.size();
+  return num_spike_data_written_ == send_recv_count_per_rank_ * idx_.size();
 }
 
 inline void


### PR DESCRIPTION
During code review with @suku248 we realized one could query the `SendBufferPosition` with ranks that are outside of the range for which a specific thread is responsible, returning nonsense values due to modulo arithmetic. This PR addresses that issue by adding two specific asserts.

Depends on #1416, should be merged after.

@hakonsbm @heplesser @jougs @stinebuu @jarsi 