### PR TITLE
Remove SubnetExpected exception and other references to subnet.

### DIFF
--- a/doc/conngen/conngen.txt
+++ b/doc/conngen/conngen.txt
@@ -58,6 +58,6 @@ CGConnect (SOURCES, TARGETS, CG, [PARAMETER_MAP, [MODEL]])
 
 Connect neurons from SOURCES to neurons from TARGETS using
 connectivity specified by the connection generator CG. SOURCES and
-TARGETS are either both lists containing 1 subnet, or lists of
-node IDs. PARAMETER_MAP is a dictionary mapping names of values such as
-weight and delay to value set positions. MODEL is the synapse model.
+TARGETS are both NodeCollections representing the node IDs. PARAMETER_MAP
+is a dictionary mapping names of values such as weight and delay to
+value set positions. MODEL is the synapse model.

--- a/examples/nest/Brette_et_al_2007/benchmark.sli
+++ b/examples/nest/Brette_et_al_2007/benchmark.sli
@@ -146,10 +146,6 @@ def
   /I_detector detector Create def
   I_detector detector_params SetStatus
 
-  % some connecting functions need lists (arrays) over all
-  % neurons they should work on, so we need to extract these
-  % lists from the subnetworks
-
   % all neurons
   /allNeurons E_neurons I_neurons join def
 

--- a/examples/nest/Brette_et_al_2007/cuba_stdp.sli
+++ b/examples/nest/Brette_et_al_2007/cuba_stdp.sli
@@ -232,10 +232,6 @@ def
   /I_detector detector Create def
   I_detector detector_params SetStatus
 
-  % some connecting functions need lists (arrays) over all
-  % neurons they should work on, so we need to extract these
-  % lists from the subnetworks
-
   % all neurons
   /allNeurons E_neurons I_neurons join def
 

--- a/examples/nest/brunel-2000.sli
+++ b/examples/nest/brunel-2000.sli
@@ -45,7 +45,7 @@
 
    This example shows how to
 
-      - organize subpopulations in subnets
+      - create populations
       - instrument a network with injection and recording devices
       - record data to files
       - define own functions

--- a/examples/nest/brunel-2000_newconnect.sli
+++ b/examples/nest/brunel-2000_newconnect.sli
@@ -45,7 +45,7 @@
 
    This example shows how to
 
-      - organize subpopulations in subnets
+      - create populations
       - instrument a network with injection and recording devices
       - record data to files
       - define own functions

--- a/examples/nest/brunel-2000_newconnect_dc.sli
+++ b/examples/nest/brunel-2000_newconnect_dc.sli
@@ -44,7 +44,7 @@
 
    This example shows how to
 
-      - organize subpopulations in subnets
+      - create populations
       - instrument a network with injection and recording devices
       - record data to files
       - define own functions

--- a/examples/nest/brunel-sli_neuron.sli
+++ b/examples/nest/brunel-sli_neuron.sli
@@ -45,7 +45,7 @@
 
    This example shows how to
 
-      - organize subpopulations in subnets
+      - create populations
       - instrument a network with injection and recording devices
       - record data to files
       - define own functions

--- a/examples/nest/brunel_ps.sli
+++ b/examples/nest/brunel_ps.sli
@@ -47,7 +47,7 @@
 
    This example shows how to
 
-      - organize subpopulations in subnets
+      - create populations
       - instrument a network with injection and recording devices
       - record data to files
       - define own functions

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -272,12 +272,6 @@ nest::DistributionError::message() const
 }
 
 std::string
-nest::SubnetExpected::message() const
-{
-  return std::string();
-}
-
-std::string
 nest::SimulationError::message() const
 {
   return std::string(

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -132,8 +132,7 @@ nest::NodeWithProxiesExpected::message() const
 {
   std::ostringstream out;
   out << "Nest expected a node with proxies (eg normal model neuron),"
-         "but the node with id " << id_ << " is not a node without proxies, "
-                                           "e.g., a subnet or device.";
+         "but the node with id " << id_ << " is not a node without proxies, e.g., a device.";
   return out.str();
 }
 

--- a/nestkernel/exceptions.h
+++ b/nestkernel/exceptions.h
@@ -673,25 +673,6 @@ public:
  * is given to a function
  * @ingroup KernelExceptions
  */
-class SubnetExpected : public KernelException
-{
-public:
-  SubnetExpected()
-    : KernelException( "SubnetExpected" )
-  {
-  }
-  ~SubnetExpected() throw()
-  {
-  }
-
-  std::string message() const;
-};
-
-/**
- * Exception to be thrown if the wrong argument type
- * is given to a function
- * @ingroup KernelExceptions
- */
 class SimulationError : public KernelException
 {
 public:

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -647,7 +647,7 @@ NestModule::CopyModel_l_l_DFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-   Name: Create - create a number of equal nodes in the current subnet
+   Name: Create - create nodes
 
    Synopsis:
    /model          Create -> node_ids

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -650,10 +650,10 @@ NestModule::CopyModel_l_l_DFunction::execute( SLIInterpreter* i ) const
    Name: Create - create nodes
 
    Synopsis:
-   /model          Create -> node_ids
-   /model n        Create -> node_ids
-   /model   params Create -> node_ids
-   /model n params Create -> node_ids
+   /model          Create -> NodeCollection
+   /model n        Create -> NodeCollection
+   /model   params Create -> NodeCollection
+   /model n params Create -> NodeCollection
 
    Parameters:
    /model - literal naming the modeltype (entry in modeldict)
@@ -665,9 +665,8 @@ NestModule::CopyModel_l_l_DFunction::execute( SLIInterpreter* i ) const
 
    Description:
    Create generates n new network objects of the supplied model
-   type. If n is not given, a single node is created. The objects
-   are added as children of the current working node. params is a
-   dictsionary with parameters for the new nodes.
+   type. If n is not given, a single node is created. params is a
+   dictionary with parameters for the new nodes.
 
    SeeAlso: modeldict
 */

--- a/nestkernel/nestmodule.h
+++ b/nestkernel/nestmodule.h
@@ -119,7 +119,7 @@ public:
    * -# All interface functions expect and return nodes as vectors
    *    of node IDs (Vi).
    * -# Functions must document how they loop over node ID vectors and
-   *    how the function is applied to subnets provided as
+   *    how the function is applied to NodeCollections provided as
    *    arguments.
    * -# Functions that do not require overloading on the SLI level,
    *    need not carry their argument list in the SLI function

--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -139,7 +139,7 @@ nest::TargetTableDevices::get_connections_to_device_for_lid_( const index lid,
   if ( target_to_devices_[ tid ][ lid ].size() > 0 )
   {
     const index source_node_id = kernel().vp_manager.lid_to_node_id( lid );
-    // not the root subnet and valid connector
+    // not valid connector
     if ( source_node_id > 0 and target_to_devices_[ tid ][ lid ][ syn_id ] != NULL )
     {
       target_to_devices_[ tid ][ lid ][ syn_id ]->get_all_connections(
@@ -168,7 +168,7 @@ nest::TargetTableDevices::get_connections_from_devices_( const index requested_s
 
       if ( target_from_devices_[ tid ][ ldid ].size() > 0 )
       {
-        // not the root subnet and valid connector
+        // not valid connector
         if ( target_from_devices_[ tid ][ ldid ][ syn_id ] != NULL )
         {
           target_from_devices_[ tid ][ ldid ][ syn_id ]->get_all_connections(

--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -139,7 +139,7 @@ nest::TargetTableDevices::get_connections_to_device_for_lid_( const index lid,
   if ( target_to_devices_[ tid ][ lid ].size() > 0 )
   {
     const index source_node_id = kernel().vp_manager.lid_to_node_id( lid );
-    // not valid connector
+    // not the valid connector
     if ( source_node_id > 0 and target_to_devices_[ tid ][ lid ][ syn_id ] != NULL )
     {
       target_to_devices_[ tid ][ lid ][ syn_id ]->get_all_connections(
@@ -168,7 +168,7 @@ nest::TargetTableDevices::get_connections_from_devices_( const index requested_s
 
       if ( target_from_devices_[ tid ][ ldid ].size() > 0 )
       {
-        // not valid connector
+        // not the valid connector
         if ( target_from_devices_[ tid ][ ldid ][ syn_id ] != NULL )
         {
           target_from_devices_[ tid ][ ldid ][ syn_id ]->get_all_connections(

--- a/pynest/nest/lib/hl_api_exceptions.py
+++ b/pynest/nest/lib/hl_api_exceptions.py
@@ -203,7 +203,6 @@ class NESTErrors(with_metaclass(NESTMappedException)):
         'BadParameter': 'KernelException',
         'DimensionMismatch': 'KernelException',
         'DistributionError': 'KernelException',
-        'SubnetExpected': 'KernelException',
         'SimulationError': 'KernelException',
         'InvalidDefaultResolution': 'KernelException',
         'InvalidTimeInModel': 'KernelException',

--- a/pynest/nest/tests/test_connect_array_fixed_indegree.py
+++ b/pynest/nest/tests/test_connect_array_fixed_indegree.py
@@ -44,8 +44,8 @@ class ConnectArrayFixedIndegreeTestCase(unittest.TestCase):
         ############################################
         nest.ResetKernel()
 
-        net1 = nest.Create('iaf_psc_alpha', N)  # creates source nodes
-        net2 = nest.Create('iaf_psc_alpha', N)  # creates target nodes
+        net1 = nest.Create('iaf_psc_alpha', N)  # creates source population
+        net2 = nest.Create('iaf_psc_alpha', N)  # creates target population
 
         Warr = [[y*K+x for x in range(K)] for y in range(N)]  # weight array
         Darr = [[y*K+x + 1 for x in range(K)] for y in range(N)]  # delay array

--- a/pynest/nest/tests/test_connect_array_fixed_indegree.py
+++ b/pynest/nest/tests/test_connect_array_fixed_indegree.py
@@ -36,7 +36,7 @@ class ConnectArrayFixedIndegreeTestCase(unittest.TestCase):
     def test_Connect_Array_Fixed_Indegree(self):
         """Tests of connections with fixed indegree and parameter arrays"""
 
-        N = 20  # number of neurons in each subnet
+        N = 20  # number of neurons in each population
         K = 5   # number of connections per neuron
 
         ############################################
@@ -44,8 +44,8 @@ class ConnectArrayFixedIndegreeTestCase(unittest.TestCase):
         ############################################
         nest.ResetKernel()
 
-        net1 = nest.Create('iaf_psc_alpha', N)  # creates source subnet
-        net2 = nest.Create('iaf_psc_alpha', N)  # creates target subnet
+        net1 = nest.Create('iaf_psc_alpha', N)  # creates source nodes
+        net2 = nest.Create('iaf_psc_alpha', N)  # creates target nodes
 
         Warr = [[y*K+x for x in range(K)] for y in range(N)]  # weight array
         Darr = [[y*K+x + 1 for x in range(K)] for y in range(N)]  # delay array
@@ -55,10 +55,10 @@ class ConnectArrayFixedIndegreeTestCase(unittest.TestCase):
                     'weight': Warr, 'delay': Darr}
         conn_dict = {'rule': 'fixed_indegree', 'indegree': K}
 
-        # connects source to target subnet
+        # connects source to target
         nest.Connect(net1, net2, conn_spec=conn_dict, syn_spec=syn_dict)
 
-        for i in range(N):  # loop on all neurons of target subnet
+        for i in range(N):  # loop on all target neurons
 
             # gets all connections to the target neuron
             conns = nest.GetConnections(target=net2[i:i+1])

--- a/pynest/nest/tests/test_connect_array_fixed_outdegree.py
+++ b/pynest/nest/tests/test_connect_array_fixed_outdegree.py
@@ -36,7 +36,7 @@ class ConnectArrayFixedOutdegreeTestCase(unittest.TestCase):
     def test_Connect_Array_Fixed_Outdegree(self):
         """Tests of connections with fixed outdegree and parameter arrays"""
 
-        N = 20  # number of neurons in each subnet
+        N = 20  # number of neurons in each population
         K = 5   # number of connections per neuron
 
         ############################################
@@ -44,8 +44,8 @@ class ConnectArrayFixedOutdegreeTestCase(unittest.TestCase):
         ############################################
         nest.ResetKernel()
 
-        net1 = nest.Create('iaf_psc_alpha', N)  # creates source subnet
-        net2 = nest.Create('iaf_psc_alpha', N)  # creates target subnet
+        net1 = nest.Create('iaf_psc_alpha', N)  # creates source nodes
+        net2 = nest.Create('iaf_psc_alpha', N)  # creates target nodes
 
         Warr = [[y*K+x for x in range(K)] for y in range(N)]  # weight array
         Darr = [[y*K+x + 1 for x in range(K)] for y in range(N)]  # delay array
@@ -55,10 +55,10 @@ class ConnectArrayFixedOutdegreeTestCase(unittest.TestCase):
                     'weight': Warr, 'delay': Darr}
         conn_dict = {'rule': 'fixed_outdegree', 'outdegree': K}
 
-        # connects source to target subnet
+        # connects source to target
         nest.Connect(net1, net2, conn_spec=conn_dict, syn_spec=syn_dict)
 
-        for i in range(N):  # loop on all neurons of source subnet
+        for i in range(N):  # loop on all source neurons of
 
             # gets all connections from the source neuron
             conns = nest.GetConnections(source=net1[i:i+1])

--- a/pynest/nest/tests/test_connect_array_fixed_outdegree.py
+++ b/pynest/nest/tests/test_connect_array_fixed_outdegree.py
@@ -44,8 +44,8 @@ class ConnectArrayFixedOutdegreeTestCase(unittest.TestCase):
         ############################################
         nest.ResetKernel()
 
-        net1 = nest.Create('iaf_psc_alpha', N)  # creates source nodes
-        net2 = nest.Create('iaf_psc_alpha', N)  # creates target nodes
+        net1 = nest.Create('iaf_psc_alpha', N)  # creates source population
+        net2 = nest.Create('iaf_psc_alpha', N)  # creates target population
 
         Warr = [[y*K+x for x in range(K)] for y in range(N)]  # weight array
         Darr = [[y*K+x + 1 for x in range(K)] for y in range(N)]  # delay array
@@ -58,7 +58,7 @@ class ConnectArrayFixedOutdegreeTestCase(unittest.TestCase):
         # connects source to target
         nest.Connect(net1, net2, conn_spec=conn_dict, syn_spec=syn_dict)
 
-        for i in range(N):  # loop on all source neurons of
+        for i in range(N):  # loop on all source neurons
 
             # gets all connections from the source neuron
             conns = nest.GetConnections(source=net1[i:i+1])

--- a/sli/sliexceptions.h
+++ b/sli/sliexceptions.h
@@ -82,7 +82,7 @@ public:
    * @code
    * catch(IllegalOperation &e)
    * {
-   *   i->error("ChangeSubnet","Target node must be a subnet.");
+   *   i->error("SetStatus","Nodes must be a NodeCollection or SynapseCollection.");
    *   i->raiseerror(e.what());
    *   return;
    * }

--- a/testsuite/mpitests/test_connect_array_all_to_all_mpi.sli
+++ b/testsuite/mpitests/test_connect_array_all_to_all_mpi.sli
@@ -45,7 +45,7 @@ skip_if_not_threaded
 [2 3] % check for 2, 3 processes
 {
 
-/N 10 def          % number of neurons in each subnet
+/N 10 def          % number of neurons in each population
 
 ResetKernel
 
@@ -70,11 +70,11 @@ ResetKernel
 /syn_dict << /synapse_model /static_synapse /weight Warr /delay Darr >> def
 /conn_dict << /rule /all_to_all >> def
 
-sources targets conn_dict syn_dict Connect % connects source to target subnet
+sources targets conn_dict syn_dict Connect % connects source to target
 
 /pass true def % error control flag
 /n_loc 0 def  % used to check n. of neurons belonging to this MPI process
-targets % loop on all neurons of target subnet
+targets % loop through all target neurons
 {
   /neuron2 exch def
 

--- a/testsuite/mpitests/test_connect_array_fixed_indegree_mpi.sli
+++ b/testsuite/mpitests/test_connect_array_fixed_indegree_mpi.sli
@@ -56,8 +56,8 @@ ResetKernel
 
 /node_id1 N 1 add def            % node_id1 = N + 1
 
-/net1 /iaf_psc_alpha N Create def   % creates source nodes
-/net2 /iaf_psc_alpha N Create def   % creates target nodes
+/net1 /iaf_psc_alpha N Create def   % creates source population
+/net2 /iaf_psc_alpha N Create def   % creates target population
 
 /NC N K mul def     % number of connections
 /Dmax NC 1 add def  % maximum delay

--- a/testsuite/mpitests/test_connect_array_fixed_indegree_mpi.sli
+++ b/testsuite/mpitests/test_connect_array_fixed_indegree_mpi.sli
@@ -45,7 +45,7 @@ skip_if_not_threaded
 [2 3] % check for 2, 3 processes
 {
 
-/N 20 def          % number of neurons in each subnet
+/N 20 def          % number of neurons in each population
 /K 5 def           % number of connections per neuron
 
 ResetKernel
@@ -55,11 +55,9 @@ ResetKernel
 >> SetKernelStatus
 
 /node_id1 N 1 add def            % node_id1 = N + 1
-/node_id2 N 2 mul def            % node_id2 = N * 2
-/net1 [1 N] Range def        % node IDs of source subnet
-/net2 [node_id1 node_id2] Range def  % node IDs of target subnet
 
-/iaf_psc_alpha N 2 mul Create ;  % creates source and target subnets
+/net1 /iaf_psc_alpha N Create def   % creates source nodes
+/net2 /iaf_psc_alpha N Create def   % creates target nodes
 
 /NC N K mul def     % number of connections
 /Dmax NC 1 add def  % maximum delay
@@ -72,11 +70,11 @@ ResetKernel
 /syn_dict << /synapse_model /static_synapse /weight Warr /delay Darr >> def
 /conn_dict << /rule /fixed_indegree /indegree K >> def
 
-net1 net2 conn_dict syn_dict Connect % connects source to target subnet
+net1 net2 conn_dict syn_dict Connect % connects source to target
 
 /pass true def % error control flag
 /n_loc 0 def  % used to check n. of neurons belonging to this MPI process
-net2 % loop on all neurons of target subnet
+net2 % loop through all target neurons
 {
         /neuron2 exch def
 

--- a/testsuite/mpitests/test_connect_array_fixed_outdegree_mpi.sli
+++ b/testsuite/mpitests/test_connect_array_fixed_outdegree_mpi.sli
@@ -45,7 +45,7 @@ skip_if_not_threaded
 [1 2 3] % check for 1, 2, 3 processes
 {
 
-  /N 20 def          % number of neurons in each subnet
+  /N 20 def          % number of neurons in each population
   /K 5 def           % number of connections per neuron
 
   ResetKernel
@@ -68,7 +68,7 @@ skip_if_not_threaded
   /syn_dict << /synapse_model /static_synapse /weight Warr /delay Darr >> def
   /conn_dict << /rule /fixed_outdegree /outdegree K >> def
 
-  net1 net2 conn_dict syn_dict Connect % connects source to target subnet
+  net1 net2 conn_dict syn_dict Connect % connects source to target
 
   /Warr_all 0 array def % creates empty weight array
   net1 % loop over all source neurons

--- a/testsuite/unittests/issue-463.sli
+++ b/testsuite/unittests/issue-463.sli
@@ -59,7 +59,7 @@ net1 net2 conn_dict syn_dict Connect % Connect source to target neurons
 
 /Warr1 [] def  % create empty array
 
-net2 % loop on all neurons of target subnet
+net2 % loop through all target neurons
 {
         /neuron2 exch dup cvnodecollection def
         % gets all connections to the target neuron

--- a/topology/grid_layer.h
+++ b/topology/grid_layer.h
@@ -114,15 +114,15 @@ public:
 
   /**
    * Get position of node. Only possible for local nodes.
-   * @param sind subnet index of node
-   * @returns position of node identified by Subnet local index value.
+   * @param sind index of node
+   * @returns position of node.
    */
   Position< D > get_position( index sind ) const;
 
   /**
    * Get position of node. Also allowed for non-local nodes.
    * @param lid local index of node
-   * @returns position of node identified by Subnet local index value.
+   * @returns position of node.
    */
   Position< D > lid_to_position( index lid ) const;
 

--- a/topology/layer.h
+++ b/topology/layer.h
@@ -285,13 +285,13 @@ public:
 
   /**
    * Get position of node. Only possible for local nodes.
-   * @param sind local subnet index of node
-   * @returns position of node identified by Subnet local index value.
+   * @param sind index of node
+   * @returns position of node.
    */
   virtual Position< D > get_position( index sind ) const = 0;
 
   /**
-   * @param sind local subnet index of node
+   * @param sind index of node
    * @returns position of node as std::vector
    */
   std::vector< double > get_position_vector( const index sind ) const;

--- a/topology/topologymodule.cpp
+++ b/topology/topologymodule.cpp
@@ -274,7 +274,7 @@ TopologyModule::init( SLIInterpreter* i )
   dict - dictionary with layer specification
 
   Description: The Topology module organizes neuronal networks in
-  layers. A layer is a special type of subnet which contains information
+  layers. A layer is a special type of NodeCollection which contains information
   about the spatial position of its nodes. There are three classes of
   layers: grid-based layers, in which each element is placed at a
   location in a regular grid; free layers, in which elements can be


### PR DESCRIPTION
As subnets are removed the `SubnetExpected` exception is no longer needed.