### PR TITLE
Update syn_spec when a synapse parameter is list and we use fixed_total_number

### DIFF
--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -85,6 +85,8 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, connect_np_arr
                                 "'" + key + "' has to be an array of "
                                 "dimension " + str(conn_spec['N']) + ", a "
                                 "scalar or a dictionary.")
+                        else:
+                            syn_spec[key] = value
                     else:
                         raise kernel.NESTError(
                             "'" + key + "' has the wrong type. "

--- a/pynest/nest/tests/test_weights_as_lists.py
+++ b/pynest/nest/tests/test_weights_as_lists.py
@@ -40,7 +40,7 @@ class WeightsAsListTestCase(unittest.TestCase):
         src = nest.Create('iaf_psc_alpha', 3)
         tgt = nest.Create('iaf_psc_delta', 3)
 
-        # weight has to be a list with dimenstion (n_sources x 1) when one_to_one is used
+        # weight has to be a list with dimension (n_sources x 1) when one_to_one is used
         ref_weights = [1.2, -3.5, 0.4]
 
         conn_dict = {'rule': 'one_to_one'}
@@ -58,7 +58,7 @@ class WeightsAsListTestCase(unittest.TestCase):
         src = nest.Create('iaf_psc_alpha', 3)
         tgt = nest.Create('iaf_psc_delta', 2)
 
-        # weight has to be a list of lists with dimenstion (n_target x n_sources) when all_to_all is used
+        # weight has to be a list of lists with dimension (n_target x n_sources) when all_to_all is used
         ref_weights = [[1.2, -3.5, 2.5], [0.4, -0.2, 0.7]]
 
         conn_dict = {'rule': 'all_to_all'}
@@ -79,7 +79,7 @@ class WeightsAsListTestCase(unittest.TestCase):
         src = nest.Create('iaf_psc_alpha', 5)
         tgt = nest.Create('iaf_psc_delta', 3)
 
-        # weight has to be a list of lists with dimenstion (n_target x indegree) when fixed_indegree is used
+        # weight has to be a list of lists with dimension (n_target x indegree) when fixed_indegree is used
         ref_weights = [[1.2, -3.5], [0.4, -0.2], [0.6, 2.2]]
 
         conn_dict = {'rule': 'fixed_indegree', 'indegree': 2}
@@ -100,7 +100,7 @@ class WeightsAsListTestCase(unittest.TestCase):
         src = nest.Create('iaf_psc_alpha', 2)
         tgt = nest.Create('iaf_psc_delta', 5)
 
-        # weight has to be a list of lists with dimenstion (n_source x outegree) when fixed_outdegree is used
+        # weight has to be a list of lists with dimension (n_source x outegree) when fixed_outdegree is used
         ref_weights = [[1.2, -3.5, 0.4], [-0.2, 0.6, 2.2]]
 
         conn_dict = {'rule': 'fixed_outdegree', 'outdegree': 3}
@@ -122,7 +122,7 @@ class WeightsAsListTestCase(unittest.TestCase):
         tgt = nest.Create('iaf_psc_delta', 4)
         conn_dict = {'rule': 'fixed_total_number', 'N': 4}
 
-        # weight has to be a list with dimenstion (n_conns x 1) when fixed_total_number is used
+        # weight has to be a list with dimension (n_conns x 1) when fixed_total_number is used
         ref_weights = [1.2, -3.5, 0.4, -0.2]
 
         syn_dict = {'weight': ref_weights}

--- a/pynest/nest/tests/test_weights_as_lists.py
+++ b/pynest/nest/tests/test_weights_as_lists.py
@@ -20,7 +20,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Creation tests
+Weights given as lists with the different connection rules
 """
 
 import unittest
@@ -29,21 +29,23 @@ import nest
 
 @nest.ll_api.check_stack
 class WeightsAsListTestCase(unittest.TestCase):
-    """Weights as lists tests"""
+    """Test weights given as lists"""
 
     def setUp(self):
         nest.ResetKernel()
 
     def test_OneToOneWeight(self):
-        """Weight as list for one_to_one"""
+        """Weight given as list, when connection rule is one_to_one"""
 
+        src = nest.Create('iaf_psc_alpha', 3)
+        tgt = nest.Create('iaf_psc_delta', 3)
+
+        # weight has to be a list with dimenstion (n_sources x 1) when one_to_one is used
         ref_weights = [1.2, -3.5, 0.4]
 
-        A = nest.Create("iaf_psc_alpha", 3)
-        B = nest.Create("iaf_psc_delta", 3)
         conn_dict = {'rule': 'one_to_one'}
         syn_dict = {'weight': ref_weights}
-        nest.Connect(A, B, conn_dict, syn_dict)
+        nest.Connect(src, tgt, conn_dict, syn_dict)
 
         conns = nest.GetConnections()
         weights = conns.weight
@@ -51,69 +53,80 @@ class WeightsAsListTestCase(unittest.TestCase):
         self.assertEqual(weights, ref_weights)
 
     def test_AllToAllWeight(self):
-        """Weight as list for all_to_all"""
+        """Weight given as list of lists, when connection rule is all_to_all"""
 
+        src = nest.Create('iaf_psc_alpha', 3)
+        tgt = nest.Create('iaf_psc_delta', 2)
+
+        # weight has to be a list of lists with dimenstion (n_target x n_sources) when all_to_all is used
         ref_weights = [[1.2, -3.5, 2.5], [0.4, -0.2, 0.7]]
 
-        A = nest.Create("iaf_psc_alpha", 3)
-        B = nest.Create("iaf_psc_delta", 2)
         conn_dict = {'rule': 'all_to_all'}
         syn_dict = {'weight': ref_weights}
-        nest.Connect(A, B, conn_dict, syn_dict)
+        nest.Connect(src, tgt, conn_dict, syn_dict)
 
         conns = nest.GetConnections()
         weights = conns.weight
 
+        # Need to flatten ref_weights in order to compare with the weights given by the SynapseCollection.
         ref_weights = [w for sub_weights in ref_weights for w in sub_weights]
 
         self.assertEqual(weights.sort(), ref_weights.sort())
 
     def test_FixedIndegreeWeight(self):
-        """Weight as list for fixed_indegree"""
+        """Weight given as list of list, when connection rule is fixed_indegree"""
 
+        src = nest.Create('iaf_psc_alpha', 5)
+        tgt = nest.Create('iaf_psc_delta', 3)
+
+        # weight has to be a list of lists with dimenstion (n_target x indegree) when fixed_indegree is used
         ref_weights = [[1.2, -3.5], [0.4, -0.2], [0.6, 2.2]]
 
-        A = nest.Create("iaf_psc_alpha", 5)
-        B = nest.Create("iaf_psc_delta", 3)
         conn_dict = {'rule': 'fixed_indegree', 'indegree': 2}
         syn_dict = {'weight': ref_weights}
-        nest.Connect(A, B, conn_dict, syn_dict)
+        nest.Connect(src, tgt, conn_dict, syn_dict)
 
         conns = nest.GetConnections()
         weights = conns.weight
 
+        # Need to flatten ref_weights in order to compare with the weights given by the SynapseCollection.
         ref_weights = [w for sub_weights in ref_weights for w in sub_weights]
 
         self.assertEqual(weights.sort(), ref_weights.sort())
 
     def test_FixedOutdegreeWeight(self):
-        """Weight as list for fixed_outdegree"""
+        """Weight given as list of lists, when connection rule is fixed_outdegree"""
 
+        src = nest.Create('iaf_psc_alpha', 2)
+        tgt = nest.Create('iaf_psc_delta', 5)
+
+        # weight has to be a list of lists with dimenstion (n_source x outegree) when fixed_outdegree is used
         ref_weights = [[1.2, -3.5, 0.4], [-0.2, 0.6, 2.2]]
 
-        A = nest.Create("iaf_psc_alpha", 2)
-        B = nest.Create("iaf_psc_delta", 5)
         conn_dict = {'rule': 'fixed_outdegree', 'outdegree': 3}
         syn_dict = {'weight': ref_weights}
-        nest.Connect(A, B, conn_dict, syn_dict)
+        nest.Connect(src, tgt, conn_dict, syn_dict)
 
         conns = nest.GetConnections()
         weights = conns.weight
 
+        # Need to flatten ref_weights in order to compare with the weights given by the SynapseCollection.
         ref_weights = [w for sub_weights in ref_weights for w in sub_weights]
 
         self.assertEqual(weights.sort(), ref_weights.sort())
 
     def test_FixedTotalNumberWeight(self):
-        """Weight as list for fixed_total_number"""
+        """Weight given as list, when connection rule is fixed_total_number"""
 
+        src = nest.Create('iaf_psc_alpha', 3)
+        tgt = nest.Create('iaf_psc_delta', 4)
+        conn_dict = {'rule': 'fixed_total_number', 'N': 4}
+
+        # weight has to be a list with dimenstion (n_conns x 1) when fixed_total_number is used
         ref_weights = [1.2, -3.5, 0.4, -0.2]
 
-        A = nest.Create("iaf_psc_alpha", 3)
-        B = nest.Create("iaf_psc_delta", 4)
-        conn_dict = {'rule': 'fixed_total_number', 'N': 4}
         syn_dict = {'weight': ref_weights}
-        nest.Connect(A, B, conn_dict, syn_dict)
+        nest.Connect(src, tgt, conn_dict, syn_dict)
 
         conns = nest.GetConnections()
         weights = conns.weight

--- a/pynest/nest/tests/test_weights_as_lists.py
+++ b/pynest/nest/tests/test_weights_as_lists.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# test_weights_as_lists.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Creation tests
+"""
+
+import unittest
+import warnings
+import nest
+
+
+@nest.ll_api.check_stack
+class WeightsAsListTestCase(unittest.TestCase):
+    """Creation tests"""
+
+    def test_FixedTotalNumberWeight(self):
+        """..."""
+
+        nest.ResetKernel()
+        
+        ref_weights = [1.2, -3.5, 0.4, -0.2]
+
+        A = nest.Create("iaf_psc_alpha", 3)  
+        B = nest.Create("iaf_psc_delta", 4)  
+        conn_dict = {'rule': 'fixed_total_number', 'N': 4}  
+        syn_dict = {'weight': ref_weights}  
+        nest.Connect(A, B, conn_dict, syn_dict)
+        
+        conns = nest.GetConnections()
+        weights = conns.weight
+        
+        self.assertEqual(weights, ref_weights)
+
+
+def suite():
+    suite = unittest.makeSuite(WeightsAsListTestCase, 'test')
+    return suite
+
+
+def run():
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    run()

--- a/pynest/nest/tests/test_weights_as_lists.py
+++ b/pynest/nest/tests/test_weights_as_lists.py
@@ -24,30 +24,100 @@ Creation tests
 """
 
 import unittest
-import warnings
 import nest
 
 
 @nest.ll_api.check_stack
 class WeightsAsListTestCase(unittest.TestCase):
-    """Creation tests"""
+    """Weights as lists tests"""
 
-    def test_FixedTotalNumberWeight(self):
-        """..."""
-
+    def setUp(self):
         nest.ResetKernel()
-        
-        ref_weights = [1.2, -3.5, 0.4, -0.2]
 
-        A = nest.Create("iaf_psc_alpha", 3)  
-        B = nest.Create("iaf_psc_delta", 4)  
-        conn_dict = {'rule': 'fixed_total_number', 'N': 4}  
-        syn_dict = {'weight': ref_weights}  
+    def test_OneToOneWeight(self):
+        """Weight as list for one_to_one"""
+
+        ref_weights = [1.2, -3.5, 0.4]
+
+        A = nest.Create("iaf_psc_alpha", 3)
+        B = nest.Create("iaf_psc_delta", 3)
+        conn_dict = {'rule': 'one_to_one'}
+        syn_dict = {'weight': ref_weights}
         nest.Connect(A, B, conn_dict, syn_dict)
-        
+
         conns = nest.GetConnections()
         weights = conns.weight
-        
+
+        self.assertEqual(weights, ref_weights)
+
+    def test_AllToAllWeight(self):
+        """Weight as list for all_to_all"""
+
+        ref_weights = [[1.2, -3.5, 2.5], [0.4, -0.2, 0.7]]
+
+        A = nest.Create("iaf_psc_alpha", 3)
+        B = nest.Create("iaf_psc_delta", 2)
+        conn_dict = {'rule': 'all_to_all'}
+        syn_dict = {'weight': ref_weights}
+        nest.Connect(A, B, conn_dict, syn_dict)
+
+        conns = nest.GetConnections()
+        weights = conns.weight
+
+        ref_weights = [w for sub_weights in ref_weights for w in sub_weights]
+
+        self.assertEqual(weights.sort(), ref_weights.sort())
+
+    def test_FixedIndegreeWeight(self):
+        """Weight as list for fixed_indegree"""
+
+        ref_weights = [[1.2, -3.5], [0.4, -0.2], [0.6, 2.2]]
+
+        A = nest.Create("iaf_psc_alpha", 5)
+        B = nest.Create("iaf_psc_delta", 3)
+        conn_dict = {'rule': 'fixed_indegree', 'indegree': 2}
+        syn_dict = {'weight': ref_weights}
+        nest.Connect(A, B, conn_dict, syn_dict)
+
+        conns = nest.GetConnections()
+        weights = conns.weight
+
+        ref_weights = [w for sub_weights in ref_weights for w in sub_weights]
+
+        self.assertEqual(weights.sort(), ref_weights.sort())
+
+    def test_FixedOutdegreeWeight(self):
+        """Weight as list for fixed_outdegree"""
+
+        ref_weights = [[1.2, -3.5, 0.4], [-0.2, 0.6, 2.2]]
+
+        A = nest.Create("iaf_psc_alpha", 2)
+        B = nest.Create("iaf_psc_delta", 5)
+        conn_dict = {'rule': 'fixed_outdegree', 'outdegree': 3}
+        syn_dict = {'weight': ref_weights}
+        nest.Connect(A, B, conn_dict, syn_dict)
+
+        conns = nest.GetConnections()
+        weights = conns.weight
+
+        ref_weights = [w for sub_weights in ref_weights for w in sub_weights]
+
+        self.assertEqual(weights.sort(), ref_weights.sort())
+
+    def test_FixedTotalNumberWeight(self):
+        """Weight as list for fixed_total_number"""
+
+        ref_weights = [1.2, -3.5, 0.4, -0.2]
+
+        A = nest.Create("iaf_psc_alpha", 3)
+        B = nest.Create("iaf_psc_delta", 4)
+        conn_dict = {'rule': 'fixed_total_number', 'N': 4}
+        syn_dict = {'weight': ref_weights}
+        nest.Connect(A, B, conn_dict, syn_dict)
+
+        conns = nest.GetConnections()
+        weights = conns.weight
+
         self.assertEqual(weights, ref_weights)
 
 


### PR DESCRIPTION
This PR fixes #1607.

When using `fixed_total_number` and a list for one of the synapse parameters (like `weight`) we need to update `syn_spec` before sending it to the kernel because the parameter value has previously been converted to a numpy array.