### PR TITLE
Fix Wundefined-var-template warnings

### DIFF
--- a/nestkernel/layer.h
+++ b/nestkernel/layer.h
@@ -512,6 +512,7 @@ protected:
   MaskDatum mask_;
 };
 
+// Must define these static members here to avoid linker errors and Wundefined-var-template warnings.
 template < int D >
 std::shared_ptr< Ntree< D, index > > Layer< D >::cached_ntree_;
 template < int D >

--- a/nestkernel/layer.h
+++ b/nestkernel/layer.h
@@ -512,6 +512,11 @@ protected:
   MaskDatum mask_;
 };
 
+template < int D >
+std::shared_ptr< Ntree< D, index > > Layer< D >::cached_ntree_;
+template < int D >
+std::vector< std::pair< Position< D >, index > >* Layer< D >::cached_vector_ = 0;
+
 inline void
 AbstractLayer::set_node_collection( NodeCollectionPTR node_collection )
 {

--- a/nestkernel/layer_impl.h
+++ b/nestkernel/layer_impl.h
@@ -38,12 +38,6 @@ namespace nest
 {
 
 template < int D >
-std::shared_ptr< Ntree< D, index > > Layer< D >::cached_ntree_;
-
-template < int D >
-std::vector< std::pair< Position< D >, index > >* Layer< D >::cached_vector_ = 0;
-
-template < int D >
 Position< D >
 Layer< D >::compute_displacement( const Position< D >& from_pos, const Position< D >& to_pos ) const
 {


### PR DESCRIPTION
Moved definitions of static members from layer_impl.h to layer.h to fix `Wundefined-var-template` warnings when compiling with Clang.