### PR TITLE
Drop Python2 support: adjust Travis packages list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,12 +86,12 @@ addons:
      - libreadline6-dev
      - libncurses5-dev
      - libgsl0-dev
-     - python-all-dev
-     - ipython
+     - python3-all-dev
+     - ipython3
      - pkg-config
      - openmpi-bin
      - libopenmpi-dev
-     - python-nose
+     - python3-nose
      - libpcre3
      - libpcre3-dev
      - llvm-3.6-dev
@@ -103,7 +103,7 @@ addons:
      - libboost-python-dev
      - libboost-program-options-dev
      - libboost-test-dev
-     - python-mpi4py
+     - python3-mpi4py
 cache:
    directory:
      - $HOME/.cache


### PR DESCRIPTION
This PR is an addition to #1507 and adjusts the list of packages installed on Travis.
Note: It seems the Boost still has some Python2 dependencies and there is no Python3 equivalent for libboost-python-dev. 