### PR TITLE
Count local devices for each thread

### DIFF
--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -51,7 +51,7 @@ NodeManager::NodeManager()
   , wfr_is_used_( false )
   , wfr_network_size_( 0 ) // zero to force update
   , num_active_nodes_( 0 )
-  , num_local_devices_( 0 )
+  , num_thread_local_devices_()
   , have_nodes_changed_( true )
   , exceptions_raised_() // cannot call kernel(), not complete yet
 {
@@ -69,9 +69,8 @@ NodeManager::initialize()
   // explicitly force construction of wfr_nodes_vec_ to ensure consistent state
   wfr_network_size_ = 0;
   local_nodes_.resize( kernel().vp_manager.get_num_threads() );
+  num_thread_local_devices_.resize( kernel().vp_manager.get_num_threads(), 0 );
   ensure_valid_thread_local_ids();
-
-  num_local_devices_ = 0;
 }
 
 void
@@ -238,8 +237,8 @@ NodeManager::add_devices_( Model& model, index min_node_id, index max_node_id, N
 
       for ( index node_id = min_node_id; node_id <= max_node_id; ++node_id )
       {
-        // keep track of number of local devices
-        ++num_local_devices_;
+        // keep track of number of thread local devices
+        ++num_thread_local_devices_[ t ];
 
         Node* node = model.allocate( t );
         node->set_node_id_( node_id );
@@ -247,7 +246,7 @@ NodeManager::add_devices_( Model& model, index min_node_id, index max_node_id, N
         node->set_model_id( model.get_model_id() );
         node->set_thread( t );
         node->set_vp( kernel().vp_manager.thread_to_vp( t ) );
-        node->set_local_device_id( num_local_devices_ - 1 );
+        node->set_local_device_id( num_thread_local_devices_[ t ] - 1 );
         node->set_initialized();
 
         local_nodes_[ t ].add_local_node( *node );
@@ -275,8 +274,8 @@ NodeManager::add_music_nodes_( Model& model, index min_node_id, index max_node_i
       {
         for ( index node_id = min_node_id; node_id <= max_node_id; ++node_id )
         {
-          // keep track of number of local devices
-          ++num_local_devices_;
+          // keep track of number of thread local devices
+          ++num_thread_local_devices_[ t ];
 
           Node* node = model.allocate( 0 );
           node->set_node_id_( node_id );
@@ -284,7 +283,7 @@ NodeManager::add_music_nodes_( Model& model, index min_node_id, index max_node_i
           node->set_model_id( model.get_model_id() );
           node->set_thread( 0 );
           node->set_vp( kernel().vp_manager.thread_to_vp( 0 ) );
-          node->set_local_device_id( num_local_devices_ - 1 );
+          node->set_local_device_id( num_thread_local_devices_[ t ] - 1 );
           node->set_initialized();
 
           local_nodes_[ 0 ].add_local_node( *node );
@@ -416,9 +415,9 @@ NodeManager::get_max_num_local_nodes() const
 }
 
 index
-NodeManager::get_num_local_devices() const
+NodeManager::get_num_thread_local_devices( thread t ) const
 {
-  return num_local_devices_;
+  return num_thread_local_devices_[ t ];
 }
 
 Node*

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -117,9 +117,9 @@ public:
   index get_max_num_local_nodes() const;
 
   /**
-   * Returns the number of devices per virtual process.
+   * Returns the number of devices per thread.
    */
-  index get_num_local_devices() const;
+  index get_num_thread_local_devices( thread t ) const;
 
   /**
    * Print network information.
@@ -311,7 +311,7 @@ private:
   index wfr_network_size_;
   size_t num_active_nodes_; //!< number of nodes created by prepare_nodes
 
-  index num_local_devices_; //!< stores number of local devices
+  std::vector< index > num_thread_local_devices_; //!< stores number of thread local devices
 
   bool have_nodes_changed_; //!< true if new nodes have been created
                             //!< since startup or last call to simulate

--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -82,8 +82,8 @@ nest::TargetTableDevices::resize_to_number_of_neurons()
   {
     const thread tid = kernel().vp_manager.get_thread_id();
     target_to_devices_[ tid ].resize( kernel().node_manager.get_max_num_local_nodes() + 1 );
-    target_from_devices_[ tid ].resize( kernel().node_manager.get_num_local_devices() + 1 );
-    sending_devices_node_ids_[ tid ].resize( kernel().node_manager.get_num_local_devices() + 1 );
+    target_from_devices_[ tid ].resize( kernel().node_manager.get_num_thread_local_devices( tid ) + 1 );
+    sending_devices_node_ids_[ tid ].resize( kernel().node_manager.get_num_thread_local_devices( tid ) + 1 );
   } // end omp parallel
 }
 

--- a/pynest/nest/tests/test_regression_issue-1409.py
+++ b/pynest/nest/tests/test_regression_issue-1409.py
@@ -46,7 +46,7 @@ class MultiplePoissonGeneratorsTestCase(unittest.TestCase):
 
             parrots = nest.Create('parrot_neuron', num_neurons)
             poisson_generator = nest.Create('poisson_generator', num_pg)
-            nest.SetStatus(poisson_generator, 'rate', 2000.)
+            poisson_generator.rate = 2000.
 
             nest.Connect(poisson_generator, parrots, 'all_to_all')
 

--- a/pynest/nest/tests/test_regression_issue-1409.py
+++ b/pynest/nest/tests/test_regression_issue-1409.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# test_regression_issue-1409.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import nest
+import numpy as np
+import unittest
+
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+class MultiplePoissonGeneratorsTestCase(unittest.TestCase):
+
+    def test_multiple_poisson_generators(self):
+        """Invariable number of spikes with multiple poisson generators"""
+        local_num_threads = 4
+        time_simulation = 100
+        num_neurons = 1
+        num_pg = 50
+        num_iterations = 50
+
+        num_spikes = []
+        for i in range(num_iterations):
+            nest.ResetKernel()
+            nest.SetKernelStatus({'local_num_threads': local_num_threads})
+            nest.set_verbosity('M_WARNING')
+            print('num iter {:>5d}/{}'.format(i+1, num_iterations), end='\r')
+
+            parrots = nest.Create('parrot_neuron', num_neurons)
+            poisson_generator = nest.Create('poisson_generator', num_pg)
+            nest.SetStatus(poisson_generator, 'rate', 2000.)
+
+            nest.Connect(poisson_generator, parrots, 'all_to_all')
+
+            nest.Simulate(time_simulation)
+            num_spikes.append(nest.GetKernelStatus('local_spike_counter'))
+
+        self.assertEqual(len(np.unique(num_spikes)), 1)
+
+
+def suite():
+    t = unittest.TestLoader().loadTestsFromTestCase(MultiplePoissonGeneratorsTestCase)
+    return unittest.TestSuite([t])
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())


### PR DESCRIPTION
This PR fixes #1409.

When creating devices, the number of local devices are counted. With NEST 3.0, the counting happens in parallell, but not in a thread safe way, so sometimes the threads might overwrite the variable. Then we get a problem with device ids, which in return can mess up spike delivery.

With this PR we now create a vector for the counting instead, so each thread keep track of the number of devices on the thread.

@lionelkusch could you check if this fixes your issue?