### PR TITLE
Update MUSIC tutorial

### DIFF
--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -17,6 +17,7 @@ Tutorials
 
    music_tutorial/music_tutorial_1
    music_tutorial/music_tutorial_2
+   music_tutorial/music_tutorial_sli
    music_tutorial/music_tutorial_3
    music_tutorial/music_tutorial_4
    music_tutorial/music_tutorial_tips

--- a/doc/tutorials/music_tutorial/music_tutorial_1.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_1.rst
@@ -14,7 +14,7 @@ and NEST is configured properly.
 
 Please install MUSIC using the instructions on `the MUSIC website <https://github.com/INCF/MUSIC>`_.
 
-In the install of NEST, you need to add the following configuration option to
+In the installation of NEST, you need to add the following configuration option to
 your cmake.
 
 .. code-block:: sh
@@ -47,8 +47,6 @@ constructs.
 While the focus here is on MUSIC, we need to know a few things about how
 NEST works in order to understand how MUSIC interacts with it.
 
-Go straight to part 1 of tutorial - connect 2 simulations using PyNEST
-
 The Basics of NEST
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -58,7 +56,7 @@ and connections between them.
 Neurons are the basic building blocks, and in NEST they are generally
 spiking point neuron models. Devices are supporting units that for
 instance generate inputs to neurons or record data from them. The
-Poisson spike generator, the spike detector recording device and the
+poisson spike generator, the spike detector recording device, and the
 MUSIC input and output proxies are all devices. Neurons and devices are
 collectively called nodes, and are connected using connections.
 

--- a/doc/tutorials/music_tutorial/music_tutorial_1.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_1.rst
@@ -56,7 +56,7 @@ and connections between them.
 Neurons are the basic building blocks, and in NEST they are generally
 spiking point neuron models. Devices are supporting units that for
 instance generate inputs to neurons or record data from them. The
-poisson spike generator, the spike detector recording device, and the
+Poisson spike generator, the spike detector recording device, and the
 MUSIC input and output proxies are all devices. Neurons and devices are
 collectively called nodes, and are connected using connections.
 

--- a/doc/tutorials/music_tutorial/music_tutorial_1.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_1.rst
@@ -15,7 +15,7 @@ and NEST is configured properly.
 Please install MUSIC using the instructions on `the MUSIC website <https://github.com/INCF/MUSIC>`_.
 
 In the installation of NEST, you need to add the following configuration option to
-your cmake.
+your CMake.
 
 .. code-block:: sh
 

--- a/doc/tutorials/music_tutorial/music_tutorial_1.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_1.rst
@@ -1,5 +1,5 @@
 Introduction to the MUSIC Interface
-=====================================
+===================================
 
 The `MUSIC interface <http://software.incf.org/software/music>`_, a
 standard by the INCF, allows the transmission of data between applications
@@ -24,7 +24,7 @@ your cmake.
     make install
 
 A Quick Introduction to NEST and MUSIC
----------------------------------------
+--------------------------------------
 
 In this tutorial, we will show you how to use the MUSIC library together
 with NEST. We will cover how to use the library from PyNEST and from the
@@ -48,7 +48,7 @@ While the focus here is on MUSIC, we need to know a few things about how
 NEST works in order to understand how MUSIC interacts with it.
 
 The Basics of NEST
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 A NEST network consists of three types of elements: neurons, devices,
 and connections between them.
@@ -161,7 +161,7 @@ from a port, then sends the appropriate channel inputs to each input
 proxy. These proxies each connect to the recipient neurons as above.
 
 Publication
--------------
+-----------
 
 Djurfeldt M. et al. 2010. Run-time interoperability between neuronal
 network simulators based on the music framework. Neuroinformatics.

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -22,7 +22,7 @@ called *send.py*.
 
     neurons = nest.Create('iaf_psc_alpha', 2, {'I_e': [400.0, 405.0]})
 
-    music_out = nest.Create('music_event_out_proxy', 1, params={'port_name':'p_out'})
+    music_out = nest.Create('music_event_out_proxy', 1, {'port_name':'p_out'})
 
     for i, neuron in enumerate(neurons):
         nest.Connect(neuron, music_out, "one_to_one", {'music_channel': i})

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -8,7 +8,7 @@ from :doc:`the introduction to this tutorial <music_tutorial_1>`.
 We need a sending process, a receiving process and a MUSIC
 configuration file.
 
-To try out the example, save the following sending process code in a python file
+To try out the example, save the following sending process code in a Python file
 called *send.py*.
 
 
@@ -239,4 +239,3 @@ did in our earlier python example. This is far more effective, and the
 outside process is not limited to the generators implemented in NEST but
 can create any kind of spiking input. In the next section we will take a
 look at how to do this.
-

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -20,7 +20,7 @@ called *send.py*.
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
 
-    neurons = nest.Create('iaf_psc_alpha', 2, params={'I_e': [400.0, 405.0]})
+    neurons = nest.Create('iaf_psc_alpha', 2, {'I_e': [400.0, 405.0]})
 
     music_out = nest.Create('music_event_out_proxy', 1, params={'port_name':'p_out'})
 

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -6,7 +6,10 @@ MUSIC. We’ll implement the simple network in :numref:`neuronmusic3`
 from :doc:`the introduction to this tutorial <music_tutorial_1>`.
 
 We need a sending process, a receiving process and a MUSIC
-configuration file:
+configuration file.
+
+To try out the example, save the following sending process code in a python file
+called *send.py*.
 
 
 .. code-block:: python
@@ -17,16 +20,15 @@ configuration file:
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
 
-    neurons = nest.Create('iaf_psc_alpha', 2, [{'I_e': 400.0}, {'I_e': 405.0}])
+    neurons = nest.Create('iaf_psc_alpha', 2, params={'I_e': [400.0, 405.0]})
 
-    music_out = nest.Create('music_event_out_proxy', 1,
-        params = {'port_name':'p_out'})
+    music_out = nest.Create('music_event_out_proxy', 1, params={'port_name':'p_out'})
 
-    for i, n in enumerate(neurons):
-        nest.Connect([n], music_out, "one_to_one",{'music_channel': i})
+    for i, neuron in enumerate(neurons):
+        nest.Connect(neuron, music_out, "one_to_one", {'music_channel': i})
 
     sdetector = nest.Create("spike_detector")
-    nest.SetStatus(sdetector, {"record_to": "ascii", "label": "send"})
+    sdetector.set(record_to="ascii", label="send")
 
     nest.Connect(neurons, sdetector)
 
@@ -37,13 +39,13 @@ and set a useful kernel parameter. On line 6, we create two simple
 intergrate-and-fire neuron models, one with a current input of 400mA,
 and one with 405mA, just so they will respond differently. If you use
 ipython to work interactively, you can check their current status
-dictionary with ``nest.GetStatus(neurons)``. The definitive
-documentation for NEST nodes is the header file, in this case
+dictionary with ``neurons.get()``. The definitive
+documentation for NEST models is the header file, in this case
 ``models/iaf_psc_alpha.h`` in the NEST source.
 
 We create a single ``music_event_out_proxy`` for our
 output on line 8, and set the port name. We loop over all the neurons on
-lines 11-20 and connect them to the proxy one by one, each one with a
+lines 10-11 and connect them to the proxy one by one, each one with a
 different output channel. As we saw earlier, each MUSIC port can have
 any number of channels. Since the proxy is a device, it ignores any
 weight or delay settings here.
@@ -53,6 +55,8 @@ have done directly in the ``Create`` call) and connect the
 neurons to the spike detector so we can see what we’re sending. Then we
 simulate for one second.
 
+For the receiving process script, *receive.py* we do:
+
 .. code-block:: python
     :linenos:
 
@@ -61,18 +65,16 @@ simulate for one second.
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
 
-    music_in = nest.Create("music_event_in_proxy", 2,
-        params = {'port_name': 'p_in'})
+    music_in = nest.Create("music_event_in_proxy", 2, params={'port_name': 'p_in'})
 
-    for i, n in enumerate(music_in):
-        nest.SetStatus([n], {'music_channel': i})
+    music_in.music_channel = [c for c in range(len(music_in))]
 
     nest.SetAcceptableLatency('p_in', 2.0)
 
     parrots = nest.Create("parrot_neuron", 2)
 
     sdetector = nest.Create("spike_detector")
-    nest.SetStatus(sdetector, {"record_to": ["ascii"], "label": "receive"})
+    sdetector.set(record_to="ascii", label="receive")
 
     nest.Connect(music_in, parrots, 'one_to_one', {"weight":1.0, "delay": 2.0})
     nest.Connect(parrots, sdetector)
@@ -81,33 +83,36 @@ simulate for one second.
 
 The receiving process follows the same logic, but is just a little more
 involved. We create two ``music_event_in_proxy`` — one
-per channel — on lines 6-7 and set the input port name. As we discussed
+per channel — on line 6 and set the input port name. As we discussed
 above, a NEST node can accept many inputs but only emit one stream of
 data, so we need one input proxy per channel to be able to distinguish
-the channels from each other. On lines 9-10 we set the input channel for
+the channels from each other. On line 8 we set the input channel for
 each input proxy.
 
-:doc:`The SetAcceptableLatency command <music_tutorial_setlatency>` on line 12 sets the
+:doc:`The SetAcceptableLatency command <music_tutorial_setlatency>` on line 10 sets the
 maximum time, in milliseconds, that MUSIC is allowed to delay delivery of spikes
 transmitted through the named port. This should never be more than the
 *minimum* of the delays from the input proxies to their targets; that’s
-the 2.0 ms we set on line 20 in our case.
+the 2.0 ms we set on line 10 in our case.
 
-On line 14 we create a set of :doc:`parrot neurons <music_tutorial_parrot>`.
-They simply repeat the input they’re given. On lines 16-18 we create and
+On line 12 we create a set of :doc:`parrot neurons <music_tutorial_parrot>`.
+They simply repeat the input they’re given. On lines 14-15 we create and
 configure a spike detector to save our inputs. We connect the input proxies
-one-to-one with the parrot neurons on line 20, then the parrot neurons to
-the spike detector on line 21. We will discuss the reasons for this in a moment.
+one-to-one with the parrot neurons on line 17, then the parrot neurons to
+the spike detector on line 18. We will discuss the reasons for this in a moment.
 Finally we simulate for one second.
+
+Lastly, we have the MUSIC configuration file *python.music*:
 
 .. code-block:: sh
 
-      binary=./send.py
-      np=2
+      [from]
+          binary=./send.py
+          np=2
 
       [to]
-      binary=./receive.py
-      np=2
+          binary=./receive.py
+          np=2
 
       from.p_out -> to.p_in [2]
 
@@ -156,7 +161,7 @@ We run the files together, and sort the output numerically
 look at the beginning of the two files side by side:
 
 
-.. code-block:: sh
+.. code-block::
 
     send.spikes                receive.spikes
 
@@ -171,7 +176,7 @@ look at the beginning of the two files side by side:
 
 As expected, the received spikes are two milliseconds later than the
 sent spikes. The delay parameter for the connection from the input
-proxies to the parrot neurons in ``receive.py`` on line 20
+proxies to the parrot neurons in ``receive.py`` on line 10
 accounts for the delay.
 
 Also — and it may be obvious in a simple model like this — the neuron
@@ -197,13 +202,13 @@ below:
     import nest
 
     mcip = nest.Create('music_cont_in_proxy')
-    nest.SetStatus(mcip, {'port_name' : 'contdata'})
+    mcip.port_name = 'contdata'
 
     time = 0
     while time < 1000:
         nest.Simulate (10)
-        data = nest.GetStatus (mcip, 'data')
-        print data
+        data = mcip.get('data')
+        print(data)
         time += 10
 
 The start mirrors our earlier receiving example: you create a continuous

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -65,7 +65,7 @@ For the receiving process script, *receive.py* we do:
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
 
-    music_in = nest.Create("music_event_in_proxy", 2, params={'port_name': 'p_in'})
+    music_in = nest.Create("music_event_in_proxy", 2, {'port_name': 'p_in'})
 
     music_in.music_channel = [c for c in range(len(music_in))]
 

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -1,5 +1,5 @@
 Connect two NEST simulations using MUSIC
-======================================================
+========================================
 
 Let’s look at an example of two NEST simulations connected through
 MUSIC. We’ll implement the simple network in :numref:`neuronmusic3`

--- a/doc/tutorials/music_tutorial/music_tutorial_3.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_3.rst
@@ -282,7 +282,7 @@ queue is empty we’re done and go back around the main loop again.
 Lastly we call ``runtime.finalize()`` as before.
 
 Building the Code
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 We have to build our ``C++`` code. The example code is
 already set up for the GNU Autotools, just to show how to do this for a

--- a/doc/tutorials/music_tutorial/music_tutorial_4.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_4.rst
@@ -100,7 +100,7 @@ C++.
 
 As the ``pymusic`` bindings are still quite new the
 documentation is still lagging behind. This quick introduction should
-nevertheless bee enough for you to get going with the bindings. And
+nevertheless be enough for you to get going with the bindings. And
 should you need further help, the authors are only an email away.
 
 

--- a/doc/tutorials/music_tutorial/music_tutorial_4.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_4.rst
@@ -100,7 +100,5 @@ C++.
 
 As the ``pymusic`` bindings are still quite new the
 documentation is still lagging behind. This quick introduction should
-nevertheless be enough for you to get going with the bindings. And
-should you need further help, the authors are only an email away.
-
+nevertheless be enough for you to get going with the bindings. Feel free to ask our `Mailing List <https://www.nest-initiative.org/mailinglist/>`_  if you need further help.
 

--- a/doc/tutorials/music_tutorial/music_tutorial_parrot.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_parrot.rst
@@ -1,7 +1,7 @@
 Those parrot neurons, or why you never connect devices to each other
 --------------------------------------------------------------------
 
-In ``receivesimple.py`` above, we used parrot neurons as
+In ``receive.py`` in :doc:`Part 2 of the MUSIC tutorial <music_tutorial_2>`, we used parrot neurons as
 target for the input proxies, then connected the spike detector to those
 neurons. Couldn’t we have connected the spike detector directly to the
 proxies?
@@ -13,7 +13,7 @@ simulation, but devices such as the spike detector and the MUSIC event
 handler are usually duplicated aross all nodes.
 
 When you connect a set of neurons to a spike detector, you normally
-don’t want all that spike data travel across the network to a single
+don’t want all that spike data to travel across the network to a single
 computing node where it gets saved. It would be very inefficient.
 Instead, the spike detector is duplicated on each node and each clone
 saves the data from its local neurons. In the same way, the MUSIC event
@@ -23,16 +23,16 @@ channels that its local targets request.
 But if you connect the input proxies directly to the spike detector,
 *all* channels have a local spike detector target on every computing
 node. We would get duplicate spike traces, one for each MPI process on
-the receiving side. To test this, replace line 21 in
+the receiving side. To test this, replace line 18 in
 ``receive.py`` with
 
 .. code-block:: python
 
     nest.Connect(music_in, sdetector)
 
-Run this simulation and you will notice that the
+Run this simulation and you will notice that
 ``receive-N-0.spikes`` and
-:math:``receive-N-1.spikes`` are now identical and about twice as
+``receive-N-1.spikes`` are now identical and about twice as
 big as before. Collate the input files and compare again:
 
 .. code-block::
@@ -56,9 +56,9 @@ applied anywhere along the path from the inputs to the outputs.
 
 The lesson is that you don’t connect two NEST devices to each other
 unless the documentation specifically tells you that you can. Always add
-a layer of normal neuron models, such as parrot neurons, in between.
+a layer of neuron models, such as parrot neurons, in between.
 This is true for devices in general of course, but this connection
 pattern, where you want to record the MUSIC input from another
-simulation, is so common that it’s worth warning for this.
+simulation, is so common that it’s worth warning about this.
 
 

--- a/doc/tutorials/music_tutorial/music_tutorial_sli.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_sli.rst
@@ -14,56 +14,58 @@ the scope of this tutorial. The code follows the same structure as the
 other examples, and should be straightforward to follow. But we will
 give a few pointers for how to connect things with MUSIC.
 
+The sli version of the sending process file from
+:doc:`Part 2 of the MUSIC tutorial <music_tutorial_2>`, *sender.sli*, is outlined
+below. Comments are prefixed with a “%”.
+
 ::
 
-    % create 2 neurons, get list of IDs. 
-    /iaf_neuron [2] LayoutNetwork /neuron_out_net Set
-    /neuron_out neuron_out_net GetGlobalNodes def
+    % create 2 neurons, get NodeCollection representing IDs.
+    /NUM_NEURONS 2 def
+    /iaf_psc_alpha NUM_NEURONS Create /neuron_out Set
 
-    % create output proxy. We use only one, so we use plain Create.
+    % create output proxy.
     /music_event_out_proxy << /port_name (p_out) >> Create /music_out Set
 
     % connect the neurons to the proxy, and give them a separate channel each
-    neuron_out {
-        /i Set /n Set
-        n music_out << /music_channel i >> Connect
-    } forallindexed
+    [NUM_NEURONS] Range
+    {
+        /index Set
+        neuron_out [index] Take music_out << /rule /one_to_one >> << /music_channel index 1 sub >> Connect
+    } forall
 
     1000.0 Simulate
 
-Comments are prefixed with a “%”. On line 2-3 we create two
-:math:`\texttt{iaf\_neuron}` in a subnet (nodes in SLI are organized in
-a tree-like fashion), save the subnet ID in
-:math:`\texttt{neuron\_out\_net}` then get an array of the neuron IDs in
-the subnet and save in :math:`\texttt{neuron\_out}`.
+On line 2-3 we create two `iaf_psc_alpha` in a NodeCollection and save it in `neuron_out`.
 
-What is the difference between :math:`\texttt{Set}` on line 2 and
-:math:`\texttt{def}` on line 3? Just the order of the arguments: with
-:math:`\texttt{Set}` you first give the object, then the name you want
-to associate with it. With :math:`\texttt{put}` you give the name first,
+The difference between ``def`` on line 2 and
+``Set`` on line 3 is the order of the arguments: with
+``Set`` you first give the object, then the name you want
+to associate with it. With ``def`` you give the name first,
 then the object.  Both are used extensively so you need to be aware
 of them.
 
 On line 6 we create a MUSIC output proxy with port name
-:math:`\texttt{p\_out}`. Dictionaries are bracketed with “<<” and “>>”,
+`p_out`. Dictionaries are bracketed with “<<” and “>>”,
 and strings are bracketed with parenthesis.
 
-On lines 9-12 we iterate over all neurons with index and store the index
-in “i” and the neuron ID in “n”. Then connect each one to the output
-proxy with its own music channel. Note that here we use
-:math:`\texttt{Set}` to assign the neuron ID and sequence on the stack
-to variables. We’d have to rotate the top stack elements if we wanted to
-use :math:`\texttt{put}`.
+On lines 9-13 we iterate over the range of all neurons and store the index
+in `index`. Then we connect each neuron in the NodeCollection to the output
+proxy with its own music channel. To get the individual node we use ``Take``.
+Note that we use ``Set`` to assign the index on the stack
+to a variable. We’d have to rotate the top stack elements if we wanted to
+use ``def``.
+
+For the receiving sli file, *receiver.sli*, we have:
 
 ::
 
-    % create 2 neurons, get list of IDs.
-    /music_event_in_proxy [2] LayoutNetwork /music_in_net Set
-    music_in_net GetGlobalNodes /music_in Set
+    % Create 2 MUSIC nodes, get NodeCollection representing IDs.
+    /NUM_NODES 2 def
+    /music_event_in_proxy NUM_NODES Create /music_in Set
 
-    % 2 parrot neurons.
-    /parrot_neuron [2] LayoutNetwork /parrot_in_net Set
-    parrot_in_net GetGlobalNodes /parrot_in Set
+    % Create 2 parrot neurons.
+    /parrot_neuron NUM_NODES Create /parrot_in Set
 
     % Create spike detector
     /spike_detector Create /sdetector Set
@@ -72,35 +74,46 @@ use :math:`\texttt{put}`.
     >> SetStatus
 
     % set port name and channel for all music input proxies.
-    music_in {
-        /i Set /m Set
-        m << /port_name (p_in) /music_channel i >> SetStatus
-    } forallindexed
+    music_in
+    {
+      /music_node Set
+      /channel music_node 1 sub def
+      music_node << /port_name (p_in) /music_channel channel >> SetStatus
+    } forall
 
     % set acceptable latency
     (p_in) 2.0 SetAcceptableLatency
 
     % connect music proxies to parrots, one to one
-    music_in {
-        /i Set /m Set
-        m parrot_in i get 1.0 2.0 Connect
-    } forallindexed
+    music_in parrot_in << /rule /one_to_one >> << /delay 2.0 >> Connect
 
-    parrot_in [sdetector]  Connect
+    parrot_in sdetector Connect
 
     1000.0 Simulate
 
 SLI, like PyNEST, has a specific function for setting the acceptable
-latency, as we do on line 23. In lines 26-29 we do one-on-one
-connections between the input proxies and the parrot neurons, and set
-the desired delay. We iterate over all music proxies, and for each proxy
-we get the corresponding element in the :math:`\texttt{parrot\_in}`
-array, then connect them with weight 1.0 and delay 2.0. You must give
-both parameters even though only the delay matters.
+latency, as we do on line 23. In line 26 we do a one-to-one
+connection between the input proxies and the parrot neurons, and set
+the desired delay.
+
+For the MUSIC configuration file we now need to use `binary=nest` to make it
+run with nest, and pass the correct files as arguments:
+
+.. code-block:: sh
+
+        [from]
+            binary=nest
+            np=2
+            args=send.sli
+
+        [to]
+            binary=nest
+            np=2
+            args=receive.sli
+
+        from.p_out -> to.p_in [2]
 
 For more information on using SLI, the browser based help we mentioned
-in the introduciton is quite helpful, but the best resource is the set
+in the introduction is quite helpful, but the best resource is the set
 of example models in the NEST source code distribution. That will show
 you many useful idioms and typical ways to accomplish common tasks.
-
-

--- a/doc/tutorials/music_tutorial/music_tutorial_sli.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_sli.rst
@@ -96,7 +96,7 @@ latency, as we do on line 23. In line 26 we do a one-to-one
 connection between the input proxies and the parrot neurons, and set
 the desired delay.
 
-For the MUSIC configuration file we now need to use `binary=nest` to make it
+For the MUSIC configuration file, we now need to use `binary=nest` to make it
 run with nest, and pass the correct files as arguments:
 
 .. code-block:: sh

--- a/doc/tutorials/music_tutorial/music_tutorial_sli.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_sli.rst
@@ -14,7 +14,7 @@ the scope of this tutorial. The code follows the same structure as the
 other examples, and should be straightforward to follow. But we will
 give a few pointers for how to connect things with MUSIC.
 
-The sli version of the sending process file from
+The SLI version of the sending process file from
 :doc:`Part 2 of the MUSIC tutorial <music_tutorial_2>`, *sender.sli*, is outlined
 below. Comments are prefixed with a “%”.
 

--- a/doc/tutorials/music_tutorial/music_tutorial_sli.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_sli.rst
@@ -56,7 +56,7 @@ Note that we use ``Set`` to assign the index on the stack
 to a variable. We’d have to rotate the top stack elements if we wanted to
 use ``def``.
 
-For the receiving sli file, *receiver.sli*, we have:
+For the receiving SLI file, *receiver.sli*, we have:
 
 ::
 

--- a/doc/tutorials/music_tutorial/music_tutorial_tips.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_tips.rst
@@ -44,7 +44,7 @@ Disable messages
 
     .. code:: python
 
-        nest.sli_run("M_ERROR setverbosity")
+        nest.set_verbosity("M_ERROR")
 
     There is unfortunately no straightforward way to suppress the
     initial welcome message. That is somewhat unfortunate, as they add


### PR DESCRIPTION
This PR updates the MUSIC tutorial for ReadTheDocs. I have updated the code snippets to work with NEST 3.0 and updated the text in a few places to fit with the changes as well.

`music_tutorial_sli.rst` was not previously part of the tutorial on ReadTheDocs, you could search for it and find it, but it was not part of the index. I don't know if this was deliberate? I placed it between part 2 and 3 of the tutorial, because part 2 is about MUSIC connected to NEST, and part 3+4 are about MUSIC C++ and Python interfaces. But let me know if I should remove it again.

I am also wondering if part 2 and 3 are relevant for the NEST documentation? 
I have read through these quickly, but it would be great if someone else could have a closer look.

Also, I am not getting MUSIC to work at the moment, so I have not tested that the code snippets work properly. I know the NEST code runs (until simulation, where I get a MUSIC error), but I have not been able to test that the MUSIC configuration file works. This is particularly important for lines [102-114 in `music_tutorial_sli.rst`](https://github.com/nest/nest-simulator/pull/1552/files#diff-5e27bcba41f3596e8a5cdaa64492a5a2R102-R114), because I added the code for the configuration. So I suggest @jougs should have a close look here.

This fixes #1495 .