### PR TITLE
Add tips for installing NEST with conda to documentation

### DIFF
--- a/doc/installation/conda_recommendations.rst
+++ b/doc/installation/conda_recommendations.rst
@@ -7,15 +7,16 @@ conda.
 Create a dedicated environment for NEST
 ---------------------------------------
 
-We recommend that you **create a dedicated environment for NEST**, which
+We recommend that you create a dedicated environment for NEST, which
 should ensure there are no conflicts with previously installed packages.
 
 Install all programs
 --------------------
 
-We strongly recommend that you **install all programs** you'll need, 
+We strongly recommend that you install all programs you'll need,
 (such as ``ipython`` or ``jupyter-lab``) in the environment 
-(``<envname>``) **at the same time**, by **appending them to the command below**.
+(``<envname>``) at the same time, by appending them to the
+``conda create --name ENVNAME -c conda-forge`` command.
 
 Installing packages later may override previously installed dependencies 
 and potentially break packages! See `managing environments in the Conda 
@@ -41,5 +42,8 @@ this obvious would be to reduce conda stack to ``0`` (conda documentation
 `here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#nested-activation>`_),
 and/or to a certain degree by not auto-activating the base environment (conda documentation
 `here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#conda-init>`_).
-Then packages from base do not 'leak' into your new environments. Note however, that packages from your system
-will usually also be available in your conda environment and may cause similar conflicts.
+Then packages from base do not 'leak' into your new environments.
+
+.. note::
+   Packages from your system will usually also be available in your conda
+   environment and may cause similar conflicts.

--- a/doc/installation/conda_recommendations.rst
+++ b/doc/installation/conda_recommendations.rst
@@ -1,0 +1,25 @@
+Conda environment recommendations
+=================================
+
+This page provides a series of recommendations for installing NEST with
+conda.
+
+Create a dedicated environment for NEST
+---------------------------------------
+
+We recommend that you **create a dedicated environment for NEST**, which
+should ensure there are no conflicts with previously installed packages.
+
+Install all programs
+--------------------
+
+We strongly recommend that you **install all programs** you'll need, 
+(such as ``ipython`` or ``jupyter-lab``) in the environment 
+(``<envname>``) **at the same time**, by **appending them to the command below**.
+
+Installing packages later may override previously installed dependencies 
+and potentially break packages! See `managing environments in the Conda 
+documentation <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands>`_
+for more information.
+
+

--- a/doc/installation/conda_recommendations.rst
+++ b/doc/installation/conda_recommendations.rst
@@ -22,4 +22,24 @@ and potentially break packages! See `managing environments in the Conda
 documentation <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands>`_
 for more information.
 
+Keep your base environment empty
+--------------------------------
 
+Your base environment should be as empty as possible in order to avoid
+conflicts with other environments. Always install packages only in the new
+environments (don't worry about duplicates, conda will link the packages
+if they are used in multiple environments, and not produce disk eating copies).
+
+Get a good overview
+-------------------
+
+Obtain a good overview of which packages are installed where. You can use
+``conda env export -n base`` and ``conda env export -n yournestenv``
+(replacing the ``yournestenv`` name with whatever you chose). Make
+sure each environment contains all dependencies. One way to make
+this obvious would be to reduce conda stack to ``0`` (conda documentation
+`here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#nested-activation>`_),
+and/or to a certain degree by not auto-activating the base environment (conda documentation
+`here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#conda-init>`_).
+Then packages from base do not 'leak' into your new environments. Note however, that packages from your system
+will usually also be available in your conda environment and may cause similar conflicts.

--- a/doc/installation/conda_recommendations.rst
+++ b/doc/installation/conda_recommendations.rst
@@ -7,16 +7,15 @@ conda.
 Create a dedicated environment for NEST
 ---------------------------------------
 
-We recommend that you create a dedicated environment for NEST, which
-should ensure there are no conflicts with previously installed packages.
+Create a dedicated environment for NEST, which should ensure there are
+no conflicts with previously installed packages.
 
 Install all programs
 --------------------
 
-We strongly recommend that you install all programs you'll need,
-(such as ``ipython`` or ``jupyter-lab``) in the environment 
-(``<envname>``) at the same time, by appending them to the
-``conda create --name ENVNAME -c conda-forge`` command.
+Install all programs you'll need, (such as ``ipython`` or ``jupyter-lab``)
+in the environment (``<envname>``) at the same time, by appending them to
+the ``conda create --name ENVNAME -c conda-forge`` command.
 
 Installing packages later may override previously installed dependencies 
 and potentially break packages! See `managing environments in the Conda 

--- a/doc/installation/conda_tips.rst
+++ b/doc/installation/conda_tips.rst
@@ -1,5 +1,5 @@
-Conda environment recommendations
-=================================
+Tips for installing NEST with conda
+===================================
 
 This page provides a series of recommendations for installing NEST with
 conda.

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -122,8 +122,8 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
    .. tab:: Conda (Linux/macOS)
 
-       1. Create your conda environment and install NEST. Please refer to
-          our :doc:`conda_recommendations`.
+       1. Create your conda environment and install NEST. Please check out 
+          our :doc:`conda_tips`.
 
           Without OpenMPI:
 

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -123,23 +123,7 @@ compile NEST from source, see section** :ref:`advanced_install`.
    .. tab:: Conda (Linux/macOS)
 
        1. Create your conda environment and install NEST. Please refer to
-          our :doc:`conda_guidelines`. We recommend
-          that you **create a dedicated environment for NEST**, which
-          should ensure there are no conflicts with previously
-          installed packages.
-
-          .. note::
-
-             We strongly recommend that you **install all programs**
-             you'll need, (such as ``ipython`` or ``jupyter-lab``) in
-             the environment (``<envname>``) **at the same time**, by
-             **appending them to the command below**.
-
-             Installing packages later may override previously
-             installed dependencies and potentially break packages!
-             See `managing environments in the Conda documentation
-             <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands>`_
-             for more information.
+          our :doc:`conda_recommendations`.
 
           Without OpenMPI:
 

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -122,7 +122,8 @@ compile NEST from source, see section** :ref:`advanced_install`.
 
    .. tab:: Conda (Linux/macOS)
 
-       1. Create your conda environment and install NEST. We recommend
+       1. Create your conda environment and install NEST. Please refer to
+          our :doc:`conda_guidelines`. We recommend
           that you **create a dedicated environment for NEST**, which
           should ensure there are no conflicts with previously
           installed packages.

--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -127,11 +127,11 @@ compile NEST from source, see section** :ref:`advanced_install`.
           should ensure there are no conflicts with previously
           installed packages.
 
-          .. pull-quote::
+          .. note::
 
-          We strongly recommend that you **install all programs**
+             We strongly recommend that you **install all programs**
              you'll need, (such as ``ipython`` or ``jupyter-lab``) in
-             the environment (ENVNAME) **at the same time**, by
+             the environment (``<envname>``) **at the same time**, by
              **appending them to the command below**.
 
              Installing packages later may override previously


### PR DESCRIPTION
This PR creates a page containing recommendations for installing NEST with conda. The page consists of the "general" information mentioned in #1677 as well as the tips previously found in ``doc/installation/index.rst``.

It fixes #1677.

