### PR TITLE
Update hpc_benchmark.py

### DIFF
--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -436,7 +436,7 @@ class Logger(object):
 
             self.f = open(fn, 'w')
 
-            return self
+        return self
 
     def log(self, value):
         if nest.Rank() < self.max_rank_log:


### PR DESCRIPTION
This pull request addresses issue  #1685. If self is returned in all cases (also for ranks >30) all ranks can access the class logger, while only ranks < 30 actually write output. Thus the AttributeError is not thrown anymore. Has been tested on JURECA with upto 128 MPI processes.