### PR TITLE
Update to latest Python on MacOS Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
       env: MATRIX_EVAL="CC=clang-7 && CXX=clang++-7" xRUN_BUILD_AND_TESTSUITE=1
     - stage: Python-Full-build-Clang7-OsX
       os: osx
-      osx_image: xcode10.2 # Python 3.8.3 running on macOS 10.14.4
+      osx_image: xcode10.2 # Python 3.8.4 running on macOS 10.14.4
       language: shell      # language 'python' results in errors on macOS
       env: xTHREADING=1 xMPI=0 xGSL=1 xLIBNEUROSIM=0 xLTDL=1 xREADLINE=1 xPYTHON=1 xMUSIC=0 xSTATIC_ANALYSIS=0 xRUN_BUILD_AND_TESTSUITE=1 CACHE_NAME=JOB   # Without MUSIC, MPI and Libneurosim
 #https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon

--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -53,7 +53,7 @@ if [ "$xPYTHON" = "1" ] ; then
             -DPYTHON_INCLUDE_DIR=$PYPREFIX/include/python3.6m/"
     fi
     if [[ $OSTYPE = darwin* ]]; then
-	PYPREFIX="/usr/local/Cellar/python@3.8/3.8.3_2/Frameworks/Python.framework/Versions/3.8"
+	PYPREFIX="/usr/local/Cellar/python@3.8/3.8.4/Frameworks/Python.framework/Versions/3.8"
 	CONFIGURE_PYTHON="\
             -DPYTHON_LIBRARY=$PYPREFIX/lib/libpython3.8.dylib
             -DPYTHON_INCLUDE_DIR=$PYPREFIX/include/python3.8"


### PR DESCRIPTION
After my emergency fix in #1690, Travis again changed their Python version. This is another emergency PR that should work for the time being and until  #1623 provides a more stable permanent solution.

Please review and merge quickly! 