### PR TITLE
Enable MUSIC tests and correct NEST testsuite results summary

### DIFF
--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -346,101 +346,102 @@ else
 fi
 
 echo
-echo "Phase 6: Running MUSIC tests is deactivated"
-echo "-------------------------------------------"
-#if test "${MUSIC}"; then
-#    junit_open '06_musictests'
-#
-#    BASEDIR="$PWD"
-#    tmpdir="$(mktemp -d)"
-#
-#    TESTDIR="${TEST_BASEDIR}/musictests/"
-#
-#    for test_name in $(ls ${TESTDIR} | grep '.*\.music$') ; do
-#        music_file="${TESTDIR}/${test_name}"
-#
-#        # Collect the list of SLI files from the .music file.
-#        sli_files=$(grep '\.sli' ${music_file} | sed -e "s#args=#${TESTDIR}#g")
-#        sli_files=$(for f in ${sli_files}; do if test -f ${f}; then echo ${f}; fi; done)
-#
-#        # Check if there is an accompanying shell script for the test.
-#        sh_file="${TESTDIR}/$(basename ${music_file} .music).sh"
-#        if test ! -f "${sh_file}"; then unset sh_file; fi
-#
-#        # Calculate the total number of processes in the .music file.
-#        np=$(($(sed -n 's/np=//p' ${music_file} | paste -sd'+' -)))
-#        command="$(sli -c "${np} (${MUSIC}) (${test_name}) mpirun =")"
-#
-#        proc_txt="processes"
-#        if test $np -eq 1; then proc_txt="process"; fi
-#        echo          "Running test '${test_name}' with $np $proc_txt... " >> "${TEST_LOGFILE}"
-#        printf '%s' "  Running test '${test_name}' with $np $proc_txt... "
-#
-#        # Copy everything to the tmpdir. As some files might not
-#        # exist, variables can also be empty. To prevent 'cp' from
-#        # terminating on non-existent files, its exit code and error
-#        # message are suppressed.
-#        cp "${music_file}" "${sh_file}" "${sli_files}" "${tmpdir}" 2>/dev/null || :
-#        cd "${tmpdir}"
-#
-#        # Create the runner script
-#        echo "#!/bin/sh" >  runner.sh
-#        echo "set +e" >> runner.sh
-#        echo "NEST_DATA_PATH=\"${tmpdir}\"" >> runner.sh
-#        echo "${command} > output.log 2>&1" >> runner.sh
-#        if test -n "${sh_file}"; then
-#            chmod 755 "$(basename "${sh_file}")"
-#            echo "./$(basename "${sh_file}")" >> runner.sh
-#        fi
-#        echo "echo \$? > exit_code ; exit 0" >> runner.sh
-#
-#        # Run the script and copy all output to the logfile.
-#        chmod 755 runner.sh
-#        ./runner.sh
-#        sed -e 's/^/   > /g' output.log >> "${TEST_LOGFILE}"
-#
-#        # Retrieve the exit code. This is either the one of the mpirun
-#        # call or of the accompanying shell script if present.
-#        exit_code=$(cat exit_code)
-#
-#        rm "${tmpdir}/*"
-#        cd "${BASEDIR}"
-#
-#        # If the name of the test contains 'failure', we expect it to
-#        # fail and the test logic is inverted.
-#        TEST_TOTAL=$(( ${TEST_TOTAL} + 1 ))
-#        if test -z $(echo ${test_name} | grep failure); then
-#            if test $exit_code -eq 0; then
-#                echo "Success"
-#                TEST_PASSED=$(( ${TEST_PASSED} + 1 ))
-#            elif test $exit_code -ge 200 && $exit_code -le 215; then
-#                echo "Skipped"
-#                TEST_SKIPPED=$(( ${TEST_SKIPPED} + 1 ))
-#            else
-#                echo "Failure"
-#                TEST_FAILED=$(( ${TEST_FAILED} + 1 ))
-#            fi
-#        else
-#            if test $exit_code -ne 0; then
-#                echo "Success (expected failure)"
-#                TEST_PASSED=$(( ${TEST_PASSED} + 1 ))
-#            elif test $exit_code -ge 200 && $exit_code -le 215; then
-#                echo "Skipped"
-#                TEST_SKIPPED=$(( ${TEST_SKIPPED} + 1 ))
-#            else
-#                echo "Failure (test failed to fail)"
-#                TEST_FAILED=$(( ${TEST_FAILED} + 1 ))
-#            fi
-#        fi
-#    done
-#
-#    rm -rf "$tmpdir"
-#
-#    junit_close
-#else
-#  echo "  Not running MUSIC tests because NEST was compiled without support"
-#  echo "  for it. See the file README.md for details."
-#fi
+echo "Phase 6: Running MUSIC tests"
+echo "----------------------------"
+if test "${MUSIC}"; then
+    junit_open '06_musictests'
+
+    # Create a temporary directory with a unique name.
+    BASEDIR="$PWD"
+    tmpdir="$(mktemp -d)"
+
+    TESTDIR="${TEST_BASEDIR}/musictests/"
+
+    for test_name in $(ls ${TESTDIR} | grep '.*\.music$') ; do
+        music_file="${TESTDIR}/${test_name}"
+
+        # Collect the list of SLI files from the .music file.
+        sli_files=$(grep '\.sli' ${music_file} | sed -e "s#args=#${TESTDIR}#g")
+        sli_files=$(for f in ${sli_files}; do if test -f ${f}; then echo ${f}; fi; done)
+        sli_files=${sli_files//$'\n'/ }
+
+        # Check if there is an accompanying shell script for the test.
+        sh_file="${TESTDIR}/$(basename ${music_file} .music).sh"
+        if test ! -f "${sh_file}"; then unset sh_file; fi
+
+        # Calculate the total number of processes from the .music file.
+        np=$(($(sed -n 's/np=//p' ${music_file} | paste -sd'+' -)))
+        command="$(sli -c "${np} (${MUSIC}) (${test_name}) mpirun =")"
+
+        proc_txt="processes"
+        if test $np -eq 1; then proc_txt="process"; fi
+        echo          "Running test '${test_name}' with $np $proc_txt... " >> "${TEST_LOGFILE}"
+        printf '%s' "  Running test '${test_name}' with $np $proc_txt... "
+
+        # Copy everything to the tmpdir.
+        # Variables might also be empty. To prevent 'cp' from terminating with an error in such a case,
+        # exit code is suppressed.
+        cp ${music_file} ${sh_file} ${sli_files} ${tmpdir} 2>/dev/null || :
+
+        # Create the runner script in the tmpdir.
+        cd "${tmpdir}"
+        echo "#!/bin/sh" >  runner.sh
+        echo "set +e" >> runner.sh
+        echo "NEST_DATA_PATH=\"${tmpdir}\"" >> runner.sh
+        echo "${command} > ${TEST_OUTFILE} 2>&1" >> runner.sh
+        if test -n "${sh_file}"; then
+            chmod 755 "$(basename "${sh_file}")"
+            echo "./$(basename "${sh_file}")" >> runner.sh
+        fi
+        echo "echo \$? > exit_code ; exit 0" >> runner.sh
+
+        # Run the script, measure execution time, and copy all output to the logfile.
+        chmod 755 runner.sh
+        TIME_ELAPSED=$( time_cmd ./runner.sh )
+        TIME_TOTAL=$(( ${TIME_TOTAL} + ${TIME_ELAPSED} ))
+        sed -e 's/^/   > /g' ${TEST_OUTFILE} >> "${TEST_LOGFILE}"
+
+        # Retrieve the exit code. This is either the one of the mpirun call
+        # or of the accompanying shell script if present.
+        exit_code=$(cat exit_code)
+
+        # Count the total number of tests, the tests skipped and the tests with error.
+        # The values will be stored in the XML report when 'junit_close' is called.
+        JUNIT_TESTS=$(( ${JUNIT_TESTS} + 1 ))
+        if test -z $(echo ${test_name} | grep failure); then
+            if test $exit_code -eq 0; then
+                echo "Success"
+            elif test $exit_code -ge 200 && $exit_code -le 215; then
+                echo "Skipped"
+                JUNIT_SKIPS=$(( ${JUNIT_SKIPS} + 1 ))
+            else
+                echo "Failure"
+                JUNIT_FAILURES=$(( ${JUNIT_FAILURES} + 1 ))
+                junit_write "musictests" "${test_name}" "failure" "$(cat "${TEST_OUTFILE}")"
+            fi
+        else
+            if test $exit_code -ne 0; then
+                echo "Success (expected failure)"
+            elif test $exit_code -ge 200 && $exit_code -le 215; then
+                echo "Skipped"
+                JUNIT_SKIPS=$(( ${JUNIT_SKIPS} + 1 ))
+            else
+                echo "Failure (test failed to fail)"
+                JUNIT_FAILURES=$(( ${JUNIT_FAILURES} + 1 ))
+                junit_write "musictests" "${test_name}" "failure" "$(cat "${TEST_OUTFILE}")"
+            fi
+        fi
+
+        cd "${BASEDIR}"
+    done
+
+    rm -rf "$tmpdir"
+
+    junit_close
+else
+  echo "  Not running MUSIC tests because NEST was compiled without support"
+  echo "  for it. See the file README.md for details."
+fi
 
 echo
 echo "Phase 7: Running PyNEST tests"

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -360,7 +360,7 @@ if test "${MUSIC}"; then
     for test_name in $(ls ${TESTDIR} | grep '.*\.music$') ; do
         music_file="${TESTDIR}/${test_name}"
 
-        # Collect the list of SLI files from the .music file.
+        # Collect the list of SLI files from the '.music' file.
         sli_files=$(grep '\.sli' ${music_file} | sed -e "s#args=#${TESTDIR}#g")
         sli_files=$(for f in ${sli_files}; do if test -f ${f}; then echo ${f}; fi; done)
         sli_files=${sli_files//$'\n'/ }
@@ -369,7 +369,7 @@ if test "${MUSIC}"; then
         sh_file="${TESTDIR}/$(basename ${music_file} .music).sh"
         if test ! -f "${sh_file}"; then unset sh_file; fi
 
-        # Calculate the total number of processes from the .music file.
+        # Calculate the total number of processes from the '.music' file.
         np=$(($(sed -n 's/np=//p' ${music_file} | paste -sd'+' -)))
         command="$(sli -c "${np} (${MUSIC}) (${test_name}) mpirun =")"
 
@@ -378,12 +378,12 @@ if test "${MUSIC}"; then
         echo          "Running test '${test_name}' with $np $proc_txt... " >> "${TEST_LOGFILE}"
         printf '%s' "  Running test '${test_name}' with $np $proc_txt... "
 
-        # Copy everything to the tmpdir.
-        # Variables might also be empty. To prevent 'cp' from terminating with an error in such a case,
-        # exit code is suppressed.
+        # Copy everything to 'tmpdir'. 
+        # Variables might also be empty. To prevent 'cp' from terminating in such a case,
+        # the exit code is suppressed.
         cp ${music_file} ${sh_file} ${sli_files} ${tmpdir} 2>/dev/null || :
 
-        # Create the runner script in the tmpdir.
+        # Create the runner script in 'tmpdir'.
         cd "${tmpdir}"
         echo "#!/bin/sh" >  runner.sh
         echo "set +e" >> runner.sh
@@ -395,7 +395,7 @@ if test "${MUSIC}"; then
         fi
         echo "echo \$? > exit_code ; exit 0" >> runner.sh
 
-        # Run the script, measure execution time, and copy all output to the logfile.
+        # Run the script and measure execution time. Copy the output to the logfile.
         chmod 755 runner.sh
         TIME_ELAPSED=$( time_cmd ./runner.sh )
         TIME_TOTAL=$(( ${TIME_TOTAL} + ${TIME_ELAPSED} ))
@@ -405,8 +405,10 @@ if test "${MUSIC}"; then
         # or of the accompanying shell script if present.
         exit_code=$(cat exit_code)
 
-        # Count the total number of tests, the tests skipped and the tests with error.
-        # The values will be stored in the XML report when 'junit_close' is called.
+        # Count the total number of tests, the tests skipped, and the tests with error.
+        # The values will be stored in the XML report at 'junit_close'.
+        # Test failures and diagnostic information are also stored in the xml-report file 
+        # with 'unit_write'.
         JUNIT_TESTS=$(( ${JUNIT_TESTS} + 1 ))
         if test -z $(echo ${test_name} | grep failure); then
             if test $exit_code -eq 0; then

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -378,7 +378,7 @@ if test "${MUSIC}"; then
         echo          "Running test '${test_name}' with $np $proc_txt... " >> "${TEST_LOGFILE}"
         printf '%s' "  Running test '${test_name}' with $np $proc_txt... "
 
-        # Copy everything to 'tmpdir'. 
+        # Copy everything to 'tmpdir'.
         # Variables might also be empty. To prevent 'cp' from terminating in such a case,
         # the exit code is suppressed.
         cp ${music_file} ${sh_file} ${sli_files} ${tmpdir} 2>/dev/null || :

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -407,7 +407,7 @@ if test "${MUSIC}"; then
 
         # Count the total number of tests, the tests skipped, and the tests with error.
         # The values will be stored in the XML report at 'junit_close'.
-        # Test failures and diagnostic information are also stored in the xml-report file 
+        # Test failures and diagnostic information are also stored in the xml-report file
         # with 'unit_write'.
         JUNIT_TESTS=$(( ${JUNIT_TESTS} + 1 ))
         if test -z $(echo ${test_name} | grep failure); then

--- a/testsuite/junit_xml.sh
+++ b/testsuite/junit_xml.sh
@@ -95,7 +95,7 @@ junit_open ()
 
     echo '<?xml version="1.0" encoding="UTF-8" ?>' > "${JUNIT_FILE}"
 
-    echo "<testsuite errors=\"0\" failures=XXX name=\"$1\" tests=XXX skip=XXX time=XXX timestamp=\"${timestamp}\">" >> "${JUNIT_FILE}"
+    echo "<testsuite errors=\"0\" failures=XXX name=\"$1\" tests=XXX skipped=XXX time=XXX timestamp=\"${timestamp}\">" >> "${JUNIT_FILE}"
     echo '  <properties>' >> "${JUNIT_FILE}"
     echo "    <property name=\"os.arch\" value=\"${INFO_ARCH}\" />" >> "${JUNIT_FILE}"
     echo "    <property name=\"os.name\" value=\"${INFO_OS}\" />" >> "${JUNIT_FILE}"
@@ -141,7 +141,7 @@ junit_close ()
 
     portable_inplace_sed "${JUNIT_FILE}" "s/time=XXX/time=\"${TIME_TOTAL}\"/"
     portable_inplace_sed "${JUNIT_FILE}" "s/tests=XXX/tests=\"${JUNIT_TESTS}\"/"
-    portable_inplace_sed "${JUNIT_FILE}" "s/skip=XXX/skip=\"${JUNIT_SKIPS}\"/"
+    portable_inplace_sed "${JUNIT_FILE}" "s/skipped=XXX/skipped=\"${JUNIT_SKIPS}\"/"
     portable_inplace_sed "${JUNIT_FILE}" "s/failures=XXX/failures=\"${JUNIT_FAILURES}\"/"
 
     echo '  <system-out><![CDATA[]]></system-out>' >> "${JUNIT_FILE}"


### PR DESCRIPTION
This PR reactivates the MUSIC tests. It also fixes an issue with incorrect entries in the NEST test suite results table that were encountered when forcing an error condition to test the correct behavior of the test suite.

_Resolved issues:_ #1557 
_Suggested reviewer:_ @heplesser 