### PR TITLE
Add missing initialiser in copy constructor for stdp_nn_pre-centered_connection

### DIFF
--- a/models/stdp_nn_pre-centered_connection.h
+++ b/models/stdp_nn_pre-centered_connection.h
@@ -322,6 +322,7 @@ STDPNNPreCenteredConnection< targetidentifierT >::STDPNNPreCenteredConnection(
   , mu_plus_( rhs.mu_plus_ )
   , mu_minus_( rhs.mu_minus_ )
   , Wmax_( rhs.Wmax_ )
+  , Kplus_( rhs.Kplus_ )
   , t_lastspike_( rhs.t_lastspike_ )
 {
 }


### PR DESCRIPTION
This fixes #1435.

@jasperalbers This should also go into 2.20.1.