### PR TITLE
Fix int/float data type check

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -75,7 +75,6 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
   skip_syn_params_ = {
     names::weight, names::delay, names::min_delay, names::max_delay, names::num_connections, names::synapse_model
   };
-  integer_params_ = { names::receptor_type, names::music_channel, names::synapse_label };
 
   default_weight_.resize( syn_specs.size() );
   default_delay_.resize( syn_specs.size() );
@@ -523,12 +522,8 @@ nest::ConnBuilder::set_synapse_params( DictionaryDatum syn_defaults, DictionaryD
 
       for ( auto param : synapse_params_[ indx ] )
       {
-        if ( integer_params_.find( param.first ) != integer_params_.end() )
+        if ( param.second->provides_long() )
         {
-          if ( not param.second->provides_long() )
-          {
-            throw BadParameter( param.first.toString() + " must be given as integer." );
-          }
           ( *param_dicts_[ indx ][ tid ] )[ param.first ] = Token( new IntegerDatum( 0 ) );
         }
         else

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -235,9 +235,6 @@ private:
   //! synapse-specific parameters that should be skipped when we set default synapse parameters
   std::set< Name > skip_syn_params_;
 
-  //! synapse-specific parameters that must be integers
-  std::set< Name > integer_params_;
-
   /**
    * Collects all array parameters in a vector.
    *


### PR DESCRIPTION
Fixes #1352.

@alberto-antonietti: it was already some time ago that you filed this issue, I don't know if we could still ask you to check if the fix works for you?

Currently, only three white-listed synapse parameters are allowed to be integers (or longs). This means that if a custom parameter of type int is added, the type check will actually try to verify that it is a float, rather than an int. This is because it is outside the whitelist.

This PR removes the whitelist entirely. I have verified that trying to set the ``receptor_type`` to a floating-point value still raises a type error as expected (int expected, float provided).