### PR TITLE
Rename suggest_vp_for_node_id to node_id_to_vp

### DIFF
--- a/libnestutil/dict_util.h
+++ b/libnestutil/dict_util.h
@@ -53,7 +53,7 @@ updateValueParam( DictionaryDatum const& d, Name const n, VT& value, nest::Node*
     {
       throw BadParameter( "Cannot use Parameter with this model." );
     }
-    auto vp = kernel().vp_manager.suggest_vp_for_node_id( node->get_node_id() );
+    auto vp = kernel().vp_manager.node_id_to_vp( node->get_node_id() );
     auto tid = kernel().vp_manager.vp_to_thread( vp );
     auto rng = get_vp_rng( tid );
     value = pd->get()->value( rng, node );

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1423,7 +1423,7 @@ nest::FixedTotalNumberBuilder::connect_()
   local_targets.reserve( size_targets / kernel().mpi_manager.get_num_processes() );
   for ( size_t t = 0; t < targets_->size(); t++ )
   {
-    int vp = kernel().vp_manager.suggest_vp_for_node_id( ( *targets_ )[ t ] );
+    int vp = kernel().vp_manager.node_id_to_vp( ( *targets_ )[ t ] );
     ++number_of_targets_on_vp[ vp ];
     if ( kernel().vp_manager.is_local_vp( vp ) )
     {
@@ -1506,7 +1506,7 @@ nest::FixedTotalNumberBuilder::connect_()
         std::vector< index >::const_iterator tnode_id_it = local_targets.begin();
         for ( ; tnode_id_it != local_targets.end(); ++tnode_id_it )
         {
-          if ( kernel().vp_manager.suggest_vp_for_node_id( *tnode_id_it ) == vp_id )
+          if ( kernel().vp_manager.node_id_to_vp( *tnode_id_it ) == vp_id )
           {
             thread_local_targets.push_back( *tnode_id_it );
           }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1244,7 +1244,7 @@ nest::ConnectionManager::connection_required( Node*& source, Node*& target, thre
     if ( not source->has_proxies() )
     {
       const index target_node_id = target->get_node_id();
-      target_vp = kernel().vp_manager.suggest_vp_for_node_id( target_node_id );
+      target_vp = kernel().vp_manager.node_id_to_vp( target_node_id );
       const bool target_vp_local = kernel().vp_manager.is_local_vp( target_vp );
       const thread target_thread = kernel().vp_manager.vp_to_thread( target_vp );
 

--- a/nestkernel/model_manager_impl.h
+++ b/nestkernel/model_manager_impl.h
@@ -174,7 +174,7 @@ ModelManager::get_proxy_node( thread tid, index node_id )
   const int model_id = kernel().modelrange_manager.get_model_id( node_id );
   Node* proxy = proxy_nodes_[ tid ].at( model_id );
   proxy->set_node_id_( node_id );
-  proxy->set_vp( kernel().vp_manager.suggest_vp_for_node_id( node_id ) );
+  proxy->set_vp( kernel().vp_manager.node_id_to_vp( node_id ) );
   return proxy;
 }
 

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -340,8 +340,7 @@ NodeCollectionPrimitive::MPI_local_begin( NodeCollectionPTR cp ) const
 {
   size_t num_processes = kernel().mpi_manager.get_num_processes();
   size_t rank = kernel().mpi_manager.get_rank();
-  size_t rank_first_node =
-    kernel().mpi_manager.get_process_id_of_vp( kernel().vp_manager.node_id_to_vp( first_ ) );
+  size_t rank_first_node = kernel().mpi_manager.get_process_id_of_vp( kernel().vp_manager.node_id_to_vp( first_ ) );
   size_t offset = ( rank - rank_first_node + num_processes ) % num_processes;
   if ( offset > size() ) // Too few node IDs to be shared among all MPI processes.
   {

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -322,7 +322,7 @@ NodeCollectionPrimitive::local_begin( NodeCollectionPTR cp ) const
 {
   size_t num_vps = kernel().vp_manager.get_num_virtual_processes();
   size_t current_vp = kernel().vp_manager.thread_to_vp( kernel().vp_manager.get_thread_id() );
-  size_t vp_first_node = kernel().vp_manager.suggest_vp_for_node_id( first_ );
+  size_t vp_first_node = kernel().vp_manager.node_id_to_vp( first_ );
   size_t offset = ( current_vp - vp_first_node + num_vps ) % num_vps;
 
   if ( offset >= size() ) // Too few node IDs to be shared among all vps.
@@ -341,7 +341,7 @@ NodeCollectionPrimitive::MPI_local_begin( NodeCollectionPTR cp ) const
   size_t num_processes = kernel().mpi_manager.get_num_processes();
   size_t rank = kernel().mpi_manager.get_rank();
   size_t rank_first_node =
-    kernel().mpi_manager.get_process_id_of_vp( kernel().vp_manager.suggest_vp_for_node_id( first_ ) );
+    kernel().mpi_manager.get_process_id_of_vp( kernel().vp_manager.node_id_to_vp( first_ ) );
   size_t offset = ( rank - rank_first_node + num_processes ) % num_processes;
   if ( offset > size() ) // Too few node IDs to be shared among all MPI processes.
   {
@@ -644,7 +644,7 @@ NodeCollectionComposite::local_begin( NodeCollectionPTR cp ) const
 {
   size_t num_vps = kernel().vp_manager.get_num_virtual_processes();
   size_t current_vp = kernel().vp_manager.thread_to_vp( kernel().vp_manager.get_thread_id() );
-  size_t vp_first_node = kernel().vp_manager.suggest_vp_for_node_id( operator[]( 0 ) );
+  size_t vp_first_node = kernel().vp_manager.node_id_to_vp( operator[]( 0 ) );
   size_t offset = ( current_vp - vp_first_node + num_vps ) % num_vps;
 
   size_t current_part = start_part_;
@@ -667,7 +667,7 @@ NodeCollectionComposite::MPI_local_begin( NodeCollectionPTR cp ) const
   size_t num_processes = kernel().mpi_manager.get_num_processes();
   size_t rank = kernel().mpi_manager.get_rank();
   size_t rank_first_node =
-    kernel().mpi_manager.get_process_id_of_vp( kernel().vp_manager.suggest_vp_for_node_id( operator[]( 0 ) ) );
+    kernel().mpi_manager.get_process_id_of_vp( kernel().vp_manager.node_id_to_vp( operator[]( 0 ) ) );
   size_t offset = ( rank - rank_first_node + num_processes ) % num_processes;
 
   size_t current_part = start_part_;

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -196,7 +196,7 @@ NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, N
       //   - node ID local to this vp
       //   - node_id >= min_node_id
       const size_t vp = kernel().vp_manager.thread_to_vp( t );
-      const size_t min_node_id_vp = kernel().vp_manager.suggest_vp_for_node_id( min_node_id );
+      const size_t min_node_id_vp = kernel().vp_manager.node_id_to_vp( min_node_id );
 
       size_t node_id = min_node_id + ( num_vps + vp - min_node_id_vp ) % num_vps;
 
@@ -404,7 +404,7 @@ NodeManager::is_local_node( Node* n ) const
 bool
 NodeManager::is_local_node_id( index node_id ) const
 {
-  const thread vp = kernel().vp_manager.suggest_vp_for_node_id( node_id );
+  const thread vp = kernel().vp_manager.node_id_to_vp( node_id );
   return kernel().vp_manager.is_local_vp( vp );
 }
 
@@ -441,7 +441,7 @@ NodeManager::get_node_or_proxy( index node_id )
 {
   assert( 0 < node_id and node_id <= size() );
 
-  thread vp = kernel().vp_manager.suggest_vp_for_node_id( node_id );
+  thread vp = kernel().vp_manager.node_id_to_vp( node_id );
   if ( not kernel().vp_manager.is_local_vp( vp ) )
   {
     return kernel().model_manager.get_proxy_node( 0, node_id );
@@ -460,7 +460,7 @@ NodeManager::get_node_or_proxy( index node_id )
 Node*
 NodeManager::get_mpi_local_node_or_device_head( index node_id )
 {
-  thread t = kernel().vp_manager.vp_to_thread( kernel().vp_manager.suggest_vp_for_node_id( node_id ) );
+  thread t = kernel().vp_manager.vp_to_thread( kernel().vp_manager.node_id_to_vp( node_id ) );
 
   Node* node = local_nodes_[ t ].get_node_by_node_id( node_id );
 

--- a/nestkernel/rng_manager.cpp
+++ b/nestkernel/rng_manager.cpp
@@ -98,7 +98,7 @@ nest::RNGManager::set_status( const DictionaryDatum& d )
     {
       if ( kernel().vp_manager.is_local_vp( i ) )
       {
-        rng_.push_back( getValue< librandom::RngDatum >( ( *ad )[ kernel().vp_manager.suggest_vp_for_node_id( i ) ] ) );
+        rng_.push_back( getValue< librandom::RngDatum >( ( *ad )[ kernel().vp_manager.node_id_to_vp( i ) ] ) );
       }
     }
   }
@@ -139,7 +139,7 @@ nest::RNGManager::set_status( const DictionaryDatum& d )
 
       if ( kernel().vp_manager.is_local_vp( i ) )
       {
-        rng_[ kernel().vp_manager.vp_to_thread( kernel().vp_manager.suggest_vp_for_node_id( i ) ) ]->seed( s );
+        rng_[ kernel().vp_manager.vp_to_thread( kernel().vp_manager.node_id_to_vp( i ) ) ]->seed( s );
       }
 
       rng_seeds_[ i ] = s;

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -351,7 +351,7 @@ nest::SourceTable::get_next_target_data( const thread tid,
       // set values of next_target_data
       next_target_data.set_source_lid( kernel().vp_manager.node_id_to_lid( current_source.get_node_id() ) );
       next_target_data.set_source_tid( kernel().vp_manager.vp_to_thread(
-        kernel().vp_manager.suggest_vp_for_node_id( current_source.get_node_id() ) ) );
+        kernel().vp_manager.node_id_to_vp( current_source.get_node_id() ) ) );
       next_target_data.reset_marker();
 
       if ( current_source.is_primary() )

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -350,8 +350,8 @@ nest::SourceTable::get_next_target_data( const thread tid,
     {
       // set values of next_target_data
       next_target_data.set_source_lid( kernel().vp_manager.node_id_to_lid( current_source.get_node_id() ) );
-      next_target_data.set_source_tid( kernel().vp_manager.vp_to_thread(
-        kernel().vp_manager.node_id_to_vp( current_source.get_node_id() ) ) );
+      next_target_data.set_source_tid(
+        kernel().vp_manager.vp_to_thread( kernel().vp_manager.node_id_to_vp( current_source.get_node_id() ) ) );
       next_target_data.reset_marker();
 
       if ( current_source.is_primary() )

--- a/nestkernel/vp_manager.h
+++ b/nestkernel/vp_manager.h
@@ -110,7 +110,7 @@ public:
    * T the number of threads. This may be used by Network::add_node()
    * if the user has not specified anything.
    */
-  thread suggest_vp_for_node_id( const index node_id ) const;
+  thread node_id_to_vp( const index node_id ) const;
 
   /**
    * Convert a given VP ID to the corresponding thread ID

--- a/nestkernel/vp_manager_impl.h
+++ b/nestkernel/vp_manager_impl.h
@@ -40,7 +40,7 @@ VPManager::get_vp() const
 }
 
 inline thread
-VPManager::suggest_vp_for_node_id( const index node_id ) const
+VPManager::node_id_to_vp( const index node_id ) const
 {
   return node_id % get_num_virtual_processes();
 }


### PR DESCRIPTION
Nowhere in the current kernel is the conversion between GID and VP treated as a suggestion. It is a deterministic mapping and the function name should reflect this.

@heplesser @jougs @suku248 