### PR TITLE
Changes to volume transmitter documentation

### DIFF
--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -64,15 +64,16 @@ in the synapses itself.
 The volume transmitter interacts in a hybrid structure with the neuromodulated
 synapses: In addition to the delivery of the neuromodulatory spikes triggered
 by every pre-synaptic spike, the neuromodulatory spike history is delivered
-at regular time intervals. The interval is an integer multiple of the minimal
-synaptic delay ``d_min``.
+at regular time intervals. The interval is equal to deliver_interval * d_min,
+where deliver_interval is an entry in the parameter dictionary and d_min
+is the minimal synaptic delay.
 
 The implementation is based on the framework presented in [1]_.
 
 Parameters
 ++++++++++
 
-- deliver_interval - time interval given in d_min time steps, in which
+- deliver_interval - time interval given in d_min time steps in which
                      the volume signal is delivered from the volume
                      transmitter to the assigned synapses
 

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -64,7 +64,7 @@ in the synapses itself.
 The volume transmitter interacts in a hybrid structure with the neuromodulated
 synapses: In addition to the delivery of the neuromodulatory spikes triggered
 by every pre-synaptic spike, the neuromodulatory spike history is delivered
-in discrete time intervals of a manifold of the minimal synaptic delay.
+at regular time intervals. The interval is equal to the minimal synaptic delay.
 
 The implementation is based on the framework presented in [1]_.
 

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -65,8 +65,8 @@ The volume transmitter interacts in a hybrid structure with the neuromodulated
 synapses: In addition to the delivery of the neuromodulatory spikes triggered
 by every pre-synaptic spike, the neuromodulatory spike history is delivered
 at regular time intervals. The interval is equal to ``deliver_interval * d_min``,
-where ``deliver_interval`` is an entry in the parameter dictionary and ``d_min``
-is the minimal synaptic delay.
+where ``deliver_interval`` is an (integer) entry in the parameter dictionary and
+``d_min`` is the minimal synaptic delay.
 
 The implementation is based on the framework presented in [1]_.
 
@@ -75,7 +75,7 @@ Parameters
 
 - deliver_interval - time interval given in d_min time steps in which
                      the volume signal is delivered from the volume
-                     transmitter to the assigned synapses
+                     transmitter to the assigned synapses. Must be integer.
 
 References
 ++++++++++

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -48,23 +48,25 @@ Description
 +++++++++++
 
 The volume transmitter is used in combination with neuromodulated
-synaptic plasticty, plasticity that depends not only on the activity
+synaptic plasticity, plasticity that depends not only on the activity
 of the pre- and the postsynaptic neuron but also on a non-local
 neuromodulatory third signal. It collects the spikes from all neurons
-connected to the volume transmitter and delivers the spikes to a
-user-specific subset of synapses.  It is assumed that the
-neuromodulatory signal is a function of the spike times of all spikes
-emitted by the population of neurons connected to the volume
-transmitter.  The neuromodulatory dynamics is calculated in the
-synapses itself. The volume transmitter interacts in a hybrid
-structure with the neuromodulated synapses. In addition to the
-delivery of the neuromodulatory spikes triggered by every pre-synaptic
-spike, the neuromodulatory spike history is delivered in discrete time
-intervals of a manifold of the minimal synaptic delay. In order to
-insure the link between the neuromodulatory synapses and the volume
-transmitter, the volume transmitter is passed as a parameter when a
-neuromodulatory synapse is defined. The implementation is based on the
-framework presented in [1]_.
+connected to the volume transmitter and delivers the spikes to a subset
+of synapses in the network. The user specifies this subset by
+passing the volume transmitter as a parameter when a
+neuromodulatory synapse is defined.
+
+It is assumed that the neuromodulatory signal is a function of the
+spike times of all spikes emitted by the population of neurons connected
+to the volume transmitter. The neuromodulatory dynamics is calculated
+in the synapses itself.
+
+The volume transmitter interacts in a hybrid structure with the neuromodulated
+synapses: In addition to the delivery of the neuromodulatory spikes triggered
+by every pre-synaptic spike, the neuromodulatory spike history is delivered
+in discrete time intervals of a manifold of the minimal synaptic delay.
+
+The implementation is based on the framework presented in [1]_.
 
 Parameters
 ++++++++++

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -64,8 +64,8 @@ in the synapses itself.
 The volume transmitter interacts in a hybrid structure with the neuromodulated
 synapses: In addition to the delivery of the neuromodulatory spikes triggered
 by every pre-synaptic spike, the neuromodulatory spike history is delivered
-at regular time intervals. The interval is equal to deliver_interval * d_min,
-where deliver_interval is an entry in the parameter dictionary and d_min
+at regular time intervals. The interval is equal to ``deliver_interval * d_min``,
+where ``deliver_interval`` is an entry in the parameter dictionary and ``d_min``
 is the minimal synaptic delay.
 
 The implementation is based on the framework presented in [1]_.

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -64,7 +64,8 @@ in the synapses itself.
 The volume transmitter interacts in a hybrid structure with the neuromodulated
 synapses: In addition to the delivery of the neuromodulatory spikes triggered
 by every pre-synaptic spike, the neuromodulatory spike history is delivered
-at regular time intervals. The interval is equal to the minimal synaptic delay.
+at regular time intervals. The interval is an integer multiple of the minimal
+synaptic delay ``d_min``.
 
 The implementation is based on the framework presented in [1]_.
 


### PR DESCRIPTION
Hi, I was quite confused by the volume transmitter documentation and only understood it after asking someone, particularly because I didn't catch how the user specifies which synapses the thing would be connected to (which I now see is mentioned in the very end of the text, but I didn't look there before - instead, I tried and failed to understand some SLI code in an older version of the documentation, and looked in the code I am working with). I propose some changes.

I

- shifted the crucial information how someone would specify the synapses a VT is connected to closer to where the reader would wonder about it

- split into paragraphs

- small typo(s)

- colon in line 65: Make it clear that the "hybrid structure" is described in the following sentences.

I am unsure about what's the character limit per line in the documentation; I'm happy to rearrange the lines if I got it wrong.