### PR TITLE
Fix incrementation of weight and delay in connect_arrays

### DIFF
--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -219,7 +219,7 @@ connect_arrays( long* sources,
   index synapse_model_id( kernel().model_manager.get_synapsedict()->lookup( syn_model ) );
 
   // Increments pointers to weight, delay, and receptor type, if they are specified.
-  auto increment_wd = [weights, delays]( decltype( weights ) w, decltype( delays ) d )
+  auto increment_wd = [weights, delays]( decltype( weights ) & w, decltype( delays ) & d )
   {
     if ( weights != nullptr )
     {

--- a/pynest/nest/tests/test_connect_arrays.py
+++ b/pynest/nest/tests/test_connect_arrays.py
@@ -103,6 +103,25 @@ class TestConnectArrays(unittest.TestCase):
         with self.assertRaises(ValueError):
             nest.Connect(sources, targets)
 
+    def test_connect_arrays_different_weights_delays(self):
+        """Connecting NumPy arrays with different weights and delays"""
+        n = 10
+        nest.Create('iaf_psc_alpha', n)
+        sources = np.arange(1, n+1, dtype=np.uint64)
+        targets = self.non_unique
+        weights = np.linspace(0.6, 1.5, n)
+        delays = np.linspace(0.4, 1.3, n)
+
+        nest.Connect(sources, targets, syn_spec={'weight': weights, 'delay': delays},
+                     conn_spec={'rule': 'one_to_one'})
+
+        conns = nest.GetConnections()
+
+        np.testing.assert_array_equal(conns.source, sources)
+        np.testing.assert_array_equal(conns.target, targets)
+        np.testing.assert_array_almost_equal(conns.weight, weights)
+        np.testing.assert_array_almost_equal(conns.delay, delays)
+
     def test_connect_arrays_threaded(self):
         """Connecting NumPy arrays, threaded"""
         nest.SetKernelStatus({'local_num_threads': 2})


### PR DESCRIPTION
In `connect_arrays`, incrementing the weight and delay pointers did not work, leading all connections to get the weight and delay of the first element if passing arrays of weights and delays. This PR fixes the incrementation and adds a test.