### PR TITLE
Fix performance issues for weak scale benchmarks caused by creation of DictionaryDatums

### DIFF
--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -59,8 +59,8 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
   , use_pre_synaptic_element_( false )
   , use_post_synaptic_element_( false )
   , parameters_requiring_skipping_()
-  , param_dicts_()
   , dummy_param_dicts_()
+  , param_dicts_()
 {
   // read out rule-related parameters -------------------------
   //  - /rule has been taken care of above
@@ -347,7 +347,8 @@ nest::ConnBuilder::single_connect_( index snode_id, Node& target, thread target_
 
     if ( default_weight_and_delay_[ indx ] )
     {
-      kernel().connection_manager.connect( snode_id, &target, target_thread, synapse_model_id_[ indx ], dummy_param_dicts_[ target_thread ] );
+      kernel().connection_manager.connect(
+        snode_id, &target, target_thread, synapse_model_id_[ indx ], dummy_param_dicts_[ target_thread ] );
     }
     else if ( default_weight_[ indx ] )
     {
@@ -372,8 +373,13 @@ nest::ConnBuilder::single_connect_( index snode_id, Node& target, thread target_
     {
       const double delay = delays_[ indx ]->value_double( target_thread, rng, snode_id, &target );
       const double weight = weights_[ indx ]->value_double( target_thread, rng, snode_id, &target );
-      kernel().connection_manager.connect(
-        snode_id, &target, target_thread, synapse_model_id_[ indx ], dummy_param_dicts_[ target_thread ], delay, weight );
+      kernel().connection_manager.connect( snode_id,
+        &target,
+        target_thread,
+        synapse_model_id_[ indx ],
+        dummy_param_dicts_[ target_thread ],
+        delay,
+        weight );
     }
   }
 }

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -294,7 +294,7 @@ nest::ConnBuilder::disconnect()
 }
 
 void
-nest::ConnBuilder::create_param_dict_( index snode_id,
+nest::ConnBuilder::update_param_dict_( index snode_id,
   Node& target,
   thread target_thread,
   librandom::RngPtr& rng,
@@ -308,14 +308,14 @@ nest::ConnBuilder::create_param_dict_( index snode_id,
       {
         // change value of dictionary entry without allocating new datum
         IntegerDatum* id = static_cast< IntegerDatum* >(
-          ( param_dicts_[ indx ][ target_thread ][ synapse_parameter.first ] ).datum() );
+          ( ( *param_dicts_[ indx ][ target_thread ] )[ synapse_parameter.first ] ).datum() );
         ( *id ) = synapse_parameter.second->value_int( target_thread, rng, snode_id, &target );
       }
       else
       {
         // change value of dictionary entry without allocating new datum
         DoubleDatum* dd = static_cast< DoubleDatum* >(
-          ( param_dicts_[ indx ][ target_thread ][ synapse_parameter.first ] ).datum() );
+          ( ( *param_dicts_[ indx ][ target_thread ] )[ synapse_parameter.first ] ).datum() );
         ( *dd ) = synapse_parameter.second->value_double( target_thread, rng, snode_id, &target );
       }
     }
@@ -512,17 +512,17 @@ nest::ConnBuilder::set_synapse_params( DictionaryDatum syn_defaults, DictionaryD
   // create it here once to avoid re-creating the object over and over again.
     for ( thread tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )
     {
-      param_dicts_[ indx ].push_back( Dictionary() );
+      param_dicts_[ indx ].push_back( new Dictionary() );
 
       for ( auto param : synapse_params_[ indx ] )
       {
         if ( param.second->provides_long() )
         {
-          param_dicts_[ indx ][ tid ][ param.first ] = Token( new IntegerDatum( 0 ) );
+          ( *param_dicts_[ indx ][ tid ] )[ param.first ] = Token( new IntegerDatum( 0 ) );
         }
         else
         {
-          param_dicts_[ indx ][ tid ][ param.first ] = Token( new DoubleDatum( 0.0 ) );
+          ( *param_dicts_[ indx ][ tid ] )[ param.first ] = Token( new DoubleDatum( 0.0 ) );
         }
       }
     }

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -86,14 +86,14 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
   param_dicts_.resize( syn_specs.size() );
 
   // loop through vector of synapse dictionaries, and set synapse parameters
-  for ( size_t indx = 0; indx < syn_specs.size(); ++indx )
+  for ( size_t synapse_indx = 0; synapse_indx < syn_specs.size(); ++synapse_indx )
   {
-    auto syn_params = syn_specs[ indx ];
+    auto syn_params = syn_specs[ synapse_indx ];
 
-    set_synapse_model_( syn_params, indx );
-    set_default_weight_or_delay_( syn_params, indx );
+    set_synapse_model_( syn_params, synapse_indx );
+    set_default_weight_or_delay_( syn_params, synapse_indx );
 
-    DictionaryDatum syn_defaults = kernel().model_manager.get_connector_defaults( synapse_model_id_[ indx ] );
+    DictionaryDatum syn_defaults = kernel().model_manager.get_connector_defaults( synapse_model_id_[ synapse_indx ] );
 
 #ifdef HAVE_MUSIC
     // We allow music_channel as alias for receptor_type during
@@ -101,7 +101,7 @@ nest::ConnBuilder::ConnBuilder( NodeCollectionPTR sources,
     ( *syn_defaults )[ names::music_channel ] = 0;
 #endif
 
-    set_synapse_params( syn_defaults, syn_params, indx );
+    set_synapse_params( syn_defaults, syn_params, synapse_indx );
   }
 
   set_structural_plasticity_parameters( syn_specs );
@@ -298,24 +298,24 @@ nest::ConnBuilder::update_param_dict_( index snode_id,
   Node& target,
   thread target_thread,
   librandom::RngPtr& rng,
-  index indx )
+  index synapse_indx )
 {
-  assert( kernel().vp_manager.get_num_threads() == static_cast< thread >( param_dicts_[ indx ].size() ) );
+  assert( kernel().vp_manager.get_num_threads() == static_cast< thread >( param_dicts_[ synapse_indx ].size() ) );
 
-  for ( auto synapse_parameter : synapse_params_[ indx ] )
+  for ( auto synapse_parameter : synapse_params_[ synapse_indx ] )
   {
     if ( synapse_parameter.second->provides_long() )
     {
       // change value of dictionary entry without allocating new datum
       IntegerDatum* id = static_cast< IntegerDatum* >(
-        ( ( *param_dicts_[ indx ][ target_thread ] )[ synapse_parameter.first ] ).datum() );
+        ( ( *param_dicts_[ synapse_indx ][ target_thread ] )[ synapse_parameter.first ] ).datum() );
       ( *id ) = synapse_parameter.second->value_int( target_thread, rng, snode_id, &target );
     }
     else
     {
       // change value of dictionary entry without allocating new datum
       DoubleDatum* dd = static_cast< DoubleDatum* >(
-        ( ( *param_dicts_[ indx ][ target_thread ] )[ synapse_parameter.first ] ).datum() );
+        ( ( *param_dicts_[ synapse_indx ][ target_thread ] )[ synapse_parameter.first ] ).datum() );
       ( *dd ) = synapse_parameter.second->value_double( target_thread, rng, snode_id, &target );
     }
   }
@@ -329,43 +329,46 @@ nest::ConnBuilder::single_connect_( index snode_id, Node& target, thread target_
     throw IllegalConnection( "Cannot use this rule to connect to nodes without proxies (usually devices)." );
   }
 
-  for ( size_t indx = 0; indx < synapse_model_id_.size(); ++indx )
+  for ( size_t synapse_indx = 0; synapse_indx < synapse_params_.size(); ++synapse_indx )
   {
-    update_param_dict_( snode_id, target, target_thread, rng, indx );
+    update_param_dict_( snode_id, target, target_thread, rng, synapse_indx );
 
-    if ( default_weight_and_delay_[ indx ] )
-    {
-      kernel().connection_manager.connect(
-        snode_id, &target, target_thread, synapse_model_id_[ indx ], param_dicts_[ indx ][ target_thread ] );
-    }
-    else if ( default_weight_[ indx ] )
+    if ( default_weight_and_delay_[ synapse_indx ] )
     {
       kernel().connection_manager.connect( snode_id,
         &target,
         target_thread,
-        synapse_model_id_[ indx ],
-        param_dicts_[ indx ][ target_thread ],
-        delays_[ indx ]->value_double( target_thread, rng, snode_id, &target ) );
+        synapse_model_id_[ synapse_indx ],
+        param_dicts_[ synapse_indx ][ target_thread ] );
     }
-    else if ( default_delay_[ indx ] )
+    else if ( default_weight_[ synapse_indx ] )
     {
       kernel().connection_manager.connect( snode_id,
         &target,
         target_thread,
-        synapse_model_id_[ indx ],
-        param_dicts_[ indx ][ target_thread ],
+        synapse_model_id_[ synapse_indx ],
+        param_dicts_[ synapse_indx ][ target_thread ],
+        delays_[ synapse_indx ]->value_double( target_thread, rng, snode_id, &target ) );
+    }
+    else if ( default_delay_[ synapse_indx ] )
+    {
+      kernel().connection_manager.connect( snode_id,
+        &target,
+        target_thread,
+        synapse_model_id_[ synapse_indx ],
+        param_dicts_[ synapse_indx ][ target_thread ],
         numerics::nan,
-        weights_[ indx ]->value_double( target_thread, rng, snode_id, &target ) );
+        weights_[ synapse_indx ]->value_double( target_thread, rng, snode_id, &target ) );
     }
     else
     {
-      const double delay = delays_[ indx ]->value_double( target_thread, rng, snode_id, &target );
-      const double weight = weights_[ indx ]->value_double( target_thread, rng, snode_id, &target );
+      const double delay = delays_[ synapse_indx ]->value_double( target_thread, rng, snode_id, &target );
+      const double weight = weights_[ synapse_indx ]->value_double( target_thread, rng, snode_id, &target );
       kernel().connection_manager.connect( snode_id,
         &target,
         target_thread,
-        synapse_model_id_[ indx ],
-        param_dicts_[ indx ][ target_thread ],
+        synapse_model_id_[ synapse_indx ],
+        param_dicts_[ synapse_indx ][ target_thread ],
         delay,
         weight );
     }
@@ -436,7 +439,7 @@ nest::ConnBuilder::loop_over_targets_() const
 }
 
 void
-nest::ConnBuilder::set_synapse_model_( DictionaryDatum syn_params, size_t indx )
+nest::ConnBuilder::set_synapse_model_( DictionaryDatum syn_params, size_t synapse_indx )
 {
   if ( not syn_params->known( names::synapse_model ) )
   {
@@ -449,7 +452,7 @@ nest::ConnBuilder::set_synapse_model_( DictionaryDatum syn_params, size_t indx )
   }
 
   index synapse_model_id = kernel().model_manager.get_synapsedict()->lookup( syn_name );
-  synapse_model_id_[ indx ] = synapse_model_id;
+  synapse_model_id_[ synapse_indx ] = synapse_model_id;
 
   // We need to make sure that Connect can process all synapse parameters specified.
   const ConnectorModel& synapse_model = kernel().model_manager.get_synapse_prototype( synapse_model_id );
@@ -457,43 +460,43 @@ nest::ConnBuilder::set_synapse_model_( DictionaryDatum syn_params, size_t indx )
 }
 
 void
-nest::ConnBuilder::set_default_weight_or_delay_( DictionaryDatum syn_params, size_t indx )
+nest::ConnBuilder::set_default_weight_or_delay_( DictionaryDatum syn_params, size_t synapse_indx )
 {
-  DictionaryDatum syn_defaults = kernel().model_manager.get_connector_defaults( synapse_model_id_[ indx ] );
+  DictionaryDatum syn_defaults = kernel().model_manager.get_connector_defaults( synapse_model_id_[ synapse_indx ] );
 
   // All synapse models have the possibility to set the delay (see SynIdDelay), but some have
   // homogeneous weights, hence it should be possible to set the delay without the weight.
-  default_weight_[ indx ] = not syn_params->known( names::weight );
+  default_weight_[ synapse_indx ] = not syn_params->known( names::weight );
 
-  default_delay_[ indx ] = not syn_params->known( names::delay );
+  default_delay_[ synapse_indx ] = not syn_params->known( names::delay );
 
   // If neither weight nor delay are given in the dict, we handle this separately. Important for
   // hom_w synapses, on which weight cannot be set. However, we use default weight and delay for
   // _all_ types of synapses.
-  default_weight_and_delay_[ indx ] = ( default_weight_[ indx ] and default_delay_[ indx ] );
+  default_weight_and_delay_[ synapse_indx ] = ( default_weight_[ synapse_indx ] and default_delay_[ synapse_indx ] );
 
-  if ( not default_weight_and_delay_[ indx ] )
+  if ( not default_weight_and_delay_[ synapse_indx ] )
   {
-    weights_[ indx ] = syn_params->known( names::weight )
+    weights_[ synapse_indx ] = syn_params->known( names::weight )
       ? ConnParameter::create( ( *syn_params )[ names::weight ], kernel().vp_manager.get_num_threads() )
       : ConnParameter::create( ( *syn_defaults )[ names::weight ], kernel().vp_manager.get_num_threads() );
-    register_parameters_requiring_skipping_( *weights_[ indx ] );
+    register_parameters_requiring_skipping_( *weights_[ synapse_indx ] );
 
-    delays_[ indx ] = syn_params->known( names::delay )
+    delays_[ synapse_indx ] = syn_params->known( names::delay )
       ? ConnParameter::create( ( *syn_params )[ names::delay ], kernel().vp_manager.get_num_threads() )
       : ConnParameter::create( ( *syn_defaults )[ names::delay ], kernel().vp_manager.get_num_threads() );
   }
-  else if ( default_weight_[ indx ] )
+  else if ( default_weight_[ synapse_indx ] )
   {
-    delays_[ indx ] = syn_params->known( names::delay )
+    delays_[ synapse_indx ] = syn_params->known( names::delay )
       ? ConnParameter::create( ( *syn_params )[ names::delay ], kernel().vp_manager.get_num_threads() )
       : ConnParameter::create( ( *syn_defaults )[ names::delay ], kernel().vp_manager.get_num_threads() );
   }
-  register_parameters_requiring_skipping_( *delays_[ indx ] );
+  register_parameters_requiring_skipping_( *delays_[ synapse_indx ] );
 }
 
 void
-nest::ConnBuilder::set_synapse_params( DictionaryDatum syn_defaults, DictionaryDatum syn_params, size_t indx )
+nest::ConnBuilder::set_synapse_params( DictionaryDatum syn_defaults, DictionaryDatum syn_params, size_t synapse_indx )
 {
   for ( Dictionary::const_iterator default_it = syn_defaults->begin(); default_it != syn_defaults->end(); ++default_it )
   {
@@ -505,9 +508,9 @@ nest::ConnBuilder::set_synapse_params( DictionaryDatum syn_defaults, DictionaryD
 
     if ( syn_params->known( param_name ) )
     {
-      synapse_params_[ indx ][ param_name ] =
+      synapse_params_[ synapse_indx ][ param_name ] =
         ConnParameter::create( ( *syn_params )[ param_name ], kernel().vp_manager.get_num_threads() );
-      register_parameters_requiring_skipping_( *synapse_params_[ indx ][ param_name ] );
+      register_parameters_requiring_skipping_( *synapse_params_[ synapse_indx ][ param_name ] );
     }
   }
 
@@ -515,17 +518,17 @@ nest::ConnBuilder::set_synapse_params( DictionaryDatum syn_defaults, DictionaryD
   // create it here once to avoid re-creating the object over and over again.
   for ( thread tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )
   {
-    param_dicts_[ indx ].push_back( new Dictionary() );
+    param_dicts_[ synapse_indx ].push_back( new Dictionary() );
 
-    for ( auto param : synapse_params_[ indx ] )
+    for ( auto param : synapse_params_[ synapse_indx ] )
     {
       if ( param.second->provides_long() )
       {
-        ( *param_dicts_[ indx ][ tid ] )[ param.first ] = Token( new IntegerDatum( 0 ) );
+        ( *param_dicts_[ synapse_indx ][ tid ] )[ param.first ] = Token( new IntegerDatum( 0 ) );
       }
       else
       {
-        ( *param_dicts_[ indx ][ tid ] )[ param.first ] = Token( new DoubleDatum( 0.0 ) );
+        ( *param_dicts_[ synapse_indx ][ tid ] )[ param.first ] = Token( new DoubleDatum( 0.0 ) );
       }
     }
   }

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -148,8 +148,7 @@ protected:
     throw NotImplemented( "This connection rule is not implemented for structural plasticity." );
   }
 
-  void
-  update_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
+  void update_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
 
   //! Create connection between given nodes, fill parameter values
   void single_connect_( index, Node&, thread, librandom::RngPtr& );

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -148,7 +148,7 @@ protected:
     throw NotImplemented( "This connection rule is not implemented for structural plasticity." );
   }
 
-  DictionaryDatum
+  void
   create_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
 
   //! Create connection between given nodes, fill parameter values
@@ -234,8 +234,9 @@ private:
   //! dictionaries to pass to connect function, one per thread for every syn_spec
   std::vector< std::vector< DictionaryDatum > > param_dicts_;
 
-  //! empty dictionary to pass to connect function, one per thread so that the all threads do not
-  //! create and use the same dictionary as this leads to performance issues.
+  //! dictionary to pass to connect function, one per thread so that the all threads do not
+  //! create and use the same dictionary as this leads to performance issues. The dictionary
+  //! can either be empty or filled with synapse parameters.
   std::vector< DictionaryDatum > dummy_param_dicts_;
 
   //! synapse-specific parameters that should be skipped when we set default synapse parameters

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -212,11 +212,6 @@ protected:
 
   std::vector< index > synapse_model_id_;
 
-  //! dictionary to pass to connect function, one per thread so that the all threads do not
-  //! create and use the same dictionary as this leads to performance issues. The dictionary
-  //! can either be empty or filled with synapse parameters.
-  std::vector< Dictionary > dummy_param_dicts_;
-
 private:
   typedef std::map< Name, ConnParameter* > ConnParameterMap;
 

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -148,7 +148,7 @@ protected:
     throw NotImplemented( "This connection rule is not implemented for structural plasticity." );
   }
 
-  void create_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
+  Dictionary& create_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
 
   //! Create connection between given nodes, fill parameter values
   void single_connect_( index, Node&, thread, librandom::RngPtr& );
@@ -214,7 +214,7 @@ protected:
   //! dictionary to pass to connect function, one per thread so that the all threads do not
   //! create and use the same dictionary as this leads to performance issues. The dictionary
   //! can either be empty or filled with synapse parameters.
-  std::vector< DictionaryDatum > dummy_param_dicts_;
+  std::vector< Dictionary > dummy_param_dicts_;
 
 private:
   typedef std::map< Name, ConnParameter* > ConnParameterMap;
@@ -236,7 +236,7 @@ private:
   std::vector< ConnParameterMap > synapse_params_;
 
   //! dictionaries to pass to connect function, one per thread for every syn_spec
-  std::vector< std::vector< DictionaryDatum > > param_dicts_;
+  std::vector< std::vector< Dictionary > > param_dicts_;
 
   //! synapse-specific parameters that should be skipped when we set default synapse parameters
   std::set< Name > skip_syn_params_;

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -212,6 +212,11 @@ protected:
 
   std::vector< index > synapse_model_id_;
 
+  //! dictionary to pass to connect function, one per thread so that the all threads do not
+  //! create and use the same dictionary as this leads to performance issues. The dictionary
+  //! can either be empty or filled with synapse parameters.
+  std::vector< DictionaryDatum > dummy_param_dicts_;
+
 private:
   typedef std::map< Name, ConnParameter* > ConnParameterMap;
 
@@ -233,11 +238,6 @@ private:
 
   //! dictionaries to pass to connect function, one per thread for every syn_spec
   std::vector< std::vector< DictionaryDatum > > param_dicts_;
-
-  //! dictionary to pass to connect function, one per thread so that the all threads do not
-  //! create and use the same dictionary as this leads to performance issues. The dictionary
-  //! can either be empty or filled with synapse parameters.
-  std::vector< DictionaryDatum > dummy_param_dicts_;
 
   //! synapse-specific parameters that should be skipped when we set default synapse parameters
   std::set< Name > skip_syn_params_;

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -211,6 +211,9 @@ protected:
 
   std::vector< index > synapse_model_id_;
 
+  //! dictionaries to pass to connect function, one per thread for every syn_spec
+  std::vector< std::vector< DictionaryDatum > > param_dicts_;
+
 private:
   typedef std::map< Name, ConnParameter* > ConnParameterMap;
 
@@ -229,9 +232,6 @@ private:
 
   //! all other parameters, mapping name to value representation
   std::vector< ConnParameterMap > synapse_params_;
-
-  //! dictionaries to pass to connect function, one per thread for every syn_spec
-  std::vector< std::vector< DictionaryDatum > > param_dicts_;
 
   //! synapse-specific parameters that should be skipped when we set default synapse parameters
   std::set< Name > skip_syn_params_;

--- a/nestkernel/conn_builder.h
+++ b/nestkernel/conn_builder.h
@@ -148,8 +148,7 @@ protected:
     throw NotImplemented( "This connection rule is not implemented for structural plasticity." );
   }
 
-  void
-  create_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
+  void create_param_dict_( index snode_id, Node& target, thread target_thread, librandom::RngPtr& rng, index indx );
 
   //! Create connection between given nodes, fill parameter values
   void single_connect_( index, Node&, thread, librandom::RngPtr& );

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -118,7 +118,7 @@ ConnectionGeneratorBuilder::connect_()
       Node* target_node = kernel().node_manager.get_node_or_proxy( ( *targets_ )[ target ] );
       const thread target_thread = target_node->get_thread();
 
-      create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
+      update_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
 
       // Use the low-level connect() here, as we need to pass a custom weight and delay
       kernel().connection_manager.connect( ( *sources_ )[ source ],

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -125,7 +125,7 @@ ConnectionGeneratorBuilder::connect_()
         target_node,
         target_thread,
         synapse_model_id_[ 0 ],
-        param_dicts_[ 0 ][ target head ],
+        param_dicts_[ 0 ][ target_thread ],
         params[ d_idx ],
         params[ w_idx ] );
     }

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -118,14 +118,14 @@ ConnectionGeneratorBuilder::connect_()
       Node* target_node = kernel().node_manager.get_node_or_proxy( ( *targets_ )[ target ] );
       const thread target_thread = target_node->get_thread();
 
-      Dictionary& param_dict = create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
+      create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
 
       // Use the low-level connect() here, as we need to pass a custom weight and delay
       kernel().connection_manager.connect( ( *sources_ )[ source ],
         target_node,
         target_thread,
         synapse_model_id_[ 0 ],
-        param_dict,
+        param_dicts_[ 0 ][ target head ],
         params[ d_idx ],
         params[ w_idx ] );
     }

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -118,14 +118,14 @@ ConnectionGeneratorBuilder::connect_()
       Node* target_node = kernel().node_manager.get_node_or_proxy( ( *targets_ )[ target ] );
       const thread target_thread = target_node->get_thread();
 
-      DictionaryDatum param_dict = create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
+      create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
 
       // Use the low-level connect() here, as we need to pass a custom weight and delay
       kernel().connection_manager.connect( ( *sources_ )[ source ],
         target_node,
         target_thread,
         synapse_model_id_[ 0 ],
-        param_dict,
+        dummy_param_dicts_[ target_thread ],
         params[ d_idx ],
         params[ w_idx ] );
     }

--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -118,14 +118,14 @@ ConnectionGeneratorBuilder::connect_()
       Node* target_node = kernel().node_manager.get_node_or_proxy( ( *targets_ )[ target ] );
       const thread target_thread = target_node->get_thread();
 
-      create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
+      Dictionary& param_dict = create_param_dict_( ( *sources_ )[ source ], *target_node, target_thread, rng, 0 );
 
       // Use the low-level connect() here, as we need to pass a custom weight and delay
       kernel().connection_manager.connect( ( *sources_ )[ source ],
         target_node,
         target_thread,
         synapse_model_id_[ 0 ],
-        dummy_param_dicts_[ target_thread ],
+        param_dict,
         params[ d_idx ],
         params[ w_idx ] );
     }


### PR DESCRIPTION
When running weak scale benchmarks for #1549 we discovered some connection creation performance issues for weak scale benchmarks. I have done some bisecting, and found the problem comes from cfa213d0586afa8224dd2cc932283ee597d500d4, and the fact that all threads try to write to `param_dict` at the same time.

Luckily we already have a list of dictionaries for each thread, `dummy_param_dicts_`, so now we fill the dictionary on the thread if the connection has synapse properties, and just use this variable throughout. It might be an idea to change the name of the variable, I just didn't come up with a good name.

I also had to make it `protected`, as it is used by `conngen` rule.

Some benchmarks:

![hpc_benchmark_weak_scaling_connection_fix](https://user-images.githubusercontent.com/21308850/101601010-6856e880-39fc-11eb-9bb2-fc1dfaa43009.png)
![hpc_benchmark_weak_scaling_fix](https://user-images.githubusercontent.com/21308850/101601012-68ef7f00-39fc-11eb-9a7e-6da290f690d4.png)

I still need to figure out why it is not finishing for `N_VP=1152`, but that is another issue that should not be addressed in this PR.
