### PR TITLE
Support slicing of NodeCollections in NEST Server

### DIFF
--- a/examples/NESTServerClient/examples/NESTClient_example.py
+++ b/examples/NESTServerClient/examples/NESTClient_example.py
@@ -21,7 +21,7 @@
 
 from NESTServerClient import NESTServerClient
 
-print('Showing examples of client for NEST Server')
+print('Running client examples using NEST via NEST Server')
 
 # Load NEST Server client
 nestsc = NESTServerClient()

--- a/examples/NESTServerClient/examples/NESTClient_example.py
+++ b/examples/NESTServerClient/examples/NESTClient_example.py
@@ -21,14 +21,17 @@
 
 from NESTServerClient import NESTServerClient
 
+print('Showing examples of client for NEST Server')
 
-#
-# Use api from NEST Server
-#
-
-
-# API interface for NEST Server
+# Load NEST Server client
 nestsc = NESTServerClient()
+
+#
+# Use NEST Server API
+#
+print('\n')
+print('Execute script code with NEST Server API')
+print('-'*20)
 
 # Reset kernel
 nestsc.ResetKernel()
@@ -40,10 +43,10 @@ sr = nestsc.Create("spike_recorder")
 
 # Connect nodes
 nestsc.Connect(pg, neurons, syn_spec={'weight': 10.})
-nestsc.Connect(neurons, sr)
+nestsc.Connect(neurons[::10], sr)
 
 # Simulate
-nestsc.Simulate(1000.0)
+nestsc.Simulate(1000.)
 
 # Get events
 n_events = nestsc.GetStatus(sr, 'n_events')[0]
@@ -51,9 +54,11 @@ print('Number of events:', n_events)
 
 
 #
-# Use exec from NEST Server
+# Use NEST Server exec
 #
+print('\n')
+print('Execute script code from file')
+print('-'*20)
 
-
-n_events = nestsc.from_file('NESTClient_script', 'n_events')
+n_events = nestsc.from_file('NESTClient_script.py', 'n_events')['data']
 print('Number of events:', n_events)

--- a/examples/NESTServerClient/examples/NESTClient_example.py
+++ b/examples/NESTServerClient/examples/NESTClient_example.py
@@ -46,7 +46,7 @@ nestsc.Connect(pg, neurons, syn_spec={'weight': 10.})
 nestsc.Connect(neurons[::10], sr)
 
 # Simulate
-nestsc.Simulate(1000.)
+nestsc.Simulate(1000.0)
 
 # Get events
 n_events = nestsc.GetStatus(sr, 'n_events')[0]

--- a/examples/NESTServerClient/examples/NESTClient_script.py
+++ b/examples/NESTServerClient/examples/NESTClient_script.py
@@ -32,7 +32,7 @@ sr = nest.Create("spike_recorder")
 
 # Connect nodes
 nest.Connect(pg, neurons, syn_spec={"weight": 10.})
-nest.Connect(neurons, sr)
+nest.Connect(neurons[::10], sr)
 
 # Simulate
 nest.Simulate(1000.)

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -37,6 +37,8 @@ import RestrictedPython
 import os
 MODULES = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
 RESTRICTION_OFF = bool(os.environ.get('NEST_SERVER_RESTRICTION_OFF', False))
+EXCEPTION_ERROR_STATUS = 400
+NEST_ERROR_STATUS = 400
 
 if RESTRICTION_OFF:
     print('*** WARNING: NEST Server is run without a RestrictedPython trusted environment. ***')
@@ -48,6 +50,7 @@ __all__ = [
 
 app = Flask(__name__)
 CORS(app)
+
 
 
 @app.route('/', methods=['GET'])
@@ -89,9 +92,11 @@ def route_exec():
         return jsonify(response)
 
     except nest.kernel.NESTError as e:
-        abort(Response(getattr(e, 'errormessage'), 400))
+        print('NEST error: {}'.format(e))
+        abort(Response(getattr(e, 'errormessage'), NEST_ERROR_STATUS))
     except Exception as e:
-        abort(Response(str(e), 400))
+        print('Error: {}'.format(e))
+        abort(Response(str(e), EXCEPTION_ERROR_STATUS))
 
 
 # --------------------------
@@ -190,11 +195,14 @@ def get_or_error(func):
         try:
             return func(call, args, kwargs)
         except nest.kernel.NESTError as e:
-            abort(Response(getattr(e, 'errormessage'), 400))
+            print('NEST error: {}'.format(e))
+            abort(Response(getattr(e, 'errormessage'), NEST_ERROR_STATUS))
         except TypeError as e:
-            abort(Response(str(e), 400))
+            print('Type error: {}'.format(e))
+            abort(Response(str(e), EXCEPTION_ERROR_STATUS))
         except Exception as e:
-            abort(Response(str(e), 400))
+            print('Error: {}'.format(e))
+            abort(Response(str(e), EXCEPTION_ERROR_STATUS))
     return func_wrapper
 
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -191,6 +191,8 @@ def get_or_error(func):
             return func(call, args, kwargs)
         except nest.kernel.NESTError as e:
             abort(Response(getattr(e, 'errormessage'), 400))
+        except TypeError as e:
+            abort(Response(str(e), 400))
         except Exception as e:
             abort(Response(str(e), 400))
     return func_wrapper
@@ -202,7 +204,8 @@ def get_restricted_globals():
     def getitem(obj, index):
         if obj is not None and type(obj) in (list, tuple, dict, nest.NodeCollection):
             return obj[index]
-        raise Exception('Error raised in getting restricted globals. The object {} was not identified.'.format(obj))
+        raise TypeError(
+          'Error raised in getting restricted globals. The object {} was not identified.'.format(obj))
 
     restricted_builtins = RestrictedPython.safe_builtins.copy()
     restricted_builtins.update(RestrictedPython.limited_builtins)

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -211,8 +211,8 @@ def get_restricted_globals():
     def getitem(obj, index):
         if obj is not None and type(obj) in (list, tuple, dict, nest.NodeCollection):
             return obj[index]
-        raise TypeError(
-          'Error raised in getting restricted globals. The object {} was not identified.'.format(obj))
+        msg = f"Error while getting restricted globals: unidentified object '{obj}'."
+        raise TypeError(msg)
 
     restricted_builtins = RestrictedPython.safe_builtins.copy()
     restricted_builtins.update(RestrictedPython.limited_builtins)

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -52,7 +52,6 @@ app = Flask(__name__)
 CORS(app)
 
 
-
 @app.route('/', methods=['GET'])
 def index():
     return jsonify({'nest': nest.version()})

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -200,9 +200,9 @@ def get_restricted_globals():
     """ Get restricted globals for exec function.
     """
     def getitem(obj, index):
-        if obj is not None and type(obj) in (list, tuple, dict):
+        if obj is not None and type(obj) in (list, tuple, dict, nest.NodeCollection):
             return obj[index]
-        raise Exception()
+        raise Exception('Error raised in getting restricted globals. The object {} was not identified.'.format(obj))
 
     restricted_builtins = RestrictedPython.safe_builtins.copy()
     restricted_builtins.update(RestrictedPython.limited_builtins)


### PR DESCRIPTION
This PR fixed bug in NEST Server Client.
Previously, the exec function in NEST Server was not able to slice NodeCollection. 

Additionally, examples was updated for NEST Server Client.