### PR TITLE
Fix GetConnections to not include erroneous connections when using multiple threads

### DIFF
--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -117,6 +117,10 @@ nest::TargetTableDevices::get_connections_to_devices_( const index requested_sou
   if ( requested_source_node_id != 0 )
   {
     const index lid = kernel().vp_manager.node_id_to_lid( requested_source_node_id );
+    if ( kernel().vp_manager.lid_to_node_id( lid ) != requested_source_node_id )
+    {
+      return;
+    }
     get_connections_to_device_for_lid_( lid, requested_target_node_id, tid, syn_id, synapse_label, conns );
   }
   else

--- a/testsuite/regressiontests/issue-1640.sli
+++ b/testsuite/regressiontests/issue-1640.sli
@@ -1,0 +1,91 @@
+/*
+ *  issue-1640.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+ /** @BeginDocumentation
+Name: testsuite::issue-1640
+
+Synopsis: (issue-1640) run -> NEST exits if test fails
+
+Description:
+Ensure that GetConnections does not return erroneous connections
+when devices are connected as both source and target while using multiple threads.
+
+Author: Håkon Mørk
+FirstVersion: August 2020
+*/
+
+(unittest) run
+/unittest using
+
+M_ERROR setverbosity
+
+{
+  /all_conns_correct true def
+  [2 4 1] Range
+  {
+    /num_threads Set
+    [1 10 1] Range
+    {
+      /num_neurons Set
+      /expected_num_conns num_neurons def
+
+      ResetKernel
+      << /local_num_threads num_threads >> SetKernelStatus
+
+      /neurons /iaf_psc_alpha num_neurons Create def
+
+      % A poisson_generator is connected as source
+      /pg /poisson_generator Create def
+      pg neurons Connect
+
+      % An additional device is connected as target
+      /sd /spike_detector Create def
+      neurons sd Connect
+
+      % We only want the connections where the poisson_generator is source
+      /conns << /source pg >> GetConnections def
+
+      % Check that the poisson_generator is the source for all connections
+      /pg_id pg GetStatus 0 get /global_id get def
+      /conn_source_correct true conns {GetStatus /source get pg_id eq and} Fold def
+
+      % Check that number of connections is correct
+      /conn_length_correct conns length expected_num_conns eq def
+
+      /conns_correct conn_source_correct conn_length_correct and def
+      conns_correct all_conns_correct and /all_conns_correct Set
+
+      % Helpful information in case of failure
+      conns_correct not
+      {
+        num_threads cvs ( threads: ) join conns length cvs join
+        ( conns, expected ) join expected_num_conns cvs join =
+      } if
+    } forall
+  } forall
+
+  all_conns_correct
+}
+assert_or_die
+
+endusing


### PR DESCRIPTION
If a population is connected to devices both as source and target, getting connections with specified sources may give erroneous connections if multiple threads are used.

When calling `GetConnections` with specified source nodes, it will at some point attempt to collect connections where the post-synaptic nodes are devices. While iterating the source nodes, the specified source node ID is then converted to a thread-local ID, `lid`, which is converted back to a node ID later. However, when using multiple threads, the `lid` on one or more threads may not match the specified node ID. Then, if a connection exist where the erroneous node ID is a source, this erroneous connection is included in the returned collection of connections.

This PR adds a simple check of the `lid` when getting connections with devices as post-synaptic nodes, to see if it matches the specified node ID. A regressiontest is also added.

Fixes #1670 