### PR TITLE
Fix to boost include path issue #1238

### DIFF
--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+if ( HAVE_BOOST )
+  include_directories( ${BOOST_INCLUDE_DIR} )
+endif ()
+
 set( models_sources
     ac_generator.h ac_generator.cpp
     aeif_cond_alpha.h aeif_cond_alpha.cpp

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 if ( HAVE_BOOST )
-  include_directories( ${BOOST_INCLUDE_DIR} )
+    include_directories( ${BOOST_INCLUDE_DIR} )
 endif ()
 
 set( models_sources

--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -53,6 +53,10 @@ else ()
         )
 endif ()
 
+if ( HAVE_BOOST )
+  include_directories( ${BOOST_INCLUDE_DIR} )
+endif ()
+
 target_link_libraries( nest
     nestutil nestkernel random sli_lib sli_readline
     ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES} OpenMP::OpenMP_CXX )

--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -54,7 +54,7 @@ else ()
 endif ()
 
 if ( HAVE_BOOST )
-  include_directories( ${BOOST_INCLUDE_DIR} )
+    include_directories( ${BOOST_INCLUDE_DIR} )
 endif ()
 
 target_link_libraries( nest

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -115,7 +115,7 @@ if ( HAVE_MPI )
 endif ()
 
 if ( HAVE_BOOST )
-  include_directories( ${BOOST_INCLUDE_DIR} )
+    include_directories( ${BOOST_INCLUDE_DIR} )
 endif ()
 
 add_library( nestkernel ${nestkernel_sources} )

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -114,6 +114,10 @@ if ( HAVE_MPI )
   )
 endif ()
 
+if ( HAVE_BOOST )
+  include_directories( ${BOOST_INCLUDE_DIR} )
+endif ()
+
 add_library( nestkernel ${nestkernel_sources} )
 target_link_libraries( nestkernel
     nestutil random sli_lib

--- a/precise/CMakeLists.txt
+++ b/precise/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 if ( HAVE_BOOST )
-  include_directories( ${BOOST_INCLUDE_DIR} )
+    include_directories( ${BOOST_INCLUDE_DIR} )
 endif ()
 
 set( precise_sources

--- a/precise/CMakeLists.txt
+++ b/precise/CMakeLists.txt
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+if ( HAVE_BOOST )
+  include_directories( ${BOOST_INCLUDE_DIR} )
+endif ()
+
 set( precise_sources
     slice_ring_buffer.cpp slice_ring_buffer.h
     iaf_psc_alpha_ps.cpp iaf_psc_alpha_ps.h

--- a/topology/CMakeLists.txt
+++ b/topology/CMakeLists.txt
@@ -18,7 +18,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 if ( HAVE_BOOST )
-  include_directories( ${BOOST_INCLUDE_DIR} )
+    include_directories( ${BOOST_INCLUDE_DIR} )
 endif ()
 
 set( topo_sources

--- a/topology/CMakeLists.txt
+++ b/topology/CMakeLists.txt
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+if ( HAVE_BOOST )
+  include_directories( ${BOOST_INCLUDE_DIR} )
+endif ()
+
 set( topo_sources
     topologymodule.h
     topologymodule.cpp


### PR DESCRIPTION
Fix boost include path issue #1238 by adding

```
if ( HAVE_BOOST )
    include_directories( ${BOOST_INCLUDE_DIR} )
endif ()
```

in:
- models/CMakeLists.txt
- nest/CMakeLists.txt
- nestkernel/CMakeLists.txt
- precise/CMakeLists.txt
- topology/CMakeLists.txt