### PR TITLE
Add PyNEST version dunder

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     pass
 
-__version__ = version()
+__version__ = ll_api.sli_func("statusdict /version get")
 
 
 def test():

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -44,6 +44,8 @@ try:
 except ImportError:
     pass
 
+__version__ = version()
+
 
 def test():
     """Runs all PyNEST unit tests."""

--- a/pynest/nest/hl_api.py
+++ b/pynest/nest/hl_api.py
@@ -102,5 +102,4 @@ __all__ = [
     'message',
     'set_verbosity',
     'sysinfo',
-    'version',
 ]

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -43,7 +43,6 @@ __all__ = [
     'SetStatus',
     'set_verbosity',
     'sysinfo',
-    'version',
 ]
 
 
@@ -54,20 +53,6 @@ def sysinfo():
     """
 
     sr("sysinfo")
-
-
-@check_stack
-def version():
-    """Return the NEST version.
-
-    Returns
-    -------
-    str
-        The version of NEST
-
-    """
-
-    return sli_func("statusdict /version get")
 
 
 @check_stack
@@ -138,7 +123,7 @@ def help(obj=None, pager=None, return_text=False):
               "Type 'nest.Models()' to see a list of available models in NEST.\n"
               "Type 'nest.authors()' for information about the makers of NEST.\n"
               "Type 'nest.sysinfo()' to see details on the system configuration.\n"
-              "Type 'nest.version()' for information about the NEST version.\n"
+              "Type 'nest.__version__' for information about the NEST version.\n"
               "\n"
               "For more information visit https://www.nest-simulator.org.")
 

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -67,8 +67,7 @@ def version():
 
     """
 
-    sr("statusdict [[ /kernelname /version ]] get")
-    return " ".join(spp())
+    return sli_func("statusdict /version get")
 
 
 @check_stack

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -52,7 +52,7 @@ CORS(app)
 
 @app.route('/', methods=['GET'])
 def index():
-    return jsonify({'nest': nest.version()})
+    return jsonify({'nest': nest.__version__})
 
 
 @app.route('/exec', methods=['GET', 'POST'])


### PR DESCRIPTION
Adds a version dunder and removes `NEST` from the version string.
```python
>>> import nest
>>> print(nest.__version__)
'2.20.0'
```
Fixes #1348. 