### PR TITLE
Fix broken "Network models" link

### DIFF
--- a/doc/guides/spatial/index.rst
+++ b/doc/guides/spatial/index.rst
@@ -9,7 +9,7 @@ Here you can find how to build complex, layered networks in NEST.
   This module is removed in NEST 3.0, and all functionality of topology
   is now in the main ``nest`` module.
 
-  See the :doc:`guide to NEST 3.0 <../from_nest2_to_nest3>` for more information.
+  See the :doc:`../nest2_to_nest3/nest2_to_nest3_detailed_transition_guide` for more information.
 
 * If you've never used spatially-structured networks before,  we recommend you
   check out our :doc:`PyNEST tutorial on the topic <../../tutorials/pynest_tutorial/part_4_spatially_structured_networks>`

--- a/doc/models/index.rst
+++ b/doc/models/index.rst
@@ -40,8 +40,7 @@ on Github for you to check out.
 
 * **Network models**
 
-     * :doc:`../topology/index`
-
+     * :doc:`../guides/spatial/index`
 
 * :doc:`create_model`
 

--- a/doc/ref_material/pynest_apis.rst
+++ b/doc/ref_material/pynest_apis.rst
@@ -48,7 +48,7 @@ Functions related to spatially distributed nodes
 
 .. note::
 
- This used to be the topology module, which was integrated into nest in 3.0
+ This used to be a separate topology module. Now, it is integrated into NEST 3.0.
 
 .. automodule:: nest.lib.hl_api_spatial
     :members:


### PR DESCRIPTION
This PR includes a few minor fixes: 

- Updates broken "Network models" link: https://nest-simulator.readthedocs.io/en/latest/models/index.html
- Fixes transition guide link
- Rewords note about topology module