### PR TITLE
Remove stray occurrences of double_t

### DIFF
--- a/models/erfc_neuron.h
+++ b/models/erfc_neuron.h
@@ -128,10 +128,10 @@ class gainfunction_erfc
 {
 private:
   /** threshold of activation function */
-  double_t theta_;
+  double theta_;
 
   /** 1/sqrt(2pi) x inverse of the maximal slope of gain function */
-  double_t sigma_;
+  double sigma_;
 
 public:
   /** sets default parameters */
@@ -145,10 +145,10 @@ public:
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
   void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
-  bool operator()( librandom::RngPtr rng, double_t h );
+  bool operator()( librandom::RngPtr rng, double h );
 };
 
-inline bool gainfunction_erfc::operator()( librandom::RngPtr rng, double_t h )
+inline bool gainfunction_erfc::operator()( librandom::RngPtr rng, double h )
 {
   return rng->drand() < 0.5 * erfc( -( h - theta_ ) / ( sqrt( 2. ) * sigma_ ) );
 }

--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -61,7 +61,7 @@ void
 nest::inhomogeneous_poisson_generator::Parameters_::get( DictionaryDatum& d ) const
 {
   const size_t n_rates = rate_times_.size();
-  std::vector< double_t >* times_ms = new std::vector< double_t >();
+  std::vector< double >* times_ms = new std::vector< double >();
   times_ms->reserve( n_rates );
   for ( size_t n = 0; n < n_rates; ++n )
   {
@@ -69,12 +69,12 @@ nest::inhomogeneous_poisson_generator::Parameters_::get( DictionaryDatum& d ) co
   }
 
   ( *d )[ names::rate_times ] = DoubleVectorDatum( times_ms );
-  ( *d )[ names::rate_values ] = DoubleVectorDatum( new std::vector< double_t >( rate_values_ ) );
+  ( *d )[ names::rate_values ] = DoubleVectorDatum( new std::vector< double >( rate_values_ ) );
   ( *d )[ names::allow_offgrid_times ] = BoolDatum( allow_offgrid_times_ );
 }
 
 void
-nest::inhomogeneous_poisson_generator::Parameters_::assert_valid_rate_time_and_insert( const double_t t )
+nest::inhomogeneous_poisson_generator::Parameters_::assert_valid_rate_time_and_insert( const double t )
 {
   Time t_rate;
 
@@ -113,7 +113,7 @@ void
 nest::inhomogeneous_poisson_generator::Parameters_::set( const DictionaryDatum& d, Buffers_& b, Node* )
 {
   const bool times = d->known( names::rate_times );
-  const bool rates = updateValue< std::vector< double_t > >( d, names::rate_values, rate_values_ );
+  const bool rates = updateValue< std::vector< double > >( d, names::rate_values, rate_values_ );
 
   // if offgrid flag changes, it must be done so either before any rates are
   // set or when setting new rates (which removes old ones)
@@ -144,7 +144,7 @@ nest::inhomogeneous_poisson_generator::Parameters_::set( const DictionaryDatum& 
     return;
   }
 
-  const std::vector< double_t > d_times = getValue< std::vector< double_t > >( d->lookup( names::rate_times ) );
+  const std::vector< double > d_times = getValue< std::vector< double > >( d->lookup( names::rate_times ) );
 
   if ( d_times.empty() )
   {
@@ -163,7 +163,7 @@ nest::inhomogeneous_poisson_generator::Parameters_::set( const DictionaryDatum& 
   // align them to the grid if necessary and insert them
 
   // handle first rate time, and insert it
-  std::vector< double_t >::const_iterator next = d_times.begin();
+  std::vector< double >::const_iterator next = d_times.begin();
   assert_valid_rate_time_and_insert( *next );
 
   // keep track of previous rate

--- a/models/inhomogeneous_poisson_generator.h
+++ b/models/inhomogeneous_poisson_generator.h
@@ -138,7 +138,7 @@ private:
   struct Parameters_
   {
     std::vector< Time > rate_times_;
-    std::vector< double_t > rate_values_;
+    std::vector< double > rate_values_;
 
     //! Allow and round up rate times not on steps;
     bool allow_offgrid_times_;
@@ -151,15 +151,15 @@ private:
     //!< Set values from dictionary
     void set( const DictionaryDatum&, Buffers_&, Node* );
     //!< Align rate time to grid if necessary and insert it into rate_times_
-    void assert_valid_rate_time_and_insert( const double_t t );
+    void assert_valid_rate_time_and_insert( const double t );
   };
 
   // ------------------------------------------------------------
 
   struct Buffers_
   {
-    size_t idx_;    //!< index of current amplitude
-    double_t rate_; //!< current amplitude
+    size_t idx_;  //!< index of current amplitude
+    double rate_; //!< current amplitude
   };
 
   // ------------------------------------------------------------
@@ -167,7 +167,7 @@ private:
   struct Variables_
   {
     librandom::PoissonRandomDev poisson_dev_; //!< random deviate generator
-    double_t h_;                              //! time resolution (ms)
+    double h_;                                //! time resolution (ms)
   };
 
   // ------------------------------------------------------------

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -130,8 +130,8 @@ public:
     thread target_thread,
     const synindex syn_id,
     const DictionaryDatum& params,
-    const double_t delay = numerics::nan,
-    const double_t weight = numerics::nan );
+    const double delay = numerics::nan,
+    const double weight = numerics::nan );
 
   /**
    * Connect two nodes. The source and target nodes are defined by their


### PR DESCRIPTION
This PR removes a few stray `double_t` occurrences in the code. They worked on most systems so far because `math.h` often defines this type, but it should not be used in NEST code—use just plain `double`.