### PR TITLE
Refer to Vim syntax highlighting

### DIFF
--- a/doc/sli_docs/an-introduction-to-sli.rst
+++ b/doc/sli_docs/an-introduction-to-sli.rst
@@ -56,7 +56,15 @@ to find out about NEST’s command-line parameters.
                                show messages of this priority and above.
          --verbosity=QUIET     turn off all messages.
 
-If you are a Vim user and require support for SLI files, please refer to our :doc:`../contribute/templates_styleguides/vim_support_sli`.
+SLI scripts
+~~~~~~~~~~~
+Scripts can be run by typing:
+::
+
+   <prefix>/bin/nest <file>
+
+If you are a Vim user and require support for SLI files, please refer to
+our :doc:`../contribute/templates_styleguides/vim_support_sli`.
 
 Supplying SLI scripts with parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sli_docs/an-introduction-to-sli.rst
+++ b/doc/sli_docs/an-introduction-to-sli.rst
@@ -68,7 +68,7 @@ If you are a Vim user and require support for SLI files, please refer to
 our :doc:`../contribute/templates_styleguides/vim_support_sli`.
 
 Supplying SLI scripts with parameters
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using the ``--userargs=arg1:...`` command line switch, it is possible to
 supply a SLI script with parameters from the outside of NEST. A common

--- a/doc/sli_docs/an-introduction-to-sli.rst
+++ b/doc/sli_docs/an-introduction-to-sli.rst
@@ -57,7 +57,8 @@ to find out about NEST’s command-line parameters.
          --verbosity=QUIET     turn off all messages.
 
 SLI scripts
-~~~~~~~~~~~
+-----------
+
 Scripts can be run by typing:
 ::
 
@@ -67,7 +68,7 @@ If you are a Vim user and require support for SLI files, please refer to
 our :doc:`../contribute/templates_styleguides/vim_support_sli`.
 
 Supplying SLI scripts with parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 
 Using the ``--userargs=arg1:...`` command line switch, it is possible to
 supply a SLI script with parameters from the outside of NEST. A common

--- a/doc/sli_docs/an-introduction-to-sli.rst
+++ b/doc/sli_docs/an-introduction-to-sli.rst
@@ -56,6 +56,8 @@ to find out about NEST’s command-line parameters.
                                show messages of this priority and above.
          --verbosity=QUIET     turn off all messages.
 
+If you are a Vim user and require support for SLI files, please refer to our :doc:`../contribute/templates_styleguides/vim_support_sli`.
+
 Supplying SLI scripts with parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This pull request provides a link to the Vim Syntax Highlighting file in the NEST/SLI introduction.

Partial fix for #1635.