### PR TITLE
Add information on NEST and multiprocessing

### DIFF
--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -182,10 +182,11 @@ on your machine.
 Multiprocessing
 ----------------
 
-**Please do not use Python's multiprocessing package with NEST!**
+**Using Python's ``multiprocessing`` package with NEST may lead to unpredictable results!**
 
 NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. Running
-several ``ConnectLayers()`` calls simultaneously can lead to unpredictable results.
+for example several ``Connect()`` calls simultaneously can interfere with the internal
+parallelization and will likely lead to unpredictable/wrong results.
 
 .. _distributed_computing:
 

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -184,9 +184,9 @@ Multiprocessing
 
 **Using Python's ``multiprocessing`` package with NEST may lead to unpredictable results!**
 
-NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. Running
-for example several ``Connect()`` calls simultaneously can interfere with the internal
-parallelization and will likely lead to unpredictable/wrong results.
+NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. For
+example, running several ``Connect()`` calls simultaneously can interfere with the internal parallelization and will
+likely lead to unpredictable/wrong results.
 
 .. _distributed_computing:
 

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -322,5 +322,5 @@ independently of the details of parallelization.
 References
 ----------
 
-.. [1] Ippen T, Eppler JM, Plesser HE and Diesmann M (2017). Constructing Neuronal Network Models in Massively
-       Parallel Environments. Front. Neuroinform. 11:30. DOI: 10.3389/fninf.2017.00030
+.. [1] Ippen T, Eppler JM, Plesser HE and Diesmann M (2017). Constructing neuronal network models in massively
+       parallel environments. Front. Neuroinform. 11:30. DOI: 10.3389/fninf.2017.00030

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -179,6 +179,14 @@ on your machine.
  can yield 20-30% improvement in simulation speed. Finding the optimal thread number for a
  specific situation might require a bit of experimenting.
 
+Multi-processing
+----------------
+
+**Please do not use multi-processing with NEST!**
+
+NEST internally parallelizes network construction and maintains internal data structures in this process. Running several
+``ConnectLayers()`` calls simultaneously will lead to unpredictable results.
+
 .. _distributed_computing:
 
 Using distributed computing

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -184,8 +184,8 @@ Multiprocessing
 
 **Please do not use Python's multiprocessing package with NEST!**
 
-NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. Running several
-``ConnectLayers()`` calls simultaneously can lead to unpredictable results.
+NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. Running
+several ``ConnectLayers()`` calls simultaneously can lead to unpredictable results.
 
 .. _distributed_computing:
 
@@ -322,5 +322,5 @@ independently of the details of parallelization.
 References
 ----------
 
-.. [1] Ippen T, Eppler JM, Plesser HE and Diesmann M (2017). Constructing Neuronal Network Models in Massively Parallel
-       Environments. Front. Neuroinform. 11:30. DOI: 10.3389/fninf.2017.00030
+.. [1] Ippen T, Eppler JM, Plesser HE and Diesmann M (2017). Constructing Neuronal Network Models in Massively
+       Parallel Environments. Front. Neuroinform. 11:30. DOI: 10.3389/fninf.2017.00030

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -179,13 +179,13 @@ on your machine.
  can yield 20-30% improvement in simulation speed. Finding the optimal thread number for a
  specific situation might require a bit of experimenting.
 
-Multi-processing
+Multiprocessing
 ----------------
 
-**Please do not use multi-processing with NEST!**
+**Please do not use Python's multiprocessing package with NEST!**
 
 NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. Running several
-``ConnectLayers()`` calls simultaneously will lead to unpredictable results.
+``ConnectLayers()`` calls simultaneously can lead to unpredictable results.
 
 .. _distributed_computing:
 

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -184,7 +184,7 @@ Multi-processing
 
 **Please do not use multi-processing with NEST!**
 
-NEST internally parallelizes network construction and maintains internal data structures in this process. Running several
+NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. Running several
 ``ConnectLayers()`` calls simultaneously will lead to unpredictable results.
 
 .. _distributed_computing:
@@ -318,3 +318,9 @@ virtual process (*spike_detector-6-0.gdf*, *spike_detector-6-1.gdf*,
 the three data directories shows that they all contain the same spikes,
 which means that the simulation results are indeed the same
 independently of the details of parallelization.
+
+References
+----------
+
+.. [1] Ippen T, Eppler JM, Plesser HE and Diesmann M (2017). Constructing Neuronal Network Models in Massively Parallel
+       Environments. Front. Neuroinform. 11:30. DOI: 10.3389/fninf.2017.00030

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -182,7 +182,7 @@ on your machine.
 Multiprocessing
 ----------------
 
-**Using Python's ``multiprocessing`` package with NEST may lead to unpredictable results!**
+**Using Python's ``multiprocessing`` module with NEST may lead to unpredictable results!**
 
 NEST internally parallelizes network construction [1]_ and maintains internal data structures in this process. For
 example, running several ``Connect()`` calls simultaneously can interfere with the internal parallelization and will


### PR DESCRIPTION
This PR fixes #1581. 

It recommends against the use of Python's multiprocessing package on top of NEST's internal parallelization. I have also referenced [Ippen et al. (2017)](https://www.frontiersin.org/articles/10.3389/fninf.2017.00030/full), as suggested by @suku248. 

The full discussion can be found in the [mailing list](https://www.nest-simulator.org/mailinglist/hyperkitty/list/users@nest-simulator.org/thread/ZAXHALXHJTUOOX4VGD3T2FIMWNNNTILE/#ZAXHALXHJTUOOX4VGD3T2FIMWNNNTILE).

Perhaps we can update the section accordingly once we have a careful assessment about the interactions between NEST and multiprocessing?