### PR TITLE
Check if parameter is in model dictionary before setting it

### DIFF
--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -271,14 +271,13 @@ def SetStatus(nodes, params, val=None):
     if len(nodes) == 0:
         return
 
-    n0 = nodes[0]
     params_is_dict = isinstance(params, dict)
     set_status_nodes = isinstance(nodes, nest.NodeCollection)
     set_status_local_nodes = set_status_nodes and nodes.get('local')
 
     if (params_is_dict and set_status_local_nodes):
 
-        node_params = n0.get()
+        node_params = nodes[0].get()
         contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for
                          key, vals in params.items()]
 

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -273,7 +273,7 @@ def SetStatus(nodes, params, val=None):
 
     params_is_dict = isinstance(params, dict)
     set_status_nodes = isinstance(nodes, nest.NodeCollection)
-    set_status_local_nodes = set_status_nodes and nodes.get('local')
+    set_status_local_nodes = set_status_nodes and all(nodes.local)
 
     if (params_is_dict and set_status_local_nodes):
 

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -273,9 +273,11 @@ def SetStatus(nodes, params, val=None):
 
     params_is_dict = isinstance(params, dict)
     set_status_nodes = isinstance(nodes, nest.NodeCollection)
-    set_status_local_nodes = set_status_nodes and all(nodes.local)
+    if set_status_nodes:
+        local_nodes = [nodes.local] if len(nodes) == 1 else nodes.local
+        set_status_nodes = set_status_nodes and all(local_nodes)
 
-    if (params_is_dict and set_status_local_nodes):
+    if (params_is_dict and set_status_nodes):
 
         node_params = nodes[0].get()
         contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -274,11 +274,13 @@ def SetStatus(nodes, params, val=None):
     n0 = nodes[0]
     params_is_dict = isinstance(params, dict)
     set_status_nodes = isinstance(nodes, nest.NodeCollection)
-    set_status_local_nodes = set_status_nodes and n0.get('local')
+    set_status_local_nodes = set_status_nodes and nodes.get('local')
 
     if (params_is_dict and set_status_local_nodes):
-        contains_list = [is_iterable(vals) and not is_iterable(n0.get(key))
-                         for key, vals in params.items()]
+        
+        node_params = n0.get()
+        contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for key, vals in params.items()]
+        #contains_list = [is_iterable(vals) and not is_iterable(node_params[key]) for key, vals in params.items()]
 
         if any(contains_list):
             temp_param = [{} for _ in range(len(nodes))]

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -277,10 +277,10 @@ def SetStatus(nodes, params, val=None):
     set_status_local_nodes = set_status_nodes and nodes.get('local')
 
     if (params_is_dict and set_status_local_nodes):
-        
+
         node_params = n0.get()
-        contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for key, vals in params.items()]
-        #contains_list = [is_iterable(vals) and not is_iterable(node_params[key]) for key, vals in params.items()]
+        contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for
+                         key, vals in params.items()]
 
         if any(contains_list):
             temp_param = [{} for _ in range(len(nodes))]

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -402,7 +402,8 @@ class NodeCollection(object):
         if isinstance(params, dict) and self[0].get('local'):
 
             node_params = self[0].get()
-            contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for key, vals in params.items()]
+            contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for
+                             key, vals in params.items()]
 
             if any(contains_list):
                 temp_param = [{} for _ in range(self.__len__())]
@@ -736,7 +737,8 @@ class SynapseCollection(object):
 
         if isinstance(params, dict):
             node_params = self[0].get()
-            contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for key, vals in params.items()]
+            contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for
+                             key, vals in params.items()]
 
             if any(contains_list):
                 temp_param = [{} for _ in range(self.__len__())]

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -399,7 +399,9 @@ class NodeCollection(object):
         elif kwargs and params:
             raise TypeError("must either provide params or kwargs, but not both.")
 
-        if isinstance(params, dict) and self[0].get('local'):
+        local_nodes = [self.local] if len(self) == 1 else self.local
+
+        if isinstance(params, dict) and all(local_nodes):
 
             node_params = self[0].get()
             contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -401,7 +401,8 @@ class NodeCollection(object):
 
         if isinstance(params, dict) and self[0].get('local'):
 
-            contains_list = [is_iterable(vals) and not is_iterable(self[0].get(key)) for key, vals in params.items()]
+            node_params = self[0].get()
+            contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for key, vals in params.items()]
 
             if any(contains_list):
                 temp_param = [{} for _ in range(self.__len__())]
@@ -734,7 +735,8 @@ class SynapseCollection(object):
             raise TypeError("must either provide params or kwargs, but not both.")
 
         if isinstance(params, dict):
-            contains_list = [is_iterable(vals) and not is_iterable(self[0].get(key)) for key, vals in params.items()]
+            node_params = self[0].get()
+            contains_list = [is_iterable(vals) and key in node_params and not is_iterable(node_params[key]) for key, vals in params.items()]
 
             if any(contains_list):
                 temp_param = [{} for _ in range(self.__len__())]

--- a/pynest/nest/tests/test_create.py
+++ b/pynest/nest/tests/test_create.py
@@ -65,7 +65,7 @@ class CreateTestCase(unittest.TestCase):
         nest_errors = nest.kernel.NESTErrors
         params = [(tuple(), TypeError),
                   ({'V_m': [-50]}, IndexError),
-                  ({'V_mm': num_nodes*[-50.]}, KeyError),
+                  ({'V_mm': num_nodes*[-50.]}, nest_errors.DictError),
                   ({'V_m': num_nodes*[-50]}, nest_errors.TypeMismatch),
                   ({'V_m': -50, 'C_m': num_nodes*[20.]}, nest_errors.TypeMismatch),
                   ]

--- a/pynest/nest/tests/test_spatial/test_layer_GetStatus_SetStatus.py
+++ b/pynest/nest/tests/test_spatial/test_layer_GetStatus_SetStatus.py
@@ -41,7 +41,7 @@ class GetSetTestCase(unittest.TestCase):
                                 extent=[2., 2.],
                                 edge_wrap=True))
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(nest.kernel.NESTErrors.DictError):
             nest.SetStatus(layer, {'center': [1., 1.]})
 
         nest.SetStatus(layer, 'V_m', -50.)
@@ -113,7 +113,7 @@ class GetSetTestCase(unittest.TestCase):
         layer = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(
             shape=[3, 3], extent=[2., 2.], edge_wrap=True))
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(nest.kernel.NESTErrors.DictError):
             layer.set({'center': [1., 1.]})
 
         layer.set(V_m=-50.)


### PR DESCRIPTION
This PR fixes #1575. 

If you can `set` a parameter of a model, but not `get` it, an error used to be thrown on PyNEST level when you tried to use `SetStatus` or `set`. This is no longer the case.

Note that if the parameter you want to set is a single value (double/int/float..), you can not send in a list of values the length of the NodeCollection, unless the parameter is also get-able. That is, if we have
```
Double test_val;
if ( d->known( "test_val" ) )
{
  updateValue< double >( d, "test_val", test_val );
}
```
implemented in the `set` function of the model, but not in the `get` function of the model, the following is **not** possible
```
nodes.set('test_val', [3., 2., 1.])
```