### PR TITLE
Refactor/collocate target data

### DIFF
--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -290,34 +290,24 @@ bool
 nest::SourceTable::next_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
-  if ( ( current_position.lcid + 1
-           < static_cast< long >( sources_[ current_position.tid ][ current_position.syn_id ].size() )
-         and sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid + 1 ].get_node_id()
-           == current_source.get_node_id() ) )
-  {
-    return true;
-  }
+  const auto& local_sources = sources_[ current_position.tid ][ current_position.syn_id ];
+  const size_t next_lcid = current_position.lcid + 1;
 
-  return false;
+  return ( next_lcid < local_sources.size()
+	   and local_sources[ next_lcid ].get_node_id() == current_source.get_node_id() );
 }
 
 bool
 nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
-  // decrease the position without returning a TargetData if the
-  // entry preceding this entry has the same source, but only if
-  // the preceding entry was not processed yet
-  if ( ( current_position.lcid - 1 >= 0 )
-    and ( sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid - 1 ].get_node_id()
-          == current_source.get_node_id() )
-    and ( not sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid - 1 ]
-                .is_processed() ) )
-  {
-    return true;
-  }
+  const auto& local_sources = sources_[ current_position.tid ][ current_position.syn_id ];
+  const long previous_lcid = current_position.lcid - 1;  // needs to be a signed type such that negative
+                                                         // values can signal invalid indices
 
-  return false;
+  return ( previous_lcid >= 0
+	   and not local_sources[ previous_lcid ].is_processed()
+	   and local_sources[ previous_lcid ].get_node_id() == current_source.get_node_id() );
 }
 
 bool

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -274,16 +274,17 @@ nest::SourceTable::resize_sources( const thread tid )
 }
 
 bool
-nest::SourceTable::source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source ) const
+nest::SourceTable::source_should_be_processed_( const thread rank_start,
+  const thread rank_end,
+  const Source& source ) const
 {
   const thread source_rank = kernel().mpi_manager.get_process_id_of_node_id( source.get_node_id() );
 
-  return not ( source.is_processed()
-	       or source.is_disabled()
-	       // is this thread responsible for this part of the MPI
-	       // buffer?
-	       or source_rank < rank_start
-	       or rank_end <= source_rank );
+  return not( source.is_processed() or source.is_disabled()
+           // is this thread responsible for this part of the MPI
+           // buffer?
+           or source_rank < rank_start
+           or rank_end <= source_rank );
 }
 
 bool
@@ -293,8 +294,8 @@ nest::SourceTable::next_entry_has_same_source_( const SourceTablePosition& curre
   const auto& local_sources = sources_[ current_position.tid ][ current_position.syn_id ];
   const size_t next_lcid = current_position.lcid + 1;
 
-  return ( next_lcid < local_sources.size()
-	   and local_sources[ next_lcid ].get_node_id() == current_source.get_node_id() );
+  return (
+    next_lcid < local_sources.size() and local_sources[ next_lcid ].get_node_id() == current_source.get_node_id() );
 }
 
 bool
@@ -302,12 +303,11 @@ nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& c
   const Source& current_source ) const
 {
   const auto& local_sources = sources_[ current_position.tid ][ current_position.syn_id ];
-  const long previous_lcid = current_position.lcid - 1;  // needs to be a signed type such that negative
-                                                         // values can signal invalid indices
+  const long previous_lcid = current_position.lcid - 1; // needs to be a signed type such that negative
+                                                        // values can signal invalid indices
 
-  return ( previous_lcid >= 0
-	   and not local_sources[ previous_lcid ].is_processed()
-	   and local_sources[ previous_lcid ].get_node_id() == current_source.get_node_id() );
+  return ( previous_lcid >= 0 and not local_sources[ previous_lcid ].is_processed()
+    and local_sources[ previous_lcid ].get_node_id() == current_source.get_node_id() );
 }
 
 bool
@@ -347,8 +347,7 @@ nest::SourceTable::get_next_target_data( const thread tid,
       current_position.tid, current_position.syn_id, current_position.lcid,
       next_entry_has_same_source_( current_position, current_source ) );
 
-    // no need to communicate this entry if the previous entry has the
-    // same source
+    // no need to communicate this entry if the previous entry has the same source
     if ( previous_entry_has_same_source_( current_position, current_source ) )
     {
       current_source.set_processed( true ); // no need to look at this entry again
@@ -356,7 +355,8 @@ nest::SourceTable::get_next_target_data( const thread tid,
       continue;
     }
 
-    // reaching this means we found a valid TargetData
+    // reaching this means we found an entry that should be
+    // communicated via MPI, so we prepare to return the relevant data
 
     const auto node_id = current_source.get_node_id();
 

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -296,7 +296,7 @@ nest::SourceTable::source_should_be_processed_( const thread rank_start, const t
 }
 
 bool
-nest::SourceTable::next_entry_has_same_source( const SourceTablePosition& current_position,
+nest::SourceTable::next_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
   if ( ( current_position.lcid + 1
@@ -311,7 +311,7 @@ nest::SourceTable::next_entry_has_same_source( const SourceTablePosition& curren
 }
 
 bool
-nest::SourceTable::previous_entry_has_same_source( const SourceTablePosition& current_position,
+nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
   // decrease the position without returning a TargetData if the
@@ -367,11 +367,11 @@ nest::SourceTable::get_next_target_data( const thread tid,
     // entry, if existent, has the same source
     kernel().connection_manager.set_source_has_more_targets(
       current_position.tid, current_position.syn_id, current_position.lcid,
-      next_entry_has_same_source( current_position, current_source ) );
+      next_entry_has_same_source_( current_position, current_source ) );
 
     // no need to communicate this entry if the previous entry has the
     // same source
-    if ( previous_entry_has_same_source( current_position, current_source ) )
+    if ( previous_entry_has_same_source_( current_position, current_source ) )
     {
       current_position.decrease();
       continue;

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -291,6 +291,8 @@ bool
 nest::SourceTable::next_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
+  assert( not current_position.is_invalid() );
+
   const auto& local_sources = sources_[ current_position.tid ][ current_position.syn_id ];
   const size_t next_lcid = current_position.lcid + 1;
 
@@ -302,6 +304,8 @@ bool
 nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
+  assert( not current_position.is_invalid() );
+
   const auto& local_sources = sources_[ current_position.tid ][ current_position.syn_id ];
   const long previous_lcid = current_position.lcid - 1; // needs to be a signed type such that negative
                                                         // values can signal invalid indices

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -360,6 +360,11 @@ nest::SourceTable::get_next_target_data( const thread tid,
 {
   SourceTablePosition& current_position = current_positions_[ tid ];
 
+  if ( current_position.is_invalid() )
+  {
+    return false; // nothing to do here
+  }
+
   // we stay in this loop either until we can return a valid
   // TargetData object or we have reached the end of the sources table
   while ( true )

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -376,16 +376,13 @@ nest::SourceTable::get_next_target_data( const thread tid,
     }
 
     // the current position contains an entry, so we retrieve it
-    const Source& const_current_source =
-      sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid ];
+    Source& current_source = sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid ];
 
-    if ( not source_should_be_processed_( rank_start, rank_end, const_current_source ) )
+    if ( not source_should_be_processed_( rank_start, rank_end, current_source ) )
     {
       current_position.decrease();
       continue;
     }
-
-    Source& current_source = sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid ];
 
     // we need to set a marker stating whether the entry following this
     // entry, if existent, has the same source

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -360,11 +360,13 @@ nest::SourceTable::get_next_target_data( const thread tid,
 
     // reaching this means we found a valid TargetData
 
+    const auto node_id = current_source.get_node_id();
+
     // set the source rank
-    source_rank = kernel().mpi_manager.get_process_id_of_node_id( current_source.get_node_id() );
+    source_rank = kernel().mpi_manager.get_process_id_of_node_id( node_id );
 
     // set values of next_target_data
-    next_target_data.set_source_lid( kernel().vp_manager.node_id_to_lid( current_source.get_node_id() ) );
+    next_target_data.set_source_lid( kernel().vp_manager.node_id_to_lid( node_id ) );
     next_target_data.set_source_tid(
       kernel().vp_manager.vp_to_thread( kernel().vp_manager.node_id_to_vp( current_source.get_node_id() ) ) );
     next_target_data.reset_marker();

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -389,8 +389,9 @@ nest::SourceTable::get_next_target_data( const thread tid,
 
     // we need to set a marker stating whether the entry following this
     // entry, if existent, has the same source
-    kernel().connection_manager.set_source_has_more_targets(
-      current_position.tid, current_position.syn_id, current_position.lcid,
+    kernel().connection_manager.set_source_has_more_targets( current_position.tid,
+      current_position.syn_id,
+      current_position.lcid,
       next_entry_has_same_source_( current_position, current_source ) );
 
     // no need to communicate this entry if the previous entry has the same source

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -274,7 +274,7 @@ nest::SourceTable::resize_sources( const thread tid )
 }
 
 bool
-nest::SourceTable::source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source )
+nest::SourceTable::source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source ) const
 {
   if ( source.is_processed() or source.is_disabled() )
   {

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -341,9 +341,6 @@ nest::SourceTable::get_next_target_data( const thread tid,
 
     Source& current_source = sources_[ current_position.tid ][ current_position.syn_id ][ current_position.lcid ];
 
-    // we have found a valid entry, so mark it as processed
-    current_source.set_processed( true );
-
     // we need to set a marker stating whether the entry following this
     // entry, if existent, has the same source
     kernel().connection_manager.set_source_has_more_targets(
@@ -354,6 +351,7 @@ nest::SourceTable::get_next_target_data( const thread tid,
     // same source
     if ( previous_entry_has_same_source_( current_position, current_source ) )
     {
+      current_source.set_processed( true ); // no need to look at this entry again
       current_position.decrease();
       continue;
     }
@@ -403,6 +401,9 @@ nest::SourceTable::get_next_target_data( const thread tid,
       secondary_fields.set_send_buffer_pos( send_buffer_pos );
       secondary_fields.set_syn_id( current_position.syn_id );
     }
+
+    // we are about to return a valid entry, so mark it as processed
+    current_source.set_processed( true );
 
     current_position.decrease();
     return true; // found a valid entry

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -276,23 +276,14 @@ nest::SourceTable::resize_sources( const thread tid )
 bool
 nest::SourceTable::source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source ) const
 {
-  if ( source.is_processed() or source.is_disabled() )
-  {
-    // looks like we've processed this already, let's continue
-    return false;
-  }
-
   const thread source_rank = kernel().mpi_manager.get_process_id_of_node_id( source.get_node_id() );
 
-  // determine whether this thread is responsible for this part of
-  // the MPI buffer; if not we just continue with the next iteration
-  // of the loop
-  if ( source_rank < rank_start or source_rank >= rank_end )
-  {
-    return false;
-  }
-
-  return true; // if we reach this we should process it
+  return not ( source.is_processed()
+	       or source.is_disabled()
+	       // is this thread responsible for this part of the MPI
+	       // buffer?
+	       or source_rank < rank_start
+	       or rank_end <= source_rank );
 }
 
 bool

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -319,16 +319,15 @@ nest::SourceTable::populate_target_data_fields_( const SourceTablePosition& curr
 
   // set values of next_target_data
   next_target_data.set_source_lid( kernel().vp_manager.node_id_to_lid( node_id ) );
-  next_target_data.set_source_tid(
-    kernel().vp_manager.vp_to_thread( kernel().vp_manager.node_id_to_vp( node_id ) ) );
+  next_target_data.set_source_tid( kernel().vp_manager.vp_to_thread( kernel().vp_manager.node_id_to_vp( node_id ) ) );
   next_target_data.reset_marker();
 
   if ( current_source.is_primary() ) // primary connection, i.e., chemical synapses
   {
     next_target_data.set_is_primary( true );
 
-    // we store the thread index of the source table, not our own tid!
     TargetDataFields& target_fields = next_target_data.target_data;
+    // we store the thread index of the source table, not our own tid!
     target_fields.set_tid( current_position.tid );
     target_fields.set_syn_id( current_position.syn_id );
     target_fields.set_lcid( current_position.lcid );

--- a/nestkernel/source_table.h
+++ b/nestkernel/source_table.h
@@ -129,6 +129,13 @@ public:
    */
   bool is_cleared() const;
 
+  bool source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source );
+
+  bool next_entry_has_same_source( const SourceTablePosition& current_position, const Source& current_source ) const;
+
+  bool previous_entry_has_same_source( const SourceTablePosition& current_position,
+    const Source& current_source ) const;
+
   /**
    * Returns the next target data, according to the current_positions_.
    */

--- a/nestkernel/source_table.h
+++ b/nestkernel/source_table.h
@@ -94,6 +94,8 @@ private:
    */
   static const size_t min_deleted_elements_ = 1000000;
 
+  bool source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source ) const;
+
 public:
   SourceTable();
   ~SourceTable();
@@ -128,8 +130,6 @@ public:
    * Returns true if sources_ has been cleared.
    */
   bool is_cleared() const;
-
-  bool source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source );
 
   bool next_entry_has_same_source( const SourceTablePosition& current_position, const Source& current_source ) const;
 

--- a/nestkernel/source_table.h
+++ b/nestkernel/source_table.h
@@ -94,10 +94,27 @@ private:
    */
   static const size_t min_deleted_elements_ = 1000000;
 
+
+  /**
+   * Returns whether this Source object should be considered when
+   * constructing MPI buffers for communicating connections. Returns
+   * false if i) this entry was already processed, or ii) this entry
+   * is disabled (e.g., by structural plastcity) or iii) the reading
+   * thread is not responsible for the particular part of the MPI
+   * buffer where this entry would be written.
+   */
   bool source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source ) const;
 
+  /**
+   * Returns true if the following entry in the SourceTable has the
+   * same source gid.
+   */
   bool next_entry_has_same_source_( const SourceTablePosition& current_position, const Source& current_source ) const;
 
+  /**
+   * Returns true if the previous entry in the SourceTable has the
+   * same source gid.
+   */
   bool previous_entry_has_same_source_( const SourceTablePosition& current_position,
     const Source& current_source ) const;
 

--- a/nestkernel/source_table.h
+++ b/nestkernel/source_table.h
@@ -118,6 +118,10 @@ private:
   bool previous_entry_has_same_source_( const SourceTablePosition& current_position,
     const Source& current_source ) const;
 
+  void populate_target_data_fields_( const SourceTablePosition& current_position,
+    const Source& current_source,
+    TargetData& next_target_data ) const;
+
 public:
   SourceTable();
   ~SourceTable();

--- a/nestkernel/source_table.h
+++ b/nestkernel/source_table.h
@@ -96,6 +96,11 @@ private:
 
   bool source_should_be_processed_( const thread rank_start, const thread rank_end, const Source& source ) const;
 
+  bool next_entry_has_same_source_( const SourceTablePosition& current_position, const Source& current_source ) const;
+
+  bool previous_entry_has_same_source_( const SourceTablePosition& current_position,
+    const Source& current_source ) const;
+
 public:
   SourceTable();
   ~SourceTable();
@@ -130,11 +135,6 @@ public:
    * Returns true if sources_ has been cleared.
    */
   bool is_cleared() const;
-
-  bool next_entry_has_same_source( const SourceTablePosition& current_position, const Source& current_source ) const;
-
-  bool previous_entry_has_same_source( const SourceTablePosition& current_position,
-    const Source& current_source ) const;
 
   /**
    * Returns the next target data, according to the current_positions_.

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -120,11 +120,13 @@ SourceTablePosition::seek_to_next_valid_index( const std::vector< std::vector< B
 
     // if we can not find a valid lcid by decreasing synapse or thread
     // indices, we have read all entries
-    return; // reached the end
     assert( tid == -1 );
     assert( syn_id == -1 );
     assert( lcid == -1 );
+    return; // reached the end without finding a valid entry
   }
+
+  return; // found a valid entry
 }
 
 inline bool

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -132,14 +132,7 @@ SourceTablePosition::seek_to_next_valid_index( const std::vector< std::vector< B
 inline bool
 SourceTablePosition::is_invalid() const
 {
-  if ( tid < 0 and syn_id < 0 and lcid < 0 )
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return ( tid < 0 and syn_id < 0 and lcid < 0 );
 }
 
 inline void

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -132,7 +132,7 @@ SourceTablePosition::seek_to_next_valid_index( const std::vector< std::vector< B
 inline bool
 SourceTablePosition::is_invalid() const
 {
-  return ( tid < 0 and syn_id < 0 and lcid < 0 );
+  return ( tid == -1 and syn_id == -1 and lcid == -1 );
 }
 
 inline void

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -46,8 +46,20 @@ struct SourceTablePosition
   SourceTablePosition( const long tid, const long syn_id, const long lcid );
   SourceTablePosition( const SourceTablePosition& rhs );
 
+  /**
+   * Decreases indices until a valid entry is found.
+   */
   void seek_to_next_valid_index( const std::vector< std::vector< BlockVector< Source > > >& sources );
+
+  /**
+   * Decreases the inner most index (lcid).
+   */
   void decrease();
+
+  /**
+   * Returns true if the indices point outside the SourceTable, e.g.,
+   * to signal that the end was reached.
+   */
   bool is_invalid() const;
 };
 

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -120,10 +120,10 @@ SourceTablePosition::seek_to_next_valid_index( const std::vector< std::vector< B
 
     // if we can not find a valid lcid by decreasing synapse or thread
     // indices, we have read all entries
-    assert( tid < 0 );
-    assert( syn_id < 0 );
-    assert( lcid < 0 );
     return; // reached the end
+    assert( tid == -1 );
+    assert( syn_id == -1 );
+    assert( lcid == -1 );
   }
 }
 
@@ -144,6 +144,7 @@ inline void
 SourceTablePosition::decrease()
 {
   --lcid;
+  assert( lcid >= -1 );
 }
 
 inline bool operator==( const SourceTablePosition& lhs, const SourceTablePosition& rhs )


### PR DESCRIPTION
This PR refactors some code related to the collocation of buffers for the communication of connections. In particular the notorious `get_next_target_data` and `SourceTablePosition`. I'm happy about any suggestions to clean this up further, it's still a mess.

@suku248 @jarsi @heplesser 