### PR TITLE
Silence startup

### DIFF
--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -423,12 +423,6 @@ ModelManager::connector_requires_clopath_archiving( const synindex syn_id ) cons
 void
 ModelManager::clear_models_( bool called_from_destructor )
 {
-  // no message on destructor call, may come after MPI_Finalize()
-  if ( not called_from_destructor )
-  {
-    LOG( M_INFO, "ModelManager::clear_models_", "Models will be cleared and parameters reset." );
-  }
-
   // We delete all models, which will also delete all nodes. The
   // built-in models will be recovered from the pristine_models_ in
   // init()

--- a/nestkernel/rng_manager.cpp
+++ b/nestkernel/rng_manager.cpp
@@ -228,7 +228,7 @@ nest::RNGManager::create_rngs_()
 
       if ( not rng )
       {
-        throw KernelException("Error initializing knuthlfg");
+        throw KernelException( "Error initializing knuthlfg" );
       }
 
       rng_.push_back( rng );

--- a/nestkernel/rng_manager.cpp
+++ b/nestkernel/rng_manager.cpp
@@ -200,12 +200,8 @@ nest::RNGManager::create_rngs_()
   // shared_ptrs, we don't have to worry about deletion
   if ( not rng_.empty() )
   {
-    LOG( M_INFO, "Network::create_rngs_", "Deleting existing random number generators" );
-
     rng_.clear();
   }
-
-  LOG( M_INFO, "Network::create_rngs_", "Creating default RNGs" );
 
   rng_seeds_.resize( kernel().vp_manager.get_num_virtual_processes() );
 
@@ -232,9 +228,7 @@ nest::RNGManager::create_rngs_()
 
       if ( not rng )
       {
-        LOG( M_ERROR, "Network::create_rngs_", "Error initializing knuthlfg" );
-
-        throw KernelException();
+        throw KernelException("Error initializing knuthlfg");
       }
 
       rng_.push_back( rng );


### PR DESCRIPTION
This removes the none-silencable output from `ModelManager` and `RandomManager` at simulator startup and upon calls to `ResetKernel` and thereby fixes #700 and fixes #415. They were non-silencable because they were printed before the user-set verbosity is taken into account.

As pointed out by @heplesser below, another solution would have been to degrade the verbosity of the messages in question to something less than the default level. However, this would have led to a resurfacing of the issue if default level were changed.