### PR TITLE
Fix linking problems on OSX in presence of MPI4Py

### DIFF
--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -50,6 +50,9 @@ else ()
     set_target_properties( nest_lib
         PROPERTIES
         OUTPUT_NAME nest
+        
+        # delay lookup of symbols from libpython when building with MPI4Py
+        LINK_FLAGS "-Wl,-undefined -Wl,dynamic_lookup"
         )
 endif ()
 


### PR DESCRIPTION
This should fix #1678.