### PR TITLE
Correct filename quoting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ file( MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/reports/ )
 if ( HAVE_PYTHON )
   add_custom_target( installcheck
     COMMAND ${CMAKE_COMMAND} -E env
-      NEST_PATH="${CMAKE_INSTALL_FULL_BINDIR}"
+      NEST_PATH=${CMAKE_INSTALL_FULL_BINDIR}
       PYTHON="${PYTHON}"
       NEST_PYTHONPATH="${CMAKE_INSTALL_PREFIX}/${PYEXECDIR}"
       ${CMAKE_INSTALL_FULL_DATADIR}/extras/do_tests.sh --test-pynest
@@ -216,7 +216,7 @@ if ( HAVE_PYTHON )
 else ()
   add_custom_target( installcheck
     COMMAND ${CMAKE_COMMAND} -E env
-      NEST_PATH="${CMAKE_INSTALL_FULL_BINDIR}"
+      NEST_PATH=${CMAKE_INSTALL_FULL_BINDIR}
       ${CMAKE_INSTALL_FULL_DATADIR}/extras/do_tests.sh
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
     COMMENT "Execute NEST's testsuite...."

--- a/extras/nest_indirect
+++ b/extras/nest_indirect
@@ -8,7 +8,7 @@ fi
 abspath="$(cd "${0%/*}" 2>/dev/null; echo "${PWD}/${0##*/}")"
 path="$(dirname "${abspath}")"
 
-binary="$("${path}/sli" -c "(\"$1\") nest_indirect =")"
+binary="$("${path}/sli" -c "($1) nest_indirect =")"
 exitcode=$?
 
 if [ $exitcode -ne 0 ]; then

--- a/extras/nest_indirect
+++ b/extras/nest_indirect
@@ -5,10 +5,10 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-abspath="$(cd "${0%/*}" 2>/dev/null; echo "$PWD"/"${0##*/}")"
-path="`dirname $abspath`"
+abspath="$(cd "${0%/*}" 2>/dev/null; echo "${PWD}/${0##*/}")"
+path="$(dirname "${abspath}")"
 
-binary=`$path/sli -c "($1) nest_indirect ="`
+binary="$("${path}/sli" -c "(\"$1\") nest_indirect =")"
 exitcode=$?
 
 if [ $exitcode -ne 0 ]; then
@@ -16,6 +16,6 @@ if [ $exitcode -ne 0 ]; then
   exit $exitcode
 fi
 
-echo "Running " $binary
-$binary
+echo "Running $binary"
+sh -c "$binary"
 exit $?

--- a/extras/nest_serial
+++ b/extras/nest_serial
@@ -1,5 +1,5 @@
 #! /bin/sh
-set -x
+
 if [ $# -ne 1 ]; then
   echo "Usage: nest_serial <script>"
   exit 1

--- a/extras/nest_serial
+++ b/extras/nest_serial
@@ -8,7 +8,7 @@ fi
 abspath="$(cd "${0%/*}" 2>/dev/null; echo "${PWD}/${0##*/}")"
 path="$(dirname "${abspath}")"
 
-binary="$("${path}/sli" -c "(\"$1\") nest_serial =")"
+binary="$("${path}/sli" -c "($1) nest_serial =")"
 exitcode=$?
 
 if [ $exitcode -ne 0 ]; then

--- a/extras/nest_serial
+++ b/extras/nest_serial
@@ -1,14 +1,14 @@
 #! /bin/sh
-
+set -x
 if [ $# -ne 1 ]; then
   echo "Usage: nest_serial <script>"
   exit 1
 fi
 
-abspath="$(cd "${0%/*}" 2>/dev/null; echo "$PWD"/"${0##*/}")"
-path="`dirname $abspath`"
+abspath="$(cd "${0%/*}" 2>/dev/null; echo "${PWD}/${0##*/}")"
+path="$(dirname "${abspath}")"
 
-binary=`$path/sli -c "($1) nest_serial ="`
+binary="$("${path}/sli" -c "(\"$1\") nest_serial =")"
 exitcode=$?
 
 if [ $exitcode -ne 0 ]; then
@@ -16,6 +16,6 @@ if [ $exitcode -ne 0 ]; then
   exit $exitcode
 fi
 
-echo "Running " $binary
-$binary
+echo "Running $binary"
+sh -c "$binary"
 exit $?

--- a/extras/nest_vars.sh.in
+++ b/extras/nest_vars.sh.in
@@ -1,22 +1,22 @@
 #!/bin/sh
 
 # NEST is installed here. When you relocate NEST, change this variable.
-export NEST_INSTALL_DIR=@CMAKE_INSTALL_PREFIX@
+export NEST_INSTALL_DIR="@CMAKE_INSTALL_PREFIX@"
 
 # NEST finds standard *.sli files $NEST_DATA_DIR/sli
-export NEST_DATA_DIR=$NEST_INSTALL_DIR/@CMAKE_INSTALL_DATADIR@
+export NEST_DATA_DIR="${NEST_INSTALL_DIR}/@CMAKE_INSTALL_DATADIR@"
 
 # NEST finds help files $NEST_DOC_DIR/help
-export NEST_DOC_DIR=$NEST_INSTALL_DIR/@CMAKE_INSTALL_DOCDIR@
+export NEST_DOC_DIR="${NEST_INSTALL_DIR}/@CMAKE_INSTALL_DOCDIR@"
 
 # The path where NEST looks for user modules.
-export NEST_MODULE_PATH=$NEST_INSTALL_DIR/@CMAKE_INSTALL_LIBDIR@/nest
+export NEST_MODULE_PATH="${NEST_INSTALL_DIR}/@CMAKE_INSTALL_LIBDIR@/nest"
 
 # The path where the PyNEST bindings are installed.
-export NEST_PYTHON_PREFIX=$NEST_INSTALL_DIR/@PYEXECDIR@
+export NEST_PYTHON_PREFIX="${NEST_INSTALL_DIR}/@PYEXECDIR@"
 
 # Prepend NEST to PYTHONPATH in a safe way even if PYTHONPATH is undefined
-export PYTHONPATH=$NEST_PYTHON_PREFIX${PYTHONPATH:+:$PYTHONPATH}
+export PYTHONPATH="${NEST_PYTHON_PREFIX}${PYTHONPATH:+:$PYTHONPATH}"
 
 # Make nest / sli /... executables visible.
-export PATH=$NEST_INSTALL_DIR/bin:$PATH
+export PATH="${NEST_INSTALL_DIR}/bin:${PATH}"

--- a/lib/sli/processes.sli
+++ b/lib/sli/processes.sli
@@ -1258,7 +1258,7 @@ SeeAlso: nest_indirect
   {
    pop
    1 exch
-   statusdict/prefix :: (/bin/nest ) join exch
+   (') statusdict/prefix :: (/bin/nest' ) join join exch
    mpirun
   } 
   {
@@ -1272,7 +1272,7 @@ SeeAlso: nest_indirect
   } ifelse
  }
  {
-  statusdict /prefix get (/bin/nest ) join
+  (') statusdict /prefix get (/bin/nest' ) join join
   exch join
  } ifelse 
 } def
@@ -1324,7 +1324,7 @@ SeeAlso: nest_serial
  /mpirun lookup   
  {
   pop
-  statusdict /prefix get (/bin/sli ) join
+  (') statusdict /prefix get (/bin/sli' ) join join
   exch join
  } 
  {

--- a/lib/sli/processes.sli
+++ b/lib/sli/processes.sli
@@ -1273,7 +1273,7 @@ SeeAlso: nest_indirect
  }
  {
   (') statusdict /prefix get (/bin/nest' ) join join
-  exch join
+  exch (') exch (') join join join
  } ifelse 
 } def
 
@@ -1325,7 +1325,7 @@ SeeAlso: nest_serial
  {
   pop
   (') statusdict /prefix get (/bin/sli' ) join join
-  exch join
+  exch (') exch (') join join join
  } 
  {
   M_FATAL (nest_indirect) (NEST was compiled with MPI but ~/.nestrc does not specify) message

--- a/lib/sli/unittest.sli
+++ b/lib/sli/unittest.sli
@@ -323,7 +323,7 @@ SeeAlso: unittest::fail_or_die, assert, quit
  (echo ")
  /func load pcvs join
  ( exec" | ) join 
- statusdict /argv get First join
+ (') statusdict /argv get First (') join join join
  ( -) join /command Set
 
 % command ==
@@ -397,7 +397,7 @@ SeeAlso: unittest::failbutnocrash_or_die, assert, quit
  (echo ")
  /func load pcvs join
  ( exec" | ) join 
- statusdict /argv get First join
+ (') statusdict /argv get First (') join join join
  ( -) join /command Set
 
 % command ==
@@ -495,7 +495,7 @@ SeeAlso: unittest::failbutnocrash_or_die, assert, quit
   (echo ")
   /func load pcvs join
   ( exec" | ) join 
-  statusdict /argv get First join
+  (') statusdict /argv get First (') join join join
   ( -) join /command Set
 
   command 0 shpawn

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -352,8 +352,8 @@ run_test ()
 # Set environment variables.
 # The NEST_ variants of the global variables were set by
 # cmake during configuration.
-export PYTHONPATH=$NEST_PYTHONPATH:$PYTHONPATH
-export PATH=$NEST_PATH:$PATH
+export PYTHONPATH="${NEST_PYTHONPATH}:${PYTHONPATH}"
+export PATH="${NEST_PATH}:${PATH}"
 
 # Gather some information about the host
 INFO_ARCH="$(uname -m)"
@@ -363,8 +363,8 @@ INFO_OS="$(uname -s)"
 INFO_USER="$(whoami)"
 INFO_VER="$(uname -r)"
 
-TEST_BASEDIR=${NEST_DOC_DIR:-"@CMAKE_INSTALL_FULL_DOCDIR@"}
-TEST_OUTDIR=${TEST_OUTDIR:-"$( pwd )/reports"}
+TEST_BASEDIR="${NEST_DOC_DIR:-@CMAKE_INSTALL_FULL_DOCDIR@}"
+TEST_OUTDIR="${TEST_OUTDIR:-$( pwd )/reports}"
 TEST_LOGFILE="${TEST_OUTDIR}/installcheck.log"
 TEST_OUTFILE="${TEST_OUTDIR}/output.log"
 TEST_RETFILE="${TEST_OUTDIR}/output.ret"
@@ -379,7 +379,7 @@ mkdir "${TEST_OUTDIR}"
 PYTHON="${PYTHON:-python}"
 PYTHON_HARNESS="${NEST_DATA_DIR:-@CMAKE_INSTALL_FULL_DATADIR@}/extras/do_tests.py"
 
-TMPDIR=${TMPDIR:-${TEST_OUTDIR}}
+TMPDIR="${TMPDIR:-${TEST_OUTDIR}}"
 TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/nest.XXXXX")"
 NEST_DATA_PATH="${TEST_TMPDIR}"
 export NEST_DATA_PATH
@@ -612,25 +612,25 @@ fi
 #if test "x$(sli -c 'statusdict/have_music :: =')" = xtrue ; then
 #    junit_open 'core.phase_6'
 #
-#    BASEDIR=$PWD
-#    tmpdir=$(mktemp -d)
+#    BASEDIR="$PWD"
+#    tmpdir="$(mktemp -d)"
 #
-#    TESTDIR=${TEST_BASEDIR}/musictests/
+#    TESTDIR="${TEST_BASEDIR}/musictests/"
 #
 #    for test_name in $(ls ${TESTDIR} | grep '.*\.music$') ; do
-#        music_file=${TESTDIR}/${test_name}
+#        music_file="${TESTDIR}/${test_name}"
 #
 #        # Collect the list of SLI files from the .music file.
 #        sli_files=$(grep '\.sli' ${music_file} | sed -e "s#args=#${TESTDIR}#g")
 #        sli_files=$(for f in ${sli_files}; do if test -f ${f}; then echo ${f}; fi; done)
 #
 #        # Check if there is an accompanying shell script for the test.
-#        sh_file=${TESTDIR}/$(basename ${music_file} .music).sh
-#        if test ! -f ${sh_file}; then unset sh_file; fi
+#        sh_file="${TESTDIR}/$(basename ${music_file} .music).sh"
+#        if test ! -f "${sh_file}"; then unset sh_file; fi
 #
 #        # Calculate the total number of processes in the .music file.
 #        np=$(($(sed -n 's/np=//p' ${music_file} | paste -sd'+' -)))
-#        command=$(sli -c "${np} (@MUSIC_EXECUTABLE@) (${test_name}) mpirun =")
+#        command="$(sli -c "${np} (@MUSIC_EXECUTABLE@) (${test_name}) mpirun =")"
 #
 #        proc_txt="processes"
 #        if test $np -eq 1; then proc_txt="process"; fi
@@ -638,17 +638,17 @@ fi
 #        printf '%s' "  Running test '${test_name}' with $np $proc_txt... "
 #
 #        # Copy everything to the tmpdir.
-#        cp ${music_file} ${sh_file} ${sli_files} ${tmpdir}
-#        cd ${tmpdir}
+#        cp "${music_file}" "${sh_file}" "${sli_files}" "${tmpdir}"
+#        cd "${tmpdir}"
 #
 #        # Create the runner script
 #        echo "#!/bin/sh" >  runner.sh
 #        echo "set +e" >> runner.sh
-#        echo "export NEST_DATA_PATH=${tmpdir}" >> runner.sh
+#        echo "export NEST_DATA_PATH=\"${tmpdir}\"" >> runner.sh
 #        echo "${command} > output.log 2>&1" >> runner.sh
 #        if test -n "${sh_file}"; then
-#            chmod 755 $(basename ${sh_file})
-#            echo "./"$(basename ${sh_file}) >> runner.sh
+#            chmod 755 "$(basename "${sh_file}")"
+#            echo "./$(basename "${sh_file}")" >> runner.sh
 #        fi
 #        echo "echo \$? > exit_code ; exit 0" >> runner.sh
 #
@@ -661,8 +661,8 @@ fi
 #        # call or of the accompanying shell script if present.
 #        exit_code=$(cat exit_code)
 #
-#        rm ${tmpdir}/*
-#        cd ${BASEDIR}
+#        rm "${tmpdir}"/*
+#        cd "${BASEDIR}"
 #
 #        # If the name of the test contains 'failure', we expect it to
 #        # fail and the test logic is inverted.
@@ -692,7 +692,7 @@ fi
 #        fi
 #    done
 #
-#    rm -rf $tmpdir
+#    rm -rf "$tmpdir"
 #
 #    junit_close
 #else
@@ -715,13 +715,13 @@ if test "x${TEST_PYNEST}" = xtrue ; then
     #    of support for nosetests. We use the TEST_OUTDIR as Python-free
     #    dummy directory to search for tests.
 
-    if command -v @NOSETESTS@ >/dev/null 2>&1 && @PYTHON@ @NOSETESTS@ --with-xunit --xunit-file=/dev/null --where=${TEST_OUTDIR} >/dev/null 2>&1; then
+    if command -v @NOSETESTS@ >/dev/null 2>&1 && @PYTHON@ @NOSETESTS@ --with-xunit --xunit-file=/dev/null --where="${TEST_OUTDIR}" >/dev/null 2>&1; then
 
         echo
         echo "  Using nosetests."
         echo
 
-        @PYTHON@ @NOSETESTS@ -v --with-xunit --xunit-file=${TEST_OUTDIR}/pynest_tests.xml ${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/tests 2>&1 \
+        @PYTHON@ @NOSETESTS@ -v --with-xunit --xunit-file="${TEST_OUTDIR}/pynest_tests.xml" "${NEST_PYTHON_PREFIX:-@CMAKE_INSTALL_PREFIX@/@PYEXECDIR@}/nest/tests" 2>&1 \
             | tee -a "${TEST_LOGFILE}" | grep -i --line-buffered "\.\.\. ok\|fail\|skip\|error" | sed 's/^/  /'
 
         PYNEST_TEST_TOTAL="$(  tail -n 3 ${TEST_LOGFILE} | grep Ran | cut -d' ' -f2 )"
@@ -794,7 +794,7 @@ echo
 echo "Phase 8: Running C++ tests (experimental)"
 echo "-----------------------------------------"
 
-if command -v ${NEST_PATH}/run_all_cpptests > /dev/null 2>&1; then
+if command -v "${NEST_PATH}/run_all_cpptests" > /dev/null 2>&1; then
   CPP_TEST_OUTPUT="$(${NEST_PATH}/run_all_cpptests 2>&1)"
   # TODO:
   # We should check the return code ($?) of run_all_cpptests here to see
@@ -806,8 +806,8 @@ if command -v ${NEST_PATH}/run_all_cpptests > /dev/null 2>&1; then
   # https://www.boost.org/doc/libs/1_65_0/libs/test/doc/html/boost_test/test_output/log_formats/log_human_readable_format.html
   # but does the check for failures work as it should?
   # At some point, we should also count skipped tests.
-  CPP_TEST_TOTAL=$(echo "$CPP_TEST_OUTPUT" | sed -${EXTENDED_REGEX_PARAM} -n 's/.*Running ([0-9]+).*/\1/p')
-  CPP_TEST_FAILED=$(echo "$CPP_TEST_OUTPUT" | sed -${EXTENDED_REGEX_PARAM} -n 's/.*([0-9]+) failure.*/\1/p')
+  CPP_TEST_TOTAL="$(echo "$CPP_TEST_OUTPUT" | sed -${EXTENDED_REGEX_PARAM} -n 's/.*Running ([0-9]+).*/\1/p')"
+  CPP_TEST_FAILED="$(echo "$CPP_TEST_OUTPUT" | sed -${EXTENDED_REGEX_PARAM} -n 's/.*([0-9]+) failure.*/\1/p')"
 
   # replace empty strings by zero so arithmetic expressions below work
   CPP_TEST_TOTAL=${CPP_TEST_TOTAL:-0}


### PR DESCRIPTION
These changes put correct quotes in many places and allow to install NEST to "some/path with spaces", which broke on different levels before (cmake, sli, bash).

Probably fixes #1048, which was due to wrong split at a space, but haven't tested explicitly on windows.

A design decision was to put single quotes around filenames for calls in shell commands, which inhibits shell variable expansion and treats many special characters more predictable/portable. Any replacements are expected to have been done outside of NEST anyway.