### PR TITLE
Fix segfault when mpi4py is imported before NEST

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -100,6 +100,12 @@ nest::MPIManager::set_communicator( MPI_Comm global_comm )
   MPI_Comm_size( comm, &num_processes_ );
   MPI_Comm_rank( comm, &rank_ );
   recv_buffer_size_ = send_buffer_size_ * get_num_processes();
+
+  // use at least 2 * number of processes entries (need at least two
+  // entries per process to use flag of first entry as validity and
+  // last entry to communicate end of communication)
+  kernel().mpi_manager.set_buffer_size_target_data( 2 * kernel().mpi_manager.get_num_processes() );
+  kernel().mpi_manager.set_buffer_size_spike_data( 2 * kernel().mpi_manager.get_num_processes() );
 }
 
 void
@@ -133,12 +139,6 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
     set_communicator( MPI_COMM_WORLD );
 #endif
   }
-
-  // use at least 2 * number of processes entries (need at least two
-  // entries per process to use flag of first entry as validity and
-  // last entry to communicate end of communication)
-  kernel().mpi_manager.set_buffer_size_target_data( 2 * kernel().mpi_manager.get_num_processes() );
-  kernel().mpi_manager.set_buffer_size_spike_data( 2 * kernel().mpi_manager.get_num_processes() );
 
   // create off-grid-spike type for MPI communication
   // creating derived datatype

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -113,7 +113,7 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
 #ifdef HAVE_MUSIC
     kernel().music_manager.init_music( argc, argv );
     // get a communicator from MUSIC
-    set_communicator( ( MPI_Comm ) kernel().music_manager.communicator() );
+    set_communicator( static_cast< MPI_Comm >( kernel().music_manager.communicator() ) );
 #else  /* #ifdef HAVE_MUSIC */
     int provided_thread_level;
     MPI_Init_thread( argc, argv, MPI_THREAD_FUNNELED, &provided_thread_level );

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -120,9 +120,10 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
     set_communicator( MPI_COMM_WORLD );
 #endif /* #ifdef HAVE_MUSIC */
   }
-
-  MPI_Comm_size( comm, &num_processes_ );
-  MPI_Comm_rank( comm, &rank_ );
+  else
+  {
+    set_communicator( MPI_COMM_WORLD );
+  }
 
   // use at least 2 * number of processes entries (need at least two
   // entries per process to use flag of first entry as validity and

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -122,7 +122,16 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
   }
   else
   {
+#ifdef HAVE_MUSIC
+    LOG( M_ERROR,
+      "MPIManager::init_mpi()",
+      "When compiled with MUSIC, NEST must be initialized before any other modules that call MPI_Init(). "
+      "Calling MPI_Abort()." );
+    comm = MPI_COMM_WORLD;
+    mpi_abort( 1 );
+#else
     set_communicator( MPI_COMM_WORLD );
+#endif
   }
 
   // use at least 2 * number of processes entries (need at least two

--- a/testsuite/regressiontests/issue-1703.py
+++ b/testsuite/regressiontests/issue-1703.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# issue-1703.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This script ensures that importing NEST after mpi4py does not lead
+to a segmentation fault when simulating.
+
+This is a regression test for GitHub issue 1703.
+"""
+
+import sys
+import subprocess as sp
+import shlex
+
+EXIT_SUCCESS = 0
+EXIT_SKIPPED = 200
+EXIT_FAILURE = 127
+EXIT_SEGFAULT = 139
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    sys.exit(EXIT_SKIPPED)
+
+cmd = shlex.split('python -c "from mpi4py import MPI; import nest; nest.Simulate(10)"')
+exit_code = sp.call(cmd)
+
+
+if exit_code == 0:
+    sys.exit(EXIT_SUCCESS)
+elif exit_code == -11:
+    sys.exit(EXIT_SEGFAULT)
+else:
+    sys.exit(EXIT_FAILURE)

--- a/testsuite/regressiontests/issue-1703.py
+++ b/testsuite/regressiontests/issue-1703.py
@@ -45,7 +45,7 @@ except ImportError:
 
 # Attempt to import MPI from mpi4py before NEST. Running the script in a separate process,
 # in case it ends in a segmentation fault.
-cmd = shlex.split('python -c "from mpi4py import MPI; import nest; nest.Simulate(10)"')
+cmd = shlex.split('python3 -c "from mpi4py import MPI; import nest; nest.Simulate(10)"')
 exit_code = subprocess.call(cmd)
 
 if nest.ll_api.sli_func("statusdict/have_music ::"):

--- a/testsuite/regressiontests/issue-1703.py
+++ b/testsuite/regressiontests/issue-1703.py
@@ -36,17 +36,28 @@ EXIT_FAILURE = 127
 EXIT_SEGFAULT = 139
 
 try:
+    import nest
     from mpi4py import MPI
 except ImportError:
+    # Skip test if mpi4py is not installed, or if NEST is
+    # installed without Python support.
     sys.exit(EXIT_SKIPPED)
 
 cmd = shlex.split('python -c "from mpi4py import MPI; import nest; nest.Simulate(10)"')
 exit_code = sp.call(cmd)
 
-
-if exit_code == 0:
-    sys.exit(EXIT_SUCCESS)
-elif exit_code == -11:
-    sys.exit(EXIT_SEGFAULT)
+if nest.ll_api.sli_func("statusdict/have_music ::"):
+    # Expect error, not segfault
+    if exit_code == 1:
+        sys.exit(EXIT_SUCCESS)
+    elif exit_code == -11:
+        sys.exit(EXIT_SEGFAULT)
+    else:
+        sys.exit(EXIT_FAILURE)
 else:
-    sys.exit(EXIT_FAILURE)
+    if exit_code == 0:
+        sys.exit(EXIT_SUCCESS)
+    elif exit_code == -11:
+        sys.exit(EXIT_SEGFAULT)
+    else:
+        sys.exit(EXIT_FAILURE)

--- a/testsuite/regressiontests/issue-1703.py
+++ b/testsuite/regressiontests/issue-1703.py
@@ -26,6 +26,7 @@ to a segmentation fault when simulating.
 This is a regression test for GitHub issue 1703.
 """
 
+import os
 import sys
 import subprocess
 import shlex
@@ -50,7 +51,8 @@ except ImportError:
 # Attempt to import MPI from mpi4py before NEST. Running the script in a separate process,
 # in case it ends in a segmentation fault.
 cmd = shlex.split('python3 -c "from mpi4py import MPI; import nest; nest.Simulate(10)"')
-exit_code = subprocess.call(cmd)
+my_env = os.environ.copy()
+exit_code = subprocess.call(cmd, env=my_env)
 
 if nest.ll_api.sli_func("statusdict/have_music ::"):
     # Expect error, not segfault

--- a/testsuite/regressiontests/issue-1703.py
+++ b/testsuite/regressiontests/issue-1703.py
@@ -27,7 +27,7 @@ This is a regression test for GitHub issue 1703.
 """
 
 import sys
-import subprocess as sp
+import subprocess
 import shlex
 
 EXIT_SUCCESS = 0
@@ -35,16 +35,18 @@ EXIT_SKIPPED = 200
 EXIT_FAILURE = 127
 EXIT_SEGFAULT = 139
 
+# Check that NEST is installed with Python support, and that mpi4py is available.
+# If not, the test is skipped.
 try:
     import nest
     from mpi4py import MPI
 except ImportError:
-    # Skip test if mpi4py is not installed, or if NEST is
-    # installed without Python support.
     sys.exit(EXIT_SKIPPED)
 
+# Attempt to import MPI from mpi4py before NEST. Running the script in a separate process,
+# in case it ends in a segmentation fault.
 cmd = shlex.split('python -c "from mpi4py import MPI; import nest; nest.Simulate(10)"')
-exit_code = sp.call(cmd)
+exit_code = subprocess.call(cmd)
 
 if nest.ll_api.sli_func("statusdict/have_music ::"):
     # Expect error, not segfault

--- a/testsuite/regressiontests/issue-1703.py
+++ b/testsuite/regressiontests/issue-1703.py
@@ -30,6 +30,10 @@ import sys
 import subprocess
 import shlex
 
+EXIT_CODE_SUCCESS = 0
+EXIT_CODE_ERROR = 1
+EXIT_CODE_SEGFAULT = -11
+
 EXIT_SUCCESS = 0
 EXIT_SKIPPED = 200
 EXIT_FAILURE = 127
@@ -50,16 +54,16 @@ exit_code = subprocess.call(cmd)
 
 if nest.ll_api.sli_func("statusdict/have_music ::"):
     # Expect error, not segfault
-    if exit_code == 1:
+    if exit_code == EXIT_CODE_ERROR:
         sys.exit(EXIT_SUCCESS)
-    elif exit_code == -11:
+    elif exit_code == EXIT_CODE_SEGFAULT:
         sys.exit(EXIT_SEGFAULT)
     else:
         sys.exit(EXIT_FAILURE)
 else:
-    if exit_code == 0:
+    if exit_code == EXIT_CODE_SUCCESS:
         sys.exit(EXIT_SUCCESS)
-    elif exit_code == -11:
+    elif exit_code == EXIT_CODE_SEGFAULT:
         sys.exit(EXIT_SEGFAULT)
     else:
         sys.exit(EXIT_FAILURE)


### PR DESCRIPTION
If mpi4py is imported before NEST, `MPI_Init()` is called before NEST is initialized. With MPI already initialized, the communicator is never set in NEST, so any MPI communication, such as when simulating, may end in a segfault.

To avoid a segfault, this PR changes NEST initialization to set the communicator to `MPI_COMM_WORLD` automatically if MPI is already initialized. If NEST is installed with MUSIC support, this is not possible, and an error is issued.

Resolves #1703.