### PR TITLE
Bump Python version for macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
       env: MATRIX_EVAL="CC=clang-7 && CXX=clang++-7" xRUN_BUILD_AND_TESTSUITE=1
     - stage: Python-Full-build-Clang7-OsX
       os: osx
-      osx_image: xcode10.3 # Python 3.7.8 running on macOS 10.14.4
+      osx_image: xcode10.2 # Python 3.8.3 running on macOS 10.14.4
       language: shell      # language 'python' results in errors on macOS
       env: xTHREADING=1 xMPI=0 xGSL=1 xLIBNEUROSIM=0 xLTDL=1 xREADLINE=1 xPYTHON=1 xMUSIC=0 xSTATIC_ANALYSIS=0 xRUN_BUILD_AND_TESTSUITE=1 CACHE_NAME=JOB   # Without MUSIC, MPI and Libneurosim
 #https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
@@ -159,6 +159,8 @@ before_install:
            brew unlink gcc
            brew install gcc@8
            brew link gcc@8
+           find /usr/local/Cellar/ -name Python\.h
+           find /usr/local/Cellar/ -name \*python\*dylib
          fi
 
          if [ "$TRAVIS_OS_NAME" != "osx" ]; then

--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -46,16 +46,21 @@ else
 fi
 
 if [ "$xPYTHON" = "1" ] ; then
-   if [ "$TRAVIS_PYTHON_VERSION" = "3.6.10" ]; then
-      CONFIGURE_PYTHON="-DPYTHON_LIBRARY=/opt/python/3.6.10/lib/libpython3.6m.so -DPYTHON_INCLUDE_DIR=/opt/python/3.6.10/include/python3.6m/"
-   fi
-   if [[ $OSTYPE = darwin* ]]; then
-      CONFIGURE_PYTHON="-DPYTHON_LIBRARY=/usr/local/Cellar/python/3.7.8/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib -DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python/3.7.8/Frameworks/Python.framework/Versions/3.7/include//python3.7m/"
-   fi
-   mkdir -p $HOME/.matplotlib
-   cat > $HOME/.matplotlib/matplotlibrc <<EOF 
-   backend : svg
-EOF
+    if [ "$TRAVIS_PYTHON_VERSION" = "3.6.10" ]; then
+	PYPREFIX="/opt/python/3.6.10"
+	CONFIGURE_PYTHON="\
+            -DPYTHON_LIBRARY=$PYPREFIX/lib/libpython3.6m.so
+            -DPYTHON_INCLUDE_DIR=$PYPREFIX/include/python3.6m/"
+    fi
+    if [[ $OSTYPE = darwin* ]]; then
+	PYPREFIX="/usr/local/Cellar/python@3.8/3.8.3_2/Frameworks/Python.framework/Versions/3.8"
+	CONFIGURE_PYTHON="\
+            -DPYTHON_LIBRARY=$PYPREFIX/lib/libpython3.8.dylib
+            -DPYTHON_INCLUDE_DIR=$PYPREFIX/include/python3.8"
+    fi
+
+    mkdir -p $HOME/.matplotlib
+    echo "backend : svg" > $HOME/.matplotlib/matplotlibrc
 else
     CONFIGURE_PYTHON="-Dwith-python=OFF"
 fi


### PR DESCRIPTION
This fixes #1689. Being an emergency fix for build failures on macOS in our Travis setup, it should be reviewed and merged as soon as possible.