### PR TITLE
Replace Python 3.6 f-strings to achieve Python 3.5 compatibility

### DIFF
--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -72,10 +72,11 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, connect_np_arr
                     if rule == 'one_to_one':
                         if value.shape[0] != prelength:
                             if connect_np_arrays:
-                                raise kernel.NESTError(f"'{key}' has to be an array of dimension {str(prelength)}.")
+                                raise kernel.NESTError("'" + key + "' has to be an array of dimension " +
+                                                       str(prelength) + ".")
                             else:
-                                raise kernel.NESTError(f"'{key}' has to be an array of dimension {str(prelength)},"
-                                                       " a scalar or a dictionary.")
+                                raise kernel.NESTError("'" + key + "' has to be an array of dimension " +
+                                                       str(prelength) + ", a scalar or a dictionary.")
                         else:
                             syn_spec[key] = value
                     elif rule == 'fixed_total_number':


### PR DESCRIPTION
There were only two occurrences of Python 3.6+ f-string formatting. As we want to maintain Python 3.5 compatibility at least while 3.5 is officially supported, I have replaced the f-string formatting with good old concatenation (this seems to be the pattern grepping for NESTError exceptions).