### PR TITLE
Consistently use python3 command instead of python

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -164,9 +164,9 @@ and its corresponding libraries correctly. To circumvent such a problem followin
   e.g.: Please note `-Dwith-python=ON` is the default.
   cmake -DCMAKE_INSTALL_PREFIX=</install/path> \
         -DPYTHON_EXECUTABLE=/usr/bin/python3 \
-        -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.4m.so \
-        -DPYTHON_INCLUDE_DIR=/usr/include/python3.4 \
-        -DPYTHON_INCLUDE_DIR2=/usr/include/x86_64-linux-gnu/python3.4m \
+        -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.6m.so \
+        -DPYTHON_INCLUDE_DIR=/usr/include/python3.6 \
+        -DPYTHON_INCLUDE_DIR2=/usr/include/x86_64-linux-gnu/python3.6m \
         </path/to/NEST/src>
 
 Compiling for Apple OSX/macOS
@@ -232,8 +232,8 @@ CMake <3.4 is buggy about finding the matching libraries (for many years).
 Thus, you also have to specify `PYTHON_LIBRARY` and `PYTHON_INCLUDE_DIR`
 if they are not found OR the incorrect libraries are found, e.g.:
 ```
--DPYTHON_LIBRARY=/bgsys/local/python3/3.4.2/lib/libpython3.4m.a
--DPYTHON_INCLUDE_DIR=/bgsys/local/python3/3.4.2/include/python3.4m
+-DPYTHON_LIBRARY=/bgsys/local/python3/3.6.10/lib/libpython3.6m.a
+-DPYTHON_INCLUDE_DIR=/bgsys/local/python3/3.6.10/include/python3.6m
 ```
 
 A complete `cmake` line for PyNEST could look like this:
@@ -246,8 +246,8 @@ cmake -DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_XLC \
   -Dcythonize-pynest=OFF \
 	  -DCMAKE_C_COMPILER=/bgsys/drivers/ppcfloor/comm/xl/bin/mpixlc_r \
 	  -DCMAKE_CXX_COMPILER=/bgsys/drivers/ppcfloor/comm/xl/bin/mpixlcxx_r \
-	  -DPYTHON_LIBRARY=/bgsys/local/python3/3.4.2/lib/libpython3.4m.a \
-	  -DPYTHON_INCLUDE_DIR=/bgsys/local/python3/3.4.2/include/python3.4m \
+	  -DPYTHON_LIBRARY=/bgsys/local/python3/3.6.10/lib/libpython3.6m.a \
+	  -DPYTHON_INCLUDE_DIR=/bgsys/local/python3/3.6.10/include/python3.6m \
   -Dwith-ltdl=OFF \
   <nest-src>
 ```
@@ -255,12 +255,12 @@ cmake -DCMAKE_TOOLCHAIN_FILE=Platform/BlueGeneQ_XLC \
 Further, for running PyNEST, make sure all Python dependencies are installed and
 environment variables are set properly:
 ```
-module load python3/3.4.2
+module load python3/3.6.10
 
 # adds PyNEST to the PYTHONPATH
 source <nest-install-dir>/bin/nest_vars.sh
 
-# makes HOME and PYTHONPATH available for python
+# makes HOME and PYTHONPATH available for Python
 runjob \
   --exp-env HOME \
   --exp-env PATH \
@@ -268,7 +268,7 @@ runjob \
   --exp-env PYTHONUNBUFFERED \
   --exp-env PYTHONPATH \
   ... \
-  : /bgsys/local/python3/3.4.2/bin/python3.4 script.py
+  : /bgsys/local/python3/3.6.10/bin/python3 script.py
 ```
 
 BlueGene/Q and GCC

--- a/doc/extractor_userdocs.py
+++ b/doc/extractor_userdocs.py
@@ -23,12 +23,12 @@ import re
 from tqdm import tqdm
 from pprint import pformat
 try:
-    from math import comb   # breaks in python<3.8
+    from math import comb   # breaks in Python < 3.8
 except ImportError:
     from math import factorial as fac
-
     def comb(n, k):
         return fac(n) / (fac(k) * fac(n - k))
+
 import os
 import glob
 import json

--- a/doc/extractor_userdocs.py
+++ b/doc/extractor_userdocs.py
@@ -26,6 +26,7 @@ try:
     from math import comb   # breaks in Python < 3.8
 except ImportError:
     from math import factorial as fac
+
     def comb(n, k):
         return fac(n) / (fac(k) * fac(n - k))
 

--- a/doc/faqs/faqs.rst
+++ b/doc/faqs/faqs.rst
@@ -34,7 +34,7 @@ Installation
 5. **Ipython crashes with a strange error message as soon as I import
    ``nest``** If ipython crashes on ``import nest`` complaining about a
    ``Non-aligned pointer being freed``, you probably compiled NEST with
-   a different version of g++ than python. Take a look at the
+   a different version of g++ than Python. Take a look at the
    information ipython prints when it starts up. That should tell you
    which compiler was used. Then re-build NEST with the same compiler
    version.

--- a/doc/getting_help.rst
+++ b/doc/getting_help.rst
@@ -22,7 +22,7 @@ Getting help on the command line interface
        # list all functions and attributes
        dir(nest)
 
-       # Get docstring for function in python
+       # Get docstring for function in Python
        help('nest.FunctionName')
 
        # or in ipython

--- a/doc/guides/parallel_computing.rst
+++ b/doc/guides/parallel_computing.rst
@@ -224,7 +224,7 @@ command should look like this
 
 .. code-block:: bash
 
-    mpirun -np 128 python simulation.py
+    mpirun -np 128 python3 simulation.py
 
 Please refer to the MPI library documentation for details on the usage
 of ``mpirun``.
@@ -295,11 +295,11 @@ but 4 virtual processes in every run:
 .. code-block:: bash
 
     mkdir 4vp_1p; cd 4vp_1p
-    mpirun -np 1 python ../simulation.py
+    mpirun -np 1 python3 ../simulation.py
     cd ..; mkdir 4vp_2p; cd 4vp_2p
-    mpirun -np 2 python ../simulation.py
+    mpirun -np 2 python3 ../simulation.py
     cd ..; mkdir 4vp_4p; cd 4vp_4p
-    mpirun -np 4 python ../simulation.py
+    mpirun -np 4 python3 ../simulation.py
     cd ..
     diff 4vp_1p 4vp_2p
     diff 4vp_1p 4vp_4p

--- a/doc/guides/random_numbers.rst
+++ b/doc/guides/random_numbers.rst
@@ -502,11 +502,11 @@ processes in separate directories
 
      mkdir 41 42 44
      cd 41
-     mpirun -np 1 python test.py
+     mpirun -np 1 python3 test.py
      cd ../42
-     mpirun -np 2 python test.py
+     mpirun -np 2 python3 test.py
      cd ../44
-     mpirun -np 4 python test.py
+     mpirun -np 4 python3 test.py
      cd ..
 
 These directories should now have identical content, something you can

--- a/doc/guides/spatial/user_manual_scripts/layers.py
+++ b/doc/guides/spatial/user_manual_scripts/layers.py
@@ -29,20 +29,20 @@ import numpy as np
 np.random.seed(1234567)
 
 
-def beautify_layer(l, fig=plt.gcf(), xlabel=None, ylabel=None,
+def beautify_layer(layer, fig=plt.gcf(), xlabel=None, ylabel=None,
                    xlim=None, ylim=None, xticks=None, yticks=None, dx=0, dy=0):
     """Assume either x and ylims/ticks given or none"""
-    ctr = l.spatial['center']
-    ext = l.spatial['extent']
+    ctr = layer.spatial['center']
+    ext = layer.spatial['extent']
 
     if xticks is None:
-        if 'shape' in l.spatial:
-            dx = float(ext[0]) / l.spatial['shape'][0]
-            dy = float(ext[1]) / l.spatial['shape'][1]
+        if 'shape' in layer.spatial:
+            dx = float(ext[0]) / layer.spatial['shape'][0]
+            dy = float(ext[1]) / layer.spatial['shape'][1]
             xticks = ctr[0] - ext[0] / 2. + dx / 2. + dx * np.arange(
-                l.spatial['shape'][0])
+                layer.spatial['shape'][0])
             yticks = ctr[1] - ext[1] / 2. + dy / 2. + dy * np.arange(
-                l.spatial['shape'][1])
+                layer.spatial['shape'][1])
 
     if xlim is None:
         xlim = [ctr[0] - ext[0] / 2. - dx / 2., ctr[0] + ext[
@@ -69,12 +69,12 @@ def beautify_layer(l, fig=plt.gcf(), xlabel=None, ylabel=None,
 nest.ResetKernel()
 
 #{ layer1 #}
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(shape=[5, 5]))
+layer = nest.Create('iaf_psc_alpha',
+                    positions=nest.spatial.grid(shape=[5, 5]))
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=50)
-beautify_layer(l, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)')
+fig = nest.PlotLayer(layer, nodesize=50)
+beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)')
 ax = fig.gca()
 tx = []
 for r in range(5):
@@ -92,7 +92,7 @@ for r in range(5):
 
 print("#{ layer1s.log #}")
 #{ layer1s #}
-print(l.spatial)
+print(layer.spatial)
 #{ end #}
 print("#{ end.log #}")
 
@@ -107,14 +107,14 @@ print("#{ end.log #}")
 nest.ResetKernel()
 
 #{ layer2 #}
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(
-                    shape=[5, 5],
-                    extent=[2.0, 0.5]))
+layer = nest.Create('iaf_psc_alpha',
+                    positions=nest.spatial.grid(
+                        shape=[5, 5],
+                        extent=[2.0, 0.5]))
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=50)
-beautify_layer(l, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)')
+fig = nest.PlotLayer(layer, nodesize=50)
+beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)')
 ax = fig.gca()
 tx = []
 
@@ -135,22 +135,22 @@ plt.savefig('../user_manual_figures/layer2.png', bbox_inches='tight',
 nest.ResetKernel()
 
 #{ layer3 #}
-l1 = nest.Create('iaf_psc_alpha',
-                 positions=nest.spatial.grid(shape=[5, 5]))
-l2 = nest.Create('iaf_psc_alpha',
-                 positions=nest.spatial.grid(
-                     shape=[5, 5],
-                     center=[-1., 1.]))
-l3 = nest.Create('iaf_psc_alpha',
-                 positions=nest.spatial.grid(
-                     shape=[5, 5],
-                     center=[1.5, 0.5]))
+layer1 = nest.Create('iaf_psc_alpha',
+                     positions=nest.spatial.grid(shape=[5, 5]))
+layer2 = nest.Create('iaf_psc_alpha',
+                     positions=nest.spatial.grid(
+                         shape=[5, 5],
+                         center=[-1., 1.]))
+layer3 = nest.Create('iaf_psc_alpha',
+                     positions=nest.spatial.grid(
+                         shape=[5, 5],
+                         center=[1.5, 0.5]))
 #{ end #}
 
-fig = nest.PlotLayer(l1, nodesize=50)
-nest.PlotLayer(l2, nodesize=50, nodecolor='g', fig=fig)
-nest.PlotLayer(l3, nodesize=50, nodecolor='r', fig=fig)
-beautify_layer(l1, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
+fig = nest.PlotLayer(layer1, nodesize=50)
+nest.PlotLayer(layer2, nodesize=50, nodecolor='g', fig=fig)
+nest.PlotLayer(layer3, nodesize=50, nodecolor='r', fig=fig)
+beautify_layer(layer1, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
                xlim=[-1.6, 2.1], ylim=[-0.6, 1.6],
                xticks=np.arange(-1.4, 2.05, 0.2),
                yticks=np.arange(-0.4, 1.45, 0.2))
@@ -164,18 +164,18 @@ nest.ResetKernel()
 #{ layer3a #}
 nx, ny = 5, 3
 d = 0.1
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(
-                    shape=[nx, ny],
-                    extent=[nx * d, ny * d],
-                    center=[nx * d / 2., 0.]))
+layer = nest.Create('iaf_psc_alpha',
+                    positions=nest.spatial.grid(
+                        shape=[nx, ny],
+                        extent=[nx * d, ny * d],
+                        center=[nx * d / 2., 0.]))
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=100)
+fig = nest.PlotLayer(layer, nodesize=100)
 plt.plot(0, 0, 'x', markersize=20, c='k', mew=3)
 plt.plot(nx * d / 2, 0, 'o', markersize=20, c='k', mew=3, mfc='none',
          zorder=100)
-beautify_layer(l, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
+beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
                xticks=np.arange(0., 0.501, 0.05),
                yticks=np.arange(-0.15, 0.151, 0.05),
                xlim=[-0.05, 0.55], ylim=[-0.2, 0.2])
@@ -189,12 +189,12 @@ nest.ResetKernel()
 #{ layer4 #}
 pos = nest.spatial.free(pos=nest.random.uniform(min=-0.5, max=0.5),
                         num_dimensions=2)
-l = nest.Create('iaf_psc_alpha', 50,
-                positions=pos)
+layer = nest.Create('iaf_psc_alpha', 50,
+                    positions=pos)
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=50)
-beautify_layer(l, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
+fig = nest.PlotLayer(layer, nodesize=50)
+beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
                xlim=[-0.55, 0.55], ylim=[-0.55, 0.55],
                xticks=[-0.5, 0., 0.5], yticks=[-0.5, 0., 0.5])
 
@@ -206,11 +206,11 @@ nest.ResetKernel()
 
 #{ layer4b #}
 pos = nest.spatial.free(pos=[[-0.5, -0.5], [-0.25, -0.25], [0.75, 0.75]])
-l = nest.Create('iaf_psc_alpha', positions=pos)
+layer = nest.Create('iaf_psc_alpha', positions=pos)
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=50)
-beautify_layer(l, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
+fig = nest.PlotLayer(layer, nodesize=50)
+beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
                xlim=[-0.55, 0.80], ylim=[-0.55, 0.80],
                xticks=[-0.75, -0.5, -0.25, 0., 0.25, 0.5, 0.75, 1.],
                yticks=[-0.75, -0.5, -0.25, 0., 0.25, 0.5, 0.75, 1.])
@@ -224,11 +224,10 @@ nest.ResetKernel()
 #{ layer4_3d #}
 pos = nest.spatial.free(nest.random.uniform(min=-0.5, max=0.5),
                         num_dimensions=3)
-l = nest.Create('iaf_psc_alpha', 200,
-                positions=pos)
+layer = nest.Create('iaf_psc_alpha', 200, positions=pos)
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=50)
+fig = nest.PlotLayer(layer, nodesize=50)
 
 plt.savefig('../user_manual_figures/layer4_3d.png', bbox_inches='tight')
 
@@ -238,10 +237,10 @@ nest.ResetKernel()
 
 #{ layer4_3d_b #}
 pos = nest.spatial.grid(shape=[4, 5, 6])
-l = nest.Create('iaf_psc_alpha', positions=pos)
+layer = nest.Create('iaf_psc_alpha', positions=pos)
 #{ end #}
 
-fig = nest.PlotLayer(l, nodesize=50)
+fig = nest.PlotLayer(layer, nodesize=50)
 
 plt.savefig('../user_manual_figures/layer4_3d_b.png', bbox_inches='tight')
 
@@ -250,11 +249,11 @@ plt.savefig('../user_manual_figures/layer4_3d_b.png', bbox_inches='tight')
 nest.ResetKernel()
 
 #{ player #}
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(
-                    shape=[5, 1],
-                    extent=[5., 1.],
-                    edge_wrap=True))
+layer = nest.Create('iaf_psc_alpha',
+                    positions=nest.spatial.grid(
+                        shape=[5, 1],
+                        extent=[5., 1.],
+                        edge_wrap=True))
 #{ end #}
 
 # fake plot with layer on line and circle
@@ -309,10 +308,10 @@ plt.savefig('../user_manual_figures/player.png', bbox_inches='tight')
 nest.ResetKernel()
 
 #{ layer6 #}
-l1 = nest.Create('iaf_cond_alpha',
-                 positions=nest.spatial.grid(shape=[2, 1]))
-l2 = nest.Create('poisson_generator',
-                 positions=nest.spatial.grid(shape=[2, 1]))
+layer1 = nest.Create('iaf_cond_alpha',
+                     positions=nest.spatial.grid(shape=[2, 1]))
+layer2 = nest.Create('poisson_generator',
+                     positions=nest.spatial.grid(shape=[2, 1]))
 #{ end #}
 
 print("#{ layer6 #}")
@@ -324,17 +323,17 @@ print("#{ end #}")
 nest.ResetKernel()
 
 #{ vislayer #}
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(shape=[21, 21]))
+layer = nest.Create('iaf_psc_alpha',
+                    positions=nest.spatial.grid(shape=[21, 21]))
 probability_param = nest.spatial_distributions.gaussian(nest.spatial.distance, std=0.15)
 conndict = {'rule': 'pairwise_bernoulli',
             'p': probability_param,
             'mask': {'circular': {'radius': 0.4}}}
-nest.Connect(l, l, conndict)
-fig = nest.PlotLayer(l, nodesize=80)
+nest.Connect(layer, layer, conndict)
+fig = nest.PlotLayer(layer, nodesize=80)
 
-ctr = nest.FindCenterElement(l)
-nest.PlotTargets(ctr, l, fig=fig,
+ctr = nest.FindCenterElement(layer)
+nest.PlotTargets(ctr, layer, fig=fig,
                  mask=conndict['mask'], probability_parameter=probability_param,
                  src_size=250, tgt_color='red', tgt_size=20, mask_color='red',
                  probability_cmap='Greens')

--- a/doc/guides/spatial/user_manual_scripts/layers.py
+++ b/doc/guides/spatial/user_manual_scripts/layers.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-# Run as python layers.py > layers.log
+# Run as python3 layers.py > layers.log
 
 import matplotlib.pyplot as plt
 import nest

--- a/doc/guides/using_nest_with_music.rst
+++ b/doc/guides/using_nest_with_music.rst
@@ -217,7 +217,7 @@ simulated  in steps of 10 ms.
 
 ::
 
-    #!/usr/bin/python
+    #!/usr/bin/python3
 
     import nest
 
@@ -323,7 +323,7 @@ steps of 10 ms.
 
 ::
 
-    #!/usr/bin/python
+    #!/usr/bin/python3
 
     import nest
 

--- a/doc/installation/hpc_install.rst
+++ b/doc/installation/hpc_install.rst
@@ -83,7 +83,7 @@ A complete ``cmake`` line for PyNEST could look like this::
       -Dwith-ltdl=OFF \
       <nest-src>
 
-Furthermore, for running PyNEST, make sure all python dependencies are installed and
+Furthermore, for running PyNEST, make sure all Python dependencies are installed and
 environment variables are set properly::
 
     module load python3/3.4.2
@@ -91,7 +91,7 @@ environment variables are set properly::
     # adds PyNEST to the PYTHONPATH
     source <nest-install-dir>/bin/nest_vars.sh
     
-    # makes HOME and PYTHONPATH available for python
+    # makes HOME and PYTHONPATH available for Python
     runjob \
       --exp-env HOME \
       --exp-env PATH \

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -253,17 +253,13 @@ For example, in the terminal type:
 
     .. code-block:: bash
 
-         python
+         python3
 
 Once in Python you can type:
 
     .. code-block:: python
 
         import nest
-
-.. note::
-
-    If you get ImportError: No module named nest after running ``python``.  Try to run ``python3`` instead.
 
 **or as a stand alone application**::
 

--- a/doc/installation/linux_install.rst
+++ b/doc/installation/linux_install.rst
@@ -19,7 +19,7 @@ The `GNU Scientific Library <http://www.gnu.org/software/gsl/>`_ is needed by se
 For efficient sorting algorithms the Boost library <https://www.boost.org/> is used. Since this is an essential factor for the communication of spikes, some simulations are significantly faster when NEST is compile with Boost.
 If you want to use PyNEST, we recommend to install the following along with their development packages:
 
-- `Python 3.5 or higher <http://www.python.org>`_
+- `Python 3.6 or higher <http://www.python.org>`_
 - `NumPy <http://www.scipy.org>`_
 - `SciPy <http://www.scipy.org>`_
 - `Matplotlib 3.0 or higher <http://matplotlib.org>`_

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -51,34 +51,34 @@ Here is an example,
 
 .. code-block:: bash
 
-    which python
+    which python3
 
 The terminal will display the path to the binary it found:
 
 .. code-block:: bash
 
-    /home/user/ENVNAME/bin/python
+    /home/user/ENVNAME/bin/python3
 
 .. code-block:: bash
 
-    type -a python
+    type -a python3
 
 The terminal will list the paths it found to the package binaries:
 
 .. code-block:: bash
 
-    python is /home/user/ENVNAME/bin/python
-    python is /usr/bin/python
+    python3 is /home/user/ENVNAME/bin/python3
+    python3 is /usr/bin/python3
 
 .. code-block:: bash
 
-    python --version
+    python3 --version
 
 The terminal will display the version number:
 
 .. code-block:: bash
 
-    Python 3.6.5
+    Python 3.8.2
 
 
 
@@ -159,7 +159,7 @@ If your Python version is correct and you still have the same error, then try on
 
          .. code-block:: bash
 
-             which python
+             which python3
              which nest
 
      These commands will show you the path to the Python and NEST binary that your environment is using. You may have more than one installation on your system.
@@ -167,7 +167,7 @@ If your Python version is correct and you still have the same error, then try on
 
          .. code-block:: bash
 
-             /path/to/conda/envs/ENVNAME/bin/python
+             /path/to/conda/envs/ENVNAME/bin/python3
              /path/to/conda/envs/ENVNAME/bin/nest
 
 

--- a/doc/tutorials/music_tutorial/music_tutorial_2.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_2.rst
@@ -20,7 +20,7 @@ called *send.py*.
 .. code-block:: python
     :linenos:
 
-    #!/usr/bin/env python
+    #!/usr/bin/env python3
 
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
@@ -65,7 +65,7 @@ For the receiving process script, *receive.py* we do:
 .. code-block:: python
     :linenos:
 
-    #!/usr/bin/env python
+    #!/usr/bin/env python3
 
     import nest
     nest.SetKernelStatus({"overwrite_files": True})
@@ -202,7 +202,7 @@ below:
 .. code-block:: python
     :linenos:
 
-    #!/usr/bin/python
+    #!/usr/bin/python3
 
     import nest
 
@@ -240,7 +240,7 @@ slow.
 A much better approach is to forgo the use of the NEST Poisson
 generator. Generate a Poisson sequence of spike events in the *outside*
 process, and send the spike events directly into the simulation like we
-did in our earlier python example. This is far more effective, and the
+did in our earlier Python example. This is far more effective, and the
 outside process is not limited to the generators implemented in NEST but
 can create any kind of spiking input. In the next section we will take a
 look at how to do this.

--- a/doc/tutorials/music_tutorial/music_tutorial_3.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_3.rst
@@ -404,7 +404,7 @@ Concatenate them as before, and compare:
     1   87.400         0    0.0874
     2   110.40         1    0.1104
 
-Indeed, we get the expected result. The IDs from the python process on
+Indeed, we get the expected result. The IDs from the ``python`` process on
 the left are the originating neurons; the IDs on the right is the MUSIC
 channel on the receiving side. And of course NEST deals in milliseconds
 while MUSIC uses seconds.

--- a/doc/tutorials/music_tutorial/music_tutorial_4.rst
+++ b/doc/tutorials/music_tutorial/music_tutorial_4.rst
@@ -21,7 +21,7 @@ differences to the C++ API. The full example code is in the
 .. code-block:: python
     :linenos:
 
-    #!/usr/bin/python
+    #!/usr/bin/env python3
     import music
 
     [ ... ]
@@ -43,8 +43,8 @@ differences to the C++ API. The full example code is in the
         tickt = runtime.time()
 
 The sending code is almost completely identical to its C++ counterpart.
-Make sure python is used as interpreter for the code (and make sure this
-file is executable). Import music in the expected way.
+Make sure ``python3`` is used as interpreter for the code (and make sure this
+file is executable). Import ``music`` in the expected way.
 
 Unlike the C++ API, the index is not an object, but simply a label
 indicating global or local indexing. The ``map()`` call

--- a/examples/nest/music/conttest.py
+++ b/examples/nest/music/conttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # conttest.py

--- a/examples/nest/music/minimalmusicsetup_receivenest.py
+++ b/examples/nest/music/minimalmusicsetup_receivenest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # minimalmusicsetup_receivenest.py

--- a/examples/nest/music/minimalmusicsetup_sendnest.py
+++ b/examples/nest/music/minimalmusicsetup_sendnest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # minimalmusicsetup_sendnest.py

--- a/examples/nest/music/msgtest.py
+++ b/examples/nest/music/msgtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # msgtest.py

--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -26,7 +26,7 @@ if [ $? != 0 ] ; then
     exit 1
 fi
 
-python -c "import nest" >/dev/null 2>&1
+python3 -c "import nest" >/dev/null 2>&1
 if [ $? != 0 ] ; then
     echo "ERROR: PyNEST is not available. Please make sure PYTHONPATH is set correctly"
     echo "       by sourcing the script nest_vars.sh from your NEST installation."
@@ -67,7 +67,7 @@ for i in $EXAMPLES ; do
     if [ $ext = sli ] ; then
         runner=nest
     elif [ $ext = py ] ; then
-        runner=python
+        runner=python3
     fi
 
     output_dir=$basedir/example_logs/$example

--- a/extras/check_copyright_headers.py
+++ b/extras/check_copyright_headers.py
@@ -147,7 +147,7 @@ for dirpath, _, fnames in os.walk(source_dir):
                     total_errors += 1
                     break
                 if (extension == 'py' and
-                        line_src.strip() == '#!/usr/bin/env python'):
+                        line_src.strip() == '#!/usr/bin/env python3'):
                     line_src = source_file.readline()
                 line_exp = template_line.replace('{{file_name}}', fname)
                 if line_src != line_exp:

--- a/extras/help_generator/generate_help.py
+++ b/extras/help_generator/generate_help.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # generate_help.py
@@ -41,7 +41,7 @@ from helpers import delete_helpdir
 from helpers import help_generation_required
 
 if len(sys.argv) != 3:
-    print("Usage: python generate_help.py <source_dir> <build_dir>")
+    print("Usage: python3 generate_help.py <source_dir> <build_dir>")
     sys.exit(1)
 
 source_dir, build_dir = sys.argv[1:]

--- a/extras/help_generator/generate_helpindex.py
+++ b/extras/help_generator/generate_helpindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # generate_helpindex.py
@@ -33,7 +33,7 @@ import sys
 from writers import write_helpindex
 
 if len(sys.argv) != 2:
-    print("Usage: python generate_helpindex.py <help_dir>")
+    print("Usage: python3 generate_helpindex.py <help_dir>")
     sys.exit(1)
 
 help_dir = os.path.join(sys.argv[1], "help")

--- a/extras/include_checker.py
+++ b/extras/include_checker.py
@@ -239,6 +239,7 @@ def usage(exitcode):
                                " (-f <filename> | -d <base-directory>)")
     sys.exit(exitcode)
 
+
 if __name__ == '__main__':
     print_suggestion = True
     if len(sys.argv) != 5:

--- a/extras/include_checker.py
+++ b/extras/include_checker.py
@@ -28,10 +28,10 @@ This script suggest C/CPP include orders that conform to the NEST coding style
 guidelines. Call the script like (from NEST sources):
 
 For one file:
-    python extras/include_checker.py -nest $PWD -f nest/main.cpp
+    python3 extras/include_checker.py -nest $PWD -f nest/main.cpp
 
 For one directory:
-    python extras/include_checker.py -nest $PWD -d nest
+    python3 extras/include_checker.py -nest $PWD -d nest
 
 If everything is OK, or only few includes are in the wrong order, it will print
 something like:

--- a/extras/static_code_analysis.sh
+++ b/extras/static_code_analysis.sh
@@ -115,9 +115,9 @@ fi
 
 export NEST_SOURCE=$PWD
 print_msg "MSGBLD1050: " "Running check for copyright headers"
-copyright_check_errors=`python extras/check_copyright_headers.py`
+copyright_check_errors=`python3 extras/check_copyright_headers.py`
 print_msg "MSGBLD1060: " "Running sanity check for Name definition and usage"
-unused_names_errors=`python extras/check_unused_names.py`
+unused_names_errors=`python3 extras/check_unused_names.py`
 
 
 # Perfom static code analysis.

--- a/pynest/examples/Potjans_2014/README.rst
+++ b/pynest/examples/Potjans_2014/README.rst
@@ -48,7 +48,7 @@ To run the simulation, simply use:
 
 .. code-block:: bash
 
-   python run_microcircuit.py
+   python3 run_microcircuit.py
 
 The output will be saved in the ``data`` directory.
 
@@ -58,7 +58,7 @@ The command for running the script with two MPI processes is:
 
 .. code-block:: bash
 
-   mpirun -n 2 python run_microcircuit.py
+   mpirun -n 2 python3 run_microcircuit.py
 
 Note on parameters
 ##################

--- a/pynest/examples/arbor_cosim_example/arbor_proxy.py
+++ b/pynest/examples/arbor_cosim_example/arbor_proxy.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 
 # arbor_proxy.py simulates an Arbor run with MPI spike exchange to external
 # NEST. Reimplementation of the C++ version of Peyser implemented in pure

--- a/pynest/examples/arbor_cosim_example/nest_sender.py
+++ b/pynest/examples/arbor_cosim_example/nest_sender.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 
 # This is the real nest program, which requires NESTIO + ARBOR-NESTIO
 

--- a/pynest/examples/music_cont_out_proxy_example/nest_script.py
+++ b/pynest/examples/music_cont_out_proxy_example/nest_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # nest_script.py

--- a/pynest/examples/music_cont_out_proxy_example/receiver_script.py
+++ b/pynest/examples/music_cont_out_proxy_example/receiver_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # receiver_script.py

--- a/pynest/examples/sensitivity_to_perturbation.py
+++ b/pynest/examples/sensitivity_to_perturbation.py
@@ -126,7 +126,7 @@ spiketimes = []
 for trial in [0, 1]:
 
     # Before we build the network, we reset the simulation kernel to ensure
-    # that previous NEST simulations in the python shell will not disturb this
+    # that previous NEST simulations in the Python shell will not disturb this
     # simulation and set the simulation resolution (later defined
     # synaptic delays cannot be smaller than the simulation resolution).
     nest.ResetKernel()

--- a/sli/arraydatum.h
+++ b/sli/arraydatum.h
@@ -75,7 +75,7 @@ void lockPTRDatum< std::vector< double >, &SLIInterpreter::DoubleVectortype >::p
 
 /**
  * @remark This type was introduced to pass numeric arrays between
- *         python and nodes. It is *not* meant for general use. The
+ *         Python and nodes. It is *not* meant for general use. The
  *         current implementation is minimal and this was done on
  *         purpose. While it is useful to have numeric arrays at the
  *         level of SLI, this would require the implementation of many
@@ -87,7 +87,7 @@ typedef lockPTRDatum< std::vector< long >, &SLIInterpreter::IntVectortype > IntV
 
 /**
  * @remark This type was introduced to pass numeric arrays between
- *         python and nodes. It is *not* meant for general use. The
+ *         Python and nodes. It is *not* meant for general use. The
  *         current implementation is minimal and this was done on
  *         purpose. While it is useful to have numeric arrays at the
  *         level of SLI, this would require the implementation of many

--- a/testsuite/do_tests.sh.in
+++ b/testsuite/do_tests.sh.in
@@ -103,7 +103,7 @@ fi
 
 mkdir "${TEST_OUTDIR}"
 
-PYTHON="${PYTHON:-python}"
+PYTHON="${PYTHON:-python3}"
 
 TMPDIR="${TMPDIR:-${TEST_OUTDIR}}"
 TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/nest.XXXXX")"
@@ -472,7 +472,7 @@ else
 fi
 
 # Use plain python here to collect results
-python "$(dirname $0)/summarize_tests.py" "${TEST_OUTDIR}"
+python3 "$(dirname $0)/summarize_tests.py" "${TEST_OUTDIR}"
 TESTSUITE_RESULT=$?
 
 # Mac OS X: Restore old crash reporter state

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -21,7 +21,7 @@
 
 # Invoke this script as
 #
-#    python parse_test_output.py <path to test output>.xml
+#    python3 parse_test_output.py <path to test output>.xml
 #
 # It will print on a single line
 #

--- a/testsuite/unittests/test_pp_psc_delta.sli
+++ b/testsuite/unittests/test_pp_psc_delta.sli
@@ -64,7 +64,7 @@ Description:
 
 Remarks:
 
-  This test script is based on the python version 
+  This test script is based on the Python version 
   
       test_pp_psc_delta.py
       
@@ -72,7 +72,7 @@ Remarks:
   
       test_iaf_dc_aligned.sli
       
-  as a guideline. The commented code is the original python test code.
+  as a guideline. The commented code is the original Python test code.
   
   Test 5) was added later (2014), when support for several adaptation time 
   constants was added to pp_psc_delta.

--- a/testsuite/unittests/test_random_binomial.sli
+++ b/testsuite/unittests/test_random_binomial.sli
@@ -91,7 +91,7 @@ SeeAlso: rdevdict::binomial
 
 
 % compute kalpha to compare against 
-% python code to get value:
+% Python code to get value:
 % import scipy.stats
 % import scipy.optimize
 % alpha = 0.05


### PR DESCRIPTION
This does exactly what the title says and fixes #1696. It also bumps the version requirement consistently to 3.6 in all documents.

Renaming the variable `l` in some of the scripts to `layer` was required to calm down the PEP8 checker, which thinks that `l` is an ambiguous name as it can be confused with a `1`.