### PR TITLE
Fix Izhikevich model initial conditions

### DIFF
--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -78,8 +78,8 @@ nest::izhikevich::Parameters_::Parameters_()
 }
 
 nest::izhikevich::State_::State_()
-  : v_( -70.0 )       // membrane potential
-  , u_( 0.2 * -70.0 ) // membrane recovery variable (b * V_m_init)
+  : v_( -65.0 )       // membrane potential
+  , u_( 0.2 * -65.0 ) // membrane recovery variable (b * V_m_init)
   , I_( 0.0 )         // input current
 {
 }

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -78,9 +78,9 @@ nest::izhikevich::Parameters_::Parameters_()
 }
 
 nest::izhikevich::State_::State_()
-  : v_( -70.0 ) // membrane potential
-  , u_( 0.2 * -70.0 )   // membrane recovery variable (b * V_m_init)
-  , I_( 0.0 )   // input current
+  : v_( -70.0 )       // membrane potential
+  , u_( 0.2 * -70.0 ) // membrane recovery variable (b * V_m_init)
+  , I_( 0.0 )         // input current
 {
 }
 

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -78,8 +78,8 @@ nest::izhikevich::Parameters_::Parameters_()
 }
 
 nest::izhikevich::State_::State_()
-  : v_( -65.0 ) // membrane potential
-  , u_( 0.0 )   // membrane recovery variable
+  : v_( -70.0 ) // membrane potential
+  , u_( 0.2 * -70.0 )   // membrane recovery variable (b * V_m_init)
   , I_( 0.0 )   // input current
 {
 }


### PR DESCRIPTION
Presently, the Izhikevich neuron model does not start at equilibrium: the initial conditions for V and U are such that there is an initial transient, before the system settles to steady-state.

This PR proposes to change the default initial conditions such that the initial state is stable.