### PR TITLE
Fix typo in test_sp/test_mpitests.py

### DIFF
--- a/pynest/nest/tests/test_sp/test_mpitests.py
+++ b/pynest/nest/tests/test_sp/test_mpitests.py
@@ -38,7 +38,7 @@ class TestStructuralPlasticityMPI(unittest.TestCase):
 
             for test in mpitests:
                 test = os.path.join(path, test)
-                command = nest.ll_api.sli_func("mpirun", 2, "python", test)
+                command = nest.ll_api.sli_func("mpirun", 2, "nosetests", test)
                 print("Executing test with command: " + command)
                 command = command.split()
                 my_env = os.environ.copy()


### PR DESCRIPTION
Fix issue #1879 
A typo in line 41 of test_sp/test_mpitests.py that reads "python" instead of "nosetests" causes the test to fail.
Note that the error message that should be displayed in case of failure in line 50 reads "nosetests".
Test pass by fixing this typo.