### PR TITLE
Fix typo in IMapFunction::backtrace

### DIFF
--- a/sli/sliarray.cc
+++ b/sli/sliarray.cc
@@ -941,7 +941,7 @@ SLIArrayModule::IMapFunction::backtrace( SLIInterpreter* i, int p ) const
   assert( id != NULL );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count == NULL );
+  assert( count != NULL );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
   assert( pd != NULL );

--- a/sli/sliarray.cc
+++ b/sli/sliarray.cc
@@ -1061,7 +1061,7 @@ SLIArrayModule::IMap_ivFunction::backtrace( SLIInterpreter* i, int p ) const
   assert( id != NULL );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count == NULL );
+  assert( count != NULL );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
   assert( pd != NULL );
@@ -1200,7 +1200,7 @@ SLIArrayModule::IMap_dvFunction::backtrace( SLIInterpreter* i, int p ) const
   assert( id != NULL );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count == NULL );
+  assert( count != NULL );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
   assert( pd != NULL );


### PR DESCRIPTION
Executing some mpi tests in debug mode (e.g. sli -d mpitests/test_all_to_all.sli) resulted in

sli: nest-simulator/sli/sliarray.cc:944: void SLIArrayModule::IMapFunction::backtrace(SLIInterpreter *, int) const: Assertion `count == NULL' failed.

Since line 949 access variable count, the assertion should not be NULL.
Changing == to != in line 944, the error disappeared.

This is also somewhat related to issue #784, where the same message was observed.