### PR TITLE
Fix Part 4 tutorial link

### DIFF
--- a/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -22,7 +22,7 @@ sections of this primer:
 -  :doc:`Part 3: Connecting networks with
    synapses <part_3_connecting_networks_with_synapses>`
 -  :doc:`Part 4: Topologically structured
-   networks <part_4_topologically_structured_networks>`
+   networks <part_4_spatially_structured_networks>`
 
 More advanced examples can be found at `Example
 Networks <https://www.nest-simulator.org/more-example-networks/>`__, or

--- a/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -21,7 +21,7 @@ sections of this primer:
 -  :doc:`Part 2: Populations of neurons <part_2_populations_of_neurons>`
 -  :doc:`Part 3: Connecting networks with
    synapses <part_3_connecting_networks_with_synapses>`
--  :doc:`Part 4: Topologically structured
+-  :doc:`Part 4: Spatially structured
    networks <part_4_spatially_structured_networks>`
 
 More advanced examples can be found at `Example

--- a/doc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
+++ b/doc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
@@ -23,7 +23,7 @@ sections of this primer:
    networks <part_1_neurons_and_simple_neural_networks>`
 -  :doc:`Part 3: Connecting networks with
    synapses <part_3_connecting_networks_with_synapses>`
--  :doc:`Part 4: Topologically structured
+-  :doc:`Part 4: Spatially structured
    networks <part_4_spatially_structured_networks>`
 
 More advanced examples can be found at `Example

--- a/doc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
+++ b/doc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
@@ -24,7 +24,7 @@ sections of this primer:
 -  :doc:`Part 3: Connecting networks with
    synapses <part_3_connecting_networks_with_synapses>`
 -  :doc:`Part 4: Topologically structured
-   networks <part_4_topologically_structured_networks>`
+   networks <part_4_spatially_structured_networks>`
 
 More advanced examples can be found at `Example
 Networks <https://www.nest-simulator.org/more-example-networks/>`__, or

--- a/doc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
+++ b/doc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
@@ -20,7 +20,7 @@ sections of this primer:
    networks <part_1_neurons_and_simple_neural_networks>`
 -  :doc:`Part 2: Populations of neurons <part_2_populations_of_neurons>`
 -  :doc:`Part 4: Topologically structured
-   networks <part_4_topologically_structured_networks>`
+   networks <part_4_spatially_structured_networks>`
 
 More advanced examples can be found at `Example
 Networks <https://www.nest-simulator.org/more-example-networks/>`__, or

--- a/doc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
+++ b/doc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
@@ -19,7 +19,7 @@ sections of this primer:
 -  :doc:`Part 1: Neurons and simple neural
    networks <part_1_neurons_and_simple_neural_networks>`
 -  :doc:`Part 2: Populations of neurons <part_2_populations_of_neurons>`
--  :doc:`Part 4: Topologically structured
+-  :doc:`Part 4: Spatially structured
    networks <part_4_spatially_structured_networks>`
 
 More advanced examples can be found at `Example


### PR DESCRIPTION
This PR updates the broken ``Part 4: Spatially structured networks`` tutorial link.