### PR TITLE
Update Mac manual link

### DIFF
--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -241,7 +241,7 @@ these instructions.**
 
    .. tab:: macOS
 
-       For further options on installing NEST on macOS, see :ref:`mac_manual` for Macs.
+       For further options on installing NEST on macOS, see :doc:`mac_install` for Macs.
 
 
    .. tab:: HPC systems


### PR DESCRIPTION
This PR updates the link to the Mac manual and thereby fixes #1406.

The correct file name is `mac_install`, rather than `mac_manual`.