### PR TITLE
Fix SetKernelStatus examples in documentation

### DIFF
--- a/doc/faqs/faqs.rst
+++ b/doc/faqs/faqs.rst
@@ -53,12 +53,12 @@ Where does data get stored
 By default, the data files produced by NEST are stored in the directory
 from where NEST is called. The location can be changed by changing the
 property ``data_path`` of the root node using
-``nest.SetKernelStatus("data_path", "/path/to/data")``. This property
+``nest.SetKernelStatus({"data_path": "/path/to/data"})``. This property
 can also be set using the environment variable ``NEST_DATA_PATH``.
 Please note that the directory ``/path/to/data`` has to exist. A common
 prefix for all data files can be set using the property ``data_prefix``
 of the root node by calling
-``nest.SetKernelStatus("data_prefix", "prefix")`` or setting the
+``nest.SetKernelStatus({"data_prefix": "prefix"})`` or setting the
 environment variable ``NEST_DATA_PREFIX``.
 
 Neuron models

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -11,7 +11,7 @@ resolution* (default 0.1ms) and can be set using ``SetKernelStatus``:
 
 ::
 
-    SetKernelStatus("resolution", 0.1)
+    SetKernelStatus({"resolution": 0.1})
 
 Even though a neuron model can use smaller time steps internally, the
 membrane potential will only be visible to a ``multimeter`` on the
@@ -85,12 +85,11 @@ the easiest way to assert its integrity is to not change its size after
 initialization. Thus, we freeze the delay extrema after the first call
 to ``Simulate``. To still allow adding new connections inbetween calls
 to ``Simulate``, the required boundaries of delays can be set manually
-using ``SetKernelStatus`` (Please note that the delay extrema are set as
-properties of the synapse model):
+using ``SetKernelStatus``:
 
 ::
 
-    SetDefaults("static_synapse", {"min_delay": 0.5, "max_delay": 2.5})
+    SetKernelStatus({"min_delay": 0.5, "max_delay": 2.5})
 
 These settings should be used with care, though: setting the delay
 extrema too wide without need leads to decreased performance due to more


### PR DESCRIPTION
The ``min_delay`` and ``max_delay`` API seems to have changed at one point; could someone confirm that the new method (using GetKernelStatus) is correct?