### PR TITLE
Add documentation on converting from PSC to PSP

### DIFF
--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -98,6 +98,23 @@ receptor_type 1, in contrast, is filtered through an exponential
 kernel with the time constant of the excitatory synapse,
 tau_syn_ex. For an example application, see [4]_.
 
+The time course of the postsynaptic potential ``v`` is computed as
+    :math: `v(t)=(i*h)(t)`
+    with the exponential postsynaptic current
+    :math:`i(t)=J\mathrm{e}^{-t/\tau_\mathrm{syn}}\Theta (t)`,
+    the voltage impulse response
+    :math:`h(t)=\frac{1}{\tau_\mathrm{m}}\mathrm{e}^{-t/\tau_\mathrm{m}}\Theta (t)`,
+    and
+    :math:`\Theta(t)=1` if :math:`t\leq 0` and zero otherwise.
+
+    The ``PSP`` is considered as the maximum of ``v``, i.e., it is
+    computed by setting the derivative of ``v(t)`` to zero.
+    The expression for the time point at which ``v`` reaches its maximum
+    can be found in Eq. 5 of [1]_.
+
+    The amplitude of the postsynaptic current ``J`` corresponds to the
+    synaptic weight ``PSC``.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -110,10 +110,10 @@ and
 The ``PSP`` is considered as the maximum of ``v``, i.e., it is
 computed by setting the derivative of ``v(t)`` to zero.
 The expression for the time point at which ``v`` reaches its maximum
-can be found in Eq. 5 of [1]_.
+can be found in Eq. 5 of [5]_.
 
 The amplitude of the postsynaptic current ``J`` corresponds to the
-synaptic weight ``PSC`` [5]_.
+synaptic weight ``PSC``.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -99,7 +99,7 @@ kernel with the time constant of the excitatory synapse,
 tau_syn_ex. For an example application, see [4]_.
 
 The time course of the postsynaptic potential ``v`` is computed as
-:math: `v(t)=(i*h)(t)`
+:math:`v(t)=(i*h)(t)`
 with the exponential postsynaptic current
 :math:`i(t)=J\mathrm{e}^{-t/\tau_\mathrm{syn}}\Theta (t)`,
 the voltage impulse response

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -113,7 +113,7 @@ The time course of the postsynaptic potential ``v`` is computed as
     can be found in Eq. 5 of [1]_.
 
     The amplitude of the postsynaptic current ``J`` corresponds to the
-    synaptic weight ``PSC``.
+    synaptic weight ``PSC`` [5]_.
 
 Parameters
 ++++++++++
@@ -151,6 +151,11 @@ References
 .. [4] Schuecker J, Diesmann M, Helias M (2015). Modulated escape from a
        metastable state driven by colored noise. Physical Review E 92:052119
        DOI: https://doi.org/10.1103/PhysRevE.92.052119
+.. [5] Hanuschkin A, Kunkel S, Helias M, Morrison A and Diesmann M (2010)
+       A general and efficient method for incorporating precise spike times
+       in globally time-driven simulations.
+       Front. Neuroinform. 4:113.
+       DOI: https://doi.org/10.3389/fninf.2010.00113
 
 Sends
 +++++

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -99,21 +99,21 @@ kernel with the time constant of the excitatory synapse,
 tau_syn_ex. For an example application, see [4]_.
 
 The time course of the postsynaptic potential ``v`` is computed as
-    :math: `v(t)=(i*h)(t)`
-    with the exponential postsynaptic current
-    :math:`i(t)=J\mathrm{e}^{-t/\tau_\mathrm{syn}}\Theta (t)`,
-    the voltage impulse response
-    :math:`h(t)=\frac{1}{\tau_\mathrm{m}}\mathrm{e}^{-t/\tau_\mathrm{m}}\Theta (t)`,
-    and
-    :math:`\Theta(t)=1` if :math:`t\leq 0` and zero otherwise.
+:math: `v(t)=(i*h)(t)`
+with the exponential postsynaptic current
+:math:`i(t)=J\mathrm{e}^{-t/\tau_\mathrm{syn}}\Theta (t)`,
+the voltage impulse response
+:math:`h(t)=\frac{1}{\tau_\mathrm{m}}\mathrm{e}^{-t/\tau_\mathrm{m}}\Theta (t)`,
+and
+:math:`\Theta(t)=1` if :math:`t\leq 0` and zero otherwise.
 
-    The ``PSP`` is considered as the maximum of ``v``, i.e., it is
-    computed by setting the derivative of ``v(t)`` to zero.
-    The expression for the time point at which ``v`` reaches its maximum
-    can be found in Eq. 5 of [1]_.
+The ``PSP`` is considered as the maximum of ``v``, i.e., it is
+computed by setting the derivative of ``v(t)`` to zero.
+The expression for the time point at which ``v`` reaches its maximum
+can be found in Eq. 5 of [1]_.
 
-    The amplitude of the postsynaptic current ``J`` corresponds to the
-    synaptic weight ``PSC`` [5]_.
+The amplitude of the postsynaptic current ``J`` corresponds to the
+synaptic weight ``PSC`` [5]_.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -101,7 +101,7 @@ tau_syn_ex. For an example application, see [4]_.
 
 For conversion between postsynaptic potentials (PSPs) and PSCs,
 please refer to the ``postsynaptic_potential_to_current`` function in
-:doc:`helpers.py <../auto_examples/Potjans_2014/helpers>`.
+:doc:`PyNEST Microcircuit: Helper Functions <../auto_examples/Potjans_2014/helpers>`.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -98,6 +98,8 @@ receptor_type 1, in contrast, is filtered through an exponential
 kernel with the time constant of the excitatory synapse,
 tau_syn_ex. For an example application, see [4]_.
 
+Conversion from PSC to PSP:
+
 The time course of the postsynaptic potential ``v`` is computed as
 :math:`v(t)=(i*h)(t)`
 with the exponential postsynaptic current

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -98,24 +98,9 @@ receptor_type 1, in contrast, is filtered through an exponential
 kernel with the time constant of the excitatory synapse,
 tau_syn_ex. For an example application, see [4]_.
 
-Conversion from PSC to PSP:
-
-The time course of the postsynaptic potential ``v`` is computed as
-:math:`v(t)=(i*h)(t)`
-with the exponential postsynaptic current
-:math:`i(t)=J\mathrm{e}^{-t/\tau_\mathrm{syn}}\Theta (t)`,
-the voltage impulse response
-:math:`h(t)=\frac{1}{\tau_\mathrm{m}}\mathrm{e}^{-t/\tau_\mathrm{m}}\Theta (t)`,
-and
-:math:`\Theta(t)=1` if :math:`t\leq 0` and zero otherwise.
-
-The ``PSP`` is considered as the maximum of ``v``, i.e., it is
-computed by setting the derivative of ``v(t)`` to zero.
-The expression for the time point at which ``v`` reaches its maximum
-can be found in Eq. 5 of [5]_.
-
-The amplitude of the postsynaptic current ``J`` corresponds to the
-synaptic weight ``PSC``.
+For conversion between postsynaptic potentials (PSPs) and PSCs,
+please refer to the ``postsynaptic_potential_to_current`` function in
+:doc:`helpers.py <../auto_examples/Potjans_2014/helpers>`.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -87,8 +87,9 @@ matrix objects.
 If tau_m is very close to tau_syn_ex or tau_syn_in, the model
 will numerically behave as if tau_m is equal to tau_syn_ex or
 tau_syn_in, respectively, to avoid numerical instabilities.
-For details, please see IAF_neurons_singularity.ipynb in the
-NEST source code (docs/model_details).
+For details, you can check out the `IAF neurons singularity
+<https://github.com/nest/nest-simulator/blob/master/doc/model_details/IAF_neurons_singularity.ipynb>`_
+notebook in the NEST source code.
 
 iaf_psc_exp can handle current input in two ways: Current input
 through receptor_type 0 are handled as stepwise constant current

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -139,11 +139,6 @@ References
 .. [4] Schuecker J, Diesmann M, Helias M (2015). Modulated escape from a
        metastable state driven by colored noise. Physical Review E 92:052119
        DOI: https://doi.org/10.1103/PhysRevE.92.052119
-.. [5] Hanuschkin A, Kunkel S, Helias M, Morrison A and Diesmann M (2010)
-       A general and efficient method for incorporating precise spike times
-       in globally time-driven simulations.
-       Front. Neuroinform. 4:113.
-       DOI: https://doi.org/10.3389/fninf.2010.00113
 
 Sends
 +++++

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -89,8 +89,11 @@ matrix objects.
 If tau_m is very close to tau_syn_ex or tau_syn_in, the model
 will numerically behave as if tau_m is equal to tau_syn_ex or
 tau_syn_in, respectively, to avoid numerical instabilities.
-For details, please see IAF_neurons_singularity.ipynb in
-the NEST source code (docs/model_details).
+For details, you can check out the `IAF_neurons_singularity.ipynb
+<https://github.com/nest/nest-simulator/blob/master/doc/model_details/IAF_neurons_singularity.ipynb>`_
+in the NEST source code.
+
+For converting from PSC to PSP, please refer to the :doc:`iaf_psc_exp <iaf_psc_exp>` documentation.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -89,9 +89,9 @@ matrix objects.
 If tau_m is very close to tau_syn_ex or tau_syn_in, the model
 will numerically behave as if tau_m is equal to tau_syn_ex or
 tau_syn_in, respectively, to avoid numerical instabilities.
-For details, you can check out the `IAF_neurons_singularity.ipynb
+For details, you can check out the `IAF neurons singularity
 <https://github.com/nest/nest-simulator/blob/master/doc/model_details/IAF_neurons_singularity.ipynb>`_
-in the NEST source code.
+notebook in the NEST source code.
 
 For converting from PSC to PSP, please refer to the :doc:`iaf_psc_exp <iaf_psc_exp>` documentation.
 

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -93,7 +93,9 @@ For details, you can check out the `IAF neurons singularity
 <https://github.com/nest/nest-simulator/blob/master/doc/model_details/IAF_neurons_singularity.ipynb>`_
 notebook in the NEST source code.
 
-For converting from PSC to PSP, please refer to the :doc:`iaf_psc_exp <iaf_psc_exp>` documentation.
+For conversion between postsynaptic potentials (PSPs) and PSCs,
+please refer to the ``postsynaptic_potential_to_current`` function in
+:doc:`PyNEST Microcircuit: Helper Functions <../auto_examples/Potjans_2014/helpers>`.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -69,7 +69,7 @@ equation represents a piecewise constant external current.
 
 The general framework for the consistent formulation of systems with
 neuron like dynamics interacting by point events is described in
-[2]_. A flow chart can be found in [3].
+[2]_. A flow chart can be found in [3]_.
 
 Remarks:
 

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -56,7 +56,11 @@ This can be reached by specifying separate receptor ports, each for
 a different time constant. The port number has to match the respective
 "receptor_type" in the connectors.
 
-For converting from PSC to PSP, please refer to the :doc:`iaf_psc_exp <iaf_psc_exp>` documentation.
+Remarks:
+
+For conversion between postsynaptic potentials (PSPs) and PSCs,
+please refer to the ``postsynaptic_potential_to_current`` function in
+:doc:`PyNEST Microcircuit: Helper Functions <../auto_examples/Potjans_2014/helpers>`.
 
 Sends
 +++++

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -56,6 +56,8 @@ This can be reached by specifying separate receptor ports, each for
 a different time constant. The port number has to match the respective
 "receptor_type" in the connectors.
 
+For converting from PSC to PSP, please refer to the :doc:`iaf_psc_exp <iaf_psc_exp>` documentation.
+
 Sends
 +++++
 

--- a/pynest/examples/Potjans_2014/helpers.py
+++ b/pynest/examples/Potjans_2014/helpers.py
@@ -72,7 +72,7 @@ def postsynaptic_potential_to_current(C_m, tau_m, tau_syn):
     the voltage impulse response
     :math:`h(t)=\frac{1}{\tau_\mathrm{m}}\mathrm{e}^{-t/\tau_\mathrm{m}}\Theta (t)`,
     and
-    :math:`\Theta(t)=1` if :math:`t\leq 0` and zero otherwise.
+    :math:`\Theta(t)=1` if :math:`t\qeq 0` and zero otherwise.
 
     The ``PSP`` is considered as the maximum of ``v``, i.e., it is
     computed by setting the derivative of ``v(t)`` to zero.

--- a/pynest/examples/Potjans_2014/helpers.py
+++ b/pynest/examples/Potjans_2014/helpers.py
@@ -72,7 +72,7 @@ def postsynaptic_potential_to_current(C_m, tau_m, tau_syn):
     the voltage impulse response
     :math:`h(t)=\frac{1}{\tau_\mathrm{m}}\mathrm{e}^{-t/\tau_\mathrm{m}}\Theta (t)`,
     and
-    :math:`\Theta(t)=1` if :math:`t\qeq 0` and zero otherwise.
+    :math:`\Theta(t)=1` if :math:`t\geq 0` and zero otherwise.
 
     The ``PSP`` is considered as the maximum of ``v``, i.e., it is
     computed by setting the derivative of ``v(t)`` to zero.


### PR DESCRIPTION
This PR adds a section on converting from PSC to PSP to the ``iaf_psc_exp`` models' documentation, as discussed with @jhnnsnk.

More specifically, it: 

- Integrates the [relevant documentation](https://github.com/nest/nest-simulator/blob/master/pynest/examples/Potjans_2014/helpers.py#L68) into ``iaf_psc_exp.h``
- Adds the Hanuschkin et al. (2010) reference underneath
- Directs users of other ``iaf_psc_exp`` models to this conversion documentation

Open questions: 

- Should the "Conversion from PSC to PSP" title be turned into a Level 3 heading in a separate PR? @jougs mentioned that a different PR will soon do the same with all the "Remarks". 

It fixes #1590.