### PR TITLE
Rename "topology" to "spatial"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,6 @@ install/
 /reports/
 /sli/sli
 /testsuite/do_tests.sh
-/topology/setup.py
-/topology/doc/Topology_UserManual.out
 /doc/doxygen/
 /doc/_build/
 /doc/xml/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,7 +50,6 @@ doc_path = os.path.abspath(os.path.dirname(__file__))
 root_path = os.path.abspath(doc_path + "/..")
 
 sys.path.insert(0, os.path.abspath(root_path))
-sys.path.insert(0, os.path.abspath(root_path + '/topology'))
 sys.path.insert(0, os.path.abspath(root_path + '/pynest/'))
 sys.path.insert(0, os.path.abspath(root_path + '/pynest/nest'))
 sys.path.insert(0, os.path.abspath(doc_path))

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -18,7 +18,6 @@ Table of Contents
    guides/index
    models/index
    examples/index
-   topology/index
    ref_material/pynest_apis
    troubleshooting
    getting_help

--- a/doc/examples/index.rst
+++ b/doc/examples/index.rst
@@ -76,7 +76,7 @@ PyNEST examples
    :caption: Connection set algebra examples
 
    ../auto_examples/csa_example
-   ../auto_examples/csa_topology_example
+   ../auto_examples/csa_spatial_example
 
 .. toctree::
    :maxdepth: 1

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -11,6 +11,7 @@ Features
     spike-timing dependent plasticity (STDP).
 
 3.  NEST provides the possibility to create spatially-structured networks.
+    :doc:`Guide to spatially-structured networks<guides/spatial/guide_spatially_structured_networks>`
 
 4.  NEST provides many examples that help you getting started with your
     own simulation project.

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -10,9 +10,7 @@ Features
     plasticity (Tsodyks & Markram) and different variants of
     spike-timing dependent plasticity (STDP).
 
-3.  Nest provides a Topology Module for creating complex networks
-    (`Topology Module User Manual
-    (PDF) <https://www.nest-simulator.org/wp-content/uploads/2014/12/NESTTopologyUserManual.pdf>`__)
+3.  NEST provides the possibility to create spatially-structured networks.
 
 4.  NEST provides many examples that help you getting started with your
     own simulation project.
@@ -86,12 +84,12 @@ Synapse models
    2000 <http://neuro.cjb.net/cgi/content/abstract/20/1/RC50>`__)
 -  Neuromodulatory synapses using dopamine
 
-Network models
---------------
+Spatially structured networks
+-----------------------------
 
--  Topology Module for creating complex networks (`Topology Module User
-   Manual
-   (PDF) <https://www.nest-simulator.org/wp-content/uploads/2014/12/NESTTopologyUserManual.pdf>`__)
+-  Node positions in 2D or 3D space
+-  Connection-rules and parameters based on node positions
+-  :doc:`Guide to spatially-structured networks<guides/spatial/guide_spatially_structured_networks>`
 
 Interoperability
 ----------------

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -11,7 +11,7 @@ Features
     spike-timing dependent plasticity (STDP).
 
 3.  NEST provides the possibility to create spatially-structured networks.
-    :doc:`Guide to spatially-structured networks<guides/spatial/guide_spatially_structured_networks>`
+    (:doc:`Guide to spatially-structured networks<guides/spatial/guide_spatially_structured_networks>`)
 
 4.  NEST provides many examples that help you getting started with your
     own simulation project.

--- a/doc/fulldoc.conf.in
+++ b/doc/fulldoc.conf.in
@@ -756,8 +756,7 @@ INPUT		=	@PROJECT_SOURCE_DIR@/README.md \
 			@PROJECT_SOURCE_DIR@/nestkernel \
 			@PROJECT_SOURCE_DIR@/pynest \
 			@PROJECT_SOURCE_DIR@/sli \
-			@PROJECT_SOURCE_DIR@/testsuite \
-			@PROJECT_SOURCE_DIR@/topology
+			@PROJECT_SOURCE_DIR@/testsuite
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -11,7 +11,7 @@ still works, while in `PyNEST <introduction-to-pynest.md>`__, the
 `Connect()` function has been renamed to `OneToOneConnect()`.
 However, simple cases, which are just creating one-to-one connections
 between two lists of nodes are still working with the new command
-without the need to change the code. Note that the topology-module is
+without the need to change the code. Note that the spatial connection is
 not effected by theses changes. The translation between the old and the
 new connect routines is described in `Old Connection
 Routines <connection-management.md#old-connection-routines>`__.
@@ -376,13 +376,12 @@ parameters it needs to be defined in two steps:
 For further information on the distributions see :doc:`Random numbers in
 NEST <random_numbers>`.
 
-Topological Connections
------------------------
+Spatially-structured networks
+-----------------------------
 
-If the connect functions above are not sufficient, the topology provides
-more sophisticated functions. For example, it is possible to create
-receptive field structures and much more! See :doc:`Topological
-Connections <topology/index>` for more information.
+If nodes are created with spatial information, it is possible to create connections with
+attributes based on node positions. See :doc:`Spatially-structured networks <spatial/index>`
+for more information.
 
 .. _receptor-types:
 

--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -379,7 +379,7 @@ NEST <random_numbers>`.
 Spatially-structured networks
 -----------------------------
 
-If nodes are created with spatial information, it is possible to create connections with
+If nodes are created with spatial distributions, it is possible to create connections with
 attributes based on node positions. See :doc:`Spatially-structured networks <spatial/index>`
 for more information.
 

--- a/doc/guides/nest2_to_nest3/nest2_to_nest3_detailed_transition_guide.rst
+++ b/doc/guides/nest2_to_nest3/nest2_to_nest3_detailed_transition_guide.rst
@@ -158,7 +158,8 @@ Functions related to setting and getting parameters
 Function related to spatially distributed nodes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spatial structure, formerly provided by the Topology module, is now integrated into NEST and is no longer a separate module.
+Spatial structure, formerly provided by the Topology module, is now integrated into NEST and is no longer
+a separate module.
 
 
 +------------------------------------------------+----------------------------------------------------+

--- a/doc/guides/nest2_to_nest3/nest2_to_nest3_detailed_transition_guide.rst
+++ b/doc/guides/nest2_to_nest3/nest2_to_nest3_detailed_transition_guide.rst
@@ -158,7 +158,7 @@ Functions related to setting and getting parameters
 Function related to spatially distributed nodes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Topology is now integrated into NEST and no longer a separate module.
+Spatial structure, formerly provided by the Topology module, is now integrated into NEST and is no longer a separate module.
 
 
 +------------------------------------------------+----------------------------------------------------+

--- a/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
+++ b/doc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
@@ -540,10 +540,10 @@ Setting and getting attributes directly
 
     If you use a list to set the parameter, the list needs to be the same length
     as the SynapseCollection.
-    
+
     For :ref:`spatially distributed <topo_changes>` sources and targets, you can access the distance between
     the source-target pairs by calling `distance` on your SynapseCollection.
-    
+
     >>>  synColl.distance
          (0.47140452079103173,
           0.33333333333333337,
@@ -554,7 +554,7 @@ Setting and getting attributes directly
           0.4714045207910317,
           0.33333333333333326,
           0.47140452079103157)
-         
+
 
 .. _conn_s_t_iterator:
 
@@ -1071,7 +1071,7 @@ Topology module
    See the reference section :ref:`topo_ref` in our conversion guide for all changes made to functions
 
 All of the functionality of Topology has been moved to the standard
-functions. In fact, there is no longer a Topology module in PyNEST. The
+functions. In fact, there is no longer a Topology module in NEST. The
 functions for creating spatially arranged neuronal networks are now in the ``nest`` module.
 
 Create spatially distributed nodes
@@ -1301,11 +1301,11 @@ If you have a SynapseCollection with connections from a spatially distributed ne
 *distance* between the source-target pairs by calling ``.distance`` on the SynapseCollection.
 
   ::
-  
+
     s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 1]))
     t_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[1, 3]))
     nest.Connect(s_nodes, t_nodes)
-    
+
     conns = nest.GetConnections()
     dist = conns.distance
 

--- a/doc/guides/spatial/guide_spatially_structured_networks.rst
+++ b/doc/guides/spatial/guide_spatially_structured_networks.rst
@@ -1582,13 +1582,13 @@ implement the latter by testing if all the corners are inside, since our
 elliptic mask is convex. We must also define a function which returns a
 bounding box for the mask, i.e. a box completely surrounding the mask.
 
-The mask class must then be registered with the topology module, and this
+The mask class must then be registered with in NEST. This
 is done by adding a line to the function ``MyModule::init()`` in the file
 ``mymodule.cpp``:
 
 .. code:: c
 
-   nest::TopologyModule::register_mask< EllipticMask >( "elliptic" );
+   nest::NestModule::register_mask< EllipticMask >( "elliptic" );
 
 After compiling and installing your module, the mask is available to be
 used in connections, e.g.

--- a/doc/guides/spatial/guide_spatially_structured_networks.rst
+++ b/doc/guides/spatial/guide_spatially_structured_networks.rst
@@ -1582,7 +1582,7 @@ implement the latter by testing if all the corners are inside, since our
 elliptic mask is convex. We must also define a function which returns a
 bounding box for the mask, i.e. a box completely surrounding the mask.
 
-The mask class must then be registered with in NEST. This
+The mask class must then be registered in NEST. This
 is done by adding a line to the function ``MyModule::init()`` in the file
 ``mymodule.cpp``:
 

--- a/doc/guides/spatial/index.rst
+++ b/doc/guides/spatial/index.rst
@@ -6,8 +6,8 @@ Here you can find how to build complex, layered networks in NEST.
 .. note::
 
   In NEST 2.x spatially-structured networks were in the topology module.
-  This module is removed in NEST 3.0, and all functionality of topology
-  is now in the main ``nest`` module.
+  This module is removed in NEST 3.0, and all functionality that was
+  formerly provided by the topology module is now in the main ``nest`` module.
 
   See the :doc:`../nest2_to_nest3/nest2_to_nest3_detailed_transition_guide` for more information.
 
@@ -25,5 +25,3 @@ Here you can find how to build complex, layered networks in NEST.
 
    ../../tutorials/pynest_tutorial/part_4_spatially_structured_networks
    ../../examples/index
-
-

--- a/doc/guides/spatial/user_manual_scripts/connections.py
+++ b/doc/guides/spatial/user_manual_scripts/connections.py
@@ -92,20 +92,20 @@ def conn_figure(fig, layer, connd, targets=None, showmask=True, kern=None,
 # Simple connection
 
 #{ conn1 #}
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(shape=[11, 11], extent=[11., 11.]))
+spatial_nodes = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=[11, 11], extent=[11., 11.]))
 conndict = {'rule': 'pairwise_bernoulli',
             'p': 1.0,
             'mask': {'rectangular': {'lower_left': [-2., -1.],
                                      'upper_right': [2., 1.]}}}
-nest.Connect(l, l, conndict)
+nest.Connect(spatial_nodes, spatial_nodes, conndict)
 #{ end #}
 
 fig = plt.figure()
 fig.add_subplot(121)
-conn_figure(fig, l, conndict,
-            targets=((nest.FindCenterElement(l), 'red'),
-                     (nest.FindNearestElement(l, [4., 5.])[0], 'yellow')))
+conn_figure(fig, spatial_nodes, conndict,
+            targets=((nest.FindCenterElement(spatial_nodes), 'red'),
+                     (nest.FindNearestElement(spatial_nodes, [4., 5.])[0], 'yellow')))
 
 # same another time, with periodic bcs
 lpbc = nest.Create('iaf_psc_alpha',
@@ -127,12 +127,12 @@ plt.savefig('../user_manual_figures/conn1.png', bbox_inches='tight')
 
 def free_mask_fig(fig, loc, cdict):
     nest.ResetKernel()
-    l = nest.Create('iaf_psc_alpha',
-                    positions=nest.spatial.grid(shape=[11, 11], extent=[11., 11.]))
-    nest.Connect(l, l, cdict)
+    spatial_nodes = nest.Create('iaf_psc_alpha',
+                                positions=nest.spatial.grid(shape=[11, 11], extent=[11., 11.]))
+    nest.Connect(spatial_nodes, spatial_nodes, cdict)
 
     fig.add_subplot(loc)
-    conn_figure(fig, l, cdict, xticks=range(-5, 6, 2), yticks=range(-5, 6, 2))
+    conn_figure(fig, spatial_nodes, cdict, xticks=range(-5, 6, 2), yticks=range(-5, 6, 2))
 
 
 fig = plt.figure()
@@ -263,14 +263,14 @@ def conn_figure_3d(fig, layer, connd, targets=None, showmask=True,
 
 def free_mask_3d_fig(fig, loc, cdict):
     nest.ResetKernel()
-    l = nest.Create('iaf_psc_alpha',
-                    positions=nest.spatial.grid(
-                        shape=[11, 11, 11],
-                        extent=[11., 11., 11.]))
-    nest.Connect(l, l, cdict)
+    spatial_nodes = nest.Create('iaf_psc_alpha',
+                                positions=nest.spatial.grid(
+                                    shape=[11, 11, 11],
+                                    extent=[11., 11., 11.]))
+    nest.Connect(spatial_nodes, spatial_nodes, cdict)
 
     fig.add_subplot(loc, projection='3d')
-    conn_figure_3d(fig, l, cdict, xticks=range(-5, 6, 2),
+    conn_figure_3d(fig, spatial_nodes, cdict, xticks=range(-5, 6, 2),
                    yticks=range(-5, 6, 2))
 
 
@@ -308,13 +308,13 @@ conndict = {'rule': 'pairwise_bernoulli',
 
 def grid_mask_fig(fig, loc, cdict):
     nest.ResetKernel()
-    l = nest.Create('iaf_psc_alpha',
-                    positions=nest.spatial.grid(shape=[11, 11],
-                                                extent=[11., 11.]))
-    nest.Connect(l, l, cdict)
+    spatial_nodes = nest.Create('iaf_psc_alpha',
+                                positions=nest.spatial.grid(shape=[11, 11],
+                                                            extent=[11., 11.]))
+    nest.Connect(spatial_nodes, spatial_nodes, cdict)
 
     fig.add_subplot(loc)
-    conn_figure(fig, l, cdict, xticks=range(-5, 6, 2), yticks=range(-5, 6, 2),
+    conn_figure(fig, spatial_nodes, cdict, xticks=range(-5, 6, 2), yticks=range(-5, 6, 2),
                 showmask=False)
 
 
@@ -352,14 +352,14 @@ plt.savefig('../user_manual_figures/conn3.png', bbox_inches='tight')
 
 def kernel_fig(fig, loc, cdict, kern=None):
     nest.ResetKernel()
-    l = nest.Create('iaf_psc_alpha',
-                    positions=nest.spatial.grid(
-                        shape=[11, 11],
-                        extent=[11., 11.]))
-    nest.Connect(l, l, cdict)
+    spatial_nodes = nest.Create('iaf_psc_alpha',
+                                positions=nest.spatial.grid(
+                                    shape=[11, 11],
+                                    extent=[11., 11.]))
+    nest.Connect(spatial_nodes, spatial_nodes, cdict)
 
     fig.add_subplot(loc)
-    conn_figure(fig, l, cdict, xticks=range(-5, 6, 2), yticks=range(-5, 6, 2),
+    conn_figure(fig, spatial_nodes, cdict, xticks=range(-5, 6, 2), yticks=range(-5, 6, 2),
                 kern=kern)
 
 
@@ -409,20 +409,20 @@ def wd_fig(fig, loc, pos, cdict, sdict, what, rpos=None,
            yticks=np.arange(0., 1.1, 0.2), clr='blue',
            label=''):
     nest.ResetKernel()
-    l = nest.Create('iaf_psc_alpha', positions=pos)
-    nest.Connect(l, l, cdict, sdict)
+    spatial_nodes = nest.Create('iaf_psc_alpha', positions=pos)
+    nest.Connect(spatial_nodes, spatial_nodes, cdict, sdict)
 
     ax = fig.add_subplot(loc)
 
     if rpos is None:
-        rn = l[0]  # first node
+        rn = spatial_nodes[0]  # first node
     else:
-        rn = nest.FindNearestElement(l, rpos)
+        rn = nest.FindNearestElement(spatial_nodes, rpos)
 
     conns = nest.GetConnections(rn)
     vals = np.array([c.get(what) for c in conns])
     tgts = [c.get('target') for c in conns]
-    locs = np.array([nest.GetPosition(l[l.index(t)]) for t in tgts])
+    locs = np.array([nest.GetPosition(spatial_nodes[spatial_nodes.index(t)]) for t in tgts])
     ax.plot(locs[:, 0], vals, 'o', mec='none', mfc=clr, label=label)
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
@@ -514,28 +514,28 @@ parameter = 0.5 + nest.spatial.distance.x + 2. * nest.spatial.distance.y
 #{ end #}
 
 #{ conn_param_design_ex #}
-l = nest.Create('iaf_psc_alpha',
-                positions=nest.spatial.grid(shape=[11, 11],
-                                            extent=[1., 1.]))
-nest.Connect(l, l, {'rule': 'pairwise_bernoulli',
-                    'p': parameter,
-                    'mask': {'circular': {'radius': 0.5}}})
+spatial_nodes = nest.Create('iaf_psc_alpha',
+                            positions=nest.spatial.grid(shape=[11, 11],
+                                                        extent=[1., 1.]))
+nest.Connect(spatial_nodes, spatial_nodes, {'rule': 'pairwise_bernoulli',
+                                            'p': parameter,
+                                            'mask': {'circular': {'radius': 0.5}}})
 #{ end #}
 
 # --------------------------------
 
 
-def pn_fig(fig, loc, l, cdict,
+def pn_fig(fig, loc, spatial_nodes, cdict,
            xlim=[0., .5], ylim=[0, 3.5], xticks=range(0, 51, 5),
            yticks=np.arange(0., 1.1, 0.2), clr='blue',
            label=''):
-    nest.Connect(l, l, cdict)
+    nest.Connect(spatial_nodes, spatial_nodes, cdict)
 
     ax = fig.add_subplot(loc)
 
-    conns = nest.GetConnections(l)
-    dist = np.array([nest.Distance(l[l.index(s)],
-                                   l[l.index(t)])
+    conns = nest.GetConnections(spatial_nodes)
+    dist = np.array([nest.Distance(spatial_nodes[spatial_nodes.index(s)],
+                                   spatial_nodes[spatial_nodes.index(t)])
                      for s, t in zip(conns.sources(), conns.targets())])
     ax.hist(dist, bins=50, histtype='stepfilled', density=True)
     r = np.arange(0., 0.51, 0.01)
@@ -560,16 +560,16 @@ nest.ResetKernel()
 #{ conn6 #}
 pos = nest.spatial.free(nest.random.uniform(-1., 1.),
                         extent=[2., 2.], edge_wrap=True)
-l = nest.Create('iaf_psc_alpha', 1000, positions=pos)
+spatial_nodes = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 
 cdict = {'rule': 'fixed_outdegree',
          'p': nest.math.max(1. - 2 * nest.spatial.distance, 0.),
          'mask': {'circular': {'radius': 1.0}},
          'outdegree': 50,
          'allow_multapses': True, 'allow_autapses': False}
-nest.Connect(l, l, cdict)
+nest.Connect(spatial_nodes, spatial_nodes, cdict)
 #{ end #}
-pn_fig(fig, 111, l, cdict)
+pn_fig(fig, 111, spatial_nodes, cdict)
 
 plt.savefig('../user_manual_figures/conn6.png', bbox_inches='tight')
 
@@ -581,18 +581,18 @@ nest.CopyModel('static_synapse', 'exc', {'weight': 2.0})
 nest.CopyModel('static_synapse', 'inh', {'weight': -8.0})
 
 pos = nest.spatial.grid(shape=[10, 10])
-l_ex = nest.Create('iaf_psc_alpha', positions=pos)
-l_in = nest.Create('iaf_psc_alpha', positions=pos)
+ex_nodes = nest.Create('iaf_psc_alpha', positions=pos)
+in_nodes = nest.Create('iaf_psc_alpha', positions=pos)
 
-nest.Connect(l_ex, l_in, {'rule': 'pairwise_bernoulli',
-                          'p': 0.8,
-                          'mask': {'circular': {'radius': 0.5}}},
-                         {'synapse_model': 'exc'})
-nest.Connect(l_in, l_ex, {'rule': 'pairwise_bernoulli',
-                          'p': 1.0,
-                          'mask': {'rectangular': {'lower_left': [-0.2, -0.2],
-                                                   'upper_right': [0.2, 0.2]}}},
-                         {'synapse_model': 'inh'})
+nest.Connect(ex_nodes, in_nodes, {'rule': 'pairwise_bernoulli',
+                                  'p': 0.8,
+                                  'mask': {'circular': {'radius': 0.5}}},
+             {'synapse_model': 'exc'})
+nest.Connect(in_nodes, ex_nodes, {'rule': 'pairwise_bernoulli',
+                                  'p': 1.0,
+                                  'mask': {'rectangular': {'lower_left': [-0.2, -0.2],
+                                                           'upper_right': [0.2, 0.2]}}},
+             {'synapse_model': 'inh'})
 #{ end #}
 
 

--- a/doc/guides/spatial/user_manual_scripts/connections.py
+++ b/doc/guides/spatial/user_manual_scripts/connections.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-# create connectivity figures for topology manual
+# create connectivity figures for spatial manual
 
 import nest
 import matplotlib.pyplot as plt

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,14 +55,11 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
   </a>
   </embed>
 
-**Create complex networks using the Topology Module or the Microcircuit Model:**
+**Create complex networks using the Microcircuit Model:**
 
 .. raw:: html
 
   <embed>
-  <a href="topology/index.html">
-    <img src="_static/img/topology.png" alt="Topology" style="width:150px;height:150px;border:0;">
-  </a>
   <a href="microcircuit/index.html">
     <img src="_images/microcircuit.png" alt="Microcircuit" style="width:150px;height:150px;border:0;">
   </a>
@@ -84,7 +81,7 @@ Where to find what
 
 * :doc:`Example Networks <examples/index>`  demonstrate the use of dozens of the neural network models implemented in NEST.
 
-* :doc:`Topical Guides <guides/index>` provide deeper insight into several topics and concepts from :doc:`Parallel Computing <guides/parallel_computing>` to handling :doc:`Gap Junction Simulations <guides/simulations_with_gap_junctions>` and :doc:`setting up a topological network <topology/index>`.
+* :doc:`Topical Guides <guides/index>` provide deeper insight into several topics and concepts from :doc:`Parallel Computing <guides/parallel_computing>` to handling :doc:`Gap Junction Simulations <guides/simulations_with_gap_junctions>` and :doc:`setting up a spatially-structured network <guides/spatial/guide_spatially_structured_networks>`.
 
 * :doc:`Reference Material <ref_material/index>` provides a quick look up of definitions, functions and terms.
 
@@ -105,7 +102,7 @@ Interested in contributing?
 Related projects
 ################
 
-Many extensions and open-source tools related to the NEST Simulator are available. In particular, the following packages may be of interest: 
+Many extensions and open-source tools related to the NEST Simulator are available. In particular, the following packages may be of interest:
 
 - `NEST Desktop <https://nest-desktop.readthedocs.io/en/latest/>`_ - a web-based GUI application for NEST Simulator
 - `NESTML <https://nestml.readthedocs.io/en/latest/>`_ - a domain specific language to describe neuron models in NEST

--- a/doc/normaldoc.conf.in
+++ b/doc/normaldoc.conf.in
@@ -756,8 +756,7 @@ INPUT		=	@PROJECT_SOURCE_DIR@/README.md \
 			@PROJECT_SOURCE_DIR@/nestkernel \
 			@PROJECT_SOURCE_DIR@/pynest \
 			@PROJECT_SOURCE_DIR@/sli \
-			@PROJECT_SOURCE_DIR@/testsuite \
-			@PROJECT_SOURCE_DIR@/topology
+			@PROJECT_SOURCE_DIR@/testsuite
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/doc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
@@ -152,7 +152,7 @@ placement. We then need to define a Parameter for the placement of the
 neurons, or we can define the positions of the neurons explicitly. Note
 that the extent is calculated from the positions of the nodes, but we can
 also explicitly specify it. See the *Free layers* section of the
-:doc:`Guide to spatially-structured networks<../../guides/spatial/guide_spatially_structured_networks>`
+:doc:`../../guides/spatial/guide_spatially_structured_networks`
 for details.
 
 The following snippet produces :numref:`free`:
@@ -172,8 +172,9 @@ number of dimensions is deduced by NEST. Also note that when creating the
 nodes, we specify the number of neurons to be created. This is not
 necessary when using an array of positions.
 
-See the table of *Topology-specific NEST Parameters* in NUTM for a selection of NEST
-Parameters that can be used.
+See the table of *Spatially-structured specific NEST parameters* in the
+:doc:`../../guides/spatial/guide_spatially_structured_networks`
+for a selection of NEST Parameters that can be used.
 
 An example of how to create off-grid nodes with a list of positions:
 
@@ -198,12 +199,13 @@ allows us to tune our connectivity profiles by tuning the likelihood of a
 connection, the number of connections, or defining a subset of the nodes
 to connect.
 
-Chapter 3 in NTUM deals comprehensively with all the different
-possibilities, and it’s suggested that you look there for learning about
-the different constraints, as well as reading through the different
-examples listed there. Here are some representative examples for setting
-up a connectivity profile, and the following table lists the parameters
-that can be used.
+The *Connections* section in the
+:doc:`../../guides/spatial/guide_spatially_structured_networks`
+deals comprehensively with all the different possibilities, and it’s suggested
+that you look there for learning about the different constraints, as well
+as reading through the different examples listed there. Here are some
+representative examples for setting up a connectivity profile, and the
+following table lists the parameters that can be used.
 
 .. _cirgauss:
 
@@ -385,10 +387,6 @@ Section 4.1 *Query functions*.
 
 It may also be useful to look at the ``spatial`` property of the
 NodeCollection, which describes the layer properties. Other useful
-functions that may be of help are listed in NTUM Section 4.1.
-
-References
-----------
-
-.. [1] Plesser HE and Enger H.  NEST Topology User Manual,
- https://www.nest-simulator.org/wp-content/uploads/2015/04/Topology_UserManual.pdf
+functions that may be of help are listed in the
+*Inspecting Spatially distributed NodeCollections* section of our
+:doc:`../../guides/spatial/guide_spatially_structured_networks`.

--- a/doc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
@@ -151,7 +151,9 @@ For more flexibility in how we distribute neurons, we can use free spatial
 placement. We then need to define a Parameter for the placement of the
 neurons, or we can define the positions of the neurons explicitly. Note
 that the extent is calculated from the positions of the nodes, but we can
-also explicitly specify it. See Section 2.2 in NUTM for more details.
+also explicitly specify it. See the *Free layers* section of the
+:doc:`Guide to spatially-structured networks<../../guides/spatial/guide_spatially_structured_networks>`
+for details.
 
 The following snippet produces :numref:`free`:
 

--- a/examples/nest/Potjans_2014/microcircuit.sli
+++ b/examples/nest/Potjans_2014/microcircuit.sli
@@ -496,7 +496,7 @@ close
             % Connect devices
 
             % Connect to the spike detector
-            % record from a continuous range of IDs (appropriate for networks without topology)
+            % record from a continuous range of IDs (appropriate for networks without spatial information)
             target_nodes n_neurons_rec_spikes target_layer get target_pop get Take
             spike_detector_nodeIDs target_layer get target_pop get
             /all_to_all

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -119,12 +119,12 @@ set ( nestkernel_sources
       spatial/ntree.h
       spatial/ntree_impl.h
       spatial/position.h
-      spatial/topology.cpp
-      spatial/topology.h
+      spatial/spatial.cpp
+      spatial/spatial.h
       spatial/vose.cpp
       spatial/vose.h
       )
-  
+
 if ( HAVE_SIONLIB )
   set( nestkernel_sources
        ${nestkernel_sources}

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -26,8 +26,7 @@
 /**
  * Class managing flexible connection creation.
  *
- * This is a very first draft, a very much stripped-down version of the
- * Topology connection_creator.
+ * Created based on the connection_creator used for spatial networks.
  *
  */
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -2159,10 +2159,10 @@ NestModule::GetPosition_gFunction::execute( SLIInterpreter* i ) const
             layer from_pos to_node_id Displacement -> [double vector]
 
   Parameters:
-  layer       - NodeCollection for layer
-  from_node_id    - int, node_id of node in a spatial layer
-  from_pos    - double vector, position in layer
-  to_node_id      - int, node_id of node in a spatial layer
+  layer           - NodeCollection for layer
+  from_node_id    - int, node_id of node in a spatial NodeCollection
+  from_pos        - double vector, position in layer
+  to_node_id      - int, node_id of node in a spatial NodeCollection
 
   Returns:
   [double vector] - vector pointing from position "from" to position "to"
@@ -2170,7 +2170,7 @@ NestModule::GetPosition_gFunction::execute( SLIInterpreter* i ) const
   Description:
   This function returns a vector connecting the position of the "from_node_id"
   node or the explicitly given "from_pos" position and the position of the
-  "to_node_id" node. Nodes must be parts of spatial layers.
+  "to_node_id" node. Nodes must be parts of a spatial NodeCollection.
 
   The "from" position is projected into the layer of the "to_node_id" node. If
   this layer has periodic boundary conditions (EdgeWrap is true), then the
@@ -2238,9 +2238,9 @@ NestModule::Displacement_a_gFunction::execute( SLIInterpreter* i ) const
 
   Parameters:
   layer       - NodeCollection for layer
-  from_node_id    - int, node_id of node in a spatial layer
+  from_node_id    - int, node_id of node in a spatial NodeCollection
   from_pos    - double vector, position in layer
-  to_node_id      - int, node_id of node in a spatial layer
+  to_node_id      - int, node_id of node in a spatial NodeCollection
 
   Returns:
   double - distance between nodes or given position and node
@@ -2248,7 +2248,7 @@ NestModule::Displacement_a_gFunction::execute( SLIInterpreter* i ) const
   Description:
   This function returns the distance between the position of the "from_node_id"
   node or the explicitly given "from_pos" position and the position of the
-  "to_node_id" node. Nodes must be parts of spatial layers.
+  "to_node_id" node. Nodes must be parts of a spatial NodeCollection.
 
   The "from" position is projected into the layer of the "to_node_id" node. If
   this layer has periodic boundary conditions (EdgeWrap is true), then the
@@ -2333,7 +2333,7 @@ NestModule::Distance_aFunction::execute( SLIInterpreter* i ) const
   dict  - dictionary with mask specifications
 
   Description: Masks can be used when creating connections between nodes
-  with spatial information. A mask describes which area of the pool layer
+  with spatial parameters. A mask describes which area of the pool layer
   shall be searched for nodes to connect for any given node in the driver
   layer. This command creates a mask object which may be combined with other
   mask objects using Boolean operators. The mask is specified in a dictionary.

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -53,7 +53,7 @@
 #include "spatial/layer_impl.h"
 #include "spatial/mask.h"
 #include "spatial/mask_impl.h"
-#include "spatial/topology.h"
+#include "spatial/spatial.h"
 
 // Includes from sli:
 #include "arraydatum.h"
@@ -294,7 +294,7 @@ create_doughnut( const DictionaryDatum& d )
   if ( inner >= outer )
   {
     throw BadProperty(
-      "topology::create_doughnut: "
+      "nest::create_doughnut: "
       "inner_radius < outer_radius required." );
   }
 
@@ -2065,7 +2065,7 @@ NestModule::Apply_P_gFunction::execute( SLIInterpreter* i ) const
 //
 
 /** @BeginDocumentation
-  Name: topology::CreateLayer - create a spatial layer of nodes
+  Name: nest::CreateLayer - create nodes with spatial information
 
   Synopsis:
   dict CreateLayer -> layer
@@ -2073,13 +2073,11 @@ NestModule::Apply_P_gFunction::execute( SLIInterpreter* i ) const
   Parameters:
   dict - dictionary with layer specification
 
-  Description: The Topology module organizes neuronal networks in
-  layers. A layer is a special type of NodeCollection which contains information
-  about the spatial position of its nodes. There are three classes of
-  layers: grid-based layers, in which each element is placed at a
-  location in a regular grid; free layers, in which elements can be
-  placed arbitrarily in space; and random layers, where the elements are
-  distributed randomly throughout a region in space.  Which kind of layer
+  Description: Creates a NodeCollection which contains information
+  about the spatial position of its nodes. Positions can be organized
+  in one of two layer classes: grid-based layers, in which each element
+  is placed at a location in a regular grid, and free layers, in which
+  elements can be placed arbitrarily in space.  Which kind of layer
   this command creates depends on the elements in the supplied
   specification dictionary.
 
@@ -2106,7 +2104,7 @@ NestModule::CreateLayer_D_DFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::GetPosition - retrieve position of input node
+  Name: nest::GetPosition - retrieve position of input node
 
   Synopsis: NodeCollection GetPosition -> [array]
 
@@ -2155,16 +2153,16 @@ NestModule::GetPosition_gFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::Displacement - compute displacement vector
+  Name: nest::Displacement - compute displacement vector
 
   Synopsis: layer from_node_id to_node_id Displacement -> [double vector]
             layer from_pos to_node_id Displacement -> [double vector]
 
   Parameters:
   layer       - NodeCollection for layer
-  from_node_id    - int, node_id of node in a topology layer
+  from_node_id    - int, node_id of node in a spatial layer
   from_pos    - double vector, position in layer
-  to_node_id      - int, node_id of node in a topology layer
+  to_node_id      - int, node_id of node in a spatial layer
 
   Returns:
   [double vector] - vector pointing from position "from" to position "to"
@@ -2172,7 +2170,7 @@ NestModule::GetPosition_gFunction::execute( SLIInterpreter* i ) const
   Description:
   This function returns a vector connecting the position of the "from_node_id"
   node or the explicitly given "from_pos" position and the position of the
-  "to_node_id" node. Nodes must be parts of topology layers.
+  "to_node_id" node. Nodes must be parts of spatial layers.
 
   The "from" position is projected into the layer of the "to_node_id" node. If
   this layer has periodic boundary conditions (EdgeWrap is true), then the
@@ -2233,16 +2231,16 @@ NestModule::Displacement_a_gFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::Distance - compute distance between nodes
+  Name: nest::Distance - compute distance between nodes
 
   Synopsis: layer from_node_id to_node_id Distance -> double
             layer from_pos to_node_id Distance -> double
 
   Parameters:
   layer       - NodeCollection for layer
-  from_node_id    - int, node_id of node in a topology layer
+  from_node_id    - int, node_id of node in a spatial layer
   from_pos    - double vector, position in layer
-  to_node_id      - int, node_id of node in a topology layer
+  to_node_id      - int, node_id of node in a spatial layer
 
   Returns:
   double - distance between nodes or given position and node
@@ -2250,7 +2248,7 @@ NestModule::Displacement_a_gFunction::execute( SLIInterpreter* i ) const
   Description:
   This function returns the distance between the position of the "from_node_id"
   node or the explicitly given "from_pos" position and the position of the
-  "to_node_id" node. Nodes must be parts of topology layers.
+  "to_node_id" node. Nodes must be parts of spatial layers.
 
   The "from" position is projected into the layer of the "to_node_id" node. If
   this layer has periodic boundary conditions (EdgeWrap is true), then the
@@ -2325,7 +2323,7 @@ NestModule::Distance_aFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::CreateMask - create a spatial mask
+  Name: nest::CreateMask - create a spatial mask
 
   Synopsis:
   << /type dict >> CreateMask -> mask
@@ -2334,11 +2332,11 @@ NestModule::Distance_aFunction::execute( SLIInterpreter* i ) const
   /type - mask type
   dict  - dictionary with mask specifications
 
-  Description: Masks are used when creating connections in the Topology
-  module. A mask describes which area of the pool layer shall be searched
-  for nodes to connect for any given node in the driver layer. This
-  command creates a mask object which may be combined with other mask
-  objects using Boolean operators. The mask is specified in a dictionary.
+  Description: Masks can be used when creating connections between nodes
+  with spatial information. A mask describes which area of the pool layer
+  shall be searched for nodes to connect for any given node in the driver
+  layer. This command creates a mask object which may be combined with other
+  mask objects using Boolean operators. The mask is specified in a dictionary.
 
   Author: Håkon Enger
 */
@@ -2357,7 +2355,7 @@ NestModule::CreateMask_DFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::Inside - test if a point is inside a mask
+  Name: nest::Inside - test if a point is inside a mask
 
   Synopsis:
   point mask Inside -> bool
@@ -2430,7 +2428,7 @@ NestModule::Sub_M_MFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::ConnectLayers - connect two layers
+  Name: nest::ConnectLayers - connect two layers
 
   Synopsis: sourcelayer targetlayer connection_dict
   ConnectLayers -> -
@@ -2602,7 +2600,7 @@ NestModule::Sub_M_MFunction::execute( SLIInterpreter* i ) const
 
   Author: Håkon Enger, Kittel Austvoll
 
-  SeeAlso: topology::CreateLayer
+  SeeAlso: nest::CreateLayer
 */
 void
 NestModule::ConnectLayers_g_g_DFunction::execute( SLIInterpreter* i ) const
@@ -2621,7 +2619,7 @@ NestModule::ConnectLayers_g_g_DFunction::execute( SLIInterpreter* i ) const
 
 /** @BeginDocumentation
 
-  Name: topology::GetLayerStatus - return information about layer
+  Name: nest::GetLayerStatus - return information about layer
 
   Synopsis:
   layer GetLayerStatus -> dict
@@ -2647,7 +2645,7 @@ NestModule::GetLayerStatus_gFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::DumpLayerNodes - write information about layer nodes to file
+  Name: nest::DumpLayerNodes - write information about layer nodes to file
 
   Synopsis: ostream layer DumpLayerNodes -> ostream
 
@@ -2673,7 +2671,6 @@ NestModule::GetLayerStatus_gFunction::execute( SLIInterpreter* i ) const
 
   Examples:
 
-  topology using
   /my_layer << /rows 5 /columns 4 /elements /iaf_psc_alpha >> CreateLayer def
 
   (my_layer_dump.lyr) (w) file
@@ -2682,7 +2679,7 @@ NestModule::GetLayerStatus_gFunction::execute( SLIInterpreter* i ) const
 
   Author: Kittel Austvoll, Hans Ekkehard Plesser
 
-  SeeAlso: topology::DumpLayerConnections, setprecision, modeldict
+  SeeAlso: nest::DumpLayerConnections, setprecision, modeldict
 */
 void
 NestModule::DumpLayerNodes_os_gFunction::execute( SLIInterpreter* i ) const
@@ -2699,7 +2696,7 @@ NestModule::DumpLayerNodes_os_gFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-  Name: topology::DumpLayerConnections - prints a list of the connections of the
+  Name: nest::DumpLayerConnections - prints a list of the connections of the
                                          nodes in the layer to file
 
   Synopsis: ostream source_layer synapse_model DumpLayerConnections ->
@@ -2729,13 +2726,11 @@ NestModule::DumpLayerNodes_os_gFunction::execute( SLIInterpreter* i ) const
 
   Examples:
 
-  topology using
-  ...
   (out.cnn) (w) file layer_node_id /static_synapse PrintLayerConnections close
 
   Author: Kittel Austvoll, Hans Ekkehard Plesser
 
-  SeeAlso: topology::DumpLayerNodes
+  SeeAlso: nest::DumpLayerNodes
 */
 
 void

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -2065,7 +2065,7 @@ NestModule::Apply_P_gFunction::execute( SLIInterpreter* i ) const
 //
 
 /** @BeginDocumentation
-  Name: nest::CreateLayer - create nodes with spatial information
+  Name: nest::CreateLayer - create nodes with spatial properties
 
   Synopsis:
   dict CreateLayer -> layer

--- a/nestkernel/parameter.cpp
+++ b/nestkernel/parameter.cpp
@@ -22,7 +22,7 @@
 
 #include "node_collection.h"
 #include "node.h"
-#include "topology.h"
+#include "spatial.h"
 
 // includes from sli
 #include "sharedptrdatum.h"

--- a/nestkernel/spatial/connection_creator.h
+++ b/nestkernel/spatial/connection_creator.h
@@ -31,7 +31,7 @@
 #include "nest_names.h"
 #include "nestmodule.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "mask.h"
 #include "position.h"
 #include "vose.h"

--- a/nestkernel/spatial/free_layer.h
+++ b/nestkernel/spatial/free_layer.h
@@ -34,7 +34,7 @@
 // Includes from sli:
 #include "dictutils.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "layer.h"
 #include "ntree_impl.h"
 

--- a/nestkernel/spatial/grid_layer.h
+++ b/nestkernel/spatial/grid_layer.h
@@ -23,7 +23,7 @@
 #ifndef GRID_LAYER_H
 #define GRID_LAYER_H
 
-// Includes from topology:
+// Includes from spatial:
 #include "layer.h"
 
 namespace nest

--- a/nestkernel/spatial/grid_mask.h
+++ b/nestkernel/spatial/grid_mask.h
@@ -32,7 +32,7 @@
 #include "dictdatum.h"
 #include "dictutils.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "mask.h"
 #include "position.h"
 

--- a/nestkernel/spatial/layer.cpp
+++ b/nestkernel/spatial/layer.cpp
@@ -33,13 +33,13 @@
 #include "dictutils.h"
 #include "integerdatum.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "connection_creator_impl.h"
 #include "free_layer.h"
 #include "grid_layer.h"
 #include "layer_impl.h"
 #include "mask_impl.h"
-#include "topology.h"
+#include "spatial.h"
 
 namespace nest
 {

--- a/nestkernel/spatial/layer.h
+++ b/nestkernel/spatial/layer.h
@@ -36,7 +36,7 @@
 // Includes from sli:
 #include "dictutils.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "connection_creator.h"
 #include "ntree.h"
 #include "position.h"

--- a/nestkernel/spatial/layer_impl.h
+++ b/nestkernel/spatial/layer_impl.h
@@ -30,7 +30,7 @@
 #include "nest_datums.h"
 #include "booldatum.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "grid_layer.h"
 #include "grid_mask.h"
 

--- a/nestkernel/spatial/mask.h
+++ b/nestkernel/spatial/mask.h
@@ -36,7 +36,7 @@
 #include "dictdatum.h"
 #include "dictutils.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "position.h"
 
 namespace nest
@@ -403,19 +403,19 @@ public:
     if ( major_axis_ <= 0 or minor_axis_ <= 0 or polar_axis_ <= 0 )
     {
       throw BadProperty(
-        "topology::EllipseMask<D>: "
+        "nest::EllipseMask<D>: "
         "All axis > 0 required." );
     }
     if ( major_axis_ < minor_axis_ )
     {
       throw BadProperty(
-        "topology::EllipseMask<D>: "
+        "nest::EllipseMask<D>: "
         "major_axis greater than minor_axis required." );
     }
     if ( D == 2 and not( polar_angle_ == 0.0 ) )
     {
       throw BadProperty(
-        "topology::EllipseMask<D>: "
+        "nest::EllipseMask<D>: "
         "polar_angle not defined in 2D." );
     }
 
@@ -754,7 +754,7 @@ BoxMask< D >::BoxMask( const DictionaryDatum& d )
   if ( not( lower_left_ < upper_right_ ) )
   {
     throw BadProperty(
-      "topology::BoxMask<D>: "
+      "nest::BoxMask<D>: "
       "Upper right must be strictly to the right and above lower left." );
   }
 
@@ -772,7 +772,7 @@ BoxMask< D >::BoxMask( const DictionaryDatum& d )
     if ( D == 2 )
     {
       throw BadProperty(
-        "topology::BoxMask<D>: "
+        "nest::BoxMask<D>: "
         "polar_angle not defined in 2D." );
     }
     polar_angle_ = getValue< double >( d, names::polar_angle );
@@ -851,7 +851,7 @@ inline BoxMask< D >::BoxMask( const Position< D >& lower_left,
   if ( D == 2 and not( polar_angle_ == 0.0 ) )
   {
     throw BadProperty(
-      "topology::BoxMask<D>: "
+      "nest::BoxMask<D>: "
       "polar_angle not defined in 2D." );
   }
 
@@ -913,7 +913,7 @@ BallMask< D >::BallMask( const DictionaryDatum& d )
   if ( radius_ <= 0 )
   {
     throw BadProperty(
-      "topology::BallMask<D>: "
+      "nest::BallMask<D>: "
       "radius > 0 required." );
   }
 
@@ -945,13 +945,13 @@ EllipseMask< D >::EllipseMask( const DictionaryDatum& d )
   if ( major_axis_ <= 0 or minor_axis_ <= 0 )
   {
     throw BadProperty(
-      "topology::EllipseMask<D>: "
+      "nest::EllipseMask<D>: "
       "All axis > 0 required." );
   }
   if ( major_axis_ < minor_axis_ )
   {
     throw BadProperty(
-      "topology::EllipseMask<D>: "
+      "nest::EllipseMask<D>: "
       "major_axis greater than minor_axis required." );
   }
 
@@ -963,7 +963,7 @@ EllipseMask< D >::EllipseMask( const DictionaryDatum& d )
     if ( D == 2 )
     {
       throw BadProperty(
-        "topology::EllipseMask<D>: "
+        "nest::EllipseMask<D>: "
         "polar_axis not defined in 2D." );
     }
     polar_axis_ = getValue< double >( d, names::polar_axis );
@@ -971,7 +971,7 @@ EllipseMask< D >::EllipseMask( const DictionaryDatum& d )
     if ( polar_axis_ <= 0 )
     {
       throw BadProperty(
-        "topology::EllipseMask<D>: "
+        "nest::EllipseMask<D>: "
         "All axis > 0 required." );
     }
 
@@ -1002,7 +1002,7 @@ EllipseMask< D >::EllipseMask( const DictionaryDatum& d )
     if ( D == 2 )
     {
       throw BadProperty(
-        "topology::EllipseMask<D>: "
+        "nest::EllipseMask<D>: "
         "polar_angle not defined in 2D." );
     }
     polar_angle_ = getValue< double >( d, names::polar_angle );

--- a/nestkernel/spatial/ntree.h
+++ b/nestkernel/spatial/ntree.h
@@ -29,7 +29,7 @@
 #include <vector>
 #include <iterator>
 
-// Includes from topology:
+// Includes from spatial:
 #include "position.h"
 
 namespace nest

--- a/nestkernel/spatial/ntree_impl.h
+++ b/nestkernel/spatial/ntree_impl.h
@@ -25,7 +25,7 @@
 
 #include "ntree.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "mask.h"
 
 namespace nest

--- a/nestkernel/spatial/spatial.cpp
+++ b/nestkernel/spatial/spatial.cpp
@@ -1,5 +1,5 @@
 /*
- *  topology.cpp
+ *  spatial.cpp
  *
  *  This file is part of NEST.
  *
@@ -20,7 +20,7 @@
  *
  */
 
-#include "topology.h"
+#include "spatial.h"
 
 // C++ includes:
 #include <ostream>
@@ -39,7 +39,7 @@
 // Includes from sli:
 #include "sliexceptions.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "grid_layer.h"
 #include "layer.h"
 
@@ -75,7 +75,7 @@ create_layer( const DictionaryDatum& layer_dict )
 
   NodeCollectionPTR layer = AbstractLayer::create_layer( layer_dict );
 
-  ALL_ENTRIES_ACCESSED( *layer_dict, "topology::CreateLayer", "Unread dictionary entries: " );
+  ALL_ENTRIES_ACCESSED( *layer_dict, "nest::CreateLayer", "Unread dictionary entries: " );
 
   return layer;
 }
@@ -373,7 +373,7 @@ create_mask( const DictionaryDatum& mask_dict )
 
   MaskDatum datum( NestModule::create_mask( mask_dict ) );
 
-  ALL_ENTRIES_ACCESSED( *mask_dict, "topology::CreateMask", "Unread dictionary entries: " );
+  ALL_ENTRIES_ACCESSED( *mask_dict, "nest::CreateMask", "Unread dictionary entries: " );
 
   return datum;
 }
@@ -416,7 +416,7 @@ connect_layers( NodeCollectionPTR source_nc, NodeCollectionPTR target_nc, const 
 
   connection_dict->clear_access_flags();
   ConnectionCreator connector( connection_dict );
-  ALL_ENTRIES_ACCESSED( *connection_dict, "topology::CreateLayers", "Unread dictionary entries: " );
+  ALL_ENTRIES_ACCESSED( *connection_dict, "nest::CreateLayers", "Unread dictionary entries: " );
 
   source->connect( source_nc, target, target_nc, connector );
 }

--- a/nestkernel/spatial/spatial.h
+++ b/nestkernel/spatial/spatial.h
@@ -46,7 +46,7 @@ namespace nest
 {
 
 /**
- * Class representing metadata for layer containing spatial information.
+ * Class containing spatial information to be used as metadata in a NodeCollection.
  */
 class LayerMetadata : public NodeCollectionMetadata
 {

--- a/nestkernel/spatial/spatial.h
+++ b/nestkernel/spatial/spatial.h
@@ -1,5 +1,5 @@
 /*
- *  topology.h
+ *  spatial.h
  *
  *  This file is part of NEST.
  *
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef TOPOLOGY_H
-#define TOPOLOGY_H
+#ifndef SPATIAL_H
+#define SPATIAL_H
 
 // C++ includes:
 #include <vector>
@@ -37,7 +37,7 @@
 #include "iostreamdatum.h"
 #include "token.h"
 
-// Includes from topology:
+// Includes from spatial:
 #include "layer.h"
 #include "mask.h"
 
@@ -46,7 +46,7 @@ namespace nest
 {
 
 /**
- * Class representing metadata for topology layer.
+ * Class representing metadata for layer containing spatial information.
  */
 class LayerMetadata : public NodeCollectionMetadata
 {
@@ -117,4 +117,4 @@ void dump_layer_connections( const Token& syn_model,
 DictionaryDatum get_layer_status( NodeCollectionPTR layer_nc );
 }
 
-#endif /* TOPOLOGY_H */
+#endif /* SPATIAL_H */

--- a/pynest/examples/csa_example.py
+++ b/pynest/examples/csa_example.py
@@ -31,7 +31,7 @@ libneurosim. For details, see [1]_.
 See Also
 ~~~~~~~~~~
 
-:doc:`csa_topology_example`
+:doc:`csa_spatial_example`
 
 References
 ~~~~~~~~~~~~

--- a/testsuite/regressiontests/ticket-433.sli
+++ b/testsuite/regressiontests/ticket-433.sli
@@ -28,8 +28,8 @@ Synopsis: (ticket-433) run -> NEST exits if test fails
 
 Description:
  ht_neuron accepted incoming connections with invalid receptor type, leading to
- unpredictable errors. Additionally, the topology library did not seem to pass
- on the receptor_type when making connections.
+ unpredictable errors. Additionally, when making connections with nodes with
+ spatial information, the receptor_type did not seem to be passed on.
 
  Reported by Jonathan Williford.
 
@@ -51,9 +51,9 @@ M_INFO setverbosity
 %  ampa --- AMPA receptor ID
 %  retina, retina_gen, Tp --- layers
 
-% Connection function using topology library
+% Connection function using spatial connection function
 % receptor_type erroneously placed in dictionary
-/connect_topo
+/connect_spatial
 {
   retina
   Tp
@@ -66,9 +66,9 @@ M_INFO setverbosity
 }
 bind def
 
-% Connection function using topology library
+% Connection function using spatial connection function
 % receptor_type correctly placed in synapse
-/connect_topo_syn
+/connect_spatial_syn
 {
   /ht_synapse /ht_syn_ampa << /receptor_type ampa >> CopyModel
 
@@ -147,7 +147,7 @@ fail_or_die
 % third test: connect using ConnectLayers
 % this must raise an error, otherwise lacking receptor_type is not detected
 {
-  /connect_topo
+  /connect_spatial
   test_connect
 }
 fail_or_die
@@ -155,7 +155,7 @@ fail_or_die
 % fourth test: connect using ConnectLayers, but with
 % properly configured synapse model
 {
-  /connect_topo_syn
+  /connect_spatial_syn
   test_connect
 }
  pass_or_die

--- a/testsuite/regressiontests/ticket-433.sli
+++ b/testsuite/regressiontests/ticket-433.sli
@@ -51,7 +51,7 @@ M_INFO setverbosity
 %  ampa --- AMPA receptor ID
 %  retina, retina_gen, Tp --- layers
 
-% Connection function using spatial connection function
+% Connection function using spatial parameters
 % receptor_type erroneously placed in dictionary
 /connect_spatial
 {
@@ -66,7 +66,7 @@ M_INFO setverbosity
 }
 bind def
 
-% Connection function using spatial connection function
+% Connection function using spatial parameters
 % receptor_type correctly placed in synapse
 /connect_spatial_syn
 {

--- a/testsuite/regressiontests/ticket-800.sli
+++ b/testsuite/regressiontests/ticket-800.sli
@@ -22,12 +22,12 @@
 
 /** @BeginDocumentation
 
-Name: testsuite::ticket-800 Ensure that Topology parameters check their parameters
+Name: testsuite::ticket-800 Ensure that spatial parameters check their parameters
 
 Synopsis: (ticket-800) run -> NEST exits if test fails
 
 Description:
-This ticket ensures that Topology parameters check their parameters for
+This ticket ensures that spatial parameters check their parameters for
 validity, e.g., strictly positive sigma for a Gaussian.
 
 Author: Hans Ekkehard Plesser, 2014-12-13


### PR DESCRIPTION
As a follow-up to #1748, this PR renames occurrences of `topology` to `spatial`, `spatial structure`, or similar, and attempts to update related documentation.