### PR TITLE
Fix NodeCollection fingerprint

### DIFF
--- a/nestkernel/kernel_manager.cpp
+++ b/nestkernel/kernel_manager.cpp
@@ -88,8 +88,6 @@ nest::KernelManager::initialize()
     m->initialize();
   }
 
-  fingerprint_ = std::clock();
-
   ++fingerprint_;
 
   initialized_ = true;

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -332,7 +332,7 @@ public:
   virtual long find( const index ) const = 0;
 
 private:
-  unsigned long fingerprint_; //!< Unique identity of the kernel that created the //!< NodeCollection
+  unsigned long fingerprint_; //!< Unique identity of the kernel that created the NodeCollection
   static NodeCollectionPTR create_();
   static NodeCollectionPTR create_( const std::vector< index >& );
 };


### PR DESCRIPTION
NodeCollections use fingerprint to check if they are valid. Some time ago we moved from using `std::clock()` as fingerprint to using a simple counter. However `std::clock()` has somehow snuck back in, probably with some merge, which may cause issues on some systems. This PR removes the `std::clock()` again.

Possibly related to #1520.