### PR TITLE
Remove contact invitation from HPC systems tab

### DIFF
--- a/doc/installation/index.rst
+++ b/doc/installation/index.rst
@@ -324,7 +324,6 @@ these instructions.**
    .. tab:: HPC systems
 
        :doc:`Instructions for high performance computers <hpc_install>` provides some instructions for certain machines.
-       Please :doc:`contact us <../community>` if you need help with your system.
 
 
 .. toctree::


### PR DESCRIPTION
This PR removes the contact invitation from the ``HPC systems`` tab in the NEST installation instructions. 

As discussed offline, it suffices to provide our contact information in the Community, Troubleshooting and Welcome pages.