### PR TITLE
Add tests for GetConnections with synapse_model and synapse_label as arguments

### DIFF
--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -138,6 +138,39 @@ class GetConnectionsTestCase(unittest.TestCase):
             conns = nest.GetConnections(source=src, synapse_model=synapse_model)
             self.assertEqual(reference_list, conns.synapse_model)
 
+    def test_GetConnectionsSynapseLabel(self):
+        """GetConnections using synapse_label as argument"""
+
+        labeled_synapse_models = [s for s in nest.Models(mtype='synapses') if s.endswith("_lbl")]
+
+        for synapse_model in labeled_synapse_models:
+            nest.ResetKernel()
+
+            src = nest.Create('hh_psc_alpha_gap', 3)
+            trgt = nest.Create('hh_psc_alpha_gap', 5)
+
+            # First create one connection with static_synapse
+            nest.Connect(src[0], trgt[0])
+
+            try:
+                # Connect with specified synapse
+                nest.Connect(src, trgt, syn_spec={'synapse_model': synapse_model, "synapse_label": 123, })
+            except nest.kernel.NESTError:
+                # If we can't connect iaf_psc_alpha with the given synapse_model, we ignore it.
+                continue
+
+            reference_list = [synapse_model] * 3 * 5
+
+            # Call GetConnections with specified synapse_label and test that connections with
+            # corresponding model are returned
+            conns = nest.GetConnections(synapse_label=123)
+            self.assertEqual(reference_list, conns.synapse_model)
+            self.assertEqual([123] * 3 * 5, conns.synapse_label)
+
+            # Also test that it works if we specify source and synapse_label
+            conns = nest.GetConnections(source=src, synapse_label=123)
+            self.assertEqual(reference_list, conns.synapse_model)
+
 
 def suite():
 

--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -191,7 +191,7 @@ class GetConnectionsTestCase(unittest.TestCase):
 
             conns = nest.GetConnections(source=src, synapse_label=label)
             self.assertEqual(reference_list, conns.synapse_model)
-            
+
             conns = nest.GetConnections(target=tgt, synapse_label=label)
             self.assertEqual(reference_list, conns.synapse_model)
 

--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -108,6 +108,36 @@ class GetConnectionsTestCase(unittest.TestCase):
                     'Failed to get connection with source model {} (specifying {})'.format(
                         model, ', '.join(get_conn_args.keys())))
 
+    def test_GetConnectionsSynapseModel(self):
+        """GetConnections using synapse_model as argument"""
+
+        for synapse_model in nest.Models('synapses'):
+            nest.ResetKernel()
+
+            src = nest.Create('iaf_psc_alpha', 3)
+            trgt = nest.Create('iaf_psc_alpha', 5)
+
+            # First create one connection with static_synapse
+            nest.Connect(src[0], trgt[0])
+
+            try:
+                # Connect with specified synapse
+                nest.Connect(src, trgt, syn_spec={'synapse_model': synapse_model})
+            except nest.kernel.NESTError:
+                # If we can't connect iaf_psc_alpha with the given synapse_model, we ignore it.
+                continue
+
+            reference_list = [synapse_model] * 3 * 5
+            if synapse_model == 'static_synapse':
+                reference_list += ['static_synapse']
+
+            conns = nest.GetConnections(synapse_model=synapse_model)
+            self.assertEqual(reference_list, conns.synapse_model)
+
+            # Also test that it works if we specify source and synapse_model
+            conns = nest.GetConnections(source=src, synapse_model=synapse_model)
+            self.assertEqual(reference_list, conns.synapse_model)
+
 
 def suite():
 

--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -28,8 +28,11 @@ import nest
 
 nest.set_verbosity('M_ERROR')
 
+HAVE_GSL = nest.ll_api.sli_func("statusdict/have_gsl ::")
+
 
 @nest.ll_api.check_stack
+@unittest.skipIf(not HAVE_GSL, 'GSL is not available')
 class GetConnectionsTestCase(unittest.TestCase):
     """Find connections and test if values can be set."""
 

--- a/pynest/nest/tests/test_getconnections.py
+++ b/pynest/nest/tests/test_getconnections.py
@@ -28,8 +28,6 @@ import nest
 
 nest.set_verbosity('M_ERROR')
 
-HAVE_GSL = nest.ll_api.sli_func("statusdict/have_gsl ::")
-
 
 @nest.ll_api.check_stack
 class GetConnectionsTestCase(unittest.TestCase):
@@ -149,7 +147,6 @@ class GetConnectionsTestCase(unittest.TestCase):
             conns = nest.GetConnections(target=tgt, synapse_model=synapse_model)
             self.assertEqual(reference_list, conns.synapse_model)
 
-    @unittest.skipIf(not HAVE_GSL, 'GSL is not available')
     def test_GetConnectionsSynapseLabel(self):
         """GetConnections using synapse_label as argument"""
 
@@ -162,8 +159,8 @@ class GetConnectionsTestCase(unittest.TestCase):
         for synapse_model in labeled_synapse_models:
             nest.ResetKernel()
 
-            src = nest.Create('hh_psc_alpha_gap', num_src)
-            tgt = nest.Create('hh_psc_alpha_gap', num_tgt)
+            src = nest.Create('iaf_psc_alpha', num_src)
+            tgt = nest.Create('iaf_psc_alpha', num_tgt)
 
             # First create one connection with static_synapse
             nest.Connect(src[0], tgt[0])


### PR DESCRIPTION
Add tests to `test_getconnections.py` so we test for `GetConnections()` with `synapse_model` and `synapse_label` as arguments.

This PR fixes #1669.