### PR TITLE
Update .gitignore with CTestTestfile.cmake and files generated by Doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,36 @@ CMakeCache.txt
 CPackConfig.cmake
 CPackSourceConfig.cmake
 
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
+CTestTestfile.cmake
+doc/CTestTestfile.cmake
+doc/examples/microcircuit.png
+doc/examples/reference_data/
+examples/CTestTestfile.cmake
+extras/CTestTestfile.cmake
+extras/ConnPlotter/CTestTestfile.cmake
+lib/CTestTestfile.cmake
+libnestutil/CTestTestfile.cmake
+librandom/CTestTestfile.cmake
+models/CTestTestfile.cmake
+nest/CTestTestfile.cmake
+nestkernel/CTestTestfile.cmake
+precise/CTestTestfile.cmake
+pynest/CTestTestfile.cmake
+sli/CTestTestfile.cmake
+testsuite/CTestTestfile.cmake
+testsuite/cpptests/CTestTestfile.cmake
+testsuite/mpi_selftests/fail/CTestTestfile.cmake
+testsuite/mpi_selftests/pass/CTestTestfile.cmake
+testsuite/mpitests/CTestTestfile.cmake
+testsuite/musictests/CTestTestfile.cmake
+testsuite/regressiontests/CTestTestfile.cmake
+testsuite/selftests/CTestTestfile.cmake
+testsuite/unittests/CTestTestfile.cmake
+topology/CTestTestfile.cmake
+
+
 # generated files
 doc/set_rcsinfo.cmake
 doc/fulldoc.conf

--- a/.gitignore
+++ b/.gitignore
@@ -56,12 +56,13 @@ CMakeCache.txt
 CPackConfig.cmake
 CPackSourceConfig.cmake
 
+#Generated during Doxygen build
 CMakeDoxyfile.in
 CMakeDoxygenDefaults.cmake
+
+#CTestTestfiles
 CTestTestfile.cmake
 doc/CTestTestfile.cmake
-doc/examples/microcircuit.png
-doc/examples/reference_data/
 examples/CTestTestfile.cmake
 extras/CTestTestfile.cmake
 extras/ConnPlotter/CTestTestfile.cmake
@@ -85,7 +86,6 @@ testsuite/selftests/CTestTestfile.cmake
 testsuite/unittests/CTestTestfile.cmake
 topology/CTestTestfile.cmake
 
-
 # generated files
 doc/set_rcsinfo.cmake
 doc/fulldoc.conf
@@ -94,6 +94,8 @@ doc/userdocs/
 doc/pynestkernel_mock.py
 doc/from_cpp/
 doc/microcircuit/
+doc/examples/microcircuit.png
+doc/examples/reference_data/
 lib/sli/rcsinfo.sli
 extras/nest_vars.sh
 


### PR DESCRIPTION
I got several untracked files that were apparently generated by cmake/when building the Doxygen documentation. This patch adds them to .gitignore.