### PR TITLE
Efficient initialization of membrane potentials with original and optimized conditions in Potjans_2014

### DIFF
--- a/pynest/examples/Potjans_2014/network.py
+++ b/pynest/examples/Potjans_2014/network.py
@@ -238,8 +238,8 @@ class Network:
         """
         Initializes membrane potentials by sampling from a normal distribution.
 
-        One Python random number generator per virtual process (vp) is used.
-        This results in identical initial conditions if the number of vps,
+        One Python random number generator per virtual process (VP) is used.
+        This results in identical initial conditions if the number of VPs,
         meaning the product of MPI processes and the number of OpenMP threads
         per MPI process, is preserved.
 
@@ -260,13 +260,13 @@ class Network:
         mask = list(nest.GetStatus(neurons, 'local'))
         neurons_loc = np.array(neurons)[mask].tolist()
 
-        # get sequence of vps on this MPI process
+        # get sequence of VPs on this MPI process
         num_threads = nest.GetKernelStatus()['local_num_threads']
         local_vps = nest.GetStatus(neurons_loc[:num_threads], 'vp')
 
         for ivp, vp in enumerate(local_vps):
             # use knowledge that the next neuron of the same MPI process with
-            # the same vp is num_threads away
+            # the same VP is num_threads away
             neurons_vp = neurons_loc[ivp::num_threads]
             nest.SetStatus(neurons_vp, 'V_m',
                 self.pyrngs[vp].normal(V0_mean, V0_sd, len(neurons_vp)))

--- a/pynest/examples/Potjans_2014/network.py
+++ b/pynest/examples/Potjans_2014/network.py
@@ -162,16 +162,9 @@ class Network:
 
         v0_type_options = ['optimized', 'original']
         if self.net_dict['V0_type'] not in v0_type_options:
-            print(
-                '''
-                '{0}' is not a valid option for 'V0_type',
-                replacing it with '{1}.'
-                Valid options are {2}.
-                '''.format(self.net_dict['V0_type'],
-                           v0_type_options[0],
-                           v0_type_options)
-                )
-            self.net_dict['V0_type'] = v0_type_options[0]
+            raise Exception(
+                'V0_type incorrect. Valid options are ' +
+                (' and ').join(v0_type_options) + '.')
 
         if nest.Rank() == 0:
             print(

--- a/pynest/examples/Potjans_2014/network_params.py
+++ b/pynest/examples/Potjans_2014/network_params.py
@@ -195,12 +195,24 @@ net_dict = {
     # Relative standard deviation of the delay of excitatory and
     # inhibitory connections (in relative units).
     'rel_std_delay': 0.5,
+    # Initial conditions for the membrane potential, options are:
+    # 'original': uniform mean and std for all populations.
+    # 'optimized': population-specific mean and std, allowing a reduction of
+    # the initial activity burst in the network.
+    # These options are part of NEST since v2.20.0 and have been backported to
+    # NEST 2.14.1.
+    # Choose either 'original' or 'optimized'.
+    'V0_type': 'optimized',
     # Parameters of the neurons.
     'neuron_params': {
         # Membrane potential average for the neurons (in mV).
-        'V0_mean': -58.0,
+        'V0_mean': {'original': -58.0,
+                    'optimized': [-68.28, -63.16, -63.33, -63.45,
+                                  -63.11, -61.66, -66.72, -61.43]}, 
         # Standard deviation of the average membrane potential (in mV).
-        'V0_sd': 10.0,
+        'V0_sd': {'original': 10.0,
+                  'optimized': [5.36, 4.57, 4.74, 4.94,
+                                4.94, 4.55, 5.46, 4.48]},
         # Reset membrane potential of the neurons (in mV).
         'E_L': -65.0,
         # Threshold potential of the neurons (in mV).

--- a/pynest/examples/Potjans_2014/readme.md
+++ b/pynest/examples/Potjans_2014/readme.md
@@ -33,3 +33,8 @@ The default version of the simulation uses Poissonian input, which is defined in
 
 Tested configuration:
 This version has been tested with NEST 2.10.0, Python 2.7.12 and 3.5.2, NumPy 1.11.2
+
+## Modifications in NEST 2.14.1
+
+* add efficient implementation for the initialization of membrane potentials
+  with original and optimized (in NEST since v2.20.0) conditions


### PR DESCRIPTION
This PR refactors the initialization of membrane potentials in the PyNEST example Potjans_2014 for the backport version NEST 2.14.1.

* Adds the optimized initial conditions (introduced in NEST 2.20.0). They are now default.
* Revises the implementation of the initialization to be more efficient.
* Starts section in `readme.md` for modifications done in NEST 2.14.1.