### PR TITLE
Update description for parameter U in Tsodyks synapses

### DIFF
--- a/models/tsodyks2_connection.h
+++ b/models/tsodyks2_connection.h
@@ -60,7 +60,8 @@ Parameters
 The following parameters can be set in the status dictionary:
 
 ========  ======  ========================================================
- U        real    Parameter determining the increase in u with each spike (U1) [0,1], default=0.5
+ U        real    Parameter determining the increase in u with each spike
+                  (U1) [0,1], default=0.5
  u        real    The probability of release (U_se) [0,1],
                   default=0.5
  x        real    Current scaling factor of the weight, default=U

--- a/models/tsodyks2_connection.h
+++ b/models/tsodyks2_connection.h
@@ -60,8 +60,8 @@ Parameters
 The following parameters can be set in the status dictionary:
 
 ========  ======  ========================================================
- U        real    Maximum probability of release (U1) [0,1], default=0.5
- u        real    Maximum probability of release (U_se) [0,1],
+ U        real    Parameter determining the increase in u with each spike (U1) [0,1], default=0.5
+ u        real    The probability of release (U_se) [0,1],
                   default=0.5
  x        real    Current scaling factor of the weight, default=U
  tau_fac  ms      Time constant for facilitation, default = 0(off)

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -101,7 +101,7 @@ The following parameters can be set in the status dictionary:
                   releasable pool [0,1]
  y        real    Initial fraction of synaptic vesicles in the synaptic
                   cleft [0,1]
-========  ======  ======================================================
+========  ======  ========================================================
 
 References
 ++++++++++

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -92,7 +92,7 @@ Parameters
 The following parameters can be set in the status dictionary:
 
 ========  ======  ======================================================
- U        real    Maximum probability of release [0,1]
+ U        real    Parameter determining the increase in u with each spike [0,1]
  tau_psc  ms      Time constant of synaptic current
  tau_fac  ms      Time constant for facilitation
  tau_rec  ms      Time constant for depression

--- a/models/tsodyks_connection.h
+++ b/models/tsodyks_connection.h
@@ -91,8 +91,9 @@ Parameters
 
 The following parameters can be set in the status dictionary:
 
-========  ======  ======================================================
- U        real    Parameter determining the increase in u with each spike [0,1]
+========  ======  ========================================================
+ U        real    Parameter determining the increase in u with each spike
+                  [0,1]
  tau_psc  ms      Time constant of synaptic current
  tau_fac  ms      Time constant for facilitation
  tau_rec  ms      Time constant for depression

--- a/models/tsodyks_connection_hom.h
+++ b/models/tsodyks_connection_hom.h
@@ -97,7 +97,7 @@ Parameters
                   releasable pool [0,1]
  y        real    Initial fraction of synaptic vesicles in the synaptic
                   cleft [0,1]
-========  ======  ======================================================
+========  ======  ========================================================
 
 Remarks:
 

--- a/models/tsodyks_connection_hom.h
+++ b/models/tsodyks_connection_hom.h
@@ -88,7 +88,7 @@ Parameters
 ++++++++++
 
 ========  ======  ======================================================
- U        real    Maximum probability of release [0,1]
+ U        real    Parameter determining the increase in u with each spike [0,1]
  tau_psc  ms      Time constant of synaptic current
  tau_fac  ms      Time constant for facilitation
  tau_rec  ms      Time constant for depression

--- a/models/tsodyks_connection_hom.h
+++ b/models/tsodyks_connection_hom.h
@@ -87,8 +87,9 @@ an arbitrary postsynaptic effect depending on y(t).
 Parameters
 ++++++++++
 
-========  ======  ======================================================
- U        real    Parameter determining the increase in u with each spike [0,1]
+========  ======  ========================================================
+ U        real    Parameter determining the increase in u with each spike
+                  [0,1]
  tau_psc  ms      Time constant of synaptic current
  tau_fac  ms      Time constant for facilitation
  tau_rec  ms      Time constant for depression


### PR DESCRIPTION
The parameter U in the Tsodyks synapses (defined in tsodyks_connection.h, tsodyks2_connection.h, tsodyks_connection_hom.h) is the parameter determining the step increase of the release probability u with each spike, according to the original article of the model (Tsodyks, Uziel, Markram, 2000). Currently the relevant description in the files does not match this definition very well, so here it is updated. It is changed from "Maximum probability of release" to "Parameter determining the increase in u with each spike". 
Along with this, the description for u in tsodyks2_connection.h is also changed from "Maximum probability of release" to "The probability of release", which also fit the definition in the original article better.