### PR TITLE
Fix measurement of presimulation time in PyNEST Potjans_2014

### DIFF
--- a/pynest/examples/Potjans_2014/run_microcircuit.py
+++ b/pynest/examples/Potjans_2014/run_microcircuit.py
@@ -100,7 +100,7 @@ print(
         time_create) +
     '  Time to presimulate: {:.3f} s\n'.format(
         time_presimulate -
-        time_create) +
+        time_connect) +
     '  Time to simulate:    {:.3f} s\n'.format(
         time_simulate -
         time_presimulate) +


### PR DESCRIPTION
This PR fixes the measurement of the presimulation time which accidentally included the time to connect.