### PR TITLE
Updated Ubuntu dependency package names for old versions/trailing slashes in installation command

### DIFF
--- a/doc/installation/oldvers_install.rst
+++ b/doc/installation/oldvers_install.rst
@@ -97,8 +97,8 @@ command line::
     libreadline6-dev libncurses5-dev libgsl0-dev python3-all-dev python3-numpy \
     python3-scipy python3-matplotlib ipython3
 
-This command installs some Python 3 libraries. Python 3 support was added with NEST 2.4; some Python 2 libraries
-are not available anymore in modern Ubuntu.
+This command installs some Python 3 libraries. Python 3 support was added with
+NEST 2.4; some Python 2 libraries are not available anymore in modern Ubuntu.
 
 Then configure NEST using::
 

--- a/doc/installation/oldvers_install.rst
+++ b/doc/installation/oldvers_install.rst
@@ -90,12 +90,15 @@ configure it:
 Standard configuration
 -------------------------
 
-To install the packages required for the standard installation use the following
+To install the packages required for the standard installation, use the following
 command line::
 
     sudo apt-get install build-essential autoconf automake libtool libltdl7-dev \
-    libreadline6-dev libncurses5-dev libgsl0-dev python-all-dev python-numpy \
+    libreadline6-dev libncurses5-dev libgsl0-dev python3-all-dev python3-numpy \
     python3-scipy python3-matplotlib ipython3
+
+This command installs some Python 3 libraries. Python 3 support was added with NEST 2.4; some Python 2 libraries
+are not available anymore in modern Ubuntu.
 
 Then configure NEST using::
 

--- a/doc/installation/oldvers_install.rst
+++ b/doc/installation/oldvers_install.rst
@@ -97,7 +97,7 @@ command line::
     libreadline6-dev libncurses5-dev libgsl0-dev python3-all-dev python3-numpy \
     python3-scipy python3-matplotlib ipython3
 
-This command installs some Python 3 libraries. Python 3 support was added with
+This command installs Python 3 libraries. Python 3 support was added with
 NEST 2.4; some Python 2 libraries are not available anymore in modern Ubuntu.
 
 Then configure NEST using::

--- a/doc/installation/oldvers_install.rst
+++ b/doc/installation/oldvers_install.rst
@@ -93,9 +93,9 @@ Standard configuration
 To install the packages required for the standard installation use the following
 command line::
 
-    sudo apt-get install build-essential autoconf automake libtool libltdl7-dev
-    libreadline6-dev libncurses5-dev libgsl0-dev python-all-dev python-numpy
-    python-scipy python-matplotlib ipython
+    sudo apt-get install build-essential autoconf automake libtool libltdl7-dev \
+    libreadline6-dev libncurses5-dev libgsl0-dev python-all-dev python-numpy \
+    python3-scipy python3-matplotlib ipython3
 
 Then configure NEST using::
 


### PR DESCRIPTION
Closes what is left of #1779. Also added trailing \ to the multi-line `apt-get` command.

According to the release log [here](https://www.nest-simulator.org/download/), Python 3 support was already added in NEST 2.4, so the installation instructions continue to be useful for some older versions.