### PR TITLE
Remove erroneous example in NEST Tutorial

### DIFF
--- a/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -91,7 +91,7 @@ prompted for.
 
     dir(nest)
 
-One such command is ``nest.Models()`` or in ipython ``nest.Models?``, which will return a list of all
+One such command is ``nest.Models()``, which will return a list of all
 the available models you can use. If you want to obtain more information
 about a particular command, you may use Python’s standard help system.
 


### PR DESCRIPTION
`nest.Models?` in IPython would open the documentation of the `nest.Models()` function, rather than returning a list of all models (for which one needs to call `nest.Models()`).