### PR TITLE
Fix typo in stdp_connection.h

### DIFF
--- a/models/stdp_connection.h
+++ b/models/stdp_connection.h
@@ -44,7 +44,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Synapse type for spike-timing dependent plastiicty
+Synapse type for spike-timing dependent plasticity
 
 Description
 +++++++++++


### PR DESCRIPTION
This PR fixes a small typo in the short description of ``stdp_connection.h``.