### PR TITLE
Warn of SetStatus() between Prepare() and Cleanup() more thoroughly

### DIFF
--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -144,6 +144,7 @@ A more efficient solution doing exactly the same thing is
 
     nest.Prepare()
     for _ in range(20):
+        # don't use nest.SetStatus now! See notes
         nest.Run(10)
         # extract and analyse data
     nest.Cleanup()

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -144,7 +144,7 @@ A more efficient solution doing exactly the same thing is
 
     nest.Prepare()
     for _ in range(20):
-        # don't use nest.SetStatus now! See notes
+        # Check that there is no nest.SetStatus() being used now! See notes
         nest.Run(10)
         # extract and analyse data
     nest.Cleanup()


### PR DESCRIPTION
For me, the warning in the notes in that section was not enough. I changed some things in the simulation code I am working with, including replacing nest.Simulate() by nest.Prepare()/nest.Run()/nest.Cleanup(). After that, there was some SetStatus() between Prepare() and Cleanup(). I didn't catch the note that SetStatus() should not be called between Prepare() and Cleanup(). I continued making other changes, because the code seemed to continue to work. At some point, I realized that there were no/not enough spikes recorded anymore. Tracking down that the problem was in replacing Simulate() by Run() took me on the order of a week, and I only recognized the current warning in the documentation after reverting that change just to see what happens.