### PR TITLE
Add documentation how to install NEST via homebrew

### DIFF
--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -43,7 +43,9 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
    .. tab:: Homebrew (macOS)
 
-       Install homebrew on your mac (https://brew.sh/) and then install NEST via:
+       1. `Install Homebrew <https://brew.sh/>`_ on your Mac.
+
+       2. Install NEST via:
 
        .. code-block:: bash
 
@@ -272,4 +274,3 @@ these instructions.**
 
     Installation instructions for NEST 2.10 and earlier are provided :doc:`here <oldvers_install>`, but  we strongly encourage all our users to stay
     up-to-date with most recent version of NEST. We cannot support out-dated versions.
-

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -41,6 +41,13 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
        Find out more on the NeuroFedora site: https://docs.fedoraproject.org/en-US/neurofedora/nest/.       
 
+   .. tab:: MacOS - Homebrew
+
+       Install homebrew on your mac (https://brew.sh/) and then install NEST via:
+
+       .. code-block:: bash
+
+           brew install nest
 
    .. tab:: Conda (Linux/macOS)
 

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -41,7 +41,7 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
        Find out more on the NeuroFedora site: https://docs.fedoraproject.org/en-US/neurofedora/nest/.       
 
-   .. tab:: MacOS - Homebrew
+   .. tab:: Homebrew (macOS)
 
        Install homebrew on your mac (https://brew.sh/) and then install NEST via:
 
@@ -272,5 +272,4 @@ these instructions.**
 
     Installation instructions for NEST 2.10 and earlier are provided :doc:`here <oldvers_install>`, but  we strongly encourage all our users to stay
     up-to-date with most recent version of NEST. We cannot support out-dated versions.
-
 


### PR DESCRIPTION
Recently, I added the [nest formula](https://formulae.brew.sh/formula/nest#default) to homebrew-core. Here is some doc for the website on  installing nest via homebrew.