### PR TITLE
Change definition of realtime factor in print_time

### DIFF
--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -210,8 +210,8 @@ The progress of the simulation can be monitored by setting:
     SetKernelStatus({"print_time": True})
 
 If enabled, a line is printed to screen at every time step of the simulation to
-track the percentage and the absolute elapsed biological simulation time as
-well as the real-time factor, for example:
+track the percentage, the absolute elapsed biological simulation time and the
+real-time factor, for example:
 
 ::
 
@@ -226,11 +226,11 @@ argument to the ``Simulate()`` call):
     q_\text{real} = \frac{T_\text{wall}}{T_\text{sim}}
 
 If the real-time factor is larger than `1` as in the example above, the
-simulation runs more slowly than the wall-clock time passes.
+simulation runs slower than the wall-clock time.
 
-In the case that a simulation script contains multiple ``Simulate()`` calls,
+In case a simulation script contains multiple ``Simulate()`` calls,
 the percentage simulation time is reset to `0%` at the beginning of each call,
-but the abolute simulation time and the real-time factor account for the total
+but the absolute simulation time and the real-time factor account for the total
 elapsed times.
 
 .. note::

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -233,6 +233,16 @@ the percentage simulation time is reset to `0%` at the beginning of each call,
 but the absolute simulation time and the real-time factor account for the total
 elapsed times.
 
+The real-time factor should not be confused with the concept of *speedup*.
+Speedup refers to a ratio of wall-clock times, namely the wall-clock time
+needed to solve a problem serially and the wall-clock time needed to solve the
+same problem in parallel (e.g., by distributing the work across multiple
+threads or processes):
+
+.. math::
+
+    q_\text{speedup} = \frac{T_\text{wall, serial}}{T_\text{wall, parallel}}
+
 .. note::
 
     For large, distributed simulations, it is recommended to set

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -217,16 +217,16 @@ well as the real-time factor, for example:
 
     [ 25% ] Biological simulation time: 250.0 ms, Real-time factor: 2.6711
 
-The *real-time factor* is defined as the quotient of *real time* (which is also
-known as wall-clock time) and the *biological simulation time* (which is the
+The *real-time factor* is defined as the quotient of *wall-clock time* (which
+is also known as real time) and the *biological simulation time* (which is the
 argument to the ``Simulate()`` call):
 
 .. math::
 
-    q_\text{real} = \frac{T_\text{real}}{T_\text{sim}}
+    q_\text{real} = \frac{T_\text{wall}}{T_\text{sim}}
 
 If the real-time factor is larger than `1` as in the example above, the
-simulation runs more slowly than real time passes.
+simulation runs more slowly than the wall-clock time passes.
 
 In the case that a simulation script contains multiple ``Simulate()`` calls,
 the percentage simulation time is reset to `0%` at the beginning of each call,
@@ -237,6 +237,7 @@ elapsed times.
 
     For large, distributed simulations, it is recommended to set
     ``{"print_time": False}`` to avoid the overhead of the print calls.
-    In these cases, the real-time factor can be computed by measuring the real
-    time manually and dividing by the set biological simulation time.
+    In these cases, the real-time factor can be computed by measuring the
+    wall-clock time manually and dividing by the set biological simulation
+    time.
 

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -199,3 +199,44 @@ a Poisson spike train using different seeds and output files for each run:
         nest.Connect(nrn, sd)
     
         nest.Simulate(100)
+
+Monitoring elapsed time
+-----------------------
+
+The progress of the simulation can be monitored by setting:
+
+::
+
+    SetKernelStatus({"print_time": True})
+
+If enabled, a line is printed to screen at every time step of the simulation to
+track the percentage and the absolute elapsed biological simulation time as
+well as the real-time factor, for example:
+
+::
+
+    [ 25% ] Biological simulation time: 250.0 ms, Real-time factor: 2.6711
+
+The *real-time factor* is defined as the quotient of *real time* (which is also
+known as wall-clock time) and the *biological simulation time* (which is the
+argument to the ``Simulate()`` call):
+
+.. math::
+
+    q_\text{real} = \frac{T_\text{real}}{T_\text{sim}}
+
+If the real-time factor is larger than `1` as in the example above, the
+simulation runs more slowly than real time passes.
+
+In the case that a simulation script contains multiple ``Simulate()`` calls,
+the percentage simulation time is reset to `0%` at the beginning of each call,
+but the abolute simulation time and the real-time factor account for the total
+elapsed times.
+
+.. note::
+
+    For large, distributed simulations, it is recommended to set
+    ``{"print_time": False}`` to avoid the overhead of the print calls.
+    In these cases, the real-time factor can be computed by measuring the real
+    time manually and dividing by the set biological simulation time.
+

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -210,31 +210,32 @@ The progress of the simulation can be monitored by setting:
     SetKernelStatus({"print_time": True})
 
 If enabled, a line is printed to screen at every time step of the simulation to
-track the percentage, the absolute elapsed biological simulation time and the
-real-time factor, for example:
+track the percentage, the absolute elapsed model time and the real-time factor,
+for example:
 
 ::
 
-    [ 25% ] Biological simulation time: 250.0 ms, Real-time factor: 2.6711
+    [ 25% ] Model time: 250.0 ms, Real-time factor: 2.6711
 
 The *real-time factor* is defined as the quotient of *wall-clock time* (which
-is also known as real time) and the *biological simulation time* (which is the
-argument to the ``Simulate()`` call):
+is also known as real time) and the *model time* (which is the duration by
+which the state of the model is advanced in time, or in short, the argument to
+the ``Simulate()`` call):
 
 .. math::
 
-    q_\text{real} = \frac{T_\text{wall}}{T_\text{bio}}
+    q_\text{real} = \frac{T_\text{wall}}{T_\text{model}}
 
 If the real-time factor is larger than `1` as in the example above, the
 simulation runs slower than the wall-clock time.
 
 In case a simulation script contains multiple ``Simulate()`` calls,
 the percentage simulation time is reset to `0%` at the beginning of each call,
-but the absolute simulation time and the real-time factor account for the total
+but the absolute model time and the real-time factor account for the total
 elapsed times.
 
-The real-time factor should not be confused with the concept of *speedup*.
-Speedup refers to a ratio of wall-clock times, namely the wall-clock time
+The real-time factor should not be confused with the concept of speedup.
+*Speedup* refers to a ratio of wall-clock times, namely the wall-clock time
 needed to solve a problem serially and the wall-clock time needed to solve the
 same problem in parallel (e.g., by distributing the work across multiple
 threads or processes):
@@ -248,6 +249,5 @@ threads or processes):
     For large, distributed simulations, it is recommended to set
     ``{"print_time": False}`` to avoid the overhead of the print calls.
     In these cases, the real-time factor can be computed by measuring the
-    wall-clock time manually and dividing by the set biological simulation
-    time.
+    wall-clock time manually and dividing by the set model time.
 

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -223,7 +223,7 @@ argument to the ``Simulate()`` call):
 
 .. math::
 
-    q_\text{real} = \frac{T_\text{wall}}{T_\text{sim}}
+    q_\text{real} = \frac{T_\text{wall}}{T_\text{bio}}
 
 If the real-time factor is larger than `1` as in the example above, the
 simulation runs slower than the wall-clock time.

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -1015,7 +1015,7 @@ nest::SimulationManager::print_progress_()
     // ms
     double t_real_acc = ( t_real_ ) / 1000.;
     double t_sim_acc = ( to_do_total_ - to_do_ ) * Time::get_resolution().get_ms();
-    // real-time factor = real time / biological simulation time
+    // real-time factor = wall-clock time / biological simulation time
     rt_factor = t_real_acc / t_sim_acc;
   }
 

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -1015,15 +1015,15 @@ nest::SimulationManager::print_progress_()
     // ms
     double t_real_acc = ( t_real_ ) / 1000.;
     double t_sim_acc = ( to_do_total_ - to_do_ ) * Time::get_resolution().get_ms();
-    // realtime factor = wallclock time / biological time simulated
+    // real-time factor = real time / biological simulation time
     rt_factor = t_real_acc / t_sim_acc;
   }
 
   int percentage = ( 100 - int( float( to_do_ ) / to_do_total_ * 100 ) );
 
-  std::cout << "\r" << std::setw( 3 ) << std::right << percentage << " %: "
-            << "network time: " << std::fixed << std::setprecision( 1 ) << clock_.get_ms() << " ms, "
-            << "realtime factor: " << std::setprecision( 4 ) << rt_factor
+  std::cout << "\r[ " << std::setw( 3 ) << std::right << percentage << "% ] "
+            << "Biological simulation time: " << std::fixed << std::setprecision( 1 ) << clock_.get_ms() << " ms, "
+            << "Real-time factor: " << std::setprecision( 4 ) << rt_factor
             << std::resetiosflags( std::ios_base::floatfield );
   std::flush( std::cout );
 }

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -1015,14 +1015,14 @@ nest::SimulationManager::print_progress_()
     // ms
     double t_real_acc = ( t_real_ ) / 1000.;
     double t_sim_acc = ( to_do_total_ - to_do_ ) * Time::get_resolution().get_ms();
-    // real-time factor = wall-clock time / biological simulation time
+    // real-time factor = wall-clock time / model time
     rt_factor = t_real_acc / t_sim_acc;
   }
 
   int percentage = ( 100 - int( float( to_do_ ) / to_do_total_ * 100 ) );
 
   std::cout << "\r[ " << std::setw( 3 ) << std::right << percentage << "% ] "
-            << "Biological simulation time: " << std::fixed << std::setprecision( 1 ) << clock_.get_ms() << " ms, "
+            << "Model time: " << std::fixed << std::setprecision( 1 ) << clock_.get_ms() << " ms, "
             << "Real-time factor: " << std::setprecision( 4 ) << rt_factor
             << std::resetiosflags( std::ios_base::floatfield );
   std::flush( std::cout );

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -1015,7 +1015,8 @@ nest::SimulationManager::print_progress_()
     // ms
     double t_real_acc = ( t_real_ ) / 1000.;
     double t_sim_acc = ( to_do_total_ - to_do_ ) * Time::get_resolution().get_ms();
-    rt_factor = t_sim_acc / t_real_acc;
+    // realtime factor = wallclock time / biological time simulated
+    rt_factor = t_real_acc / t_sim_acc;
   }
 
   int percentage = ( 100 - int( float( to_do_ ) / to_do_total_ * 100 ) );


### PR DESCRIPTION
If `print_time` was enabled, the realtime factor was printed out as "biological time simulated / wall-clock time".
However, the inverse definition, "wall-clock time / biological simulation time" is currently used in benchmark measurements of the state propagation.
The latter definition is beneficial because the factor then decreases if the simulation becomes faster.
This PR changes the definition accordingly.

In addition, this PR adds a new section "Monitoring elapsed time" to the documentation guide `running_simulations.rst`.

Note that the realtime factor is not the "speedup" often used in the context of computer architectures.
The new documentation distinguishes between the two.

Let's discuss the following points:
1. Do we prefer to write "realtime factor" or "real time factor"?
--> The result of the discussion is "real-time factor".
2. We currently define the factor in symbols by  `T_sim / T_bio` which might be misleading because the argument to the `Simulate()` call is often named `T_sim` or similar but in fact we refer to the biological time.
--> The result of the discussion is to use `T_wall / T_model`.

It would be great if @sarakonradi could have a look.