### PR TITLE
Move "Editor support" from README into documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,3 @@ Here is a suitable BibTeX entry:
 Please get in touch with us about your publications that used NEST, we will add
 them to our [publication list](https://www.nest-simulator.org/publications), thus
 making them visible to potential readers.
-
-## Editor support
-
-A simple syntax file for VIM users has been provided. Copy it to your vim
-configuration folder to make it available to VIM:
-```
-    $ cp ${prefix}/share/nest/extras/EditorSupport/vim/syntax/sli.vim ~/.vim/syntax/sli.vim
-```
-Then add the following lines to your `~/.vimrc` file to use it:
-```
-    " sli
-    au BufRead,BufNewFile *.sli set filetype=sli
-    au FileType sli setl foldenable foldmethod=syntax
-```

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -20,7 +20,7 @@ You can find all the details for our development workflow on the `NEST developer
 
 For making changes to the PyNEST APIs, please see our :doc:`templates_styleguides/pyapi_template`.
 
-If you are a VIM user and require support for SLI files, please refer to our :doc:`templates_styleguides/vim_support_sli`.
+If you are a Vim user and require support for SLI files, please refer to our :doc:`templates_styleguides/vim_support_sli`.
 
 Contribute a Python example script
 ----------------------------------

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -13,7 +13,6 @@ If you find an error in the code or documentaton or want to suggest a feature, s
 
 Make sure to check that your issue has not already been reported there before creating a new one.
 
-
 Make changes to code or documentation
 -------------------------------------
 

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -6,7 +6,7 @@ are happy to consider your contributions (e.g., new models, bug or
 documentation fixes) for addition to the official version of NEST.
 
 Report bugs and request features
----------------------------------
+--------------------------------
 
 If you find an error in the code or documentaton or want to suggest a feature, submit `an issue on GitHub
 <https://github.com/nest/nest-simulator/issues>`_.
@@ -22,7 +22,7 @@ You can find all the details for our development workflow on the `NEST developer
 For making changes to the PyNEST APIs, please see our :doc:`templates_styleguides/pyapi_template`.
 
 Contribute a Python example script
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 
 If you have a Python example network to contribute, please refer to our template to ensure you cover the required information:
 
@@ -30,6 +30,6 @@ If you have a Python example network to contribute, please refer to our template
 
 
 Have a question?
-------------------
+----------------
 
 If you want to get in contact with us, see our :ref:`nest_community` page for ways you can reach us.

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -20,6 +20,8 @@ You can find all the details for our development workflow on the `NEST developer
 
 For making changes to the PyNEST APIs, please see our :doc:`templates_styleguides/pyapi_template`.
 
+If you use VIM and would like to edit SLI files, please refer to our :doc:`templates_styleguides/vim_support_sli`.
+
 Contribute a Python example script
 ----------------------------------
 

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -20,7 +20,7 @@ You can find all the details for our development workflow on the `NEST developer
 
 For making changes to the PyNEST APIs, please see our :doc:`templates_styleguides/pyapi_template`.
 
-If you use VIM and would like to edit SLI files, please refer to our :doc:`templates_styleguides/vim_support_sli`.
+If you are a VIM user and require support for SLI files, please refer to our :doc:`templates_styleguides/vim_support_sli`.
 
 Contribute a Python example script
 ----------------------------------

--- a/doc/contribute/index.rst
+++ b/doc/contribute/index.rst
@@ -24,10 +24,7 @@ For making changes to the PyNEST APIs, please see our :doc:`templates_styleguide
 Contribute a Python example script
 ----------------------------------
 
-If you have a Python example network to contribute, please refer to our template to ensure you cover the required information:
-
-:doc:`templates_styleguides/example_template`
-
+If you have a Python example network to contribute, please refer to our :doc:`templates_styleguides/example_template` to ensure you cover the required information.
 
 Have a question?
 ----------------

--- a/doc/contribute/templates_styleguides/vim_support_sli.rst
+++ b/doc/contribute/templates_styleguides/vim_support_sli.rst
@@ -1,7 +1,7 @@
-VIM support for SLI files
+Vim support for SLI files
 =========================
 
-A simple syntax file for VIM users is provided below. Copy it to your vim configuration folder to make it available to VIM:
+A simple syntax file for Vim users is provided below. Copy it to your Vim configuration folder to make it available to Vim:
 
 
 .. code-block::

--- a/doc/contribute/templates_styleguides/vim_support_sli.rst
+++ b/doc/contribute/templates_styleguides/vim_support_sli.rst
@@ -1,14 +1,14 @@
 VIM support for SLI files
 =========================
 
-A simple syntax file for VIM users has been provided. Copy it to your vim configuration folder to make it available to VIM:
+A simple syntax file for VIM users is provided below. Copy it to your vim configuration folder to make it available to VIM:
 
 
 .. code-block::
 
    $ cp ${prefix}/share/nest/extras/EditorSupport/vim/syntax/sli.vim ~/.vim/syntax/sli.vim
 
-Then add the following lines to your ~/.vimrc file to use it:
+Then add the following lines to your ``~/.vimrc`` file to use it:
 
 .. code-block::
 

--- a/doc/contribute/templates_styleguides/vim_support_sli.rst
+++ b/doc/contribute/templates_styleguides/vim_support_sli.rst
@@ -1,16 +1,16 @@
-Editor support
-==============
+VIM support for SLI files
+=========================
 
 A simple syntax file for VIM users has been provided. Copy it to your vim configuration folder to make it available to VIM:
 
 
-.. bash::
+.. code-block::
 
    $ cp ${prefix}/share/nest/extras/EditorSupport/vim/syntax/sli.vim ~/.vim/syntax/sli.vim
 
 Then add the following lines to your ~/.vimrc file to use it:
 
-.. bash::
+.. code-block::
 
     " sli
     au BufRead,BufNewFile *.sli set filetype=sli

--- a/doc/contribute/templates_styleguides/vim_support_sli.rst
+++ b/doc/contribute/templates_styleguides/vim_support_sli.rst
@@ -1,0 +1,17 @@
+Editor support
+==============
+
+A simple syntax file for VIM users has been provided. Copy it to your vim configuration folder to make it available to VIM:
+
+
+.. bash::
+
+   $ cp ${prefix}/share/nest/extras/EditorSupport/vim/syntax/sli.vim ~/.vim/syntax/sli.vim
+
+Then add the following lines to your ~/.vimrc file to use it:
+
+.. bash::
+
+    " sli
+    au BufRead,BufNewFile *.sli set filetype=sli
+    au FileType sli setl foldenable foldmethod=syntax


### PR DESCRIPTION
This PR moves the information on Vim support for SLI files from the README.md into the "Contributing to NEST" section of the NEST simulator documentation. 

It fixes #1420.