### PR TITLE
Add special cases for empty NodeCollections

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -358,11 +358,11 @@ nest::ConnectionManager::connect( NodeCollectionPTR sources,
 {
   if ( sources->empty() )
   {
-    throw BadProperty( "Presynaptic nodes cannot be an empty NodeCollection" );
+    throw IllegalConnection( "Presynaptic nodes cannot be an empty NodeCollection" );
   }
   if ( targets->empty() )
   {
-    throw BadProperty( "Postsynaptic nodes cannot be an empty NodeCollection" );
+    throw IllegalConnection( "Postsynaptic nodes cannot be an empty NodeCollection" );
   }
 
   conn_spec->clear_access_flags();

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -356,6 +356,15 @@ nest::ConnectionManager::connect( NodeCollectionPTR sources,
   const DictionaryDatum& conn_spec,
   const DictionaryDatum& syn_spec )
 {
+  if ( sources->empty() )
+  {
+    throw BadProperty( "Presynaptic nodes cannot be an empty NodeCollection" );
+  }
+  if ( targets->empty() )
+  {
+    throw BadProperty( "Postsynaptic nodes cannot be an empty NodeCollection" );
+  }
+
   conn_spec->clear_access_flags();
   syn_spec->clear_access_flags();
 

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -294,6 +294,10 @@ NodeCollectionPrimitive::to_array() const
 
 NodeCollectionPTR NodeCollectionPrimitive::operator+( NodeCollectionPTR rhs ) const
 {
+  if ( not valid() or not rhs->valid() )
+  {
+    throw KernelException( "InvalidNodeCollection" );
+  }
   if ( rhs->empty() )
   {
     return NodeCollectionPTR( new NodeCollectionPrimitive( *this ) );
@@ -318,10 +322,7 @@ NodeCollectionPTR NodeCollectionPrimitive::operator+( NodeCollectionPTR rhs ) co
   {
     throw BadProperty( "Can only join NodeCollections with same metadata." );
   }
-  if ( not valid() or not rhs->valid() )
-  {
-    throw KernelException( "InvalidNodeCollection" );
-  }
+
   auto const* const rhs_ptr = dynamic_cast< NodeCollectionPrimitive const* >( rhs.get() );
 
   if ( rhs_ptr ) // if rhs is Primitive

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -300,7 +300,19 @@ NodeCollectionPTR NodeCollectionPrimitive::operator+( NodeCollectionPTR rhs ) co
   }
   if ( empty() )
   {
-    return NodeCollectionPTR( rhs );
+    auto const* const rhs_ptr = dynamic_cast< NodeCollectionPrimitive const* >( rhs.get() );
+    if ( rhs_ptr )
+    {
+      // rhs is primitive
+      return std::make_shared< NodeCollectionPrimitive >( *rhs_ptr );
+    }
+    else
+    {
+      // rhs is composite
+      auto const* const rhs_ptr = dynamic_cast< NodeCollectionComposite const* >( rhs.get() );
+      assert( rhs_ptr );
+      return std::make_shared< NodeCollectionComposite >( *rhs_ptr );
+    }
   }
   if ( ( get_metadata().get() or rhs->get_metadata().get() ) and not( get_metadata() == rhs->get_metadata() ) )
   {

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -294,6 +294,14 @@ NodeCollectionPrimitive::to_array() const
 
 NodeCollectionPTR NodeCollectionPrimitive::operator+( NodeCollectionPTR rhs ) const
 {
+  if ( rhs->empty() )
+  {
+    return NodeCollectionPTR( new NodeCollectionPrimitive( *this ) );
+  }
+  if ( empty() )
+  {
+    return NodeCollectionPTR( rhs );
+  }
   if ( ( get_metadata().get() or rhs->get_metadata().get() ) and not( get_metadata() == rhs->get_metadata() ) )
   {
     throw BadProperty( "Can only join NodeCollections with same metadata." );
@@ -400,11 +408,17 @@ NodeCollectionPrimitive::NodeCollectionPrimitive::slice( size_t start, size_t st
 void
 NodeCollectionPrimitive::print_me( std::ostream& out ) const
 {
-  std::string metadata = metadata_.get() ? metadata_->get_type() : "None";
-
-  out << "NodeCollection("
-      << "metadata=" << metadata << ", ";
-  print_primitive( out );
+  out << "NodeCollection(";
+  if ( empty() )
+  {
+    out << "<empty>";
+  }
+  else
+  {
+    std::string metadata = metadata_.get() ? metadata_->get_type() : "None";
+    out << "metadata=" << metadata << ", ";
+    print_primitive( out );
+  }
   out << ")";
 }
 
@@ -550,6 +564,10 @@ NodeCollectionComposite::NodeCollectionComposite( const NodeCollectionComposite&
 
 NodeCollectionPTR NodeCollectionComposite::operator+( NodeCollectionPTR rhs ) const
 {
+  if ( rhs->empty() )
+  {
+    return NodeCollectionPTR( new NodeCollectionComposite( *this ) );
+  }
   if ( get_metadata().get() and not( get_metadata() == rhs->get_metadata() ) )
   {
     throw BadProperty( "can only join NodeCollections with the same metadata" );

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -334,6 +334,13 @@ public:
   virtual bool is_range() const = 0;
 
   /**
+   * Checks if the NodeCollection has no elements.
+   *
+   * @return true if the NodeCollection is empty, false otherwise
+   */
+  virtual bool empty() const = 0;
+
+  /**
    * Returns index of node with given node ID in NodeCollection.
    *
    * @return Index of node with given node ID; -1 if node not in NodeCollection.
@@ -435,6 +442,7 @@ public:
   NodeCollectionMetadataPTR get_metadata() const override;
 
   bool is_range() const override;
+  bool empty() const override;
 
   long find( const index ) const override;
 
@@ -561,6 +569,7 @@ public:
   NodeCollectionMetadataPTR get_metadata() const override;
 
   bool is_range() const override;
+  bool empty() const override;
 
   long find( const index ) const override;
 };
@@ -781,6 +790,12 @@ NodeCollectionPrimitive::is_range() const
   return true;
 }
 
+inline bool
+NodeCollectionPrimitive::empty() const
+{
+  return last_ == 0;
+}
+
 inline long
 NodeCollectionPrimitive::find( const index neuron_id ) const
 {
@@ -885,6 +900,13 @@ NodeCollectionComposite::get_metadata() const
 inline bool
 NodeCollectionComposite::is_range() const
 {
+  return false;
+}
+
+inline bool
+NodeCollectionComposite::empty() const
+{
+  // Composite NodeCollections can never be empty.
   return false;
 }
 } // namespace nest

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -371,7 +371,7 @@ def GetStatus(nodes, keys=None, output=''):
         raise TypeError("The first input (nodes) must be NodeCollection or a SynapseCollection with connection handles")
 
     if len(nodes) == 0:
-        return nodes
+        return
 
     if keys is None:
         cmd = 'GetStatus'

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -371,7 +371,7 @@ def GetStatus(nodes, keys=None, output=''):
         raise TypeError("The first input (nodes) must be NodeCollection or a SynapseCollection with connection handles")
 
     if len(nodes) == 0:
-        return
+        return [] if output == 'json' else ()
 
     if keys is None:
         cmd = 'GetStatus'

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -371,7 +371,7 @@ def GetStatus(nodes, keys=None, output=''):
         raise TypeError("The first input (nodes) must be NodeCollection or a SynapseCollection with connection handles")
 
     if len(nodes) == 0:
-        return [] if output == 'json' else ()
+        return '[]' if output == 'json' else ()
 
     if keys is None:
         cmd = 'GetStatus'

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -331,7 +331,7 @@ class NodeCollection(object):
         set
         """
 
-        if self.empty():
+        if not self.__bool__():
             return
 
         # ------------------------- #
@@ -400,7 +400,7 @@ class NodeCollection(object):
             If the specified parameter does not exist for the nodes.
         """
 
-        if self.empty():
+        if not self.__bool__():
             return
         if kwargs and params is None:
             params = kwargs
@@ -460,9 +460,9 @@ class NodeCollection(object):
 
         return index
 
-    def empty(self):
-        """Returns whether the NodeCollection is empty."""
-        return self.__len__() == 0
+    def __bool__(self):
+        """Converts the NodeCollection to a bool. False if it is empty, True otherwise."""
+        return self.__len__() > 0
 
     def __array__(self, dtype=None):
         """Convert the NodeCollection to a NumPy array."""

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -454,6 +454,10 @@ class NodeCollection(object):
 
         return index
 
+    def empty(self):
+        """Returns whether the NodeCollection is empty."""
+        return self.__len__() == 0
+
     def __array__(self, dtype=None):
         """Convert the NodeCollection to a NumPy array."""
         return numpy.array(self.tolist(), dtype=dtype)

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -182,7 +182,9 @@ class NodeCollection(object):
 
     _datum = None
 
-    def __init__(self, data):
+    def __init__(self, data=None):
+        if data is None:
+            data = []
         if isinstance(data, kernel.SLIDatum):
             if data.dtype != "nodecollectiontype":
                 raise TypeError("Need NodeCollection Datum.")

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -331,7 +331,7 @@ class NodeCollection(object):
         set
         """
 
-        if not self.__bool__():
+        if not self:
             return
 
         # ------------------------- #
@@ -400,7 +400,7 @@ class NodeCollection(object):
             If the specified parameter does not exist for the nodes.
         """
 
-        if not self.__bool__():
+        if not self:
             return
         if kwargs and params is None:
             params = kwargs
@@ -462,7 +462,7 @@ class NodeCollection(object):
 
     def __bool__(self):
         """Converts the NodeCollection to a bool. False if it is empty, True otherwise."""
-        return self.__len__() > 0
+        return len(self) > 0
 
     def __array__(self, dtype=None):
         """Convert the NodeCollection to a NumPy array."""

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -332,7 +332,7 @@ class NodeCollection(object):
         """
 
         if not self:
-            return
+            raise ValueError('Cannot get parameter of empty NodeCollection')
 
         # ------------------------- #
         #      Checks of input      #
@@ -469,6 +469,9 @@ class NodeCollection(object):
         return numpy.array(self.tolist(), dtype=dtype)
 
     def __getattr__(self, attr):
+        if not self:
+            raise AttributeError('Cannot get attribute of empty NodeCollection')
+
         if attr == 'spatial':
             metadata = sli_func('GetMetadata', self._datum)
             val = metadata if metadata else None

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -330,6 +330,10 @@ class NodeCollection(object):
         --------
         set
         """
+
+        if self.empty():
+            return
+
         # ------------------------- #
         #      Checks of input      #
         # ------------------------- #
@@ -396,6 +400,8 @@ class NodeCollection(object):
             If the specified parameter does not exist for the nodes.
         """
 
+        if self.empty():
+            return
         if kwargs and params is None:
             params = kwargs
         elif kwargs and params:

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -707,13 +707,13 @@ class TestNodeCollection(unittest.TestCase):
 
         for empty_nc in [nest.NodeCollection(), nest.NodeCollection([])]:
 
-            with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+            with self.assertRaises(nest.kernel.NESTErrors.IllegalConnection):
                 nest.Connect(nodes, empty_nc)
 
-            with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+            with self.assertRaises(nest.kernel.NESTErrors.IllegalConnection):
                 nest.Connect(empty_nc, nodes)
 
-            with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+            with self.assertRaises(nest.kernel.NESTErrors.IllegalConnection):
                 nest.Connect(empty_nc, empty_nc)
 
             with self.assertRaises(ValueError):

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -715,9 +715,14 @@ class TestNodeCollection(unittest.TestCase):
         with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
             nest.Connect(empty_nc, empty_nc)
 
+        with self.assertRaises(ValueError):
+            empty_nc.get()
+
+        with self.assertRaises(AttributeError):
+            empty_nc.V_m
+
         self.assertFalse(empty_nc)
         self.assertTrue(nodes)
-        self.assertIsNone(empty_nc.get())
         self.assertIsNone(empty_nc.set())  # Also checking that it does not raise an error
 
     def test_empty_nc_addition(self):

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -703,26 +703,36 @@ class TestNodeCollection(unittest.TestCase):
 
     def test_empty_nc(self):
         """Connection with empty NodeCollection raises error"""
-        empty = nest.NodeCollection([])
+        empty_nc = nest.NodeCollection([])
         nodes = nest.Create('iaf_psc_alpha', 5)
 
         with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
-            nest.Connect(nodes, empty)
+            nest.Connect(nodes, empty_nc)
 
         with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
-            nest.Connect(empty, nodes)
+            nest.Connect(empty_nc, nodes)
 
         with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
-            nest.Connect(empty, empty)
+            nest.Connect(empty_nc, empty_nc)
+
+        self.assertTrue(empty_nc.empty())
+        self.assertFalse(nodes.empty())
+        self.assertIsNone(empty_nc.get())
+        self.assertIsNone(empty_nc.set())  # Also checking that it does not raise an error
 
     def test_empty_nc_addition(self):
         """Combine NodeCollection with empty NodeCollection and connect"""
         n = 5
+        vm = -50.
 
         nodes_a = nest.NodeCollection([])
         nodes_a += nest.Create('iaf_psc_alpha', n)
         nest.Connect(nodes_a, nodes_a)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
+        self.assertFalse(nodes_a.empty())
+        self.assertIsNotNone(nodes_a.get())
+        nodes_a.V_m = vm
+        self.assertEqual(nodes_a.V_m,  n*(vm,))
 
         nest.ResetKernel()
 
@@ -730,6 +740,10 @@ class TestNodeCollection(unittest.TestCase):
         nodes_b += nest.NodeCollection([])
         nest.Connect(nodes_b, nodes_b)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
+        self.assertFalse(nodes_b.empty())
+        self.assertIsNotNone(nodes_b.get())
+        nodes_b.V_m = vm
+        self.assertEqual(nodes_b.V_m,  n*(vm,))
 
 
 def suite():

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -703,34 +703,35 @@ class TestNodeCollection(unittest.TestCase):
 
     def test_empty_nc(self):
         """Connection with empty NodeCollection raises error"""
-        empty_nc = nest.NodeCollection([])
         nodes = nest.Create('iaf_psc_alpha', 5)
 
-        with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
-            nest.Connect(nodes, empty_nc)
+        for empty_nc in [nest.NodeCollection(), nest.NodeCollection([])]:
 
-        with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
-            nest.Connect(empty_nc, nodes)
+            with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+                nest.Connect(nodes, empty_nc)
 
-        with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
-            nest.Connect(empty_nc, empty_nc)
+            with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+                nest.Connect(empty_nc, nodes)
 
-        with self.assertRaises(ValueError):
-            empty_nc.get()
+            with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+                nest.Connect(empty_nc, empty_nc)
 
-        with self.assertRaises(AttributeError):
-            empty_nc.V_m
+            with self.assertRaises(ValueError):
+                empty_nc.get()
 
-        self.assertFalse(empty_nc)
-        self.assertTrue(nodes)
-        self.assertIsNone(empty_nc.set())  # Also checking that it does not raise an error
+            with self.assertRaises(AttributeError):
+                empty_nc.V_m
+
+            self.assertFalse(empty_nc)
+            self.assertTrue(nodes)
+            self.assertIsNone(empty_nc.set())  # Also checking that it does not raise an error
 
     def test_empty_nc_addition(self):
         """Combine NodeCollection with empty NodeCollection and connect"""
         n = 5
         vm = -50.
 
-        nodes_a = nest.NodeCollection([])
+        nodes_a = nest.NodeCollection()
         nodes_a += nest.Create('iaf_psc_alpha', n)
         nest.Connect(nodes_a, nodes_a)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -715,8 +715,8 @@ class TestNodeCollection(unittest.TestCase):
         with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
             nest.Connect(empty_nc, empty_nc)
 
-        self.assertTrue(empty_nc.empty())
-        self.assertFalse(nodes.empty())
+        self.assertFalse(bool(empty_nc))
+        self.assertTrue(bool(nodes))
         self.assertIsNone(empty_nc.get())
         self.assertIsNone(empty_nc.set())  # Also checking that it does not raise an error
 
@@ -729,10 +729,10 @@ class TestNodeCollection(unittest.TestCase):
         nodes_a += nest.Create('iaf_psc_alpha', n)
         nest.Connect(nodes_a, nodes_a)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
-        self.assertFalse(nodes_a.empty())
+        self.assertTrue(bool(nodes_a))
         self.assertIsNotNone(nodes_a.get())
         nodes_a.V_m = vm
-        self.assertEqual(nodes_a.V_m,  n*(vm,))
+        self.assertEqual(nodes_a.V_m, n * (vm,))
 
         nest.ResetKernel()
 
@@ -740,10 +740,10 @@ class TestNodeCollection(unittest.TestCase):
         nodes_b += nest.NodeCollection([])
         nest.Connect(nodes_b, nodes_b)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
-        self.assertFalse(nodes_b.empty())
+        self.assertTrue(bool(nodes_b))
         self.assertIsNotNone(nodes_b.get())
         nodes_b.V_m = vm
-        self.assertEqual(nodes_b.V_m,  n*(vm,))
+        self.assertEqual(nodes_b.V_m, n * (vm,))
 
 
 def suite():

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -701,6 +701,36 @@ class TestNodeCollection(unittest.TestCase):
             with self.assertRaises(err):
                 sliced = n[case]
 
+    def test_empty_nc(self):
+        """Connection with empty NodeCollection raises error"""
+        empty = nest.NodeCollection([])
+        nodes = nest.Create('iaf_psc_alpha', 5)
+
+        with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+            nest.Connect(nodes, empty)
+
+        with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+            nest.Connect(empty, nodes)
+
+        with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
+            nest.Connect(empty, empty)
+
+    def test_empty_nc_addition(self):
+        """Combine NodeCollection with empty NodeCollection and connect"""
+        n = 5
+
+        nodes_a = nest.NodeCollection([])
+        nodes_a += nest.Create('iaf_psc_alpha', n)
+        nest.Connect(nodes_a, nodes_a)
+        self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
+
+        nest.ResetKernel()
+
+        nodes_b = nest.Create('iaf_psc_alpha', n)
+        nodes_b += nest.NodeCollection([])
+        nest.Connect(nodes_b, nodes_b)
+        self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
+
 
 def suite():
     suite = unittest.makeSuite(TestNodeCollection, 'test')

--- a/pynest/nest/tests/test_NodeCollection.py
+++ b/pynest/nest/tests/test_NodeCollection.py
@@ -715,8 +715,8 @@ class TestNodeCollection(unittest.TestCase):
         with self.assertRaises(nest.kernel.NESTErrors.BadProperty):
             nest.Connect(empty_nc, empty_nc)
 
-        self.assertFalse(bool(empty_nc))
-        self.assertTrue(bool(nodes))
+        self.assertFalse(empty_nc)
+        self.assertTrue(nodes)
         self.assertIsNone(empty_nc.get())
         self.assertIsNone(empty_nc.set())  # Also checking that it does not raise an error
 
@@ -729,7 +729,7 @@ class TestNodeCollection(unittest.TestCase):
         nodes_a += nest.Create('iaf_psc_alpha', n)
         nest.Connect(nodes_a, nodes_a)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
-        self.assertTrue(bool(nodes_a))
+        self.assertTrue(nodes_a)
         self.assertIsNotNone(nodes_a.get())
         nodes_a.V_m = vm
         self.assertEqual(nodes_a.V_m, n * (vm,))
@@ -740,7 +740,7 @@ class TestNodeCollection(unittest.TestCase):
         nodes_b += nest.NodeCollection([])
         nest.Connect(nodes_b, nodes_b)
         self.assertEqual(nest.GetKernelStatus('num_connections'), n*n)
-        self.assertTrue(bool(nodes_b))
+        self.assertTrue(nodes_b)
         self.assertIsNotNone(nodes_b.get())
         nodes_b.V_m = vm
         self.assertEqual(nodes_b.V_m, n * (vm,))

--- a/pynest/nest/tests/test_json.py
+++ b/pynest/nest/tests/test_json.py
@@ -64,6 +64,12 @@ class StatusTestCase(unittest.TestCase):
             d_json = nest.GetStatus(n, output='json')
             self.assertIsInstance(d_json, str)
 
+        nest.ResetKernel()
+        n = nest.NodeCollection()
+        d_json = nest.GetStatus(n, output='json')
+        self.assertIsInstance(d_json, str)
+        self.assertEqual(d_json, '[]')
+
 
 def suite():
     suite = unittest.makeSuite(StatusTestCase, 'test')


### PR DESCRIPTION
Joining two NodeCollections, where one of them is empty, will return a copy of the non-empty NodeCollection. If both are empty, a single empty NodeCollection is returned.

Connecting where one or both NodeCollections are empty will throw a `BadProperty` error. Printing an empty NodeCollection will now print
```
NodeCollection(<empty>)
```

Fixes #1522 