### PR TITLE
Rename and refactor test_spatial_kernels.py

### DIFF
--- a/pynest/nest/tests/test_spatial/test_all.py
+++ b/pynest/nest/tests/test_spatial/test_all.py
@@ -37,7 +37,7 @@ from . import test_dumping
 from . import test_plotting
 from . import test_rotated_rect_mask
 from . import test_selection_function_and_elliptical_mask
-from . import test_spatial_kernels
+from . import test_spatial_distributions
 
 
 def suite():
@@ -49,7 +49,7 @@ def suite():
     suite.addTest(test_plotting.suite())
     suite.addTest(test_rotated_rect_mask.suite())
     suite.addTest(test_selection_function_and_elliptical_mask.suite())
-    suite.addTest(test_spatial_kernels.suite())
+    suite.addTest(test_spatial_distributions.suite())
 
     return suite
 

--- a/pynest/nest/tests/test_spatial/test_spatial_distributions.py
+++ b/pynest/nest/tests/test_spatial/test_spatial_distributions.py
@@ -196,13 +196,14 @@ class SpatialTester(object):
         self.c = self._L / 2. + x0  # used to calculate gamma
         self.d = self._L / 2. + y0  # used to calculate delta
 
+        self.sqrt_a2_b2 = math.sqrt(self.a ** 2 + self.b ** 2)
+        self.sqrt_a2_d2 = math.sqrt(self.a ** 2 + self.d ** 2)
+        self.sqrt_d2_c2 = math.sqrt(self.d ** 2 + self.c ** 2)
+
         self._L_half = self._L / 2.
         self.pi_half = math.pi / 2.
         self.two_pi = 2 * math.pi
         self.four_pi = 4 * math.pi
-        self.sqrt_a2_b2 = math.sqrt(self.a ** 2 + self.b ** 2)
-        self.sqrt_a2_d2 = math.sqrt(self.a ** 2 + self.d ** 2)
-        self.sqrt_d2_c2 = math.sqrt(self.d ** 2 + self.c ** 2)
 
     def _constant(self, _):
         """Constant spatial distribution"""
@@ -214,9 +215,7 @@ class SpatialTester(object):
 
     def _exponential(self, D):
         """Exponential spatial distribution"""
-        return (self._params['c'] +
-                self._params['a'] *
-                math.exp(-D / self._params['tau']))
+        return self._params['c'] + self._params['a'] * math.exp(-D / self._params['tau'])
 
     def _gauss(self, D):
         """Gaussian spatial distribution"""
@@ -341,7 +340,7 @@ class SpatialTester(object):
     def _pdf_2d(self, D):
         """Calculate the probability density function in 2D, at the distance D"""
         if D <= self._L_half:
-            return (max(0., min(1., self._distribution(D))) * math.pi * D)
+            return max(0., min(1., self._distribution(D))) * math.pi * D
         elif self._L_half < D <= self._max_dist:
             return max(0., min(1., self._distribution(D))) * D * (math.pi - 4. * math.acos(self._L / (D * 2.)))
         else:
@@ -373,8 +372,7 @@ class SpatialTester(object):
         elif self._L / math.sqrt(2) < D <= self._max_dist:
             A = self.four_pi * D ** 2.
             C = self.two_pi * D * (D - self._L_half)
-            alpha = math.asin(1. / math.sqrt(2. - self._L ** 2. /
-                                             (2. * D ** 2.)))
+            alpha = math.asin(1. / math.sqrt(2. - self._L ** 2. / (2. * D ** 2.)))
             beta = self.pi_half
             gamma = math.asin(math.sqrt((1. - .5 * (self._L / D) ** 2.) /
                                         (1. - .25 * (self._L / D) ** 2.)))

--- a/pynest/nest/tests/test_spatial/test_spatial_distributions.py
+++ b/pynest/nest/tests/test_spatial/test_spatial_distributions.py
@@ -176,7 +176,11 @@ class SpatialTester(object):
                           'mask': maskdict}
 
     def _calculate_constants(self, spatial_distribution):
-        """Calculate constant variables used when calculating distributions and pdfs"""
+        """Calculate constant variables used when calculating distributions and probability density functions
+
+        Variables that can be pre-calculated are calculated here to make the calculation of distributions
+        and probability density functions more efficient.
+        """
         # Constants for spatial distribution functions
         if spatial_distribution == 'gaussian':
             self.two_sigma2 = 2. * self._params['sigma']**2
@@ -186,10 +190,11 @@ class SpatialTester(object):
                                                     self._params['theta']**self._params['kappa'])
         # Constants for pdfs
         x0, y0 = self._roi_2d()  # move coordinates to the right reference area
-        self.a = self._L / 2. - x0
-        self.b = self._L / 2. - y0
-        self.c = self._L / 2. + x0
-        self.d = self._L / 2. + y0
+        # Constants used when using open boundary conditions
+        self.a = self._L / 2. - x0  # used to calculate alpha
+        self.b = self._L / 2. - y0  # used to calculate beta
+        self.c = self._L / 2. + x0  # used to calculate gamma
+        self.d = self._L / 2. + y0  # used to calculate delta
 
         self._L_half = self._L / 2.
         self.pi_half = math.pi / 2.
@@ -334,7 +339,7 @@ class SpatialTester(object):
         return np.array([self._x_d, self._y_d]) if self._x_d > self._y_d else np.array([self._y_d, self._x_d])
 
     def _pdf_2d(self, D):
-        """Calculate the probability density function in 2D"""
+        """Calculate the probability density function in 2D, at the distance D"""
         if D <= self._L_half:
             return (max(0., min(1., self._distribution(D))) * math.pi * D)
         elif self._L_half < D <= self._max_dist:
@@ -343,8 +348,8 @@ class SpatialTester(object):
             return 0.
 
     def _pdf_2d_obc(self, D):
-        """Calculate the probability density function in 2D with open boundary conditions"""
-        # calculate alpha,beta,gamma,delta:
+        """Calculate the probability density function in 2D with open boundary conditions, at the distance D"""
+        # calculate alpha, beta, gamma, delta:
         alpha = math.acos(self.a / D) if self.a / D <= 1. else 0.
         beta = math.acos(self.b / D) if self.b / D <= 1. else 0.
         gamma = math.acos(self.c / D) if self.c / D <= 1. else 0.
@@ -360,7 +365,7 @@ class SpatialTester(object):
             return 0.
 
     def _pdf_3d(self, D):
-        """Calculate the probability density function in 3D"""
+        """Calculate the probability density function in 3D, at the distance D"""
         if D <= self._L_half:
             return max(0., min(1., self._distribution(D))) * self.four_pi * D ** 2.
         elif self._L_half < D <= self._L / math.sqrt(2):

--- a/pynest/nest/tests/test_spatial/test_spatial_distributions.py
+++ b/pynest/nest/tests/test_spatial/test_spatial_distributions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# test_spatial_kernels.py
+# test_spatial_distributions.py
 #
 # This file is part of NEST.
 #

--- a/pynest/nest/tests/test_spatial/test_spatial_kernels.py
+++ b/pynest/nest/tests/test_spatial/test_spatial_kernels.py
@@ -20,7 +20,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Tests distribution of connections created with spatial kernels.
+Tests distribution of connections created with spatial distributions.
 
 Original code by Daniel Hjertholm with Birgit Kriener.
 Converted to automated test by Hans Ekkehard Plesser.
@@ -50,7 +50,7 @@ try:
     fig = plt.figure()
     plt.close(fig)
     PLOTTING_POSSIBLE = True
-except:
+except Exception:
     PLOTTING_POSSIBLE = False
 
 # If False, tests will be run; otherwise, a single case will be plotted.
@@ -64,33 +64,33 @@ SEED = 1234567
 
 
 class SpatialTester(object):
-    '''Tests for spatially structured networks.'''
+    """Tests for spatially structured networks."""
 
-    def __init__(self, seed, dim, L, N, kernel_name, kernel_params=None,
+    def __init__(self, seed, dim, L, N, spatial_distribution, distribution_params=None,
                  open_bc=False, x0=0., y0=0.):
-        '''
+        """
         Construct a test object.
 
         Parameters
         ----------
-            seed         : Random seed for test
-            dim          : Dimensions (2 or 3)
-            L            : Side length of area / volume.
-            N            : Number of nodes.
-            kernel_name  : Name of kernel to use.
-            kernel_params: Dict with params to update.
-            open_bc      : Network with open boundary conditions
-            x0, y0       : Location of source neuron; open_bc only
+            seed                  : Random seed for test
+            dim                   : Dimensions (2 or 3)
+            L                     : Side length of area / volume.
+            N                     : Number of nodes.
+            spatial_distribution  : Name of spatial distribution to use.
+            distribution_params   : Dict with params to update.
+            open_bc               : Network with open boundary conditions
+            x0, y0                : Location of source neuron; open_bc only
 
         Note
         ----
-        For each new kernel to be added, the following needs to be
+        For each new distribution to be added, the following needs to be
         defined:
 
-        self._<kernel>  : lambda-function implementing kernel function
-        kernels entry   : mapping kernel name to kernel function
-        default_params  : default set of parameters for kernel
-        '''
+        self._<distribution>        : function implementing distribution function
+        spatial_distributions entry : mapping distribution name to distribution function
+        default_params              : default set of parameters for distribution
+        """
 
         if dim != 2 and open_bc:
             raise ValueError("open_bc only supported for 2D")
@@ -105,37 +105,24 @@ class SpatialTester(object):
         if (self._dimensions == 2):
             if (self._open_bc):
                 self._max_dist = self._L * math.sqrt(2)
+                self._pdf = self._pdf_2d_obc
             else:
                 self._max_dist = self._L / math.sqrt(2)
+                self._pdf = self._pdf_2d
         elif (self._dimensions == 3):
             self._max_dist = self._L * math.sqrt(3) / 2
+            self._pdf = self._pdf_3d
 
         self._target_dists = None
         self._all_dists = None
 
-        # kernel functions
-        self._constant = lambda D: self._params
-        self._linear = lambda D: self._params['c'] + self._params['a'] * D
-        self._exponential = lambda D: (self._params['c'] +
-                                       self._params['a'] *
-                                       math.exp(-D / self._params['tau']))
-        self._gauss = lambda D: (self._params['c'] +
-                                 self._params['p_center'] *
-                                 math.exp(-(D - self._params['mean']) ** 2 /
-                                          (2. * self._params['sigma'] ** 2)))
-        self._gamma = lambda D: (D ** (self._params['kappa'] - 1) /
-                                 (self._params['theta'] **
-                                  self._params['kappa'] *
-                                  scipy.special.gamma(self._params['kappa'])) *
-                                 math.exp(-D / self._params['theta']))
-
-        kernels = {
+        spatial_distributions = {
             'constant': self._constant,
             'linear': self._linear,
             'exponential': self._exponential,
             'gaussian': self._gauss,
             'gamma': self._gamma}
-        self._kernel = kernels[kernel_name]
+        self._distribution = spatial_distributions[spatial_distribution]
 
         default_params = {
             'constant': 1.,
@@ -145,12 +132,15 @@ class SpatialTester(object):
             'gaussian': {'p_center': 1., 'sigma': self._L / 4.,
                          'mean': 0., 'c': 0.},
             'gamma': {'kappa': 3., 'theta': self._L / 4.}}
-        self._params = default_params[kernel_name]
-        if kernel_params is not None:
-            if kernel_name == 'constant':
-                self._params = kernel_params
+        self._params = default_params[spatial_distribution]
+        if distribution_params is not None:
+            if spatial_distribution == 'constant':
+                self._params = distribution_params
             else:
-                self._params.update(kernel_params)
+                self._params.update(distribution_params)
+
+        # Pre-calculate constant variables for efficiency
+        self._calculate_constants(spatial_distribution)
 
         if self._dimensions == 3:
             maskdict = {'box': {'lower_left': [-self._L / 2.] * 3,
@@ -162,29 +152,78 @@ class SpatialTester(object):
             maskdict = {'rectangular': {'lower_left': [-self._L] * 2,
                                         'upper_right': [self._L] * 2}}
 
-        if kernel_name == 'constant':
-            kernel = nest.CreateParameter('constant', {'value': self._params})
-        elif kernel_name == 'linear':
-            kernel = (self._params['c'] + self._params['a'] *
-                      nest.spatial.distance)
-        elif kernel_name == 'exponential':
-            kernel = self._params['c'] + nest.spatial_distributions.exponential(
+        if spatial_distribution == 'constant':
+            distribution = nest.CreateParameter('constant', {'value': self._params})
+        elif spatial_distribution == 'linear':
+            distribution = self._params['c'] + self._params['a'] * nest.spatial.distance
+        elif spatial_distribution == 'exponential':
+            distribution = self._params['c'] + nest.spatial_distributions.exponential(
                 nest.spatial.distance,
                 beta=self._params['tau'])
-        elif kernel_name == 'gaussian':
-            kernel = self._params['c'] + nest.spatial_distributions.gaussian(
+        elif spatial_distribution == 'gaussian':
+            distribution = self._params['c'] + nest.spatial_distributions.gaussian(
                 nest.spatial.distance,
                 mean=self._params['mean'],
                 std=self._params['sigma'])
-        elif kernel_name == 'gamma':
-            kernel = nest.spatial_distributions.gamma(
+        elif spatial_distribution == 'gamma':
+            distribution = nest.spatial_distributions.gamma(
                 nest.spatial.distance,
                 kappa=self._params['kappa'],
                 theta=self._params['theta'])
 
         self._conndict = {'rule': 'pairwise_bernoulli',
-                          'p': kernel,
+                          'p': distribution,
                           'mask': maskdict}
+
+    def _calculate_constants(self, spatial_distribution):
+        """Calculate constant variables used when calculating distributions and pdfs"""
+        # Constants for spatial distribution functions
+        if spatial_distribution == 'gaussian':
+            self.two_sigma2 = 2. * self._params['sigma']**2
+        elif spatial_distribution == 'gamma':
+            self.kappa_m_1 = self._params['kappa'] - 1
+            self.gamma_kappa_mul_theta_pow_kappa = (scipy.special.gamma(self._params['kappa']) *
+                                                    self._params['theta']**self._params['kappa'])
+        # Constants for pdfs
+        x0, y0 = self._roi_2d()  # move coordinates to the right reference area
+        self.a = self._L / 2. - x0
+        self.b = self._L / 2. - y0
+        self.c = self._L / 2. + x0
+        self.d = self._L / 2. + y0
+
+        self._L_half = self._L / 2.
+        self.pi_half = math.pi / 2.
+        self.two_pi = 2 * math.pi
+        self.four_pi = 4 * math.pi
+        self.sqrt_a2_b2 = math.sqrt(self.a ** 2 + self.b ** 2)
+        self.sqrt_a2_d2 = math.sqrt(self.a ** 2 + self.d ** 2)
+        self.sqrt_d2_c2 = math.sqrt(self.d ** 2 + self.c ** 2)
+
+    def _constant(self, _):
+        """Constant spatial distribution"""
+        return self._params
+
+    def _linear(self, D):
+        """Linear spatial distribution"""
+        return self._params['c'] + self._params['a'] * D
+
+    def _exponential(self, D):
+        """Exponential spatial distribution"""
+        return (self._params['c'] +
+                self._params['a'] *
+                math.exp(-D / self._params['tau']))
+
+    def _gauss(self, D):
+        """Gaussian spatial distribution"""
+        return (self._params['c'] +
+                self._params['p_center'] *
+                math.exp(-(D - self._params['mean']) ** 2 / self.two_sigma2))
+
+    def _gamma(self, D):
+        """Gamma spatial distribution"""
+        return (D**self.kappa_m_1 /
+                self.gamma_kappa_mul_theta_pow_kappa *
+                math.exp(-D / self._params['theta']))
 
     def _create_distance_data(self):
 
@@ -196,13 +235,13 @@ class SpatialTester(object):
         self._all_dists = self._all_distances()
 
     def _reset(self, seed):
-        '''
+        """
         Reset NEST and seed PRNGs.
 
         Parameters
         ----------
             seed: PRNG seed value.
-        '''
+        """
 
         nest.ResetKernel()
         if seed is None:
@@ -213,7 +252,7 @@ class SpatialTester(object):
                               'grng_seed': seed + 2})
 
     def _build(self):
-        '''Create populations.'''
+        """Create populations."""
         if self._open_bc:
             x = rnd.uniform(-self._L / 2., self._L / 2., self._N)
             y = rnd.uniform(-self._L / 2., self._L / 2., self._N)
@@ -247,17 +286,17 @@ class SpatialTester(object):
             self._driver = nest.FindCenterElement(self._ls)
 
     def _connect(self):
-        '''Connect populations.'''
+        """Connect populations."""
 
         nest.Connect(self._ls, self._lt, self._conndict)
 
     def _all_distances(self):
-        '''Return distances to all nodes in target population.'''
+        """Return distances to all nodes in target population."""
 
         return nest.Distance(self._driver, self._lt)
 
     def _target_distances(self):
-        '''Return distances from source node to connected nodes.'''
+        """Return distances from source node to connected nodes."""
 
         # Distance from source node to all nodes in target population
         dist = np.array(nest.Distance(self._driver, self._lt))
@@ -275,198 +314,73 @@ class SpatialTester(object):
         return target_dist
 
     def _positions(self):
-        '''Return positions of all nodes.'''
+        """Return positions of all nodes."""
         return [tuple(pos) for pos in
                 nest.GetPosition(self._lt)]
 
     def _target_positions(self):
-        '''Return positions of all connected target nodes.'''
+        """Return positions of all connected target nodes."""
 
         return [tuple(pos) for pos in
                 nest.GetTargetPositions(self._driver, self._lt)[0]]
 
-    def _roi_2d(self, x, y, L):
-        '''
+    def _roi_2d(self):
+        """
         Moves coordinates (x,y) to triangle area (x',y') in [0,L/2]X[0,x']
         without loss of generality
-        '''
-        x = -x if (x >= -self._L / 2.) and (x < 0) else x
-        y = -y if (y >= -self._L / 2.) and (y < 0) else y
-        return np.array([x, y]) if x > y else np.array([y, x])
+        """
+        self._x_d = -self._x_d if (self._x_d >= -self._L / 2.) and (self._x_d < 0) else self._x_d
+        self._y_d = -self._y_d if (self._y_d >= -self._L / 2.) and (self._y_d < 0) else self._y_d
+        return np.array([self._x_d, self._y_d]) if self._x_d > self._y_d else np.array([self._y_d, self._x_d])
 
-    def _pdf(self, D):
-        '''
-        Unnormalized probability density function (PDF).
+    def _pdf_2d(self, D):
+        """Calculate the probability density function in 2D"""
+        if D <= self._L_half:
+            return (max(0., min(1., self._distribution(D))) * math.pi * D)
+        elif self._L_half < D <= self._max_dist:
+            return max(0., min(1., self._distribution(D))) * D * (math.pi - 4. * math.acos(self._L / (D * 2.)))
+        else:
+            return 0.
 
-        Parameters
-        ----------
-            D: Distance in interval [0, max_dist], scalar.
+    def _pdf_2d_obc(self, D):
+        """Calculate the probability density function in 2D with open boundary conditions"""
+        # calculate alpha,beta,gamma,delta:
+        alpha = math.acos(self.a / D) if self.a / D <= 1. else 0.
+        beta = math.acos(self.b / D) if self.b / D <= 1. else 0.
+        gamma = math.acos(self.c / D) if self.c / D <= 1. else 0.
+        delta = math.acos(self.d / D) if self.d / D <= 1. else 0.
+        kofD = max(0., min(1., self._distribution(D)))
 
-        Return values
-        -------------
-            Not-normalized PDF at distance D.
-        '''
+        if (D >= 0) and (D < self.a):
+            return self.two_pi * D * kofD
+        if (self.sqrt_a2_b2 > self.c and self.sqrt_a2_d2 > self.c and
+                D >= self.c and D < self.sqrt_a2_b2):
+            return 2 * D * (math.pi - alpha - beta - delta - gamma) * kofD
+        if D >= self.sqrt_d2_c2:
+            return 0.
 
-        # TODO: The code below can most likely be optimized noticeably
-        # by avoiding duplicate tests.
-        if self._dimensions == 2:
-            if self._open_bc:
-
-                # move coordinates to right reference area:
-                x0, y0 = self._roi_2d(self._x_d, self._y_d, self._L)
-
-                # define a,b,c,d; alpha,beta,gamma,delta:
-                a, b, c, d = self._L / 2. - np.array([x0, y0, -x0, -y0])
-                alpha = math.acos(a / D) if a / D <= 1. else 0.
-                beta = math.acos(b / D) if b / D <= 1. else 0.
-                gamma = math.acos(c / D) if c / D <= 1. else 0.
-                delta = math.acos(d / D) if d / D <= 1. else 0.
-                kofD = max(0., min(1., self._kernel(D)))
-
-                # cases:
-                if (math.sqrt(a ** 2 + b ** 2) <= d):
-                    if D < 0.:
-                        return 0.
-                    if (D >= 0.) and (D < a):
-                        return 2 * math.pi * D * kofD
-                    if (D >= a) and (D < b):
-                        return 2 * D * (math.pi - alpha) * kofD
-                    if (D >= b) and (D < math.sqrt(a ** 2 + b ** 2)):
-                        return 2 * D * (math.pi - alpha - beta) * kofD
-                    if (D >= math.sqrt(a ** 2 + b ** 2)) and (D < d):
-                        return D * (3 * math.pi / 2. - alpha - beta) * kofD
-
-                    if (c >= math.sqrt(a ** 2 + d ** 2)):
-                        if (D >= d) and (D < math.sqrt(a ** 2 + d ** 2)):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * delta) * kofD
-                        if (D >= math.sqrt(a ** 2 + d ** 2)) and (D < c):
-                            return D * (math.pi - beta - delta) * kofD
-                        if (D >= c) and (D < math.sqrt(b ** 2 + c ** 2)):
-                            return D * (math.pi - beta - delta -
-                                        2 * gamma) * kofD
-                        if ((D >= math.sqrt(b ** 2 + c ** 2)) and
-                                (D < math.sqrt(d ** 2 + c ** 2))):
-                            return D * (math.pi / 2. - delta - gamma) * kofD
-
-                    if (c < math.sqrt(a ** 2 + d ** 2)):
-                        if (D >= d) and (D < c):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * delta) * kofD
-                        if (D >= c) and (D < math.sqrt(a ** 2 + d ** 2)):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * (delta + gamma)) * kofD
-                        if ((D >= math.sqrt(a ** 2 + d ** 2)) and
-                                (D < math.sqrt(b ** 2 + c ** 2))):
-                            return D * (math.pi - beta - delta -
-                                        2 * gamma) * kofD
-                        if ((D >= math.sqrt(b ** 2 + c ** 2)) and
-                                (D < math.sqrt(d ** 2 + c ** 2))):
-                            return D * (math.pi / 2. - delta - gamma) * kofD
-                    if (D >= math.sqrt(d ** 2 + c ** 2)):
-                        return 0.
-
-                else:
-                    if D < 0:
-                        return 0.
-                    if (D >= 0) and (D < a):
-                        return 2 * math.pi * D * kofD
-                    if (D >= a) and (D < b):
-                        return 2 * D * (math.pi - alpha) * kofD
-                    if (D >= b) and (D < d):
-                        return 2 * D * (math.pi - alpha - beta) * kofD
-
-                    if (((math.sqrt(a ** 2 + b ** 2) > c) and
-                         (math.sqrt(a ** 2 + d ** 2) > c))):
-                        if (D >= d) and (D < c):
-                            return 2 * D * (math.pi - alpha - beta -
-                                            delta) * kofD
-                        if (D >= c) and (D < math.sqrt(a ** 2 + b ** 2)):
-                            return 2 * D * (math.pi - alpha - beta -
-                                            delta - gamma) * kofD
-                        if ((D >= math.sqrt(a ** 2 + b ** 2)) and
-                                (D < math.sqrt(a ** 2 + d ** 2))):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * (delta + gamma)) * kofD
-                        if ((D >= math.sqrt(a ** 2 + d ** 2)) and
-                                (D < math.sqrt(b ** 2 + c ** 2))):
-                            return D * (math.pi - beta - delta -
-                                        2 * gamma) * kofD
-                        if ((D >= math.sqrt(b ** 2 + c ** 2)) and
-                                (D < math.sqrt(d ** 2 + c ** 2))):
-                            return D * (math.pi / 2. - delta - gamma) * kofD
-
-                    if (((math.sqrt(a ** 2 + b ** 2) <= c) and
-                         (math.sqrt(a ** 2 + d ** 2) <= c))):
-                        if (D >= d) and (D < math.sqrt(a ** 2 + b ** 2)):
-                            return 2 * D * (math.pi -
-                                            (alpha + beta + delta)) * kofD
-                        if ((D >= math.sqrt(a ** 2 + b ** 2)) and
-                                (D < math.sqrt(a ** 2 + d ** 2))):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * delta) * kofD
-                        if (D < c) and (D >= math.sqrt(a ** 2 + d ** 2)):
-                            return D * (math.pi - beta - delta) * kofD
-                        if (D >= c) and (D < math.sqrt(b ** 2 + c ** 2)):
-                            return D * (math.pi - beta - delta -
-                                        2 * gamma) * kofD
-                        if ((D >= math.sqrt(b ** 2 + c ** 2)) and
-                                (D < math.sqrt(d ** 2 + c ** 2))):
-                            return D * (math.pi / 2. - delta - gamma) * kofD
-
-                    if (((math.sqrt(a ** 2 + b ** 2) < c) and
-                         (math.sqrt(a ** 2 + d ** 2) > c))):
-                        if (D >= d) and (D < math.sqrt(a ** 2 + b ** 2)):
-                            return 2 * D * (math.pi - alpha - beta -
-                                            delta) * kofD
-                        if (D >= math.sqrt(a ** 2 + b ** 2)) and (D < c):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * delta) * kofD
-                        if (D >= c) and (D < math.sqrt(a ** 2 + d ** 2)):
-                            return D * (3 * math.pi / 2. - alpha - beta -
-                                        2 * (delta + gamma)) * kofD
-                        if ((D >= math.sqrt(a ** 2 + d ** 2)) and
-                                (D < math.sqrt(b ** 2 + c ** 2))):
-                            return D * (math.pi - beta - delta -
-                                        2 * gamma) * kofD
-                        if ((D >= math.sqrt(b ** 2 + c ** 2)) and
-                                (D < math.sqrt(d ** 2 + c ** 2))):
-                            return D * (math.pi / 2. - delta - gamma) * kofD
-                    if (D >= math.sqrt(d ** 2 + c ** 2)):
-                        return 0.
-
-            else:
-                if D <= self._L / 2.:
-                    return (max(0., min(1., self._kernel(D))) * math.pi * D)
-                elif self._L / 2. < D <= self._max_dist:
-                    return ((max(0., min(1., self._kernel(D))) * D *
-                             (math.pi - 4. * math.acos(self._L / (D * 2.)))))
-                else:
-                    return 0.
-
-        elif self._dimensions == 3:
-            if D <= self._L / 2.:
-                return (max(0., min(1., self._kernel(D))) *
-                        4. * math.pi * D ** 2.)
-            elif self._L / 2. < D <= self._L / math.sqrt(2):
-                return (max(0., min(1., self._kernel(D))) *
-                        2. * math.pi * D * (3. * self._L - 4. * D))
-            elif self._L / math.sqrt(2) < D <= self._max_dist:
-                A = 4. * math.pi * D ** 2.
-                C = 2. * math.pi * D * (D - self._L / 2.)
-                alpha = math.asin(1. / math.sqrt(2. - self._L ** 2. /
-                                                 (2. * D ** 2.)))
-                beta = math.pi / 2.
-                gamma = math.asin(math.sqrt((1. - .5 * (self._L / D) ** 2.) /
-                                            (1. - .25 * (self._L / D) ** 2.)))
-                T = D ** 2. * (alpha + beta + gamma - math.pi)
-                return (max(0., min(1., self._kernel(D))) *
-                        (A + 6. * C * (-1. + 4. * gamma / math.pi) - 48. * T))
-            else:
-                return 0.
+    def _pdf_3d(self, D):
+        """Calculate the probability density function in 3D"""
+        if D <= self._L_half:
+            return max(0., min(1., self._distribution(D))) * self.four_pi * D ** 2.
+        elif self._L_half < D <= self._L / math.sqrt(2):
+            return max(0., min(1., self._distribution(D))) * self.two_pi * D * (3. * self._L - 4. * D)
+        elif self._L / math.sqrt(2) < D <= self._max_dist:
+            A = self.four_pi * D ** 2.
+            C = self.two_pi * D * (D - self._L_half)
+            alpha = math.asin(1. / math.sqrt(2. - self._L ** 2. /
+                                             (2. * D ** 2.)))
+            beta = self.pi_half
+            gamma = math.asin(math.sqrt((1. - .5 * (self._L / D) ** 2.) /
+                                        (1. - .25 * (self._L / D) ** 2.)))
+            T = D ** 2. * (alpha + beta + gamma - math.pi)
+            return (max(0., min(1., self._distribution(D))) *
+                    (A + 6. * C * (-1. + 4. * gamma / math.pi) - 48. * T))
+        else:
+            return 0.
 
     def _cdf(self, D):
-        '''
+        """
         Normalized cumulative distribution function (CDF).
 
         Parameters
@@ -476,11 +390,11 @@ class SpatialTester(object):
         Return values
         -------------
             List of CDF(d) for each distance d in D.
-        '''
-        cdf = []
+        """
+        cdf = np.zeros(len(D))
         last_d = 0.
-        for d in D:
-            cdf.append(scipy.integrate.quad(self._pdf, last_d, d)[0])
+        for i, d in enumerate(D):
+            cdf[i] = scipy.integrate.quad(self._pdf, last_d, d)[0]
             last_d = d
 
         cdf = np.cumsum(cdf)
@@ -490,7 +404,7 @@ class SpatialTester(object):
         return normed_cdf
 
     def ks_test(self):
-        '''
+        """
         Perform a Kolmogorov-Smirnov GOF test on the distribution
         of distances to connected nodes.
 
@@ -498,7 +412,7 @@ class SpatialTester(object):
         -------------
             KS statistic.
             p-value from KS test.
-        '''
+        """
 
         if self._target_dists is None:
             self._create_distance_data()
@@ -509,21 +423,21 @@ class SpatialTester(object):
         return ks, p
 
     def z_test(self):
-        '''
+        """
         Perform a Z-test on the total number of connections.
 
         Return values
         -------------
             Standard score (z-score).
             Two-sided p-value.
-        '''
+        """
 
         if self._target_dists is None or self._all_dists is None:
             self._create_distance_data()
 
         num_targets = len(self._target_dists)
 
-        ps = ([max(0., min(1., self._kernel(D)))
+        ps = ([max(0., min(1., self._distribution(D)))
                for D in self._all_dists])
         expected_num_targets = sum(ps)
         variance_num_targets = sum([p * (1. - p) for p in ps])
@@ -540,15 +454,15 @@ class SpatialTester(object):
 
 if PLOTTING_POSSIBLE:
     class PlottingSpatialTester(SpatialTester):
-        '''Add plotting capability to SpatialTester.'''
+        """Add plotting capability to SpatialTester."""
 
-        def __init__(self, seed, dim, L, N, kernel_name, kernel_params=None,
+        def __init__(self, seed, dim, L, N, spatial_distribution, distribution_params=None,
                      open_bc=False, x0=0., y0=0.):
-            SpatialTester.__init__(self, seed, dim, L, N, kernel_name,
-                                   kernel_params, open_bc, x0, y0)
+            SpatialTester.__init__(self, seed, dim, L, N, spatial_distribution,
+                                   distribution_params, open_bc, x0, y0)
 
         def show_network(self):
-            '''Plot nodes in the network.'''
+            """Plot nodes in the network."""
 
             # Adjust size of nodes in plot based on number of nodes.
             nodesize = max(0.01, round(111. / 11 - self._N / 1100.))
@@ -583,10 +497,10 @@ if PLOTTING_POSSIBLE:
             plt.subplots_adjust(bottom=0.15, left=0.17)
 
         def show_CDF(self):
-            '''
+            """
             Plot the cumulative distribution function (CDF) of
             source-target distances.
-            '''
+            """
 
             plt.figure()
             x = np.linspace(0, self._max_dist, 1000)
@@ -604,13 +518,13 @@ if PLOTTING_POSSIBLE:
             plt.legend(loc='center right')
 
         def show_PDF(self, bins=100):
-            '''
+            """
             Plot the probability density function of source-target distances.
 
             Parameters
             ----------
                 bins: Number of histogram bins for PDF plot.
-            '''
+            """
 
             plt.figure()
             x = np.linspace(0, self._max_dist, 1000)
@@ -630,155 +544,155 @@ if PLOTTING_POSSIBLE:
 
 class TestSpatial2D(unittest.TestCase):
     """
-    Test for 2D kernels.
+    Test for 2D distributions.
     """
 
     def test_constant(self):
-        kernel = 'constant'
+        distribution = 'constant'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_linear(self):
-        kernel = 'linear'
+        distribution = 'linear'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_exponential(self):
-        kernel = 'exponential'
+        distribution = 'exponential'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_gaussian(self):
-        kernel = 'gaussian'
+        distribution = 'gaussian'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_gamma(self):
-        kernel = 'gamma'
+        distribution = 'gamma'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
 
 class TestSpatial2DOBC(unittest.TestCase):
     """
-    Test for 2D kernels with open boundary conditions.
+    Test for 2D distributions with open boundary conditions.
     """
 
     def test_constant(self):
-        kernel = 'constant'
+        distribution = 'constant'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel, open_bc=True)
+                             spatial_distribution=distribution, open_bc=True)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_linear(self):
-        kernel = 'linear'
+        distribution = 'linear'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel, open_bc=True)
+                             spatial_distribution=distribution, open_bc=True)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_exponential(self):
-        kernel = 'exponential'
+        distribution = 'exponential'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel, open_bc=True)
+                             spatial_distribution=distribution, open_bc=True)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_gaussian(self):
-        kernel = 'gaussian'
+        distribution = 'gaussian'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel, open_bc=True)
+                             spatial_distribution=distribution, open_bc=True)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_gamma(self):
-        kernel = 'gamma'
+        distribution = 'gamma'
         test = SpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                             kernel_name=kernel, open_bc=True)
+                             spatial_distribution=distribution, open_bc=True)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
 
 class TestSpatial3D(unittest.TestCase):
     """
-    Test for 3D kernels.
+    Test for 3D distributions.
     """
 
     def test_constant(self):
-        kernel = 'constant'
+        distribution = 'constant'
         test = SpatialTester(seed=SEED, dim=3, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_linear(self):
-        kernel = 'linear'
+        distribution = 'linear'
         test = SpatialTester(seed=SEED, dim=3, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_exponential(self):
-        kernel = 'exponential'
+        distribution = 'exponential'
         test = SpatialTester(seed=SEED, dim=3, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_gaussian(self):
-        kernel = 'gaussian'
+        distribution = 'gaussian'
         test = SpatialTester(seed=SEED, dim=3, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
     def test_gamma(self):
-        kernel = 'gamma'
+        distribution = 'gamma'
         test = SpatialTester(seed=SEED, dim=3, L=1.0, N=10000,
-                             kernel_name=kernel)
+                             spatial_distribution=distribution)
         _, p_ks = test.ks_test()
         _, p_Z = test.z_test()
-        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(kernel))
-        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(kernel))
+        self.assertGreater(p_ks, P_MIN, '{} failed KS-test'.format(distribution))
+        self.assertGreater(p_Z, P_MIN, '{} failed Z-test'.format(distribution))
 
 
 def suite():
@@ -797,7 +711,7 @@ if __name__ == '__main__':
         runner.run(suite())
     elif PLOTTING_POSSIBLE:
         test = PlottingSpatialTester(seed=SEED, dim=2, L=1.0, N=10000,
-                                     kernel_name='gaussian')
+                                     spatial_distribution='gaussian')
         ks, p = test.ks_test()
         print('p-value of KS-test:', p)
         z, p = test.z_test()

--- a/pynest/nest/tests/test_spatial/test_spatial_kernels.py
+++ b/pynest/nest/tests/test_spatial/test_spatial_kernels.py
@@ -260,25 +260,17 @@ class SpatialTester(object):
         '''Return distances from source node to connected nodes.'''
 
         # Distance from source node to all nodes in target population
-        dist = nest.Distance(self._driver, self._lt)
+        dist = np.array(nest.Distance(self._driver, self._lt))
 
         # Target nodes
         connections = nest.GetConnections(source=self._driver)
-        target_nodes = connections.get('target')
+        target_array = np.array(connections.target)
 
-        target_dist = []
+        # Convert lt node IDs to a NumPy array
+        lt_array = np.array(self._lt.tolist())
 
-        # target_nodes and lt will both be sorted, so we can iterate through
-        # both to see if they match, and put the correct distance in a list
-        # containig target distances if true.
-        counter = 0
-        for indx, nc in enumerate(self._lt):
-            if nc.get('global_id') == target_nodes[counter]:
-                target_dist.append(dist[indx])
-                counter += 1
-                # target_nodes might be shorter than lt
-                if counter == len(target_nodes):
-                    break
+        # Pick distance values of connected targets only
+        target_dist = dist[np.isin(lt_array, target_array)]
 
         return target_dist
 


### PR DESCRIPTION
This PR renames test_spatial_kernels.py to test_spatial_distributions.py as we are using distributions instead of kernels. It also refactors calculation-heavy parts of the test to make it more efficient.