### PR TITLE
Use ring buffer that allows for multiple values per slot

### DIFF
--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -29,7 +29,7 @@
 #include "event.h"
 #include "nest_types.h"
 #include "recordables_map.h"
-#include "ring_buffer.h"
+#include "ring_buffer_impl.h"
 #include "universal_data_logger.h"
 
 namespace nest
@@ -266,10 +266,17 @@ private:
     Buffers_( iaf_psc_alpha& );
     Buffers_( const Buffers_&, iaf_psc_alpha& );
 
-    /** buffers and summs up incoming spikes/currents */
-    RingBuffer ex_spikes_;
-    RingBuffer in_spikes_;
-    RingBuffer currents_;
+    //! Idices for access to different channels of input_buffer_
+    enum
+    {
+      SYN_IN = 0,
+      SYN_EX,
+      I0,
+      NUM_INPUT_CHANNELS
+    };
+
+    /** buffers and sums up incoming spikes/currents */
+    MultiValueRingBuffer< NUM_INPUT_CHANNELS > input_buffer_;
 
     //! Logger for all analog data
     UniversalDataLogger< iaf_psc_alpha > logger_;

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -29,7 +29,7 @@
 #include "event.h"
 #include "nest_types.h"
 #include "recordables_map.h"
-#include "ring_buffer.h"
+#include "ring_buffer_impl.h"
 #include "universal_data_logger.h"
 
 namespace nest
@@ -292,8 +292,18 @@ private:
     Buffers_( iaf_psc_exp& );
     Buffers_( const Buffers_&, iaf_psc_exp& );
 
+    //! Idices for access to different channels of input_buffer_
+    enum
+    {
+      SYN_IN = 0,
+      SYN_EX,
+      I0,
+      I1,
+      NUM_INPUT_CHANNELS
+    };
+
     /** buffers and sums up incoming spikes/currents */
-    TestRingBuffer input_buffer_;
+    MultiValueRingBuffer< NUM_INPUT_CHANNELS > input_buffer_;
 
     //! Logger for all analog data
     UniversalDataLogger< iaf_psc_exp > logger_;

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -293,9 +293,7 @@ private:
     Buffers_( const Buffers_&, iaf_psc_exp& );
 
     /** buffers and sums up incoming spikes/currents */
-    RingBuffer spikes_ex_;
-    RingBuffer spikes_in_;
-    std::vector< RingBuffer > currents_;
+    TestRingBuffer input_buffer_;
 
     //! Logger for all analog data
     UniversalDataLogger< iaf_psc_exp > logger_;

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -57,7 +57,7 @@ set ( nestkernel_sources
       proxynode.h proxynode.cpp
       recording_device.h recording_device.cpp
       pseudo_recording_device.h
-      ring_buffer.h ring_buffer.cpp
+      ring_buffer.h ring_buffer_impl.h ring_buffer.cpp
       slice_ring_buffer.cpp slice_ring_buffer.h
       spikecounter.h spikecounter.cpp
       stimulating_device.h

--- a/nestkernel/ring_buffer.cpp
+++ b/nestkernel/ring_buffer.cpp
@@ -94,3 +94,36 @@ nest::ListRingBuffer::clear()
     buffer_[ i ].clear();
   }
 }
+
+
+nest::TestRingBuffer::TestRingBuffer()
+  : buffer_( kernel().connection_manager.get_min_delay()
+        + kernel().connection_manager.get_max_delay(),
+             std::array< double, 4 >() )
+{
+}
+
+void
+nest::TestRingBuffer::resize()
+{
+  size_t size = kernel().connection_manager.get_min_delay()
+    + kernel().connection_manager.get_max_delay();
+  if ( buffer_.size() != size )
+  {
+    buffer_.resize( size, std::array< double, 4 >() );
+  }
+}
+
+void
+nest::TestRingBuffer::clear()
+{
+  resize(); // does nothing if size is fine
+  // set all elements to 0.0
+  for ( auto it = buffer_.begin(); it < buffer_.end(); ++it )
+  {
+    for ( auto iit = (*it).begin(); iit < (*it).end(); ++iit )
+    {
+      (*iit) = 0.0;
+    }
+  }
+}

--- a/nestkernel/ring_buffer.cpp
+++ b/nestkernel/ring_buffer.cpp
@@ -94,36 +94,3 @@ nest::ListRingBuffer::clear()
     buffer_[ i ].clear();
   }
 }
-
-
-nest::TestRingBuffer::TestRingBuffer()
-  : buffer_( kernel().connection_manager.get_min_delay()
-        + kernel().connection_manager.get_max_delay(),
-             std::array< double, 4 >() )
-{
-}
-
-void
-nest::TestRingBuffer::resize()
-{
-  size_t size = kernel().connection_manager.get_min_delay()
-    + kernel().connection_manager.get_max_delay();
-  if ( buffer_.size() != size )
-  {
-    buffer_.resize( size, std::array< double, 4 >() );
-  }
-}
-
-void
-nest::TestRingBuffer::clear()
-{
-  resize(); // does nothing if size is fine
-  // set all elements to 0.0
-  for ( auto it = buffer_.begin(); it < buffer_.end(); ++it )
-  {
-    for ( auto iit = (*it).begin(); iit < (*it).end(); ++iit )
-    {
-      (*iit) = 0.0;
-    }
-  }
-}

--- a/nestkernel/ring_buffer.h
+++ b/nestkernel/ring_buffer.h
@@ -354,59 +354,26 @@ ListRingBuffer::get_index_( const delay d ) const
 }
 
 
-class TestRingBuffer
+template < unsigned int num_values >
+class MultiValueRingBuffer
 {
 public:
-  TestRingBuffer();
+  MultiValueRingBuffer();
 
-  void add_value( const long idx1, const long idx2, const double val );
+  void add_value( const long idx0, const long idx1, const double val );
 
-  void set_value( const long idx1, const long idx2, const double val );
-
-  std::array< double, 4 >& get_values( const long idx1 );
-
-  void reset_values( const long idx1 );
+  std::array< double, num_values >& get_values( const long idx0 );
 
   void clear();
 
   void resize();
 
-  size_t
-  size() const
-  {
-    return buffer_.size();
-  }
+  size_t size() const;
 
 private:
   //! Buffered data
-  std::vector< std::array< double, 4 > > buffer_;
+  std::vector< std::array< double, num_values > > buffer_;
 };
-
-inline void
-TestRingBuffer::add_value( const long idx1, const long idx2, const double val )
-{
-  buffer_[ idx1 ][ idx2 ] += val;
-}
-
-inline void
-TestRingBuffer::set_value( const long idx1, const long idx2, const double val )
-{
-  buffer_[ idx1 ][ idx2 ] = val;
-}
-
-inline std::array< double, 4 >&
-TestRingBuffer::get_values( const long idx1 )
-{
-  assert( 0 <= idx1 and ( size_t ) idx1 < buffer_.size() );
-  return buffer_[ idx1 ];
-}
-
-inline void
-TestRingBuffer::reset_values( const long idx1 )
-{
-  assert( 0 <= idx1 and ( size_t ) idx1 < buffer_.size() );
-  memset( &buffer_[ idx1 ][0], 0, buffer_[ idx1 ].size() * sizeof buffer_[ idx1 ][0] );
-}
 
 } // namespace nest
 

--- a/nestkernel/ring_buffer.h
+++ b/nestkernel/ring_buffer.h
@@ -24,6 +24,7 @@
 #define RING_BUFFER_H
 
 // C++ includes:
+#include <array>
 #include <list>
 #include <vector>
 
@@ -351,7 +352,63 @@ ListRingBuffer::get_index_( const delay d ) const
   assert( ( size_t ) idx < buffer_.size() );
   return idx;
 }
+
+
+class TestRingBuffer
+{
+public:
+  TestRingBuffer();
+
+  void add_value( const long idx1, const long idx2, const double val );
+
+  void set_value( const long idx1, const long idx2, const double val );
+
+  std::array< double, 4 >& get_values( const long idx1 );
+
+  void reset_values( const long idx1 );
+
+  void clear();
+
+  void resize();
+
+  size_t
+  size() const
+  {
+    return buffer_.size();
+  }
+
+private:
+  //! Buffered data
+  std::vector< std::array< double, 4 > > buffer_;
+};
+
+inline void
+TestRingBuffer::add_value( const long idx1, const long idx2, const double val )
+{
+  buffer_[ idx1 ][ idx2 ] += val;
 }
+
+inline void
+TestRingBuffer::set_value( const long idx1, const long idx2, const double val )
+{
+  buffer_[ idx1 ][ idx2 ] = val;
+}
+
+inline std::array< double, 4 >&
+TestRingBuffer::get_values( const long idx1 )
+{
+  assert( 0 <= idx1 and ( size_t ) idx1 < buffer_.size() );
+  return buffer_[ idx1 ];
+}
+
+inline void
+TestRingBuffer::reset_values( const long idx1 )
+{
+  assert( 0 <= idx1 and ( size_t ) idx1 < buffer_.size() );
+  memset( &buffer_[ idx1 ][0], 0, buffer_[ idx1 ].size() * sizeof buffer_[ idx1 ][0] );
+}
+
+} // namespace nest
 
 
 #endif

--- a/nestkernel/ring_buffer_impl.h
+++ b/nestkernel/ring_buffer_impl.h
@@ -1,0 +1,80 @@
+/*
+ *  ring_buffer_impl.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef RING_BUFFER_IMPL_H
+#define RING_BUFFER_IMPL_H
+
+#include "ring_buffer.h"
+
+template < unsigned int num_values >
+nest::MultiValueRingBuffer< num_values >::MultiValueRingBuffer()
+  : buffer_( kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay(),
+      std::array< double, num_values >() )
+{
+}
+
+template < unsigned int num_values >
+void
+nest::MultiValueRingBuffer< num_values >::add_value( const long idx0, const long idx1, const double val )
+{
+  buffer_[ idx0 ][ idx1 ] += val;
+}
+
+template < unsigned int num_values >
+std::array< double, num_values >&
+nest::MultiValueRingBuffer< num_values >::get_values( const long idx0 )
+{
+  assert( 0 <= idx0 and ( size_t ) idx0 < buffer_.size() );
+  return buffer_[ idx0 ];
+}
+
+template < unsigned int num_values >
+void
+nest::MultiValueRingBuffer< num_values >::resize()
+{
+  size_t size = kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay();
+  if ( buffer_.size() != size )
+  {
+    buffer_.resize( size, std::array< double, num_values >() );
+  }
+}
+
+template < unsigned int num_values >
+void
+nest::MultiValueRingBuffer< num_values >::clear()
+{
+  resize(); // does nothing if size is fine
+  // set all elements to 0.0
+  for ( index idx0 = 0; idx0 < buffer_.size(); ++idx0 )
+  {
+    memset( &buffer_[ idx0 ][ 0 ], 0, buffer_[ idx0 ].size() * sizeof buffer_[ idx0 ][ 0 ] );
+  }
+}
+
+template < unsigned int num_values >
+size_t
+nest::MultiValueRingBuffer< num_values >::size() const
+{
+  return buffer_.size();
+}
+
+#endif


### PR DESCRIPTION
Using the new `MultiValueRingBuffer` increases cache performance of access to input buffers during neuronal update and spike delivery. Instead of using one ring buffer per input channel (e.g. exc. synapses, inh. synapses, input current), only a single ring buffer is used that stores the inputs per time slot for all input channels bunched into an array.

This PR only implements the usage of the `MultiValueRingBuffer` for the neuron models `iaf_psc_exp` and `iaf_psc_alpha`.