### PR TITLE
Add table to spike_recorder documentation

### DIFF
--- a/doc/guides/recording_from_simulations.rst
+++ b/doc/guides/recording_from_simulations.rst
@@ -94,7 +94,7 @@ instance:
 
  stop
    A floating point number (default: `infinity`) specifying the
-   deactication time in ms, relative to `origin`. The value of `stop`
+   deactivation time in ms, relative to `origin`. The value of `stop`
    must be greater than or equal to `start`
 
 Recorders for every-day situations

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -64,9 +64,6 @@ spike creation rather than that of their arrival.
 The call to ``Connect`` will fail if the connection direction is
 reversed (i.e., connecting *sr* to *neurons*).
 
-To learn more about recording devices in NEST, please refer to the
-:doc:`../guides/recording_from_simulations` guide.
-
 Properties
 ++++++++++
 
@@ -91,6 +88,9 @@ All recorders have a set of common properties that can be set using
               deactivation time in ms, relative to origin. The value of stop
               must be greater than or equal to start
 ===========  ======================================================================
+
+To learn more about recording devices in NEST, please refer to the
+:doc:`../guides/recording_from_simulations` guide.
 
 EndUserDocs */
 

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -64,6 +64,9 @@ spike creation rather than that of their arrival.
 The call to ``Connect`` will fail if the connection direction is
 reversed (i.e., connecting *sr* to *neurons*).
 
+To learn more about recording devices in NEST, please refer to the
+:doc:`../guides/recording_from_simulations` guide.
+
 EndUserDocs */
 
 namespace nest

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -67,7 +67,7 @@ reversed (i.e., connecting *sr* to *neurons*).
 To learn more about recording devices in NEST, please refer to the
 :doc:`../guides/recording_from_simulations` guide.
 
-Parameters
+Properties
 ++++++++++
 
 All recorders have a set of common properties that can be set using

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -88,7 +88,7 @@ All recorders have a set of common properties that can be set using
  start        A positive floating point number (default: `0.0`) specifying the
               activation time in ms, relative to origin.
  stop         A floating point number (default: `infinity`) specifying the
-              deactication time in ms, relative to origin. The value of stop
+              deactivation time in ms, relative to origin. The value of stop
               must be greater than or equal to start
 ===========  ======================================================================
 

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -89,7 +89,7 @@ All recorders have a set of common properties that can be set using
               must be greater than or equal to start
 ===========  ======================================================================
 
-To learn more about recording devices in NEST, please refer to the
+To learn more about recording devices and backends in NEST, please refer to the
 :doc:`../guides/recording_from_simulations` guide.
 
 EndUserDocs */

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -71,7 +71,7 @@ All recorders have a set of common properties that can be set using
 ``SetDefaults`` on the model class or ``SetStatus`` on a device instance:
 
 ===========  ======================================================================
- label        A string (default: `“”`) specifying an arbitrary textual label for
+ label        A string (default: `""`) specifying an arbitrary textual label for
               the device. Recording backends might use the label to generate
               device specific identifiers like filenames and such.
  n_events     The number of events that were collected by the recorder can be
@@ -79,7 +79,7 @@ All recorders have a set of common properties that can be set using
               reset to 0. Other values cannot be set.
  origin       A positive floating point number (default : `0.0`) used as the
               reference time for `start` and `stop`.
- record_to    A string (default: `“memory”`) containing the name of the recording
+ record_to    A string (default: `"memory"`) containing the name of the recording
               backend where to write data to. An empty string turns all
               recording of individual events off.
  start        A positive floating point number (default: `0.0`) specifying the

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -67,6 +67,31 @@ reversed (i.e., connecting *sr* to *neurons*).
 To learn more about recording devices in NEST, please refer to the
 :doc:`../guides/recording_from_simulations` guide.
 
+Parameters
+++++++++++
+
+All recorders have a set of common properties that can be set using
+``SetDefaults`` on the model class or ``SetStatus`` on a device instance:
+
+===========  ======================================================================
+ label        A string (default: `“”`) specifying an arbitrary textual label for
+              the device. Recording backends might use the label to generate
+              device specific identifiers like filenames and such.
+ n_events     The number of events that were collected by the recorder can be
+              read out of the `n_events` entry. The number of events can be
+              reset to 0. Other values cannot be set.
+ origin       A positive floating point number (default : `0.0`) used as the
+              reference time for `start` and `stop`.
+ record_to    A string (default: `“memory”`) containing the name of the recording
+              backend where to write data to. An empty string turns all
+              recording of individual events off.
+ start        A positive floating point number (default: `0.0`) specifying the
+              activation time in ms, relative to origin.
+ stop         A floating point number (default: `infinity`) specifying the
+              deactication time in ms, relative to origin. The value of stop
+              must be greater than or equal to start
+===========  ======================================================================
+
 EndUserDocs */
 
 namespace nest


### PR DESCRIPTION
This PR adds a configuration table to the ``spike_recorder`` documentation, as discussed offline in the NEST Doc Meeting. It also includes a link to the "Recording from simulations" guide.