### PR TITLE
Correctly initialize result vector in music_rate_in_proxy::get_status()

### DIFF
--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -150,7 +150,7 @@ nest::music_rate_in_proxy::get_status( DictionaryDatum& d ) const
   P_.get( d );
   S_.get( d );
 
-  ( *d )[ names::data ] = DoubleVectorDatum( new std::vector< double >(1, B_.data_ ) );
+  ( *d )[ names::data ] = DoubleVectorDatum( new std::vector< double >( 1, B_.data_ ) );
 }
 
 void

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -37,6 +37,7 @@
 
 // Includes from nestkernel:
 #include "kernel_manager.h"
+#include "event_delivery_manager_impl.h"
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -150,7 +150,7 @@ nest::music_rate_in_proxy::get_status( DictionaryDatum& d ) const
   P_.get( d );
   S_.get( d );
 
-  ( *d )[ names::data ] = DoubleVectorDatum( new std::vector< double >( B_.data_ ) );
+  ( *d )[ names::data ] = DoubleVectorDatum( new std::vector< double >(1, B_.data_ ) );
 }
 
 void

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -167,7 +167,7 @@ private:
 
   struct Buffers_
   {
-    double data_;
+    std::vector< double > data_; //!< The buffer for incoming data
   };
 
   // ------------------------------------------------------------

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -167,7 +167,7 @@ private:
 
   struct Buffers_
   {
-    std::vector< double > data_; //!< The buffer for incoming data
+    double data_;
   };
 
   // ------------------------------------------------------------


### PR DESCRIPTION
Corrects the type of the `Buffers_::data_` variable in the MUSIC rate in proxy model.

With the original uninitialised `double`, passing the variable to the `std::vector` constructor may lead to an `std::bad_alloc` error. This can happen when the model tries to copy the vector with
```c++
( *d )[ names::data ] = DoubleVectorDatum( new std::vector< double >( B_.data_ ) );
```

This PR changes the variable to an `std::vector`.

Fixes #1449.