### PR TITLE
Update edgecolor to default value in examples and code that use scatterplot

### DIFF
--- a/pynest/examples/spatial/test_3d.py
+++ b/pynest/examples/spatial/test_3d.py
@@ -42,7 +42,7 @@ l1 = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 xpos, ypos, zpos = zip(*nest.GetPosition(l1))
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
-ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor='none')
+ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor=None)
 
 # full connections in volume [-0.2,0.2]**3
 nest.Connect(l1, l1,
@@ -57,7 +57,7 @@ nest.Connect(l1, l1,
 ctr = nest.FindCenterElement(l1)
 xtgt, ytgt, ztgt = zip(*nest.GetTargetPositions(ctr, l1)[0])
 xctr, yctr, zctr = nest.GetPosition(ctr)
-ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor='none')
+ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor=None)
 ax.scatter(xtgt, ytgt, ztgt, s=40, facecolor='g', edgecolor='g')
 
 tgts = nest.GetTargetNodes(ctr, l1)[0]

--- a/pynest/examples/spatial/test_3d.py
+++ b/pynest/examples/spatial/test_3d.py
@@ -42,7 +42,7 @@ l1 = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 xpos, ypos, zpos = zip(*nest.GetPosition(l1))
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
-ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor=None)
+ax.scatter(xpos, ypos, zpos, s=15, facecolor='b')
 
 # full connections in volume [-0.2,0.2]**3
 nest.Connect(l1, l1,
@@ -57,7 +57,7 @@ nest.Connect(l1, l1,
 ctr = nest.FindCenterElement(l1)
 xtgt, ytgt, ztgt = zip(*nest.GetTargetPositions(ctr, l1)[0])
 xctr, yctr, zctr = nest.GetPosition(ctr)
-ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor=None)
+ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r')
 ax.scatter(xtgt, ytgt, ztgt, s=40, facecolor='g', edgecolor='g')
 
 tgts = nest.GetTargetNodes(ctr, l1)[0]

--- a/pynest/examples/spatial/test_3d_exp.py
+++ b/pynest/examples/spatial/test_3d_exp.py
@@ -42,7 +42,7 @@ l1 = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 xpos, ypos, zpos = zip(*nest.GetPosition(l1))
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
-ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor=None)
+ax.scatter(xpos, ypos, zpos, s=15, facecolor='b')
 
 # Exponential connections in full volume [-0.75,0.75]**3
 nest.Connect(l1, l1,
@@ -58,7 +58,7 @@ nest.Connect(l1, l1,
 ctr = nest.FindCenterElement(l1)
 xtgt, ytgt, ztgt = zip(*nest.GetTargetPositions(ctr, l1)[0])
 xctr, yctr, zctr = nest.GetPosition(ctr)
-ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor=None)
+ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r')
 ax.scatter(xtgt, ytgt, ztgt, s=40, facecolor='g', edgecolor='g')
 
 tgts = nest.GetTargetNodes(ctr, l1)[0]

--- a/pynest/examples/spatial/test_3d_exp.py
+++ b/pynest/examples/spatial/test_3d_exp.py
@@ -42,7 +42,7 @@ l1 = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 xpos, ypos, zpos = zip(*nest.GetPosition(l1))
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
-ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor='none')
+ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor=None)
 
 # Exponential connections in full volume [-0.75,0.75]**3
 nest.Connect(l1, l1,
@@ -58,7 +58,7 @@ nest.Connect(l1, l1,
 ctr = nest.FindCenterElement(l1)
 xtgt, ytgt, ztgt = zip(*nest.GetTargetPositions(ctr, l1)[0])
 xctr, yctr, zctr = nest.GetPosition(ctr)
-ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor='none')
+ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor=None)
 ax.scatter(xtgt, ytgt, ztgt, s=40, facecolor='g', edgecolor='g')
 
 tgts = nest.GetTargetNodes(ctr, l1)[0]

--- a/pynest/examples/spatial/test_3d_gauss.py
+++ b/pynest/examples/spatial/test_3d_gauss.py
@@ -42,7 +42,7 @@ l1 = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 xpos, ypos, zpos = zip(*nest.GetPosition(l1))
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
-ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor=None)
+ax.scatter(xpos, ypos, zpos, s=15, facecolor='b')
 
 # Gaussian connections in full volume [-0.75,0.75]**3
 nest.Connect(l1, l1,
@@ -57,7 +57,7 @@ nest.Connect(l1, l1,
 ctr = nest.FindCenterElement(l1)
 xtgt, ytgt, ztgt = zip(*nest.GetTargetPositions(ctr, l1)[0])
 xctr, yctr, zctr = nest.GetPosition(ctr)
-ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor=None)
+ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r')
 ax.scatter(xtgt, ytgt, ztgt, s=40, facecolor='g', edgecolor='g')
 
 tgts = nest.GetTargetNodes(ctr, l1)[0]

--- a/pynest/examples/spatial/test_3d_gauss.py
+++ b/pynest/examples/spatial/test_3d_gauss.py
@@ -42,7 +42,7 @@ l1 = nest.Create('iaf_psc_alpha', 1000, positions=pos)
 xpos, ypos, zpos = zip(*nest.GetPosition(l1))
 fig = plt.figure()
 ax = fig.add_subplot(111, projection='3d')
-ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor='none')
+ax.scatter(xpos, ypos, zpos, s=15, facecolor='b', edgecolor=None)
 
 # Gaussian connections in full volume [-0.75,0.75]**3
 nest.Connect(l1, l1,
@@ -57,7 +57,7 @@ nest.Connect(l1, l1,
 ctr = nest.FindCenterElement(l1)
 xtgt, ytgt, ztgt = zip(*nest.GetTargetPositions(ctr, l1)[0])
 xctr, yctr, zctr = nest.GetPosition(ctr)
-ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor='none')
+ax.scatter([xctr], [yctr], [zctr], s=40, facecolor='r', edgecolor=None)
 ax.scatter(xtgt, ytgt, ztgt, s=40, facecolor='g', edgecolor='g')
 
 tgts = nest.GetTargetNodes(ctr, l1)[0]

--- a/pynest/nest/lib/hl_api_spatial.py
+++ b/pynest/nest/lib/hl_api_spatial.py
@@ -953,7 +953,7 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         else:
             ax = fig.gca()
 
-        ax.scatter(xpos, ypos, s=nodesize, facecolor=nodecolor, edgecolor=None)
+        ax.scatter(xpos, ypos, s=nodesize, facecolor=nodecolor)
         _draw_extent(ax, xctr, yctr, xext, yext)
 
     elif len(ext) == 3:
@@ -1086,9 +1086,9 @@ def PlotTargets(src_nrn, tgt_layer, syn_type=None, fig=None,
         tgtpos = GetTargetPositions(src_nrn, tgt_layer, syn_type)
         if tgtpos:
             xpos, ypos = zip(*tgtpos[0])
-            ax.scatter(xpos, ypos, s=tgt_size, facecolor=tgt_color, edgecolor=None)
+            ax.scatter(xpos, ypos, s=tgt_size, facecolor=tgt_color)
 
-        ax.scatter(srcpos[:1], srcpos[1:], s=src_size, facecolor=src_color, edgecolor=None, alpha=0.4, zorder=-10)
+        ax.scatter(srcpos[:1], srcpos[1:], s=src_size, facecolor=src_color, alpha=0.4, zorder=-10)
 
         if mask is not None or probability_parameter is not None:
             edges = [xctr - xext, xctr + xext, yctr - yext, yctr + yext]
@@ -1111,10 +1111,9 @@ def PlotTargets(src_nrn, tgt_layer, syn_type=None, fig=None,
         tgtpos = GetTargetPositions(src_nrn, tgt_layer, syn_type)
         if tgtpos:
             xpos, ypos, zpos = zip(*tgtpos[0])
-            ax.scatter3D(xpos, ypos, zpos, s=tgt_size, facecolor=tgt_color, edgecolor=None)
+            ax.scatter3D(xpos, ypos, zpos, s=tgt_size, facecolor=tgt_color)
 
-        ax.scatter3D(srcpos[:1], srcpos[1:2], srcpos[2:], s=src_size, facecolor=src_color, edgecolor=None,
-                     alpha=0.4, zorder=-10)
+        ax.scatter3D(srcpos[:1], srcpos[1:2], srcpos[2:], s=src_size, facecolor=src_color, alpha=0.4, zorder=-10)
 
     plt.draw_if_interactive()
 

--- a/pynest/nest/lib/hl_api_spatial.py
+++ b/pynest/nest/lib/hl_api_spatial.py
@@ -953,8 +953,7 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         else:
             ax = fig.gca()
 
-        ax.scatter(xpos, ypos, s=nodesize, facecolor=nodecolor,
-                   edgecolor='none')
+        ax.scatter(xpos, ypos, s=nodesize, facecolor=nodecolor, edgecolor=None)
         _draw_extent(ax, xctr, yctr, xext, yext)
 
     elif len(ext) == 3:
@@ -1087,12 +1086,9 @@ def PlotTargets(src_nrn, tgt_layer, syn_type=None, fig=None,
         tgtpos = GetTargetPositions(src_nrn, tgt_layer, syn_type)
         if tgtpos:
             xpos, ypos = zip(*tgtpos[0])
-            ax.scatter(xpos, ypos, s=tgt_size, facecolor=tgt_color,
-                       edgecolor='none')
+            ax.scatter(xpos, ypos, s=tgt_size, facecolor=tgt_color, edgecolor=None)
 
-        ax.scatter(srcpos[:1], srcpos[1:], s=src_size, facecolor=src_color,
-                   edgecolor='none',
-                   alpha=0.4, zorder=-10)
+        ax.scatter(srcpos[:1], srcpos[1:], s=src_size, facecolor=src_color, edgecolor=None, alpha=0.4, zorder=-10)
 
         if mask is not None or probability_parameter is not None:
             edges = [xctr - xext, xctr + xext, yctr - yext, yctr + yext]
@@ -1115,11 +1111,9 @@ def PlotTargets(src_nrn, tgt_layer, syn_type=None, fig=None,
         tgtpos = GetTargetPositions(src_nrn, tgt_layer, syn_type)
         if tgtpos:
             xpos, ypos, zpos = zip(*tgtpos[0])
-            ax.scatter3D(xpos, ypos, zpos, s=tgt_size, facecolor=tgt_color,
-                         edgecolor='none')
+            ax.scatter3D(xpos, ypos, zpos, s=tgt_size, facecolor=tgt_color, edgecolor=None)
 
-        ax.scatter3D(srcpos[:1], srcpos[1:2], srcpos[2:], s=src_size,
-                     facecolor=src_color, edgecolor='none',
+        ax.scatter3D(srcpos[:1], srcpos[1:2], srcpos[2:], s=src_size, facecolor=src_color, edgecolor=None,
                      alpha=0.4, zorder=-10)
 
     plt.draw_if_interactive()


### PR DESCRIPTION
Use `None` instead of `'none'` for `edgecolor` in scatterplots in examples and plotting functions.

Using `'none'` led to an error message for me, I have Python 3.7.6, but I have tested the proposed changes with Python 3.5 and Python 3.6 as well.

UPDATE after comments: Have removed `edgecolor` as `None` is default, and there is the problem with `'none'`.