### PR TITLE
Softer checks for compiler warnings in CI

### DIFF
--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -215,6 +215,10 @@ echo "MSGBLD0232: Setting configuration variables."
 # set above based on the ones set in the build stage matrix in
 # '.travis.yml'.
 
+# Compile with warnings by default, but turn off if building against
+# libraries triggering many warnings.
+COMPILE_WITH_WARNINGS="ON"
+
 if [ "$xOPENMP" = "1" ] ; then
     CONFIGURE_OPENMP="-Dwith-openmp=ON"
 else
@@ -223,6 +227,7 @@ fi
 
 if [ "$xMPI" = "1" ] ; then
     CONFIGURE_MPI="-Dwith-mpi=ON"
+    COMPILE_WITH_WARNINGS="OFF"
 else
     CONFIGURE_MPI="-Dwith-mpi=OFF"
 fi
@@ -245,6 +250,7 @@ if [ "$xMUSIC" = "1" ] ; then
     CONFIGURE_MUSIC="-Dwith-music=$HOME/.cache/music.install"
     chmod +x extras/install_music.sh
     ./extras/install_music.sh
+    COMPILE_WITH_WARNINGS="OFF"
 else
     CONFIGURE_MUSIC="-Dwith-music=OFF"
 fi
@@ -292,9 +298,11 @@ if [ "$xLIBNEUROSIM" = "1" ] ; then
     else
         export LD_LIBRARY_PATH=$HOME/.cache/csa.install/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     fi
+    COMPILE_WITH_WARNINGS="OFF"
 else
     CONFIGURE_LIBNEUROSIM="-Dwith-libneurosim=OFF"
 fi
+
 
 cp extras/nestrc.sli ~/.nestrc
 # Explicitly allow MPI oversubscription. This is required by Open MPI versions > 3.0.
@@ -318,7 +326,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX="$NEST_RESULT" \
     -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
     -Dwith-optimize=ON \
-    -Dwith-warning=ON \
+    -Dwith-warning="$COMPILE_WITH_WARNINGS" \
     $CONFIGURE_BOOST \
     $CONFIGURE_OPENMP \
     $CONFIGURE_MPI \


### PR DESCRIPTION
The recently introduced check for the number of compiler warnings appears too strict, since in particular the inclusion of external libraries can lead to large numbers of warnings with the exact number depending on details of header file inclusion. This leads to failing CI tests for rather obscure reasons and is thus counterproductive.

This PR addresses this in two ways:
1. The number of warnings is only checked when building without external dependencies. In this case we have 8 warnings at present; the test now accepts any number of warnings <= 8.
1. NEST is built (on Travis) with warnings=OFF if built with MPI, MUSIC or libneurosim as these cases trigger a large number of warnings, leading to unnecessarily bloated build logs.

@lekshmideepu This will solve the problem causing #5437.5 to fail for PR #1839.