### PR TITLE
Enhance PyNEST error messages from kernel

### DIFF
--- a/pynest/nest/lib/hl_api_exceptions.py
+++ b/pynest/nest/lib/hl_api_exceptions.py
@@ -82,7 +82,8 @@ class NESTErrors(metaclass=NESTMappedException):
 
             Parameters:
             -----------
-            message: full error message to report.
+            message: str
+                full error message to report.
             """
 
             Exception.__init__(self, message)

--- a/pynest/nest/lib/hl_api_exceptions.py
+++ b/pynest/nest/lib/hl_api_exceptions.py
@@ -101,7 +101,7 @@ class NESTErrors(metaclass=NESTMappedException):
             commandname: command name from SLI.
             errormessage: message from SLI.
             """
-            message = "{} in {}{}".format(errorname, commandname, errormessage)
+            message = "{} in SLI function {}{}".format(errorname, commandname, errormessage)
             NESTErrors.NESTError.__init__(self, message)
 
             self.errorname = errorname

--- a/pynest/nest/lib/hl_api_exceptions.py
+++ b/pynest/nest/lib/hl_api_exceptions.py
@@ -77,23 +77,22 @@ class NESTErrors(metaclass=NESTMappedException):
         """Base exception class for all NEST exceptions.
         """
 
-        def __init__(self, message, *args, **kwargs):
+        def __init__(self, message):
             """Initializer for NESTError base class.
 
             Parameters:
             -----------
             message: full error message to report.
-            *args, **kwargs: passed through to Exception base class.
             """
 
-            Exception.__init__(self, message, *args, **kwargs)
+            Exception.__init__(self, message)
             self.message = message
 
     class SLIException(NESTError):
         """Base class for all exceptions coming from sli.
         """
 
-        def __init__(self, commandname, errormessage, errorname='SLIException', *args, **kwargs):
+        def __init__(self, commandname, errormessage, errorname='SLIException'):
             """Initialize function.
 
             Parameters:
@@ -101,10 +100,9 @@ class NESTErrors(metaclass=NESTMappedException):
             errorname: error name from SLI.
             commandname: command name from SLI.
             errormessage: message from SLI.
-            *args, **kwargs: passed through to NESTErrors.NESTError base class.
             """
             message = "{} in {}{}".format(errorname, commandname, errormessage)
-            NESTErrors.NESTError.__init__(self, message, errorname, commandname, errormessage, *args, **kwargs)
+            NESTErrors.NESTError.__init__(self, message)
 
             self.errorname = errorname
             self.commandname = commandname


### PR DESCRIPTION
PyNEST classes for error messages that come from the kernel are corrected to correctly display messages, which fixes #1599. 

Previously, error information was passed as arguments to the constructor of the `Exception` class. However, arguments passed to the `Exception` constructor are all passed as `*args` and displayed as the error message without further processing. Passing several arguments would then make the error message a tuple with all the arguments. This PR changes the PyNEST exception classes to pass only the error message as an argument to the `Exception` class constructor.

#### Example:
```python
>>> n = nest.Create('iaf_psc_alpha')
>>> sr = nest.Create('spike_recorder')
>>> v = nest.Create('voltmeter')
>>> nest.Connect(sr, n)
nest.lib.hl_api_exceptions.IllegalConnection: IllegalConnection in SLI function Connect_g_g_D_D: Creation of connection is not possible because:
Source node does not send output.

>>> nest.Connect(v, sr)
nest.lib.hl_api_exceptions.IllegalConnection: IllegalConnection in SLI function Connect_g_g_D_D: Creation of connection is not possible because:
The target node or synapse model does not support data logging requests.
```