### PR TITLE
Update model documentation output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ CPackSourceConfig.cmake
 doc/set_rcsinfo.cmake
 doc/fulldoc.conf
 doc/normaldoc.conf
-doc/userdocs/
+doc/models/
 doc/pynestkernel_mock.py
 doc/from_cpp/
 doc/microcircuit/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -202,7 +202,7 @@ from doc.extractor_userdocs import ExtractUserDocs, relative_glob  # noqa
 def config_inited_handler(app, config):
     ExtractUserDocs(
         relative_glob("models/*.h", "nestkernel/*.h", basedir='..'),
-        outdir="userdocs/"
+        outdir="models/"
     )
 
 

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -14,7 +14,7 @@ Table of Contents
    Install <installation/index>
    getting_started
    tutorials/index
-   userdocs/index
+   models/index
    guides/index
    models/index
    examples/index

--- a/doc/guides/recording_from_simulations.rst
+++ b/doc/guides/recording_from_simulations.rst
@@ -100,11 +100,11 @@ instance:
 Recorders for every-day situations
 ----------------------------------
 
-.. include:: ../userdocs/multimeter.rst
+.. include:: ../models/multimeter.rst
 
-.. include:: ../userdocs/spike_detector.rst
+.. include:: ../models/spike_detector.rst
 
-.. include:: ../userdocs/weight_recorder.rst
+.. include:: ../models/weight_recorder.rst
 
 .. _recording_backends:
 
@@ -174,12 +174,12 @@ dictionary to ``SetKernelStatus``.
 
     nest.SetKernelStatus({"recording_backends": {'sionlib': {'buffer_size': 512}}})
 
-.. include:: ../userdocs/recording_backend_memory.rst
+.. include:: ../models/recording_backend_memory.rst
 
-.. include:: ../userdocs/recording_backend_ascii.rst
+.. include:: ../models/recording_backend_ascii.rst
 
-.. include:: ../userdocs/recording_backend_screen.rst
+.. include:: ../models/recording_backend_screen.rst
 
 .. _sionlib_backend:
 
-.. include:: ../userdocs/recording_backend_sionlib.rst
+.. include:: ../models/recording_backend_sionlib.rst


### PR DESCRIPTION
As discussed with @steffengraber and @terhorstd offline, this PR renames the output directory of the automatically generated RST files from ``userdocs`` to ``models``. 

Relevant links in the documentation and ``.gitignore`` are updated accordingly.

It fixes #1643.