### PR TITLE
Fix stdout in nest server and add option to disable restriction

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -173,10 +173,6 @@ def get_globals():
     """ Get globals for exec function.
     """
     copied_globals = globals().copy()
-    copied_globals.update(dict(
-        _print_ = RestrictedPython.PrintCollector,
-        _getattr_ = getattr
-    ))
 
     # Add modules to copied globals
     modules = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -22,7 +22,6 @@
 import importlib
 import inspect
 import io
-import os
 import sys
 
 import flask
@@ -34,7 +33,11 @@ from werkzeug.wrappers import Response
 
 import nest
 import RestrictedPython
+
+import os
+MODULES = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
 RESTRICTION_OFF = bool(os.environ.get('NEST_SERVER_RESTRICTION_OFF', False))
+
 if RESTRICTION_OFF:
     print('*** WARNING: NEST Server is run without a RestrictedPython trusted environment. ***')
 
@@ -174,8 +177,7 @@ def get_globals():
     copied_globals = globals().copy()
 
     # Add modules to copied globals
-    modules = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
-    modules = dict([(module, importlib.import_module(module)) for module in modules])
+    modules = dict([(module, importlib.import_module(module)) for module in MODULES])
     copied_globals.update(modules)
 
     return copied_globals

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -34,8 +34,8 @@ from werkzeug.wrappers import Response
 
 import nest
 import RestrictedPython
-RESTRICTED_OFF = bool(os.environ.get('NEST_SERVER_RESTRICTED_OFF', False))
-if RESTRICTED_OFF:
+RESTRICTION_OFF = bool(os.environ.get('NEST_SERVER_RESTRICTION_OFF', False))
+if RESTRICTION_OFF:
     print('*** WARNING: NEST Server is running without any restriction. ***')
 
 
@@ -64,7 +64,7 @@ def route_exec():
 
         locals = dict()
         response = dict()
-        if RESTRICTED_OFF:
+        if RESTRICTION_OFF:
             with Capturing() as stdout:
                 exec(source_cleaned, get_globals(), locals)
             if len(stdout) > 0:

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -218,8 +218,7 @@ def get_restricted_globals():
     )
 
     # Add modules to restricted globals
-    module_names = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
-    modules = dict([(module, importlib.import_module(module)) for module in module_names])
+    modules = dict([(module, importlib.import_module(module)) for module in MODULES])
     restricted_globals.update(modules)
 
     return restricted_globals

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -36,7 +36,7 @@ import nest
 import RestrictedPython
 RESTRICTION_OFF = bool(os.environ.get('NEST_SERVER_RESTRICTION_OFF', False))
 if RESTRICTION_OFF:
-    print('*** WARNING: NEST Server is running without any restriction. ***')
+    print('*** WARNING: NEST Server is run without a RestrictedPython trusted environment. ***')
 
 
 __all__ = [

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -32,12 +32,11 @@ from flask_cors import CORS, cross_origin
 from werkzeug.exceptions import abort
 from werkzeug.wrappers import Response
 
+import nest
 import RestrictedPython
 RESTRICTED_OFF = bool(os.environ.get('NEST_SERVER_RESTRICTED_OFF', False))
 if RESTRICTED_OFF:
     print('*** WARNING: NEST Server is running without any restriction. ***')
-
-import nest
 
 
 __all__ = [
@@ -176,7 +175,7 @@ def get_globals():
 
     # Add modules to copied globals
     modules = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
-    modules = dict([(module,importlib.import_module(module)) for module in modules])
+    modules = dict([(module, importlib.import_module(module)) for module in modules])
     copied_globals.update(modules)
 
     return copied_globals
@@ -206,14 +205,14 @@ def get_restricted_globals():
     restricted_builtins = RestrictedPython.safe_builtins.copy()
     restricted_builtins.update(RestrictedPython.limited_builtins)
     restricted_builtins.update(RestrictedPython.utility_builtins)
-    restricted_builtins.update(dict(max = max, min = min, sum = sum))
+    restricted_builtins.update(dict(max=max, min=min, sum=sum))
 
     restricted_globals = dict(
-        __builtins__ = restricted_builtins,
-        _print_ = RestrictedPython.PrintCollector,
-        _getattr_ = RestrictedPython.Guards.safer_getattr,
-        _getitem_ = getitem,
-        _getiter_ = iter,
+        __builtins__=restricted_builtins,
+        _print_=RestrictedPython.PrintCollector,
+        _getattr_=RestrictedPython.Guards.safer_getattr,
+        _getitem_=getitem,
+        _getiter_=iter,
     )
 
     # Add modules to restricted globals


### PR DESCRIPTION
This PR fixed empty stdout of exec route of nest server.

The restriction of Python globals is enabled by default
An option was added to disable restriction with these steps in bash:
```
export NEST_SERVER_RESTRICTION_OFF=TRUE
nest-server start -o
```

To add more python modules for exec, e.g. numpy:
```
export NEST_SERVER_MODULES='nest,numpy'
nest-server start -o
```