### PR TITLE
Fix GetConnections to correctly get connections with devices as sources when specifying only target

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -926,7 +926,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
 
       // Getting regular connections, if they exist.
       ConnectorBase* connections = connections_[ tid ][ syn_id ];
-      if ( connections != NULL )
+      if ( connections != nullptr )
       {
         const size_t num_connections_in_thread = connections->size();
         for ( index lcid = 0; lcid < num_connections_in_thread; ++lcid )

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -924,6 +924,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
       std::vector< index > target_device_node_ids;
       split_to_neuron_device_vectors_( tid, target, target_neuron_node_ids, target_device_node_ids );
 
+      // Getting regular connections, if they exist.
       ConnectorBase* connections = connections_[ tid ][ syn_id ];
       if ( connections != NULL )
       {
@@ -946,11 +947,11 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
           0, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
       }
 
+      // Getting connections to devices.
       for ( std::vector< index >::const_iterator t_node_id = target_device_node_ids.begin();
             t_node_id != target_device_node_ids.end();
             ++t_node_id )
       {
-        // Then, we get connections to devices.
         target_table_devices_.get_connections_to_devices_( 0, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
       }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -940,7 +940,6 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
       // Getting connections from devices.
       for ( auto t_node_id : target_neuron_node_ids )
       {
-        // target_table_devices_ contains connections both to and from devices
         target_table_devices_.get_connections_from_devices_(
           0, t_node_id, tid, syn_id, synapse_label, conns_in_thread );
       }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -938,21 +938,18 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
       }
 
       // Getting connections from devices.
-      for ( std::vector< index >::const_iterator t_node_id = target_neuron_node_ids.begin();
-            t_node_id != target_neuron_node_ids.end();
-            ++t_node_id )
+      for ( auto t_node_id : target_neuron_node_ids )
       {
         // target_table_devices_ contains connections both to and from devices
         target_table_devices_.get_connections_from_devices_(
-          0, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
+          0, t_node_id, tid, syn_id, synapse_label, conns_in_thread );
       }
 
       // Getting connections to devices.
-      for ( std::vector< index >::const_iterator t_node_id = target_device_node_ids.begin();
-            t_node_id != target_device_node_ids.end();
-            ++t_node_id )
+      for ( auto t_device_id : target_device_node_ids )
       {
-        target_table_devices_.get_connections_to_devices_( 0, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
+        target_table_devices_.get_connections_to_devices_(
+          0, t_device_id, tid, syn_id, synapse_label, conns_in_thread );
       }
 
       if ( conns_in_thread.size() > 0 )

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -934,16 +934,16 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
           connections->get_connection_with_specified_targets(
             source_node_id, target_neuron_node_ids, tid, lcid, synapse_label, conns_in_thread );
         }
+      }
 
-        for ( std::vector< index >::const_iterator t_node_id = target_neuron_node_ids.begin();
-              t_node_id != target_neuron_node_ids.end();
-              ++t_node_id )
-        {
-          // target_table_devices_ contains connections both to and from
-          // devices. First we get connections from devices.
-          target_table_devices_.get_connections_from_devices_(
-            0, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
-        }
+      // Getting connections from devices.
+      for ( std::vector< index >::const_iterator t_node_id = target_neuron_node_ids.begin();
+            t_node_id != target_neuron_node_ids.end();
+            ++t_node_id )
+      {
+        // target_table_devices_ contains connections both to and from devices
+        target_table_devices_.get_connections_from_devices_(
+          0, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
       }
 
       for ( std::vector< index >::const_iterator t_node_id = target_device_node_ids.begin();

--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -26,6 +26,8 @@ GetConnections
 import unittest
 import nest
 
+nest.set_verbosity('M_ERROR')
+
 
 @nest.ll_api.check_stack
 class GetConnectionsTestCase(unittest.TestCase):
@@ -67,6 +69,7 @@ class GetConnectionsTestCase(unittest.TestCase):
     def test_GetConnectionsTargetModels(self):
         """GetConnections iterating models for target"""
         for model in nest.Models():
+            nest.ResetKernel()
             alpha = nest.Create('iaf_psc_alpha')
             try:
                 other = nest.Create(model)
@@ -75,14 +78,19 @@ class GetConnectionsTestCase(unittest.TestCase):
                 # If we can't create a node with this model, or connect
                 # to a node of this model, we ignore it.
                 continue
-            conns = nest.GetConnections(alpha, other)
-            self.assertEqual(
-                len(conns), 1,
-                'Failed to get connection with target model {}'.format(model))
+            for get_conn_args in [{'source': alpha, 'target': other},
+                                  {'source': alpha},
+                                  {'target': other}]:
+                conns = nest.GetConnections(**get_conn_args)
+                self.assertEqual(
+                    len(conns), 1,
+                    'Failed to get connection with target model {} (specifying {})'.format(
+                        model, ', '.join(get_conn_args.keys())))
 
     def test_GetConnectionsSourceModels(self):
         """GetConnections iterating models for source"""
         for model in nest.Models():
+            nest.ResetKernel()
             alpha = nest.Create('iaf_psc_alpha')
             try:
                 other = nest.Create(model)
@@ -91,10 +99,14 @@ class GetConnectionsTestCase(unittest.TestCase):
                 # If we can't create a node with this model, or connect
                 # to a node of this model, we ignore it.
                 continue
-            conns = nest.GetConnections(other, alpha)
-            self.assertEqual(
-                len(conns), 1,
-                'Failed to get connection with source model {}'.format(model))
+            for get_conn_args in [{'source': other, 'target': alpha},
+                                  {'source': other},
+                                  {'target': alpha}]:
+                conns = nest.GetConnections(**get_conn_args)
+                self.assertEqual(
+                    len(conns), 1,
+                    'Failed to get connection with source model {} (specifying {})'.format(
+                        model, ', '.join(get_conn_args.keys())))
 
 
 def suite():


### PR DESCRIPTION
Getting connections with a device as pre-synaptic endpoint, when specifying only targets, was in an if-statement. The if-statement checked if a connector object had been created for that thread and synapse. Therefore connections with devices as pre-synaptic endpoint would be retrieved only if there were other connections, without devices, present.

Getting connections with devices as pre-synaptic endpoints is with this PR moved out of the if-statement. Additionally, the test of `GetConnections()` is made more robust to be able to catch errors like this.

Fixes #1431