### PR TITLE
Use theme options to show logo on readthedocs

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -9,11 +9,11 @@ p {
 .wy-nav-content {
     max-width: 950px;
 }
-
+/**
 .wy-side-nav-search>a, .wy-side-nav-search .wy-dropdown>a {
    content: url(../../_static/img/nest_logo.png);
 }
-
+**/
 .wy-side-nav-search {
 	background: linear-gradient(45deg, #fff, #eee);
 	color: #888;

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -9,11 +9,7 @@ p {
 .wy-nav-content {
     max-width: 950px;
 }
-/**
-.wy-side-nav-search>a, .wy-side-nav-search .wy-dropdown>a {
-   content: url(../../_static/img/nest_logo.png);
-}
-**/
+
 .wy-side-nav-search {
 	background: linear-gradient(45deg, #fff, #eee);
 	color: #888;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -165,6 +165,9 @@ numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+html_logo = '_static/img/nest_logo.png'
+html_theme_options = {'logo_only': True,
+                      'display_version': False}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This PR fix issue #1451.

Theme options are used to display the logo in HTML code on redthedocs (or sphinx html output) instead of changing the theme's CSS. 
Thanks to @clinssen  for this tip.

A preview of the result can be seen here:
https://nest-simulator-sg.readthedocs.io/en/fix-issue-1451/