### PR TITLE
Clarify conda installation with MPI

### DIFF
--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -152,7 +152,14 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
              conda create --name ENVNAME -c conda-forge nest-simulator=*=mpi_openmpi*
 
-          The syntax for this install follows the pattern: ``nest-simulator=<version>=<build_string>``
+          The syntax for this install follows the pattern:
+          ``nest-simulator=<version>=<build_string>``. Build strings can be
+          found by browsing the `conda forge file list
+          <https://anaconda.org/conda-forge/nest-simulator/files>`_ (note
+          there are multiple pages). For example, to install
+          `linux-64/nest-simulator-2.20.0-mpi_openmpi_py38hb43900d_0.tar.bz2``
+          on Linux with Python 3.8, you would use the version specifier
+          ``nest-simulator=2.20.0=mpi_openmpi_py38hb43900d_0``.
 
        2. Activate your environment:
 

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -42,9 +42,9 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
        2. Disable the binary package in the repository file created under ``/etc/apt/sources.list.d/`` by commenting
           out the ``deb`` line, while keeping the ``deb-src`` line. It should look similar to this:
-           
+
           .. code-block:: bash
-           
+
               #deb http://ppa.launchpad.net/nest-simulator/nest/ubuntu focal main
               deb-src http://ppa.launchpad.net/nest-simulator/nest/ubuntu focal main
 
@@ -108,7 +108,7 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
            sudo dnf install python3-nest
 
-       Find out more on the NeuroFedora site: https://docs.fedoraproject.org/en-US/neurofedora/nest/.       
+       Find out more on the NeuroFedora site: https://docs.fedoraproject.org/en-US/neurofedora/nest/.
 
    .. tab:: Homebrew (macOS)
 
@@ -128,7 +128,7 @@ compile NEST from source, see section** :ref:`advanced_install`.
           installed packages.
 
           .. pull-quote::
-        
+
           We strongly recommend that you **install all programs**
              you'll need, (such as ``ipython`` or ``jupyter-lab``) in
              the environment (ENVNAME) **at the same time**, by
@@ -144,28 +144,32 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
           .. code-block:: sh
 
-             conda create --name ENVNAME -c conda-forge nest-simulator
+              conda create --name ENVNAME -c conda-forge nest-simulator
 
           With OpenMPI:
 
           .. code-block:: sh
 
-             conda create --name ENVNAME -c conda-forge nest-simulator=*=mpi_openmpi*
+              conda create --name ENVNAME -c conda-forge nest-simulator=*=mpi_openmpi*
 
           The syntax for this install follows the pattern:
           ``nest-simulator=<version>=<build_string>``. Build strings can be
           found by listing the available versions with
-          ```
-          conda search -c conda-forge nest-simulator
-          ```
+
+          .. code-block:: sh
+
+              conda search -c conda-forge nest-simulator
+
           or by browsing the `conda forge file list
           <https://anaconda.org/conda-forge/nest-simulator/files>`_ (note
-          there are multiple pages). For example, to install
-          one of the 2.20.x versions with MPI support by OpenMPI you would use the version specifier
-          ``nest-simulator=2.20.*=*openmpi*``. The Python version dependency is automatically resolved
-          if you add ``python=3`` or ``python=3.8`` depending on how specific you are tied to a Python version.
-          Leaving the Python version and build identifyer open will make conda install the latest versions
-          compatible with all requested packages.
+          there are multiple pages). For example, to install one of the
+          2.20.x versions with MPI support by OpenMPI, you would use the
+          version specifier ``nest-simulator=2.20.*=*openmpi*``. The Python
+          dependency is automatically resolved if you add to the above
+          command a version specifier for Python, for example ``python=3`` or
+          ``python=3.8``. If the Python version and build identifier are left
+          unspecified, ``conda`` will install the latest version compatible
+          with all requested packages.
 
        2. Activate your environment:
 
@@ -173,12 +177,12 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
              conda activate ENVNAME
 
-	     
+
 In addition to native installations from ready-made packages, we
 provide containerized versions of NEST in several formats:
 
 .. tabs::
-	  
+
    .. tab:: Docker (Linux/macOS)
 
        Docker provides an isolated container to run applications. The

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -154,12 +154,18 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
           The syntax for this install follows the pattern:
           ``nest-simulator=<version>=<build_string>``. Build strings can be
-          found by browsing the `conda forge file list
+          found by listing the available versions with
+          ```
+          conda search -c conda-forge nest-simulator
+          ```
+          or by browsing the `conda forge file list
           <https://anaconda.org/conda-forge/nest-simulator/files>`_ (note
           there are multiple pages). For example, to install
-          `linux-64/nest-simulator-2.20.0-mpi_openmpi_py38hb43900d_0.tar.bz2``
-          on Linux with Python 3.8, you would use the version specifier
-          ``nest-simulator=2.20.0=mpi_openmpi_py38hb43900d_0``.
+          one of the 2.20.x versions with MPI support by OpenMPI you would use the version specifier
+          ``nest-simulator=2.20.*=*openmpi*``. The Python version dependency is automatically resolved
+          if you add ``python=3`` or ``python=3.8`` depending on how specific you are tied to a Python version.
+          Leaving the Python version and build identifyer open will make conda install the latest versions
+          compatible with all requested packages.
 
        2. Activate your environment:
 


### PR DESCRIPTION
Describe how the build string in `nest-simulator=<version>=<build_string>` can be found.