### PR TITLE
Add test of connecting arrays using MPI

### DIFF
--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -218,9 +218,6 @@ def Connect(pre, post, conn_spec=None, syn_spec=None,
     # If pre and post are arrays of node IDs, and conn_spec is unspecified,
     # the node IDs are connected one-to-one.
     if use_connect_arrays:
-        if NumProcesses() > 1:
-            raise RuntimeError("Connecting arrays using MPI is currently not supported.")
-
         if return_synapsecollection:
             raise ValueError("SynapseCollection cannot be returned when connecting two arrays of node IDs")
 

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# test_connect_arrays_mpi.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess as sp
+import unittest
+import nest
+import numpy as np
+
+try:
+    from mpi4py import MPI
+    HAVE_MPI4PY = True
+except ImportError:
+    HAVE_MPI4PY = False
+
+HAVE_MPI = nest.ll_api.sli_func("statusdict/have_mpi ::")
+MULTIPLE_PROCESSES = nest.NumProcesses() > 1
+
+
+class ConnectArraysMPICase(unittest.TestCase):
+    non_unique = np.array([1, 1, 3, 5, 4, 5, 9, 7, 2, 8], dtype=np.uint64)
+    comm = MPI.COMM_WORLD
+
+    # With nosetests, only run these tests if using multiple processes
+    __test__ = MULTIPLE_PROCESSES
+
+    def assert_connections(self, expected_sources, expected_targets, rule='one_to_one'):
+        """Gather connections from all processes and assert against expected connections"""
+        conns = nest.GetConnections()
+        projections = [[s, t] for s, t in zip(conns.source, conns.target)]
+        if rule == 'one_to_one':
+            expected_projections = np.array([[s, t] for s, t in zip(expected_sources, expected_targets)])
+        elif rule == 'all_to_all':
+            expected_projections = np.array([[s, t] for s in expected_sources for t in expected_targets])
+        else:
+            self.assertFalse(True, 'rule={} is not valid'.format(rule))
+
+        recv_projections = self.comm.gather(projections, root=0)
+        if self.comm.Get_rank() == 0:
+            # Flatten the projection lists to a single list of projections
+            recv_projections = np.array([proj for part in recv_projections for proj in part])
+            # Results must be sorted to make comparison possible
+            np.testing.assert_array_equal(np.sort(recv_projections, axis=0), np.sort(expected_projections, axis=0))
+        else:
+            self.assertIsNone(recv_projections)
+
+    def setUp(self):
+        nest.ResetKernel()
+
+    def test_connect_arrays_unique(self):
+        """Connecting NumPy arrays of unique node IDs with MPI"""
+        n = 10
+        nest.Create('iaf_psc_alpha', n)
+        sources = np.arange(1, n+1, dtype=np.uint64)
+        targets = np.arange(1, n+1, dtype=np.uint64)
+        weights = 1.5
+        delays = 1.4
+
+        nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays})
+
+        self.assert_connections(sources, targets, rule='all_to_all')
+
+    def test_connect_arrays_nonunique(self):
+        """Connecting NumPy arrays with non-unique node IDs with MPI"""
+        n = 10
+        nest.Create('iaf_psc_alpha', n)
+        sources = np.arange(1, n+1, dtype=np.uint64)
+        targets = self.non_unique
+        weights = np.ones(n)
+        delays = np.ones(n)
+        nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays},
+                     conn_spec='one_to_one')
+
+        self.assert_connections(sources, targets)
+
+    def test_connect_arrays_threaded(self):
+        """Connecting NumPy arrays, threaded with MPI"""
+        nest.SetKernelStatus({'local_num_threads': 2})
+        n = 10
+        nest.Create('iaf_psc_alpha', n)
+        sources = np.arange(1, n+1, dtype=np.uint64)
+        targets = self.non_unique
+        weights = np.ones(len(sources))
+        delays = np.ones(len(sources))
+        syn_model = 'static_synapse'
+
+        nest.Connect(sources, targets, conn_spec='one_to_one',
+                     syn_spec={'weight': weights, 'delay': delays, 'synapse_model': syn_model})
+
+        self.assert_connections(sources, targets)
+
+
+class TestConnectArraysMPI(unittest.TestCase):
+
+    # With nosetests, only run this test if using a single process
+    __test__ = not MULTIPLE_PROCESSES
+
+    @unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
+    @unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
+    def testWithMPI(self):
+        """Connect NumPy arrays with MPI"""
+        directory = os.path.dirname(os.path.realpath(__file__))
+        script = os.path.realpath(__file__)
+        failing_tests = []
+        # for script in scripts:
+        test_script = os.path.join(directory, script)
+        command = nest.ll_api.sli_func(
+            "mpirun", 2, "nosetests", test_script)
+        command = command.split()
+        my_env = os.environ.copy()
+        retcode = sp.call(command, env=my_env, stdout=sp.PIPE, stderr=sp.PIPE)
+        if retcode != 0:
+            failing_tests.append(script)
+
+        self.assertTrue(not failing_tests, 'The following tests failed when ' +
+                        'executing with "mpirun -np 2 nosetests [script]": ' +
+                        ", ".join(failing_tests))
+
+
+if __name__ == '__main__':
+    raise RuntimeError('This test must be run with nosetests')

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -35,7 +35,6 @@ HAVE_MPI = nest.ll_api.sli_func("statusdict/have_mpi ::")
 MULTIPLE_PROCESSES = nest.NumProcesses() > 1
 
 
-@unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
 @unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
 class ConnectArraysMPICase(unittest.TestCase):
     """

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -51,7 +51,7 @@ class ConnectArraysMPICase(unittest.TestCase):
     # With nosetests, only run these tests if using multiple processes
     __test__ = MULTIPLE_PROCESSES
 
-    def assert_connections(self, expected_sources, expected_targets, rule='one_to_one'):
+    def assert_connections(self, expected_sources, expected_targets, rule):
         """Gather connections from all processes and assert against expected connections"""
         conns = nest.GetConnections()
         projections = [[s, t] for s, t in zip(conns.source, conns.target)]
@@ -85,7 +85,7 @@ class ConnectArraysMPICase(unittest.TestCase):
 
         nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays})
 
-        self.assert_connections(sources, targets, rule='all_to_all')
+        self.assert_connections(sources, targets, 'all_to_all')
 
     def test_connect_arrays_nonunique(self):
         """Connecting NumPy arrays with non-unique node IDs with MPI"""
@@ -98,7 +98,7 @@ class ConnectArraysMPICase(unittest.TestCase):
         nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays},
                      conn_spec='one_to_one')
 
-        self.assert_connections(sources, targets)
+        self.assert_connections(sources, targets, 'one_to_one')
 
     def test_connect_arrays_threaded(self):
         """Connecting NumPy arrays, threaded with MPI"""
@@ -114,7 +114,7 @@ class ConnectArraysMPICase(unittest.TestCase):
         nest.Connect(sources, targets, conn_spec='one_to_one',
                      syn_spec={'weight': weights, 'delay': delays, 'synapse_model': syn_model})
 
-        self.assert_connections(sources, targets)
+        self.assert_connections(sources, targets, 'one_to_one')
 
 
 @unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -47,7 +47,7 @@ class ConnectArraysMPICase(unittest.TestCase):
     non_unique = np.array([1, 1, 3, 5, 4, 5, 9, 7, 2, 8], dtype=np.uint64)
     comm = MPI.COMM_WORLD
 
-    # With nosetests, only run these tests if using multiple processes
+    # With pytest or nosetests, only run these tests if using multiple processes
     __test__ = MULTIPLE_PROCESSES
 
     def assert_connections(self, expected_sources, expected_targets, rule):

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -80,10 +80,8 @@ class ConnectArraysMPICase(unittest.TestCase):
         nest.Create('iaf_psc_alpha', n)
         sources = np.arange(1, n+1, dtype=np.uint64)
         targets = np.arange(1, n+1, dtype=np.uint64)
-        weights = 1.5
-        delays = 1.4
 
-        nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays})
+        nest.Connect(sources, targets, syn_spec={'weight': 1.5, 'delay': 1.4})
 
         self.assert_connections(sources, targets, 'all_to_all')
 
@@ -93,9 +91,7 @@ class ConnectArraysMPICase(unittest.TestCase):
         nest.Create('iaf_psc_alpha', n)
         sources = np.arange(1, n+1, dtype=np.uint64)
         targets = self.non_unique
-        weights = np.ones(n)
-        delays = np.ones(n)
-        nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays},
+        nest.Connect(sources, targets, syn_spec={'weight': np.ones(n), 'delay': np.ones(n)},
                      conn_spec='one_to_one')
 
         self.assert_connections(sources, targets, 'one_to_one')
@@ -107,12 +103,12 @@ class ConnectArraysMPICase(unittest.TestCase):
         nest.Create('iaf_psc_alpha', n)
         sources = np.arange(1, n+1, dtype=np.uint64)
         targets = self.non_unique
-        weights = np.ones(len(sources))
-        delays = np.ones(len(sources))
         syn_model = 'static_synapse'
 
         nest.Connect(sources, targets, conn_spec='one_to_one',
-                     syn_spec={'weight': weights, 'delay': delays, 'synapse_model': syn_model})
+                     syn_spec={'weight': np.ones(len(sources)),
+                               'delay': np.ones(len(sources)),
+                               'synapse_model': syn_model})
 
         self.assert_connections(sources, targets, 'one_to_one')
 

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -119,21 +119,15 @@ class TestConnectArraysMPI(unittest.TestCase):
         """Connect NumPy arrays with MPI"""
         directory = os.path.dirname(os.path.realpath(__file__))
         script = os.path.realpath(__file__)
-        failing_tests = []
-        # for script in scripts:
         test_script = os.path.join(directory, script)
-        command = nest.ll_api.sli_func(
-            "mpirun", 2, "nosetests", test_script)
+        command = nest.ll_api.sli_func("mpirun", 2, "nosetests", test_script)
         command = command.split()
-        my_env = os.environ.copy()
-        retcode = sp.call(command, env=my_env, stdout=sp.PIPE, stderr=sp.PIPE)
-        if retcode != 0:
-            failing_tests.append(script)
 
-        self.assertTrue(not failing_tests, 'The following tests failed when ' +
-                        'executing with "mpirun -np 2 nosetests [script]": ' +
-                        ", ".join(failing_tests))
+        my_env = os.environ.copy()
+        retcode = sp.call(command, env=my_env)
+
+        self.assertEqual(retcode, 0, 'Test failed when run with "mpirun -np 2 nosetests [script]"')
 
 
 if __name__ == '__main__':
-    raise RuntimeError('This test must be run with nosetests')
+    raise RuntimeError('This test must be run with nosetests or pytest')

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -57,7 +57,7 @@ class ConnectArraysMPICase(unittest.TestCase):
     multiple processes.
     """
     non_unique = np.array([1, 1, 3, 5, 4, 5, 9, 7, 2, 8], dtype=np.uint64)
-    comm = MPI.COMM_WORLD
+    comm = MPI.COMM_WORLD.Clone()
 
     # With pytest or nosetests, only run these tests if using multiple processes
     __test__ = MULTIPLE_PROCESSES

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -35,7 +35,16 @@ HAVE_MPI = nest.ll_api.sli_func("statusdict/have_mpi ::")
 MULTIPLE_PROCESSES = nest.NumProcesses() > 1
 
 
+@unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
+@unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
 class ConnectArraysMPICase(unittest.TestCase):
+    """
+    This TestCase uses mpi4py to collect and assert results from all
+    processes, and is supposed to only be run with multiple processes.
+    If running with nosetests or pytest, this TestCase is ignored when
+    run with a single process, and called from TestConnectArraysMPI using
+    multiple processes.
+    """
     non_unique = np.array([1, 1, 3, 5, 4, 5, 9, 7, 2, 8], dtype=np.uint64)
     comm = MPI.COMM_WORLD
 
@@ -108,13 +117,13 @@ class ConnectArraysMPICase(unittest.TestCase):
         self.assert_connections(sources, targets)
 
 
+@unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
+@unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
 class TestConnectArraysMPI(unittest.TestCase):
 
     # With nosetests, only run this test if using a single process
     __test__ = not MULTIPLE_PROCESSES
 
-    @unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
-    @unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
     def testWithMPI(self):
         """Connect NumPy arrays with MPI"""
         directory = os.path.dirname(os.path.realpath(__file__))

--- a/pynest/nest/tests/test_connect_arrays_mpi.py
+++ b/pynest/nest/tests/test_connect_arrays_mpi.py
@@ -19,6 +19,18 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+This file contains two TestCases, and must be run from nosetests or pytest.
+It requires NEST to be built with MPI and the Python package mpi4py.
+
+The file can be run in two modes: with a single process, or with multiple MPI
+processes. If run with multiple processes, the ConnectArraysMPICase TestCase
+is run, which tests connecting with arrays when using multiple MPI processes.
+If run with a single process, the TestConnectArraysMPI TestCase is run,
+which runs ConnectArraysMPICase in a subprocess with multiple MPI processes,
+and fails if any of the tests in ConnectArraysMPICase fail.
+"""
+
 import os
 import subprocess as sp
 import unittest
@@ -115,6 +127,11 @@ class ConnectArraysMPICase(unittest.TestCase):
 @unittest.skipIf(not HAVE_MPI, 'NEST was compiled without MPI')
 @unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
 class TestConnectArraysMPI(unittest.TestCase):
+    """
+    When run with nosetests or pytest, this TestCase runs the ConnectArraysMPICase
+    with multiple MPI processes in a subprocess. The test fails if any of the tests in
+    ConnectArraysMPICase fail.
+    """
 
     # With nosetests, only run this test if using a single process
     __test__ = not MULTIPLE_PROCESSES


### PR DESCRIPTION
Apparently connecting arrays of node IDs using MPI works after all. A test is added, which fixes #1710.