### PR TITLE
Improve BlockVector to fix issues when sorting with recent versions of Boost

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -462,7 +462,7 @@ function( NEST_PROCESS_WITH_OPENMP )
   if ( NOT TARGET OpenMP::OpenMP_CXX )
     add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
   endif()
- 
+
 endfunction()
 
 function( NEST_PROCESS_WITH_MPI )
@@ -584,8 +584,10 @@ function( NEST_PROCESS_WITH_BOOST )
       set( BOOST_ROOT "${with-boost}" )
     endif ()
 
+    set(Boost_USE_DEBUG_LIBS OFF)  # ignore debug libs
+    set(Boost_USE_RELEASE_LIBS ON) # only find release libs
     # Needs Boost version >=1.58.0 to use Boost sorting
-    find_package( Boost 1.58.0 COMPONENTS unit_test_framework )
+    find_package( Boost 1.58.0 )
     if ( Boost_FOUND )
       # export found variables to parent scope
       set( HAVE_BOOST ON PARENT_SCOPE )
@@ -594,6 +596,7 @@ function( NEST_PROCESS_WITH_BOOST )
       set( BOOST_LIBRARIES "${Boost_LIBRARIES}" PARENT_SCOPE )
       set( BOOST_INCLUDE_DIR "${Boost_INCLUDE_DIR}" PARENT_SCOPE )
       set( BOOST_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}" PARENT_SCOPE )
+      include_directories( ${Boost_INCLUDE_DIRS} )
     endif ()
   endif ()
 endfunction()

--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -24,7 +24,7 @@
 # It is invoked by the top-level Travis script '.travis.yml'.
 #
 # NOTE: This shell script is tightly coupled to Python script
-#       'extras/parse_travis_log.py'. 
+#       'extras/parse_travis_log.py'.
 #       Any changes to message numbers (MSGBLDnnnn) or the variable name
 #      'file_names' have effects on the build/test-log parsing process.
 
@@ -106,11 +106,14 @@ fi
 if [[ $OSTYPE = darwin* ]]; then
     export CC=$(ls /usr/local/bin/gcc-* | grep '^/usr/local/bin/gcc-\d$')
     export CXX=$(ls /usr/local/bin/g++-* | grep '^/usr/local/bin/g++-\d$')
-    CONFIGURE_BOOST="-Dwith-boost=OFF"
-else
-    CONFIGURE_BOOST="-Dwith-boost=ON"
-fi
- 
+
+# Download Boost
+wget --no-verbose https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz
+tar -xzf boost_1_72_0.tar.gz
+rm -fr boost_1_72_0.tar.gz
+mv boost_1_72_0 $HOME/.cache
+CONFIGURE_BOOST="-Dwith-boost=$HOME/.cache/boost_1_72_0"
+
 NEST_VPATH=build
 NEST_RESULT=result
 if [ "$(uname -s)" = 'Linux' ]; then
@@ -150,14 +153,14 @@ if [ "$xSTATIC_ANALYSIS" = "1" ]; then
         make PREFIX=$HOME/.cache CFGDIR=$HOME/.cache/cfg HAVE_RULES=yes install
         cd ..
         echo "MSGBLD0040: CPPCHECK installation completed."
-    
+
         echo "MSGBLD0050: Installing CLANG-FORMAT."
         wget --no-verbose http://llvm.org/releases/3.6.2/clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         tar xf clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04.tar.xz
         # Copy and not move because '.cache' may aleady contain other subdirectories and files.
         cp -R clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04/* $HOME/.cache
         echo "MSGBLD0060: CLANG-FORMAT installation completed."
-    
+
         # Remove these directories, otherwise the copyright-header check will complain.
         rm -rf ./cppcheck
         rm -rf ./clang+llvm-3.6.2-x86_64-linux-gnu-ubuntu-14.04
@@ -167,7 +170,7 @@ if [ "$xSTATIC_ANALYSIS" = "1" ]; then
     export PATH=$HOME/.cache/bin:$PATH
 
     echo "MSGBLD0070: Retrieving changed files."
-      # Note: BUG: Extracting the filenames may not work in all cases. 
+      # Note: BUG: Extracting the filenames may not work in all cases.
       #            The commit range might not properly reflect the history.
       #            see https://github.com/travis-ci/travis-ci/issues/2668
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
@@ -193,7 +196,7 @@ if [ "$xSTATIC_ANALYSIS" = "1" ]; then
     # Set the command line arguments for the static code analysis script and execute it.
 
     # The names of the static code analysis tools executables.
-    VERA=vera++                   
+    VERA=vera++
     CPPCHECK=cppcheck
     CLANG_FORMAT=clang-format
     PEP8=pep8

--- a/libnestutil/CMakeLists.txt
+++ b/libnestutil/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries( nestutil ${GSL_LIBRARIES} ${SIONLIB_LIBS} )
 
 target_include_directories( nestutil PRIVATE
     ${PROJECT_BINARY_DIR}/libnestutil
+    ${Boost_INCLUDE_DIRS}
     )
 
 install( TARGETS nestutil

--- a/libnestutil/block_vector.h
+++ b/libnestutil/block_vector.h
@@ -75,7 +75,7 @@ public:
   using value_type = value_type_;
   using pointer = ptr_;
   using reference = ref_;
-  using difference_type = long int;
+  using difference_type = typename BlockVector< value_type >::difference_type;
 
   bv_iterator() = default;
 
@@ -531,6 +531,10 @@ inline bv_iterator< value_type_, ref_, ptr_ >& bv_iterator< value_type_, ref_, p
 template < typename value_type_, typename ref_, typename ptr_ >
 inline bv_iterator< value_type_, ref_, ptr_ >& bv_iterator< value_type_, ref_, ptr_ >::operator+=( difference_type val )
 {
+  if ( val < 0 )
+  {
+    return operator-=( -val );
+  }
   for ( difference_type i = 0; i < val; ++i )
   {
     operator++();
@@ -541,6 +545,10 @@ inline bv_iterator< value_type_, ref_, ptr_ >& bv_iterator< value_type_, ref_, p
 template < typename value_type_, typename ref_, typename ptr_ >
 inline bv_iterator< value_type_, ref_, ptr_ >& bv_iterator< value_type_, ref_, ptr_ >::operator-=( difference_type val )
 {
+  if ( val < 0 )
+  {
+    return operator+=( -val );
+  }
   for ( difference_type i = 0; i < val; ++i )
   {
     operator--();

--- a/testsuite/cpptests/run_all.cpp
+++ b/testsuite/cpptests/run_all.cpp
@@ -22,7 +22,7 @@
 
 #define BOOST_TEST_MODULE cpptests
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 // Includes from cpptests
 #include "test_block_vector.h"

--- a/testsuite/cpptests/test_block_vector.h
+++ b/testsuite/cpptests/test_block_vector.h
@@ -32,7 +32,30 @@
 // Includes from libnestutil:
 #include "block_vector.h"
 
-BOOST_AUTO_TEST_SUITE( test_seque )
+/**
+ * Fixture filling a BlockVector and a vector with linearly increasing values.
+ */
+struct bv_vec_reference_fixture
+{
+  bv_vec_reference_fixture()
+    : N( block_vector.get_max_block_size() + 10 )
+  {
+    for ( int i = 0; i < N; ++i )
+    {
+      block_vector.push_back( i );
+      reference.push_back( i );
+    }
+  }
+  ~bv_vec_reference_fixture()
+  {
+  }
+
+  BlockVector< int > block_vector;
+  std::vector< int > reference;
+  int N;
+};
+
+BOOST_AUTO_TEST_SUITE( test_blockvector )
 
 BOOST_AUTO_TEST_CASE( test_size )
 {
@@ -98,27 +121,27 @@ BOOST_AUTO_TEST_CASE( test_erase )
     block_vector.push_back( i );
   }
 
-  auto seque_mid = block_vector;
-  seque_mid.erase( seque_mid.begin() + 2, seque_mid.begin() + 8 );
-  BOOST_REQUIRE( seque_mid.size() == 4 );
-  BOOST_REQUIRE( seque_mid[ 0 ] == 0 );
-  BOOST_REQUIRE( seque_mid[ 1 ] == 1 );
-  BOOST_REQUIRE( seque_mid[ 2 ] == 8 );
-  BOOST_REQUIRE( seque_mid[ 3 ] == 9 );
+  auto bv_mid = block_vector;
+  bv_mid.erase( bv_mid.begin() + 2, bv_mid.begin() + 8 );
+  BOOST_REQUIRE( bv_mid.size() == 4 );
+  BOOST_REQUIRE( bv_mid[ 0 ] == 0 );
+  BOOST_REQUIRE( bv_mid[ 1 ] == 1 );
+  BOOST_REQUIRE( bv_mid[ 2 ] == 8 );
+  BOOST_REQUIRE( bv_mid[ 3 ] == 9 );
 
-  auto seque_front = block_vector;
-  seque_front.erase( seque_front.begin(), seque_front.begin() + 7 );
-  BOOST_REQUIRE( seque_front.size() == 3 );
-  BOOST_REQUIRE( seque_front[ 0 ] == 7 );
-  BOOST_REQUIRE( seque_front[ 1 ] == 8 );
-  BOOST_REQUIRE( seque_front[ 2 ] == 9 );
+  auto bv_front = block_vector;
+  bv_front.erase( bv_front.begin(), bv_front.begin() + 7 );
+  BOOST_REQUIRE( bv_front.size() == 3 );
+  BOOST_REQUIRE( bv_front[ 0 ] == 7 );
+  BOOST_REQUIRE( bv_front[ 1 ] == 8 );
+  BOOST_REQUIRE( bv_front[ 2 ] == 9 );
 
-  auto seque_back = block_vector;
-  seque_back.erase( seque_back.begin() + 3, seque_back.end() );
-  BOOST_REQUIRE( seque_back.size() == 3 );
-  BOOST_REQUIRE( seque_back[ 0 ] == 0 );
-  BOOST_REQUIRE( seque_back[ 1 ] == 1 );
-  BOOST_REQUIRE( seque_back[ 2 ] == 2 );
+  auto bv_back = block_vector;
+  bv_back.erase( bv_back.begin() + 3, bv_back.end() );
+  BOOST_REQUIRE( bv_back.size() == 3 );
+  BOOST_REQUIRE( bv_back[ 0 ] == 0 );
+  BOOST_REQUIRE( bv_back[ 1 ] == 1 );
+  BOOST_REQUIRE( bv_back[ 2 ] == 2 );
 }
 
 BOOST_AUTO_TEST_CASE( test_begin )
@@ -209,10 +232,10 @@ BOOST_AUTO_TEST_CASE( test_iterator_dereference )
   BOOST_REQUIRE( *( block_vector.begin() ) == block_vector[ 0 ] );
 
   // Using operator->
-  BlockVector< std::vector< int > > nested_seque;
+  BlockVector< std::vector< int > > nested_bv;
   std::vector< int > tmp = { 42 };
-  nested_seque.push_back( tmp );
-  BOOST_REQUIRE( nested_seque.begin()->size() == 1 );
+  nested_bv.push_back( tmp );
+  BOOST_REQUIRE( nested_bv.begin()->size() == 1 );
 }
 
 BOOST_AUTO_TEST_CASE( test_iterator_assign )
@@ -260,6 +283,119 @@ BOOST_AUTO_TEST_CASE( test_iterator_compare )
   BOOST_REQUIRE( not( it_b < it_a ) );
 }
 
+BOOST_FIXTURE_TEST_CASE( test_operator_pp, bv_vec_reference_fixture )
+{
+  // operator++()
+  auto bvi = block_vector.begin();
+  for ( auto& ref : reference )
+  {
+    BOOST_REQUIRE( *bvi == ref );
+    ++bvi;
+  }
+  BOOST_REQUIRE( bvi == block_vector.end() );
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_p, bv_vec_reference_fixture )
+{
+  // operator+()
+  for ( int i = 0; i < N; ++i )
+  {
+    auto bvi = block_vector.begin();
+    auto ref_it = reference.begin();
+    auto new_bvi = bvi + i;
+    auto new_ref_it = ref_it + i;
+    BOOST_REQUIRE( *new_bvi == *new_ref_it );
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_p_eq, bv_vec_reference_fixture )
+{
+  // operator+=()
+  for ( int i = 0; i < N; ++i )
+  {
+    auto bvi = block_vector.begin();
+    auto bvi_last = block_vector.end() - 1;
+    auto ref_it = reference.begin();
+    auto ref_it_last = reference.end() - 1;
+    bvi += i;
+    ref_it += i;
+    BOOST_REQUIRE( *bvi == *ref_it );
+    bvi_last += -i;
+    ref_it_last += -i;
+    BOOST_REQUIRE( *bvi_last == *ref_it_last );
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_m_eq, bv_vec_reference_fixture )
+{
+  // operator-=()
+  for ( int i = 1; i < N - 1; ++i )
+  {
+    auto bvi = block_vector.end();
+    auto bvi_first = block_vector.begin();
+    auto ref_it = reference.end();
+    auto ref_it_first = reference.begin();
+    bvi -= i;
+    ref_it -= i;
+    BOOST_REQUIRE( *bvi == *ref_it );
+    bvi_first -= -( i - 1 );
+    ref_it_first -= -( i - 1 );
+    BOOST_REQUIRE( *bvi_first == *ref_it_first );
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_m, bv_vec_reference_fixture )
+{
+  // operator-()
+  for ( int i = 1; i < N - 1; ++i )
+  {
+    auto bvi = block_vector.end();
+    auto ref_it = reference.end();
+    auto new_bvi = bvi - i;
+    auto new_ref_it = ref_it - i;
+    BOOST_REQUIRE( *new_bvi == *new_ref_it );
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_mm, bv_vec_reference_fixture )
+{
+  // operator--()
+  auto bvi = block_vector.end() - 1;
+  for ( auto ref_it = reference.end() - 1; ref_it >= reference.begin(); --ref_it, --bvi )
+  {
+    BOOST_REQUIRE( *bvi == *ref_it );
+  }
+  BOOST_REQUIRE( bvi == block_vector.begin() - 1 );
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_eq, bv_vec_reference_fixture )
+{
+  // operator==()
+  auto bvi_pp = block_vector.begin() + 1;
+  auto bvi_copy = block_vector.begin();
+  auto bvi_mm = block_vector.begin() - 1;
+  for ( auto bvi = block_vector.begin(); bvi != block_vector.end(); ++bvi, ++bvi_copy, ++bvi_mm, ++bvi_pp )
+  {
+    BOOST_REQUIRE( bvi == bvi_copy );
+    BOOST_REQUIRE( not( bvi == bvi_pp ) );
+    BOOST_REQUIRE( not( bvi == bvi_mm ) );
+  }
+}
+
+BOOST_FIXTURE_TEST_CASE( test_operator_neq, bv_vec_reference_fixture )
+{
+  // operator!=()
+  auto bvi_pp = block_vector.begin() + 1;
+  auto bvi_copy = block_vector.begin();
+  auto bvi_mm = block_vector.begin() - 1;
+  for ( auto bvi = block_vector.begin(); bvi != block_vector.end(); ++bvi, ++bvi_copy, ++bvi_mm, ++bvi_pp )
+  {
+    BOOST_REQUIRE( not( bvi != bvi_copy ) );
+    BOOST_REQUIRE( bvi != bvi_pp );
+    BOOST_REQUIRE( bvi != bvi_mm );
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
-#endif /* TEST_SORT_H */
+#endif /* TEST_BLOCK_VECTOR_H */

--- a/testsuite/cpptests/test_sort.h
+++ b/testsuite/cpptests/test_sort.h
@@ -27,6 +27,7 @@
 #include <boost/test/unit_test.hpp>
 
 // C++ includes:
+#include <algorithm>
 #include <vector>
 
 // Includes from libnestutil:
@@ -34,71 +35,143 @@
 
 namespace nest
 {
-
+/**
+ * Wrapper for quicksort3way.
+ *
+ * When calling nest::sort() directly it is impossible to sort with the
+ * built in quicksort3way from tests. This is because if NEST is compiled
+ * with Boost support, nest::sort() sorts with Boost, and if NEST is not
+ * compiled with Boost, nest::sort() calls quicksort3way, but the Boost
+ * tests are not compiled.
+ */
 void
-nest_quicksort( BlockVector< size_t >& bv0, BlockVector< size_t >& bv1 )
+nest_quicksort( BlockVector< int >& bv0, BlockVector< int >& bv1 )
 {
   nest::quicksort3way( bv0, bv1, 0, bv0.size() - 1 );
 }
 
-bool
-is_sorted( BlockVector< size_t >::const_iterator begin, BlockVector< size_t >::const_iterator end )
+/**
+ * Fixture filling two BlockVectors and a vector with lineary decreasing numbers.
+ * The vector is then sorted.
+ */
+struct fill_bv_vec_linear
 {
-  for ( BlockVector< size_t >::const_iterator it = begin; it < --end; )
+  fill_bv_vec_linear()
+    : N( 20000 )
+    , bv_sort( N )
+    , bv_perm( N )
+    , vec_sort( N )
   {
-    if ( *it > *( ++it ) )
+    for ( int i = 0; i < N; ++i )
     {
-      return false;
+      int element = N - i;
+      bv_sort[ i ] = element;
+      bv_perm[ i ] = element;
+      vec_sort[ i ] = element;
     }
+    std::sort( vec_sort.begin(), vec_sort.end() );
   }
-  return true;
-}
+
+  const int N;
+  BlockVector< int > bv_sort;
+  BlockVector< int > bv_perm;
+  std::vector< int > vec_sort;
+};
+
+/**
+ * Fixture filling two BlockVectors and a vector with random numbers.
+ * The vector is then sorted.
+ */
+struct fill_bv_vec_random
+{
+  fill_bv_vec_random()
+    : N( 20000 )
+    , bv_sort( N )
+    , bv_perm( N )
+    , vec_sort( N )
+  {
+    for ( int i = 0; i < N; ++i )
+    {
+      const size_t k = std::rand() % N;
+      bv_sort[ i ] = k;
+      bv_perm[ i ] = k;
+      vec_sort[ i ] = k;
+    }
+    std::sort( vec_sort.begin(), vec_sort.end() );
+  }
+
+  const int N;
+  BlockVector< int > bv_sort;
+  BlockVector< int > bv_perm;
+  std::vector< int > vec_sort;
+};
 
 BOOST_AUTO_TEST_SUITE( test_sort )
 
 /**
  * Tests whether two arrays with randomly generated numbers are sorted
- * correctly by a single call to sort.
+ * correctly when sorting with the built-in quicksort.
  */
-BOOST_AUTO_TEST_CASE( test_random )
+BOOST_FIXTURE_TEST_CASE( test_quicksort_random, fill_bv_vec_random )
 {
-  const size_t N = 20000;
-  BlockVector< size_t > bv0( N );
-  BlockVector< size_t > bv1( N );
+  nest_quicksort( bv_sort, bv_perm );
 
-  for ( size_t i = 0; i < N; ++i )
-  {
-    const size_t k = std::rand() % N;
-    bv0[ i ] = k;
-    bv1[ i ] = k;
-  }
+  BOOST_REQUIRE( std::is_sorted( bv_sort.begin(), bv_sort.end() ) );
+  BOOST_REQUIRE( std::is_sorted( bv_perm.begin(), bv_perm.end() ) );
 
-  nest_quicksort( bv0, bv1 );
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_sort.begin() ) );
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_perm.begin() ) );
+}
 
-  BOOST_REQUIRE( is_sorted( bv0.begin(), bv0.end() ) );
-  BOOST_REQUIRE( is_sorted( bv1.begin(), bv1.end() ) );
+/**
+ * Tests whether two arrays with linearly decreasing numbers are sorted
+ * correctly when sorting with the built-in quicksort.
+ */
+BOOST_FIXTURE_TEST_CASE( test_quicksort_linear, fill_bv_vec_linear )
+{
+  nest_quicksort( bv_sort, bv_perm );
+
+  BOOST_REQUIRE( std::is_sorted( bv_sort.begin(), bv_sort.end() ) );
+  BOOST_REQUIRE( std::is_sorted( bv_perm.begin(), bv_perm.end() ) );
+
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_sort.begin() ) );
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_perm.begin() ) );
+}
+
+/**
+ * Tests whether two arrays with randomly generated numbers are sorted
+ * correctly when sorting with Boost.
+ */
+BOOST_FIXTURE_TEST_CASE( test_boost_random, fill_bv_vec_random )
+{
+  // Making sure we are sorting with boost
+  static_assert( HAVE_BOOST, "Compiling Boost tests, but HAVE_BOOST!=1." );
+
+  sort( bv_sort, bv_perm );
+
+  BOOST_REQUIRE( std::is_sorted( bv_sort.begin(), bv_sort.end() ) );
+  BOOST_REQUIRE( std::is_sorted( bv_perm.begin(), bv_perm.end() ) );
+
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_sort.begin() ) );
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_perm.begin() ) );
 }
 
 /**
  * Tests whether two arrays with linearly increasing numbers are sorted
- * correctly by a single call to sort.
+ * correctly when sorting with Boost.
  */
-BOOST_AUTO_TEST_CASE( test_linear )
+BOOST_FIXTURE_TEST_CASE( test_boost_linear, fill_bv_vec_linear )
 {
-  const size_t N = 20000;
-  BlockVector< size_t > bv0( N );
-  BlockVector< size_t > bv1( N );
+  // Making sure we are sorting with boost
+  static_assert( HAVE_BOOST, "Compiling Boost tests, but HAVE_BOOST!=1." );
 
-  for ( size_t i = 0; i < N; ++i )
-  {
-    bv0[ i ] = N - i - 1;
-    bv1[ i ] = N - i - 1;
-  }
+  sort( bv_sort, bv_perm );
 
-  nest_quicksort( bv0, bv1 );
+  BOOST_REQUIRE( std::is_sorted( bv_sort.begin(), bv_sort.end() ) );
+  BOOST_REQUIRE( std::is_sorted( bv_perm.begin(), bv_perm.end() ) );
 
-  BOOST_REQUIRE( is_sorted( bv0.begin(), bv0.end() ) );
-  BOOST_REQUIRE( is_sorted( bv1.begin(), bv1.end() ) );
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_sort.begin() ) );
+  BOOST_REQUIRE( std::equal( vec_sort.begin(), vec_sort.end(), bv_perm.begin() ) );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Until Boost version 1.69.0, `spreadsort` used `std::sort` for small lists (<1000 elements). But with 1.69.0 and onward it uses `pdqsort` from the Boost library instead. Because the `pdqsort` algorithm uses some operators that neither `std::sort` nor `spreadsort` uses, and because of inadequacies in the `BlockVector` implementation, this caused lists to not be sorted.

When sorting with `spreadsort` from the Boost library, iterators for the `BlockVector` to be sorted and the `BlockVector` on which the same operations are performed, are combined. The combination is implemented with the `IteratorPair` iterator, which uses `iterator_facade` from the Boost library. The `iterator_facade` uses a few core functions to infer operators of the iterator. 

The problem arose when `pdqsort` used the operator `operator-=()`. In `IteratorPair`, that operator is inferred from the function
```c++
advance( n ) 
{ 
  sort_iter_ += n; 
  perm_iter_ += n; 
} 
```
Where `sort_iter_` and `perm_iter_` are iterators for the two `BlockVector`s. However, for `operator-=()`, `advance(n)` is called with a negative `n`. The iterator of `BlockVector` didn't take into consideration that its `operator+=(n)` could be called with a negative `n`. This PR improves them to take that into consideration, solving the problem.

In addition, this PR 
- adds additional C++ tests of `BlockVector`
- switches to the single header variant for Boost tests, so that NEST can be installed with Boost without static libraries
- moves to the latest Boost version (1.72.0) on Travis

---

Fixes #1489 
Fixes #1239 