### PR TITLE
Fix duplicate "models" entry and remove dead "topology" entry from documentation TOC

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -15,8 +15,8 @@ Table of Contents
    getting_started
    tutorials/index
    guides/index
-   models/index
    examples/index
+   models/index
    ref_material/pynest_apis
    troubleshooting
    getting_help

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -14,11 +14,9 @@ Table of Contents
    Install <installation/index>
    getting_started
    tutorials/index
-   models/index
    guides/index
    models/index
    examples/index
-   topology/index
    ref_material/pynest_apis
    troubleshooting
    getting_help


### PR DESCRIPTION
What it says in the title. Currently, the "models" link in the TOC appears twice in the RTD build of "latest". The TOC Tree also contained a dead link to some topology file, which I removed.