### PR TITLE
Update hpc_benchmark.py to avoid error when running with multiple processes

### DIFF
--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -323,8 +323,9 @@ def build_network(logger):
     if params['record_spikes']:
         if params['nvp'] != 1:
             local_neurons = nest.GetLocalNodeCollection(E_neurons)
-            # Rebuilding local_neurons to get rid of the stepped composite NodeCollection,
-            # to be able to slice it.
+            # GetLocalNodeCollection returns a stepped composite NodeCollection, which
+            # cannot be sliced. In order to allow slicing it later on, we're creating a
+            # new regular NodeCollection from the plain node IDs.
             local_neurons = nest.NodeCollection(local_neurons.tolist())
         else:
             local_neurons = E_neurons

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -323,6 +323,9 @@ def build_network(logger):
     if params['record_spikes']:
         if params['nvp'] != 1:
             local_neurons = nest.GetLocalNodeCollection(E_neurons)
+            # Rebuilding local_neurons to get rid of the stepped composite NodeCollection,
+            # to be able to slice it.
+            local_neurons = nest.NodeCollection(local_neurons.tolist())
         else:
             local_neurons = E_neurons
 


### PR DESCRIPTION
When using multiple processes, the `local_neurons` NodeCollection becomes a stepped composite NodeCollection, which cannot be sliced. To make it sliceable, `local_neurons` is rebuilt as a plain composite NodeCollection, which fixes #1729.

This is the simplest solution to #1729. The downside being that using the non-stepped NodeCollection will perform a bit worse when iterated during connection. However, this only affects connection between the selected number of excitatory neurons and spike detectors. Alternatively, passing slicing arguments can be added to `GetLocalNodeCollection` to be able to keep the sliced NodeCollection a stepped composite.