### PR TITLE
Get distances between sources and targets in SynapseCollection

### DIFF
--- a/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
+++ b/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
@@ -543,7 +543,7 @@ Setting and getting attributes directly
     as the SynapseCollection.
     
     For :ref:`spatially distributed <topo_changes>` sources and targets, you can access the distance between
-    the source, target pair by calling `distance` on your SynapseCollection
+    the source, target pair by calling `distance` on your SynapseCollection.
     
     >>>  synColl.distance
          (0.47140452079103173,
@@ -1299,7 +1299,7 @@ probability and delay, and random weights from a normal distribution:
 Retrieving distance information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you have a SynapseCollection with connections from a spatially distributed network, you can retrieve the
-*distance* between the source and target pairs by calling ``.distance`` on the SynapseCollection
+*distance* between the source-target pairs by calling ``.distance`` on the SynapseCollection.
 
   ::
   
@@ -1310,12 +1310,11 @@ If you have a SynapseCollection with connections from a spatially distributed ne
     conns = nest.GetConnections()
     dist = conns.distance
 
-``.distance`` will be a tuple the length of your SynapseCollection, where ``dist[indx]`` will be the distance
-between the source, target pair at *indx*.
+``.distance`` will be a tuple of the same length as your SynapseCollection, where ``dist[indx]`` will be the distance
+between the source-target pair at *indx*.
 
-Calling ``.distance`` on a SynapseCollection where the connections are not part of a spatial network also
-works, you will receive a tuple of `0.0`. If your source, target pairs are mixed so that one in the pair has
-spatial information and the other does not, you will get an error.
+Calling ``.distance`` on a SynapseCollection where either the source or target, or both, are not spatially
+distributed also works, you will receive `nan` whenever one of the nodes is non-spatial.
 
 Improved infrastructure for handling recordings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
+++ b/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
@@ -541,6 +541,21 @@ Setting and getting attributes directly
 
     If you use a list to set the parameter, the list needs to be the same length
     as the SynapseCollection.
+    
+    For :ref:`spatially distributed <topo_changes>` sources and targets, you can access the distance between
+    the source, target pair by calling `distance` on your SynapseCollection
+    
+    >>>  synColl.distance
+         (0.47140452079103173,
+          0.33333333333333337,
+          0.4714045207910317,
+          0.33333333333333337,
+          3.925231146709438e-17,
+          0.33333333333333326,
+          0.4714045207910317,
+          0.33333333333333326,
+          0.47140452079103157)
+         
 
 .. _conn_s_t_iterator:
 
@@ -1140,8 +1155,8 @@ a value based on the nodes' position on the x-axis:
 ::
 
     snodes = nest.Create('iaf_psc_alpha', 10
-                        positions=nest.spatial.free(
-                            nest.random.uniform(min=-10., max=10.), num_dimensions=2))
+                         positions=nest.spatial.free(
+                             nest.random.uniform(min=-10., max=10.), num_dimensions=2))
     snodes.set('V_m', -60. + nest.spatial.pos.x)
 
 
@@ -1280,6 +1295,27 @@ probability and delay, and random weights from a normal distribution:
   |     tp.ConnectLayers(l, l, conn_dict)                            |                                                                     |
   |                                                                  |                                                                     |
   +------------------------------------------------------------------+---------------------------------------------------------------------+
+
+Retrieving distance information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If you have a SynapseCollection with connections from a spatially distributed network, you can retrieve the
+*distance* between the source and target pairs by calling ``.distance`` on the SynapseCollection
+
+  ::
+  
+    s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 1]))
+    t_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[1, 3]))
+    nest.Connect(s_nodes, t_nodes)
+    
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+``.distance`` will be a tuple the length of your SynapseCollection, where ``dist[indx]`` will be the distance
+between the source, target pair at *indx*.
+
+Calling ``.distance`` on a SynapseCollection where the connections are not part of a spatial network also
+works, you will receive a tuple of `0.0`. If your source, target pairs are mixed so that one in the pair has
+spatial information and the other does not, you will get an error.
 
 Improved infrastructure for handling recordings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
+++ b/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
@@ -543,7 +543,7 @@ Setting and getting attributes directly
     as the SynapseCollection.
     
     For :ref:`spatially distributed <topo_changes>` sources and targets, you can access the distance between
-    the source, target pair by calling `distance` on your SynapseCollection.
+    the source-target pairs by calling `distance` on your SynapseCollection.
     
     >>>  synColl.distance
          (0.47140452079103173,

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -1486,6 +1486,10 @@ def
     /Distance_a_g load
 def
 
+/Distance [/arraytype]
+    /Distance_a load
+def
+
 /GetLayerStatus [/nodecollectiontype]
     /GetLayerStatus_g load
 def

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -579,6 +579,11 @@ class SynapseCollection(object):
         return result
 
     def __getattr__(self, attr):
+        if attr == 'distance':
+            dist = sli_func('Distance', self._datum)
+            super().__setattr__(attr, dist)
+            return self.distance
+        
         return self.get(attr)
 
     def __setattr__(self, attr, value):

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -583,7 +583,7 @@ class SynapseCollection(object):
             dist = sli_func('Distance', self._datum)
             super().__setattr__(attr, dist)
             return self.distance
-        
+
         return self.get(attr)
 
     def __setattr__(self, attr, value):

--- a/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
+++ b/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
@@ -152,6 +152,24 @@ class SynapseCollectionDistance(unittest.TestCase):
         dist_is_nan = [math.isnan(d) for d in dist[:num_conns_nonsparial]]
         self.assertTrue(dist_is_nan)
 
+    def test_SynapseCollection_distance_spatial_nonspatial_connected(self):
+        """Test SynapseCollection distance function on non-spatial and spatial nodes that are connected"""
+
+        num_snodes = 5
+        num_tnodes = 11
+        s_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_snodes)
+
+        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+        t_nodes_spatial = nest.Create('iaf_psc_alpha', n=num_tnodes, positions=positions)
+
+        nest.Connect(s_nodes_nonspatial, t_nodes_spatial)
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        # All should be nan
+        dist_is_nan = [math.isnan(d) for d in dist]
+        self.assertTrue(dist_is_nan)
+
 
 def suite():
     suite = unittest.makeSuite(SynapseCollectionDistance, 'test')

--- a/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
+++ b/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
@@ -122,15 +122,18 @@ class SynapseCollectionDistance(unittest.TestCase):
         conns = nest.GetConnections()
         dist = conns.distance
 
-        ref_distance = tuple([0.0 for _ in range(6)])
+        dist_is_nan = [math.isnan(d) for d in dist]
 
-        self.assertEqual(ref_distance, dist)
+        self.assertTrue(dist_is_nan)
 
     def test_SynapseCollection_distance_mixed(self):
         """Test SynapseCollection distance function on non-spatial and spatial nodes"""
 
-        s_nodes_nonspatial = nest.Create('iaf_psc_alpha', 3)
-        t_nodes_nonspatial = nest.Create('iaf_psc_alpha', 2)
+        num_snodes_nonspatial = 3
+        num_tnodes_nonspatial = 2
+        num_conns_nonsparial = num_snodes_nonspatial * num_tnodes_nonspatial
+        s_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_snodes_nonspatial)
+        t_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_tnodes_nonspatial)
 
         positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
         s_nodes_spatial = nest.Create('iaf_psc_alpha', n=6, positions=positions)
@@ -141,10 +144,13 @@ class SynapseCollectionDistance(unittest.TestCase):
         conns = nest.GetConnections()
         dist = conns.distance
 
-        ref_distance = tuple([0.0 for _ in range(6)])
-        ref_distance += self.calculate_distance(conns[6:], s_nodes_spatial, t_nodes_spatial)
+        # Check part that is spatial
+        ref_distance = self.calculate_distance(conns[num_conns_nonsparial:], s_nodes_spatial, t_nodes_spatial)
+        self.assertEqual(ref_distance, dist[num_conns_nonsparial:])
 
-        self.assertEqual(ref_distance, dist)
+        # Check part that is non-spatial
+        dist_is_nan = [math.isnan(d) for d in dist[:num_conns_nonsparial]]
+        self.assertTrue(dist_is_nan)
 
 
 def suite():

--- a/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
+++ b/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# test_SynapseCollection_distance.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests distance between sources and targets of SynapseCollection
+"""
+
+import unittest
+import math
+import nest
+
+
+class SynapseCollectionDistance(unittest.TestCase):
+
+    def setUp(self):
+        nest.ResetKernel()
+
+    def calculate_distance(self, conns, s_nodes, t_nodes):
+        """Calculate a reference distance between source nodes and target nodes"""
+
+        s_pos = nest.GetPosition(s_nodes)
+        t_pos = nest.GetPosition(t_nodes)
+
+        src = conns.source
+        trgt = conns.target
+
+        in_3d = len(s_pos[0]) == 3
+
+        ref_distance = []
+        for s, t in zip(src, trgt):
+            x_ref = t_pos[t_nodes.index(t)][0] - s_pos[s_nodes.index(s)][0]
+            y_ref = t_pos[t_nodes.index(t)][1] - s_pos[s_nodes.index(s)][1]
+            z_ref = 0.0
+            if in_3d:
+                z_ref = t_pos[t_nodes.index(t)][2] - s_pos[s_nodes.index(s)][2]
+
+            ref_dist = math.sqrt(x_ref * x_ref + y_ref * y_ref + z_ref * z_ref)
+            ref_distance.append(ref_dist)
+
+        return tuple(ref_distance)
+
+    def test_SynapseCollection_distance_simple(self):
+        """Test distance on SynapseCollection where source and target are equal"""
+
+        s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 3]))
+
+        nest.Connect(s_nodes, s_nodes, {'rule': 'one_to_one'})
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        self.assertTrue(all([dd == 0. for dd in dist]))
+
+    def test_SynapseCollection_distance(self):
+        """Test SynapseCollection distance function for grid positions"""
+
+        s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 1]))
+        t_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[1, 3]))
+
+        nest.Connect(s_nodes, t_nodes)
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
+
+        self.assertEqual(ref_distance, dist)
+
+    def test_SynapseCollection_distance_free(self):
+        """Test SynapseCollection distance function for positions placed freely in space"""
+
+        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+        s_nodes = nest.Create('iaf_psc_alpha', n=5, positions=positions)
+        t_nodes = nest.Create('iaf_psc_alpha', n=7, positions=positions)
+
+        nest.Connect(s_nodes, t_nodes, {'rule': 'pairwise_bernoulli', 'p': 0.7})
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
+
+        self.assertEqual(ref_distance, dist)
+
+    def test_SynapseCollection_distance_3D(self):
+        """Test SynapseCollection distance function for spatial nodes in 3D"""
+
+        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=3)
+        s_nodes = nest.Create('iaf_psc_alpha', n=8, positions=positions)
+        t_nodes = nest.Create('iaf_psc_alpha', n=11, positions=positions)
+
+        nest.Connect(s_nodes, t_nodes)
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
+
+        self.assertEqual(ref_distance, dist)
+
+
+def suite():
+    suite = unittest.makeSuite(SynapseCollectionDistance, 'test')
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())

--- a/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
+++ b/pynest/nest/tests/test_spatial/test_SynapseCollection_distance.py
@@ -34,7 +34,7 @@ class SynapseCollectionDistance(unittest.TestCase):
         nest.ResetKernel()
 
     def calculate_distance(self, conns, s_nodes, t_nodes):
-        """Calculate a reference distance between source nodes and target nodes"""
+        """Calculate a reference distance between source and target nodes"""
 
         s_pos = nest.GetPosition(s_nodes)
         t_pos = nest.GetPosition(t_nodes)
@@ -109,6 +109,40 @@ class SynapseCollectionDistance(unittest.TestCase):
         dist = conns.distance
 
         ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
+
+        self.assertEqual(ref_distance, dist)
+
+    def test_SynapseCollection_distance_non_spatial(self):
+        """Test SynapseCollection distance function on non-spatial nodes"""
+
+        s_nodes = nest.Create('iaf_psc_alpha', 3)
+        t_nodes = nest.Create('iaf_psc_alpha', 2)
+
+        nest.Connect(s_nodes, t_nodes)
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        ref_distance = tuple([0.0 for _ in range(6)])
+
+        self.assertEqual(ref_distance, dist)
+
+    def test_SynapseCollection_distance_mixed(self):
+        """Test SynapseCollection distance function on non-spatial and spatial nodes"""
+
+        s_nodes_nonspatial = nest.Create('iaf_psc_alpha', 3)
+        t_nodes_nonspatial = nest.Create('iaf_psc_alpha', 2)
+
+        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+        s_nodes_spatial = nest.Create('iaf_psc_alpha', n=6, positions=positions)
+        t_nodes_spatial = nest.Create('iaf_psc_alpha', n=7, positions=positions)
+
+        nest.Connect(s_nodes_nonspatial, t_nodes_nonspatial)
+        nest.Connect(s_nodes_spatial, t_nodes_spatial)
+        conns = nest.GetConnections()
+        dist = conns.distance
+
+        ref_distance = tuple([0.0 for _ in range(6)])
+        ref_distance += self.calculate_distance(conns[6:], s_nodes_spatial, t_nodes_spatial)
 
         self.assertEqual(ref_distance, dist)
 

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -124,8 +124,8 @@ get_position( const index node_id )
 
   if ( not meta )
   {
-    // We return 0.0 if node_id is not spatially distributed
-    std::vector< double > positions = { 0.0 };
+    // We return NaN if node_id is not spatially distributed
+    std::vector< double > positions = { std::nan( "1" ) };
     return positions;
   }
 
@@ -350,8 +350,8 @@ distance( const ArrayDatum conns )
     NodeCollectionPTR trgt_nc = trgt_node->get_nc();
     NodeCollectionMetadataPTR meta = trgt_nc->get_metadata();
 
-    // distance is zero if source, target is not spatially distributed
-    double dist = 0.0;
+    // distance is NaN if source, target is not spatially distributed
+    double dist = std::nan( "1" );
 
     if ( meta )
     {

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -125,7 +125,7 @@ get_position( const index node_id )
   if ( not meta )
   {
     // We return 0.0 if node_id is not spatially distributed
-    std::vector < double > positions = {0.0};
+    std::vector< double > positions = { 0.0 };
     return positions;
   }
 

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -109,6 +109,26 @@ get_position( NodeCollectionPTR layer_nc )
   return result;
 }
 
+std::vector< double >
+get_position( const index node_id )
+{
+  Node* node = kernel().node_manager.get_node_or_proxy( node_id );
+
+  if ( not kernel().node_manager.is_local_node_id( node_id ) )
+  {
+    throw KernelException( "GetPosition is currently implemented for local nodes only." );
+  }
+
+  NodeCollectionPTR nc = node->get_nc();
+  AbstractLayerPTR spatial_nc = get_layer( nc );
+  NodeCollectionMetadataPTR meta = nc->get_metadata();
+  index first_node_id = meta->get_first_node_id();
+
+  auto pos_vec = spatial_nc->get_position_vector( node_id - first_node_id );
+
+  return pos_vec;
+}
+
 ArrayDatum
 displacement( NodeCollectionPTR layer_to_nc, NodeCollectionPTR layer_from_nc )
 {
@@ -222,7 +242,7 @@ distance( NodeCollectionPTR layer_to_nc, NodeCollectionPTR layer_from_nc )
     index node_id = layer_from_nc->operator[]( 0 );
     if ( not kernel().node_manager.is_local_node_id( node_id ) )
     {
-      throw KernelException( "Displacement is currently implemented for local nodes only." );
+      throw KernelException( "Distance is currently implemented for local nodes only." );
     }
     const long lid = node_id - first_node_id;
 
@@ -241,7 +261,7 @@ distance( NodeCollectionPTR layer_to_nc, NodeCollectionPTR layer_from_nc )
       index node_id = ( *it ).node_id;
       if ( not kernel().node_manager.is_local_node_id( node_id ) )
       {
-        throw KernelException( "Displacement is currently implemented for local nodes only." );
+        throw KernelException( "Distance is currently implemented for local nodes only." );
       }
 
       const long lid = node_id - first_node_id;
@@ -276,7 +296,7 @@ distance( NodeCollectionPTR layer_nc, const ArrayDatum point )
     index node_id = ( *it ).node_id;
     if ( not kernel().node_manager.is_local_node_id( node_id ) )
     {
-      throw KernelException( "Displacement is currently implemented for local nodes only." );
+      throw KernelException( "Distance is currently implemented for local nodes only." );
     }
 
     const long lid = node_id - first_node_id;
@@ -291,6 +311,41 @@ distance( NodeCollectionPTR layer_nc, const ArrayDatum point )
     {
       ++counter;
     }
+  }
+  return result;
+}
+
+std::vector< double >
+distance( const ArrayDatum conns )
+{
+  std::vector< double > result;
+
+  size_t num_conns = conns.size();
+  result.reserve( num_conns );
+
+  for ( size_t conn_indx = 0; conn_indx < num_conns; ++conn_indx )
+  {
+    ConnectionDatum conn_id = getValue< ConnectionDatum >( conns.get( conn_indx ) );
+
+    index src = conn_id.get_source_node_id();
+    auto src_position = get_position( src );
+
+    index trgt = conn_id.get_target_node_id();
+
+    if ( not kernel().node_manager.is_local_node_id( trgt ) )
+    {
+      throw KernelException( "Distance is currently implemented for local nodes only." );
+    }
+
+    Node* trgt_node = kernel().node_manager.get_node_or_proxy( trgt );
+
+    NodeCollectionPTR trgt_nc = trgt_node->get_nc();
+    AbstractLayerPTR spatial_trgt_nc = get_layer( trgt_nc );
+    NodeCollectionMetadataPTR meta = trgt_nc->get_metadata();
+    index first_trgt_node_id = meta->get_first_node_id();
+
+    double disp = spatial_trgt_nc->compute_distance( src_position, trgt - first_trgt_node_id );
+    result.push_back( disp );
   }
   return result;
 }

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -120,8 +120,16 @@ get_position( const index node_id )
   }
 
   NodeCollectionPTR nc = node->get_nc();
-  AbstractLayerPTR spatial_nc = get_layer( nc );
   NodeCollectionMetadataPTR meta = nc->get_metadata();
+
+  if ( not meta )
+  {
+    // We return 0.0 if node_id is not spatially distributed
+    std::vector < double > positions = {0.0};
+    return positions;
+  }
+
+  AbstractLayerPTR spatial_nc = get_layer( nc );
   index first_node_id = meta->get_first_node_id();
 
   auto pos_vec = spatial_nc->get_position_vector( node_id - first_node_id );
@@ -340,12 +348,21 @@ distance( const ArrayDatum conns )
     Node* trgt_node = kernel().node_manager.get_node_or_proxy( trgt );
 
     NodeCollectionPTR trgt_nc = trgt_node->get_nc();
-    AbstractLayerPTR spatial_trgt_nc = get_layer( trgt_nc );
     NodeCollectionMetadataPTR meta = trgt_nc->get_metadata();
-    index first_trgt_node_id = meta->get_first_node_id();
 
-    double disp = spatial_trgt_nc->compute_distance( src_position, trgt - first_trgt_node_id );
-    result.push_back( disp );
+    // distance is zero if source, target is not spatially distributed
+    double dist = 0.0;
+
+    if ( meta )
+    {
+      AbstractLayerPTR spatial_trgt_nc = get_layer( trgt_nc );
+      NodeCollectionMetadataPTR meta = trgt_nc->get_metadata();
+      index first_trgt_node_id = meta->get_first_node_id();
+
+      dist = spatial_trgt_nc->compute_distance( src_position, trgt - first_trgt_node_id );
+    }
+
+    result.push_back( dist );
   }
   return result;
 }

--- a/topology/topology.cpp
+++ b/topology/topology.cpp
@@ -125,7 +125,7 @@ get_position( const index node_id )
   if ( not meta )
   {
     // We return NaN if node_id is not spatially distributed
-    std::vector< double > positions = { std::nan( "1" ) };
+    std::vector< double > positions = { std::nan( "1" ), std::nan( "1" ) };
     return positions;
   }
 

--- a/topology/topology.h
+++ b/topology/topology.h
@@ -97,10 +97,12 @@ private:
 AbstractLayerPTR get_layer( NodeCollectionPTR layer_nc );
 NodeCollectionPTR create_layer( const DictionaryDatum& layer_dict );
 ArrayDatum get_position( NodeCollectionPTR layer_nc );
+std::vector< double > get_position( const index node_id );
 ArrayDatum displacement( NodeCollectionPTR layer_to_nc, NodeCollectionPTR layer_from_nc );
 ArrayDatum displacement( NodeCollectionPTR layer_nc, const ArrayDatum point );
 std::vector< double > distance( NodeCollectionPTR layer_to_nc, NodeCollectionPTR layer_from_nc );
 std::vector< double > distance( NodeCollectionPTR layer_nc, const ArrayDatum point );
+std::vector< double > distance( const ArrayDatum conns );
 MaskDatum create_mask( const DictionaryDatum& mask_dict );
 BoolDatum inside( const std::vector< double >& point, const MaskDatum& mask );
 MaskDatum intersect_mask( const MaskDatum& mask1, const MaskDatum& mask2 );

--- a/topology/topologymodule.cpp
+++ b/topology/topologymodule.cpp
@@ -230,6 +230,8 @@ TopologyModule::init( SLIInterpreter* i )
 
   i->createcommand( "Distance_a_g", &distance_a_gfunction );
 
+  i->createcommand( "Distance_a", &distance_afunction );
+
   i->createcommand( "CreateMask_D", &createmask_Dfunction );
 
   i->createcommand( "Inside_a_M", &inside_a_Mfunction );
@@ -506,6 +508,20 @@ TopologyModule::Distance_a_gFunction::execute( SLIInterpreter* i ) const
   Token result = distance( layer, point );
 
   i->OStack.pop( 2 );
+  i->OStack.push( result );
+  i->EStack.pop();
+}
+
+void
+TopologyModule::Distance_aFunction::execute( SLIInterpreter* i ) const
+{
+  i->assert_stack_load( 1 );
+
+  const ArrayDatum conns = getValue< ArrayDatum >( i->OStack.pick( 0 ) );
+
+  Token result = distance( conns );
+
+  i->OStack.pop( 1 );
   i->OStack.push( result );
   i->EStack.pop();
 }

--- a/topology/topologymodule.h
+++ b/topology/topologymodule.h
@@ -98,6 +98,12 @@ public:
     void execute( SLIInterpreter* ) const;
   } distance_a_gfunction;
 
+  class Distance_aFunction : public SLIFunction
+  {
+  public:
+    void execute( SLIInterpreter* ) const;
+  } distance_afunction;
+
   class ConnectLayers_g_g_DFunction : public SLIFunction
   {
   public:


### PR DESCRIPTION
Get the distance between source and target in a `SynapseCollection` as a tuple of same length as the SynapseCollection.

The value at index `indx` is the distance between the source, target pair at index `indx` in the SynapseCollection. I can also make it so that we return a list of lists with the distance between *all* sources and targets if that is better.

To get the distance, do
```
conn = nest.GetConnections()
distance = conn.distance
```

If the source and target pairs are not spatially distributed, zeros are returned.

This fixes #1616 