### PR TITLE
Disabling the build artefacts upload on to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,19 +218,19 @@ before_deploy:
      fi
 
 # S3 Deployment (Uploading the Travis CI build artefacts to Amazon S3).
-deploy:
-  provider: s3
-  access_key_id:
-    secure: $ARTIFACTS_KEY
-  secret_access_key:
-    secure: $ARTIFACTS_SECRET
-  bucket: "nest-travis-artefacts"
-  region: eu-central-1
-  skip_cleanup: true
-  on:
-    repo: nest/nest-simulator
-    branch: master
-    condition: $xNEST_BUILD_TYPE != STATIC_CODE_ANALYSIS
-  local-dir: "$TRAVIS_BUILD_DIR/build/artefacts_upload"
-  upload-dir: "$TRAVIS_REPO_SLUG/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER"
-  acl: bucket_owner_full_control
+#deploy:
+#  provider: s3
+#  access_key_id:
+#    secure: $ARTIFACTS_KEY
+#  secret_access_key:
+#    secure: $ARTIFACTS_SECRET
+#  bucket: "nest-travis-artefacts"
+#  region: eu-central-1
+#  skip_cleanup: true
+#  on:
+#    repo: nest/nest-simulator
+#    branch: master
+#    condition: $xNEST_BUILD_TYPE != STATIC_CODE_ANALYSIS
+#  local-dir: "$TRAVIS_BUILD_DIR/build/artefacts_upload"
+#  upload-dir: "$TRAVIS_REPO_SLUG/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER"
+#  acl: bucket_owner_full_control


### PR DESCRIPTION
Immediate fix for the S3 access key issue which prevents the build artefacts upload on to S3 and thereby failing the merge commit builds.  As we would have a new upload setup soon, it is better to disable the S3 deployment at the moment.