### PR TITLE
Fix math rendering error in documentation

### DIFF
--- a/doc/guides/weight_normalization.rst
+++ b/doc/guides/weight_normalization.rst
@@ -14,7 +14,7 @@ Keeping this norm constant at a desired target value, say :math:`w_{target}`, is
 
 .. math::
 
-   w_i &\leftarrow w_{target} \frac{w_i}{|\mathbf{w}|_1}
+   w_i \leftarrow w_{target} \frac{w_i}{|\mathbf{w}|_1}
 
 
 Implementation in NEST


### PR DESCRIPTION
Remove an unnecessary alignment character (&) from a math block, allowing MathJax to render it properly.

Follow-up to #1679.