### PR TITLE
Remove "Documentation" label from documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.md
@@ -2,7 +2,7 @@
 name: Documentation improvement
 about: Request a documentation improvement
 title: ''
-labels: 'C: Documentation'
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
This PR removes the automatically applied "Documentation" label from the ``documentation_improvement.md`` issue template, since we do not use that label at the moment. 

It would be convenient if the issue could be automatically added to the "Documentation" project. However, I am not sure if that [feature](https://help.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository) exists yet. Does anyone know?