### PR TITLE
Systematize error messages for Connect failures

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -146,7 +146,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
     {
       throw BadProperty(
         "In order to use structural plasticity, both a pre and post synaptic "
-        "element must be specified" );
+        "element must be specified." );
     }
 
     use_pre_synaptic_element_ = false;
@@ -239,7 +239,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
   {
     throw KernelException(
       "InvalidNodeCollection: "
-      "sources and targets must be valid NodeCollections" );
+      "sources and targets must be valid NodeCollections." );
   }
 }
 
@@ -1386,7 +1386,7 @@ nest::FixedTotalNumberBuilder::FixedTotalNumberBuilder( NodeCollectionPTR source
     {
       throw BadProperty(
         "Total number of connections cannot exceed product "
-        "of source and targer population sizes." );
+        "of source and target population sizes." );
     }
   }
 
@@ -1831,7 +1831,7 @@ nest::SPBuilder::SPBuilder( NodeCollectionPTR sources,
   // Check that both pre and post synaptic element are provided
   if ( not use_pre_synaptic_element_ or not use_post_synaptic_element_ )
   {
-    throw BadProperty( "pre_synaptic_element and/or post_synaptic_elements is missing" );
+    throw BadProperty( "pre_synaptic_element and/or post_synaptic_elements is missing." );
   }
 }
 
@@ -1866,7 +1866,7 @@ nest::SPBuilder::connect_()
 {
   throw NotImplemented(
     "Connection without structural plasticity is not possible for this "
-    "connection builder" );
+    "connection builder." );
 }
 
 /**
@@ -1879,7 +1879,7 @@ nest::SPBuilder::connect_( NodeCollectionPTR sources, NodeCollectionPTR targets 
 {
   throw NotImplemented(
     "Connection without structural plasticity is not possible for this "
-    "connection builder" );
+    "connection builder." );
 }
 
 void
@@ -1889,8 +1889,7 @@ nest::SPBuilder::connect_( const std::vector< index >& sources, const std::vecto
   // make sure that target and source population have the same size
   if ( sources.size() != targets.size() )
   {
-    LOG( M_ERROR, "Connect", "Source and Target population must be of the same size." );
-    throw DimensionMismatch();
+    throw DimensionMismatch( "Source and Target population must be of the same size." );
   }
 
 #pragma omp parallel

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -145,8 +145,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
     if ( syn_spec->known( names::pre_synaptic_element ) or syn_spec->known( names::post_synaptic_element ) )
     {
       throw BadProperty(
-        "In order to use structural plasticity, both a pre and post synaptic "
-        "element must be specified." );
+        "In order to use structural plasticity, both a pre and post synaptic element must be specified." );
     }
 
     use_pre_synaptic_element_ = false;
@@ -237,9 +236,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
 
   if ( not( sources_->valid() and targets_->valid() ) )
   {
-    throw KernelException(
-      "InvalidNodeCollection: "
-      "sources and targets must be valid NodeCollections." );
+    throw KernelException( "InvalidNodeCollection: sources and targets must be valid NodeCollections." );
   }
 }
 
@@ -336,9 +333,7 @@ nest::ConnBuilder::connect()
   {
     if ( make_symmetric_ )
     {
-      throw NotImplemented(
-        "Symmetric connections are not supported in combination with "
-        "structural plasticity." );
+      throw NotImplemented( "Symmetric connections are not supported in combination with structural plasticity." );
     }
     sp_connect_();
   }
@@ -409,9 +404,7 @@ nest::ConnBuilder::single_connect_( index snode_id, Node& target, thread target_
 {
   if ( this->requires_proxies() and not target.has_proxies() )
   {
-    throw IllegalConnection(
-      "Cannot use this rule to connect to nodes"
-      " without proxies (usually devices)." );
+    throw IllegalConnection( "Cannot use this rule to connect to nodes without proxies (usually devices)." );
   }
 
   if ( param_dicts_.empty() ) // indicates we have no synapse params
@@ -1103,8 +1096,7 @@ nest::FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
         LOG( M_WARNING,
           "FixedInDegreeBuilder::connect",
           "Multapses and autapses prohibited. When the sources and the targets "
-          "have a non-empty "
-          "intersection, the connect algorithm will enter an infinite loop." );
+          "have a non-empty intersection, the connect algorithm will enter an infinite loop." );
         return;
       }
 
@@ -1112,9 +1104,7 @@ nest::FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
       {
         LOG( M_WARNING,
           "FixedInDegreeBuilder::connect",
-          "Multapses are prohibited and you request more than 90% "
-          "connectivity. "
-          "Expect long connecting times!" );
+          "Multapses are prohibited and you request more than 90% connectivity. Expect long connecting times!" );
       }
     } // if (not allow_multapses_ )
 
@@ -1273,8 +1263,7 @@ nest::FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
         LOG( M_WARNING,
           "FixedOutDegreeBuilder::connect",
           "Multapses and autapses prohibited. When the sources and the targets "
-          "have a non-empty "
-          "intersection, the connect algorithm will enter an infinite loop." );
+          "have a non-empty intersection, the connect algorithm will enter an infinite loop." );
         return;
       }
 
@@ -1282,9 +1271,7 @@ nest::FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
       {
         LOG( M_WARNING,
           "FixedOutDegreeBuilder::connect",
-          "Multapses are prohibited and you request more than 90% "
-          "connectivity. "
-          "Expect long connecting times!" );
+          "Multapses are prohibited and you request more than 90% connectivity. Expect long connecting times!" );
       }
     }
 
@@ -1384,9 +1371,7 @@ nest::FixedTotalNumberBuilder::FixedTotalNumberBuilder( NodeCollectionPTR source
   {
     if ( ( N_ > static_cast< long >( sources_->size() * targets_->size() ) ) )
     {
-      throw BadProperty(
-        "Total number of connections cannot exceed product "
-        "of source and target population sizes." );
+      throw BadProperty( "Total number of connections cannot exceed product of source and target population sizes." );
     }
   }
 
@@ -1401,9 +1386,7 @@ nest::FixedTotalNumberBuilder::FixedTotalNumberBuilder( NodeCollectionPTR source
   // a bitmap
   if ( not allow_multapses_ )
   {
-    throw NotImplemented(
-      "Connect doesn't support the suppression of multapses in the "
-      "FixedTotalNumber connector." );
+    throw NotImplemented( "Connect doesn't support the suppression of multapses in the FixedTotalNumber connector." );
   }
 }
 
@@ -1864,9 +1847,7 @@ nest::SPBuilder::sp_connect( const std::vector< index >& sources, const std::vec
 void
 nest::SPBuilder::connect_()
 {
-  throw NotImplemented(
-    "Connection without structural plasticity is not possible for this "
-    "connection builder." );
+  throw NotImplemented( "Connection without structural plasticity is not possible for this connection builder." );
 }
 
 /**
@@ -1877,9 +1858,7 @@ nest::SPBuilder::connect_()
 void
 nest::SPBuilder::connect_( NodeCollectionPTR sources, NodeCollectionPTR targets )
 {
-  throw NotImplemented(
-    "Connection without structural plasticity is not possible for this "
-    "connection builder." );
+  throw NotImplemented( "Connection without structural plasticity is not possible for this connection builder." );
 }
 
 void

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -145,7 +145,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
     if ( syn_spec->known( names::pre_synaptic_element ) or syn_spec->known( names::post_synaptic_element ) )
     {
       throw BadProperty(
-        "In order to use structural plasticity, both a pre and post synaptic element must be specified." );
+        "Structural plasticity requires both a pre and post synaptic element." );
     }
 
     use_pre_synaptic_element_ = false;
@@ -1868,7 +1868,7 @@ nest::SPBuilder::connect_( const std::vector< index >& sources, const std::vecto
   // make sure that target and source population have the same size
   if ( sources.size() != targets.size() )
   {
-    throw DimensionMismatch( "Source and Target population must be of the same size." );
+    throw DimensionMismatch( "Source and target population must be of the same size." );
   }
 
 #pragma omp parallel

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -144,8 +144,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
   {
     if ( syn_spec->known( names::pre_synaptic_element ) or syn_spec->known( names::post_synaptic_element ) )
     {
-      throw BadProperty(
-        "Structural plasticity requires both a pre and post synaptic element." );
+      throw BadProperty( "Structural plasticity requires both a pre and post synaptic element." );
     }
 
     use_pre_synaptic_element_ = false;

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -127,17 +127,17 @@ protected:
   virtual void
   sp_connect_()
   {
-    throw NotImplemented( "This connection rule is not implemented for structural plasticity" );
+    throw NotImplemented( "This connection rule is not implemented for structural plasticity." );
   }
   virtual void
   disconnect_()
   {
-    throw NotImplemented( "This disconnection rule is not implemented" );
+    throw NotImplemented( "This disconnection rule is not implemented." );
   }
   virtual void
   sp_disconnect_()
   {
-    throw NotImplemented( "This connection rule is not implemented for structural plasticity" );
+    throw NotImplemented( "This connection rule is not implemented for structural plasticity." );
   }
 
   //! Create connection between given nodes, fill parameter values

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -399,8 +399,7 @@ Connection< targetidentifierT >::trigger_update_weight( const thread,
   const CommonSynapseProperties& )
 {
   throw IllegalConnection(
-    "Connection::trigger_update_weight: "
-    "Connection does not support updates that are triggered by the volume "
+    "Connection does not support updates that are triggered by a volume "
     "transmitter." );
 }
 

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -398,9 +398,7 @@ Connection< targetidentifierT >::trigger_update_weight( const thread,
   const double,
   const CommonSynapseProperties& )
 {
-  throw IllegalConnection(
-    "Connection does not support updates that are triggered by a volume "
-    "transmitter." );
+  throw IllegalConnection( "Connection does not support updates that are triggered by a volume transmitter." );
 }
 
 } // namespace nest

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1268,7 +1268,7 @@ nest::ConnectionManager::connection_required( Node*& source, Node*& target, thre
       return CONNECT;
     }
 
-    throw IllegalConnection( "We do not allow connection of a device to a global receiver at the moment" );
+    throw IllegalConnection( "We do not allow connection of a device to a global receiver at the moment." );
   }
 
   return NO_CONNECTION;

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -206,13 +206,14 @@ Node::wfr_update( Time const&, const long, const long )
 }
 
 /**
- * Default implementation of check_connection just throws UnexpectedEvent
+ * Default implementation of check_connection just throws IllegalConnection
  */
 port
 Node::send_test_event( Node&, rport, synindex, bool )
 {
-  throw UnexpectedEvent(
-    "Source node does not send output. Note that detectors need to be connected as Connect(neuron, detector)." );
+  throw IllegalConnection(
+    "Source node does not send output.\n"
+    "  Note that detectors must be connected as Connect(neuron, detector)." );
 }
 
 /**
@@ -290,9 +291,7 @@ Node::handle( DataLoggingRequest& )
 port
 Node::handles_test_event( DataLoggingRequest&, rport )
 {
-  throw IllegalConnection(
-    "Possible cause: only static synapse types may be used to connect "
-    "devices." );
+  throw IllegalConnection( "The target node or synapse model does not support data logging requests." );
 }
 
 void
@@ -322,23 +321,19 @@ Node::handle( DoubleDataEvent& )
 port
 Node::handles_test_event( DoubleDataEvent&, rport )
 {
-  throw IllegalConnection();
+  throw IllegalConnection( "The target node or synapse model does not support double data event." );
 }
 
 port
 Node::handles_test_event( DSSpikeEvent&, rport )
 {
-  throw IllegalConnection(
-    "Possible cause: only static synapse types may be used to connect "
-    "devices." );
+  throw IllegalConnection( "The target node or synapse model does not support spike input." );
 }
 
 port
 Node::handles_test_event( DSCurrentEvent&, rport )
 {
-  throw IllegalConnection(
-    "Possible cause: only static synapse types may be used to connect "
-    "devices." );
+  throw IllegalConnection( "The target node or synapse model does not support DC current input." );
 }
 
 void

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -213,7 +213,7 @@ Node::send_test_event( Node&, rport, synindex, bool )
 {
   throw IllegalConnection(
     "Source node does not send output.\n"
-    "  Note that detectors must be connected as Connect(neuron, detector)." );
+    "  Note that recorders must be connected as Connect(neuron, recorder)." );
 }
 
 /**
@@ -333,7 +333,7 @@ Node::handles_test_event( DSSpikeEvent&, rport )
 port
 Node::handles_test_event( DSCurrentEvent&, rport )
 {
-  throw IllegalConnection( "The target node or synapse model does not support DC current input." );
+  throw IllegalConnection( "The target node or synapse model does not support DS current input." );
 }
 
 void

--- a/nestkernel/universal_data_logger.h
+++ b/nestkernel/universal_data_logger.h
@@ -236,9 +236,7 @@ nest::UniversalDataLogger< HostNode >::connect_logging_device( const DataLogging
   // rports.
   if ( req.get_rport() != 0 )
   {
-    throw IllegalConnection(
-      "UniversalDataLogger::connect_logging_device(): "
-      "Connections from multimeter to node must request rport 0." );
+    throw IllegalConnection( "Connections from multimeter to node must request rport 0." );
   }
 
   // ensure that we have not connected this multimeter before
@@ -251,9 +249,7 @@ nest::UniversalDataLogger< HostNode >::connect_logging_device( const DataLogging
   }
   if ( j < n_loggers )
   {
-    throw IllegalConnection(
-      "UniversalDataLogger::connect_logging_device(): "
-      "Each multimeter can only be connected once to a given node." );
+    throw IllegalConnection( "Each multimeter can only be connected once to a given node." );
   }
 
   // we now know that we have no DataLogger_ for the given multimeter, so we
@@ -289,9 +285,7 @@ nest::UniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const DataLoggi
       // delete all access information again: the connect either succeeds
       // for all entries in recvars, or it fails, leaving the logger untouched
       node_access_.clear();
-      throw IllegalConnection(
-        "UniversalDataLogger::connect_logging_device(): "
-        "Unknown recordable " + recvars[ j ].toString() );
+      throw IllegalConnection( "Cannot connect with unknown recordable " + recvars[ j ].toString() );
     }
 
     node_access_.push_back( rec->second );
@@ -301,9 +295,7 @@ nest::UniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const DataLoggi
 
   if ( num_vars_ > 0 and req.get_recording_interval() < Time::step( 1 ) )
   {
-    throw IllegalConnection(
-      "UniversalDataLogger::connect_logging_device(): "
-      "recording interval must be >= resolution." );
+    throw IllegalConnection( "Recording interval must be >= resolution." );
   }
 
   recording_interval_ = req.get_recording_interval();
@@ -503,9 +495,7 @@ nest::DynamicUniversalDataLogger< HostNode >::connect_logging_device( const Data
   // rports.
   if ( req.get_rport() != 0 )
   {
-    throw IllegalConnection(
-      "DynamicUniversalDataLogger::connect_logging_device(): "
-      "Connections from multimeter to node must request rport 0." );
+    throw IllegalConnection( "Connections from multimeter to node must request rport 0." );
   }
 
   // ensure that we have not connected this multimeter before
@@ -518,9 +508,7 @@ nest::DynamicUniversalDataLogger< HostNode >::connect_logging_device( const Data
   }
   if ( j < n_loggers )
   {
-    throw IllegalConnection(
-      "DynamicUniversalDataLogger::connect_logging_device(): "
-      "Each multimeter can only be connected once to a given node." );
+    throw IllegalConnection( "Each multimeter can only be connected once to a given node." );
   }
 
   // we now know that we have no DataLogger_ for the given multimeter, so we
@@ -556,9 +544,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const Da
       // delete all access information again: the connect either succeeds
       // for all entries in recvars, or it fails, leaving the logger untouched
       node_access_.clear();
-      throw IllegalConnection(
-        "DynamicUniversalDataLogger::connect_logging_device(): "
-        "Unknown recordable " + recvars[ j ].toString() );
+      throw IllegalConnection( "Cannot connect with unknown recordable " + recvars[ j ].toString() );
     }
 
     node_access_.push_back( &( rec->second ) );
@@ -568,9 +554,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const Da
 
   if ( num_vars_ > 0 && req.get_recording_interval() < Time::step( 1 ) )
   {
-    throw IllegalConnection(
-      "DynamicUniversalDataLogger::connect_logging_device(): "
-      "recording interval must be >= resolution." );
+    throw IllegalConnection( "Recording interval must be >= resolution." );
   }
 
   recording_interval_ = req.get_recording_interval();

--- a/pynest/nest/tests/test_onetooneconnect.py
+++ b/pynest/nest/tests/test_onetooneconnect.py
@@ -31,11 +31,13 @@ import nest
 class OneToOneConnectTestCase(unittest.TestCase):
     """Tests of Connect with OneToOne pattern"""
 
+    def setUp(self):
+        nest.ResetKernel()
+
     def test_ConnectPrePost(self):
         """Connect pre to post"""
 
-        # Connect([pre], [post])
-        nest.ResetKernel()
+        # Connect(pre, post)
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
         nest.Connect(pre, post, "one_to_one")
@@ -46,8 +48,7 @@ class OneToOneConnectTestCase(unittest.TestCase):
     def test_ConnectPrePostParams(self):
         """Connect pre to post with a params dict"""
 
-        # Connect([pre], [post], params)
-        nest.ResetKernel()
+        # Connect(pre, post, params)
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
         nest.Connect(pre, post, "one_to_one", syn_spec={"weight": 2.0})
@@ -55,7 +56,7 @@ class OneToOneConnectTestCase(unittest.TestCase):
         weights = connections.get("weight")
         self.assertEqual(weights, [2.0, 2.0])
 
-        # Connect([pre], [post], [params, params])
+        # Connect(pre, post, [params, params])
         nest.ResetKernel()
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
@@ -68,8 +69,7 @@ class OneToOneConnectTestCase(unittest.TestCase):
     def test_ConnectPrePostWD(self):
         """Connect pre to post with a weight and delay"""
 
-        # Connect([pre], [post], w, d)
-        nest.ResetKernel()
+        # Connect(pre, post, w, d)
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
         nest.Connect(pre, post, conn_spec={"rule": "one_to_one"},
@@ -80,7 +80,7 @@ class OneToOneConnectTestCase(unittest.TestCase):
         self.assertEqual(weights, [2.0, 2.0])
         self.assertEqual(delays, [2.0, 2.0])
 
-        # Connect([pre], [post], [w, w], [d, d])
+        # Connect(pre, post, [w, w], [d, d])
         nest.ResetKernel()
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
@@ -95,12 +95,12 @@ class OneToOneConnectTestCase(unittest.TestCase):
     def test_IllegalConnection(self):
         """Wrong Connections"""
 
-        nest.ResetKernel()
         n = nest.Create('iaf_psc_alpha')
         vm = nest.Create('voltmeter')
+        sd = nest.Create('spike_detector')
 
-        self.assertRaisesRegex(
-            nest.kernel.NESTError, "IllegalConnection", nest.Connect, n, vm)
+        self.assertRaisesRegex(nest.kernel.NESTError, "IllegalConnection", nest.Connect, n, vm)
+        self.assertRaisesRegex(nest.kernel.NESTError, "IllegalConnection", nest.Connect, sd, n)
 
 
 def suite():

--- a/pynest/nest/tests/test_onetooneconnect.py
+++ b/pynest/nest/tests/test_onetooneconnect.py
@@ -37,7 +37,6 @@ class OneToOneConnectTestCase(unittest.TestCase):
     def test_ConnectPrePost(self):
         """Connect pre to post"""
 
-        # Connect(pre, post)
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
         nest.Connect(pre, post, "one_to_one")
@@ -48,7 +47,6 @@ class OneToOneConnectTestCase(unittest.TestCase):
     def test_ConnectPrePostParams(self):
         """Connect pre to post with a params dict"""
 
-        # Connect(pre, post, params)
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
         nest.Connect(pre, post, "one_to_one", syn_spec={"weight": 2.0})
@@ -56,7 +54,6 @@ class OneToOneConnectTestCase(unittest.TestCase):
         weights = connections.get("weight")
         self.assertEqual(weights, [2.0, 2.0])
 
-        # Connect(pre, post, [params, params])
         nest.ResetKernel()
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
@@ -69,7 +66,6 @@ class OneToOneConnectTestCase(unittest.TestCase):
     def test_ConnectPrePostWD(self):
         """Connect pre to post with a weight and delay"""
 
-        # Connect(pre, post, w, d)
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)
         nest.Connect(pre, post, conn_spec={"rule": "one_to_one"},
@@ -80,7 +76,6 @@ class OneToOneConnectTestCase(unittest.TestCase):
         self.assertEqual(weights, [2.0, 2.0])
         self.assertEqual(delays, [2.0, 2.0])
 
-        # Connect(pre, post, [w, w], [d, d])
         nest.ResetKernel()
         pre = nest.Create("iaf_psc_alpha", 2)
         post = nest.Create("iaf_psc_alpha", 2)

--- a/pynest/nest/tests/test_onetooneconnect.py
+++ b/pynest/nest/tests/test_onetooneconnect.py
@@ -102,16 +102,6 @@ class OneToOneConnectTestCase(unittest.TestCase):
         self.assertRaisesRegex(
             nest.kernel.NESTError, "IllegalConnection", nest.Connect, n, vm)
 
-    def test_UnexpectedEvent(self):
-        """Unexpected Event"""
-
-        nest.ResetKernel()
-        n = nest.Create('iaf_psc_alpha')
-        sd = nest.Create('spike_detector')
-
-        self.assertRaisesRegex(
-            nest.kernel.NESTError, "UnexpectedEvent", nest.Connect, sd, n)
-
 
 def suite():
 

--- a/topology/connection_creator.cpp
+++ b/topology/connection_creator.cpp
@@ -101,7 +101,7 @@ ConnectionCreator::ConnectionCreator( DictionaryDatum dict )
     }
     else
     {
-      throw BadProperty( "ConnectLayers cannot handle parameter '" + dit->first.toString() + "'." );
+      throw BadProperty( "Spatial Connect cannot handle parameter '" + dit->first.toString() + "'." );
     }
   }
 

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -284,7 +284,7 @@ ConnectionCreator::pairwise_bernoulli_on_target_( Layer< D >& source,
   Node* const first_in_tgt = kernel().node_manager.get_node_or_proxy( target_nc->operator[]( 0 ) );
   if ( not first_in_tgt->has_proxies() )
   {
-    throw IllegalConnection( "Topology Connect with pairwise_bernoulli to devices are not possible." );
+    throw IllegalConnection( "Spatial Connect with pairwise_bernoulli to devices are not possible." );
   }
 
 // sharing specs on next line commented out because gcc 4.2 cannot handle them
@@ -360,7 +360,7 @@ ConnectionCreator::fixed_indegree_( Layer< D >& source,
   Node* const first_in_tgt = kernel().node_manager.get_node_or_proxy( target_nc->operator[]( 0 ) );
   if ( not first_in_tgt->has_proxies() )
   {
-    throw IllegalConnection( "Topology Connect with fixed_indegree to devices are not possible." );
+    throw IllegalConnection( "Spatial Connect with fixed_indegree to devices are not possible." );
   }
 
   NodeCollection::const_iterator target_begin = target_nc->MPI_local_begin();
@@ -639,7 +639,7 @@ ConnectionCreator::fixed_outdegree_( Layer< D >& source,
   Node* const first_in_tgt = kernel().node_manager.get_node_or_proxy( target_nc->operator[]( 0 ) );
   if ( not first_in_tgt->has_proxies() )
   {
-    throw IllegalConnection( "Topology pairwise_bernoulli to devices are not possible." );
+    throw IllegalConnection( "Spatial Connect with fixed_outdegree to devices are not possible." );
   }
 
   NodeCollection::const_iterator target_begin = target_nc->MPI_local_begin();

--- a/topology/connection_creator_impl.h
+++ b/topology/connection_creator_impl.h
@@ -284,7 +284,7 @@ ConnectionCreator::pairwise_bernoulli_on_target_( Layer< D >& source,
   Node* const first_in_tgt = kernel().node_manager.get_node_or_proxy( target_nc->operator[]( 0 ) );
   if ( not first_in_tgt->has_proxies() )
   {
-    throw IllegalConnection( "Spatial Connect with pairwise_bernoulli to devices are not possible." );
+    throw IllegalConnection( "Spatial Connect with pairwise_bernoulli to devices is not possible." );
   }
 
 // sharing specs on next line commented out because gcc 4.2 cannot handle them
@@ -360,7 +360,7 @@ ConnectionCreator::fixed_indegree_( Layer< D >& source,
   Node* const first_in_tgt = kernel().node_manager.get_node_or_proxy( target_nc->operator[]( 0 ) );
   if ( not first_in_tgt->has_proxies() )
   {
-    throw IllegalConnection( "Spatial Connect with fixed_indegree to devices are not possible." );
+    throw IllegalConnection( "Spatial Connect with fixed_indegree to devices is not possible." );
   }
 
   NodeCollection::const_iterator target_begin = target_nc->MPI_local_begin();
@@ -639,7 +639,7 @@ ConnectionCreator::fixed_outdegree_( Layer< D >& source,
   Node* const first_in_tgt = kernel().node_manager.get_node_or_proxy( target_nc->operator[]( 0 ) );
   if ( not first_in_tgt->has_proxies() )
   {
-    throw IllegalConnection( "Spatial Connect with fixed_outdegree to devices are not possible." );
+    throw IllegalConnection( "Spatial Connect with fixed_outdegree to devices is not possible." );
   }
 
   NodeCollection::const_iterator target_begin = target_nc->MPI_local_begin();


### PR DESCRIPTION
This PR fixes #1400.

I have mostly looked at systematizing `IllegalConnection`. Other error messages might be thrown when connecting as well.

Some examples of how new changes will look:
```
SLI ] /n /iaf_psc_alpha Create def
SLI ] /v /voltmeter Create def
SLI ] /sd /spike_detector Create def
SLI ] 
SLI ] sd n Connect

May 15 09:32:38 Connect_g_g_D_D [Error]: IllegalConnection
    Creation of connection is not possible because:
    Source node does not send output.
      Note that detectors must be connected as Connect(neuron, detector).
SLI [4] clear
SLI ] 
SLI ] v sd Connect

May 15 09:33:00 Connect_g_g_D_D [Error]: IllegalConnection
    Creation of connection is not possible because:
    The target node or synapse model does not support data logging requests.

SLI ] n sd << /rule /all_to_all >> << /synapse_model /stdp_synapse >> Connect

May 15 09:51:41 Connect_g_g_D_D [Error]: IllegalConnection
    Creation of connection is not possible because:
    The target node does not support STDP synapses.
```

Some Python examples:
```
>>> sn = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[5,5]))
>>> sd_spatial = nest.Create('spike_detector', positions=nest.spatial.grid(shape=[1,1]))
>>> v = nest.Create('voltmeter')

>>> nest.Connect(sn, sd_spatial,
                 {'rule': 'pairwise_bernoulli', 'p': 0.5, 'use_on_source': False})
NESTErrors.IllegalConnection: ('IllegalConnection in ConnectLayers_g_g_D: Creation of
connection is not possible because:\nSpatial Connect with pairwise_bernoulli to devices are
not possible.', 'IllegalConnection', 'ConnectLayers_g_g_D', ': Creation of connection is not
possible because:\nSpatial Connect with pairwise_bernoulli to devices are not possible.')

>>> nest.Connect(v, sn, {'rule': 'pairwise_bernoulli', 'p': 0.5})
 NESTErrors.IllegalConnection: ('IllegalConnection in Connect_g_g_D_D: Creation of
connection is not possible because:\nEach multimeter can only be connected once to
a given node.', 'IllegalConnection', 'Connect_g_g_D_D', ': Creation of connection is not
possible because:\nEach multimeter can only be connected once to a given node.')
```

Note that Python errors renders strangely. They can be quite hard to read. I think this is a separate issue though.

**One open question I have:**
Right now we do not give any information about which C++ function fail. This is OK for the users, but for the developers hunting bugs it might be annoying. It is possible to just search for the error message though, so I don't know if it really is a problem. But I can add an option to the `IllegalConnection` `Exception` class where you can send in the name of the function, and then add that to the end of the error message. What do you think?