### PR TITLE
Only include audio backend header in MyModule if library support is detected

### DIFF
--- a/examples/MyModule/mymodule.cpp
+++ b/examples/MyModule/mymodule.cpp
@@ -29,7 +29,9 @@
 #include "drop_odd_spike_connection.h"
 #include "pif_psc_alpha.h"
 #include "step_pattern_builder.h"
+#ifdef HAVE_SFML_AUDIO
 #include "recording_backend_soundclick.h"
+#endif
 #include "recording_backend_socket.h"
 
 // Includes from nestkernel:


### PR DESCRIPTION
Fixes #1479  
Fixes #1494 