### PR TITLE
Fix for printing empty SynapseCollection

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -647,18 +647,12 @@ class SynapseCollection(object):
         MAX_SIZE_FULL_PRINT = 35  # 35 is arbitrarily chosen.
 
         params = self.get()
-        if len(params) == 0:
-            srcs = []
-            trgt = []
-            wght = []
-            dlay = []
-            s_model = []
-        else:
-            srcs = params['source']
-            trgt = params['target']
-            wght = params['weight']
-            dlay = params['delay']
-            s_model = params['synapse_model']
+
+        srcs = params['source'] if len(params) != 0 else []
+        trgt = params['target'] if len(params) != 0 else []
+        wght = params['weight'] if len(params) != 0 else []
+        dlay = params['delay'] if len(params) != 0 else []
+        s_model = params['synapse_model'] if len(params) != 0 else []
 
         if isinstance(srcs, int):
             srcs = [srcs]

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -648,11 +648,14 @@ class SynapseCollection(object):
 
         params = self.get()
 
-        srcs = params['source'] if len(params) != 0 else []
-        trgt = params['target'] if len(params) != 0 else []
-        wght = params['weight'] if len(params) != 0 else []
-        dlay = params['delay'] if len(params) != 0 else []
-        s_model = params['synapse_model'] if len(params) != 0 else []
+        if len(params) == 0:
+            return 'The synapse collection does not contain any connections.'
+
+        srcs = params['source']
+        trgt = params['target']
+        wght = params['weight']
+        dlay = params['delay']
+        s_model = params['synapse_model']
 
         if isinstance(srcs, int):
             srcs = [srcs]
@@ -668,14 +671,9 @@ class SynapseCollection(object):
         d_h = 'delay'
 
         # Find maximum number of characters for each column, used to determine width of column
-        if len(params) == 0:
-            src_len = len(src_h) + 2
-            trg_len = len(trg_h) + 2
-            sm_len = len(sm_h) + 2
-        else:
-            src_len = max(len(src_h) + 2, floor(log(max(srcs), 10)))
-            trg_len = max(len(trg_h) + 2, floor(log(max(trgt), 10)))
-            sm_len = max(len(sm_h) + 2, len(max(s_model, key=len)))
+        src_len = max(len(src_h) + 2, floor(log(max(srcs), 10)))
+        trg_len = max(len(trg_h) + 2, floor(log(max(trgt), 10)))
+        sm_len = max(len(sm_h) + 2, len(max(s_model, key=len)))
         w_len = len(w_h) + 2
         d_len = len(d_h) + 2
 

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -678,14 +678,12 @@ class SynapseCollection(object):
             src_len = len(src_h) + 2
             trg_len = len(trg_h) + 2
             sm_len = len(sm_h) + 2
-            w_len = len(w_h) + 2
-            d_len = len(d_h) + 2
         else:
             src_len = max(len(src_h) + 2, floor(log(max(srcs), 10)))
             trg_len = max(len(trg_h) + 2, floor(log(max(trgt), 10)))
             sm_len = max(len(sm_h) + 2, len(max(s_model, key=len)))
-            w_len = len(w_h) + 2
-            d_len = len(d_h) + 2
+        w_len = len(w_h) + 2
+        d_len = len(d_h) + 2
 
         # 35 is arbitrarily chosen.
         if len(srcs) >= MAX_SIZE_FULL_PRINT and not self.print_full:

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -647,11 +647,18 @@ class SynapseCollection(object):
         MAX_SIZE_FULL_PRINT = 35  # 35 is arbitrarily chosen.
 
         params = self.get()
-        srcs = params['source']
-        trgt = params['target']
-        wght = params['weight']
-        dlay = params['delay']
-        s_model = params['synapse_model']
+        if len(params) == 0:
+            srcs = []
+            trgt = []
+            wght = []
+            dlay = []
+            s_model = []
+        else:
+            srcs = params['source']
+            trgt = params['target']
+            wght = params['weight']
+            dlay = params['delay']
+            s_model = params['synapse_model']
 
         if isinstance(srcs, int):
             srcs = [srcs]
@@ -667,11 +674,18 @@ class SynapseCollection(object):
         d_h = 'delay'
 
         # Find maximum number of characters for each column, used to determine width of column
-        src_len = max(len(src_h) + 2, floor(log(max(srcs), 10)))
-        trg_len = max(len(trg_h) + 2, floor(log(max(trgt), 10)))
-        sm_len = max(len(sm_h) + 2, len(max(s_model, key=len)))
-        w_len = len(w_h) + 2
-        d_len = len(d_h) + 2
+        if len(params) == 0:
+            src_len = len(src_h) + 2
+            trg_len = len(trg_h) + 2
+            sm_len = len(sm_h) + 2
+            w_len = len(w_h) + 2
+            d_len = len(d_h) + 2
+        else:
+            src_len = max(len(src_h) + 2, floor(log(max(srcs), 10)))
+            trg_len = max(len(trg_h) + 2, floor(log(max(trgt), 10)))
+            sm_len = max(len(sm_h) + 2, len(max(s_model, key=len)))
+            w_len = len(w_h) + 2
+            d_len = len(d_h) + 2
 
         # 35 is arbitrarily chosen.
         if len(srcs) >= MAX_SIZE_FULL_PRINT and not self.print_full:
@@ -683,9 +697,9 @@ class SynapseCollection(object):
             s_model = s_model[:15] + [u'\u22EE '] + s_model[-15:]
 
         headers = f'{src_h:^{src_len}} {trg_h:^{trg_len}} {sm_h:^{sm_len}} {w_h:^{w_len}} {d_h:^{d_len}}' + '\n'
-        boarders = '-'*src_len + ' ' + '-'*trg_len + ' ' + '-'*sm_len + ' ' + '-'*w_len + ' ' + '-'*d_len + '\n'
+        borders = '-'*src_len + ' ' + '-'*trg_len + ' ' + '-'*sm_len + ' ' + '-'*w_len + ' ' + '-'*d_len + '\n'
         output = '\n'.join(format_row_(s, t, sm, w, d) for s, t, sm, w, d in zip(srcs, trgt, s_model, wght, dlay))
-        result = headers + boarders + output
+        result = headers + borders + output
 
         return result
 

--- a/pynest/nest/tests/test_synapsecollection.py
+++ b/pynest/nest/tests/test_synapsecollection.py
@@ -403,8 +403,7 @@ class TestSynapseCollection(unittest.TestCase):
         """
         Test the str functionality of empty SynapseCollection
         """
-        ref_str = (' source   target   synapse model   weight   delay \n' +
-                   '-------- -------- --------------- -------- -------\n')
+        ref_str = ('The synapse collection does not contain any connections.')
 
         conns = nest.GetConnections()
         self.assertEqual(ref_str, str(conns))

--- a/pynest/nest/tests/test_synapsecollection.py
+++ b/pynest/nest/tests/test_synapsecollection.py
@@ -399,6 +399,16 @@ class TestSynapseCollection(unittest.TestCase):
         conns = nest.GetConnections()
         self.assertEqual(ref_str, str(conns))
 
+    def test_empty_string(self):
+        """
+        Test the str functionality of empty SynapseCollection
+        """
+        ref_str = (' source   target   synapse model   weight   delay \n' +
+                   '-------- -------- --------------- -------- -------\n')
+
+        conns = nest.GetConnections()
+        self.assertEqual(ref_str, str(conns))
+
 
 def suite():
     suite = unittest.makeSuite(TestSynapseCollection, 'test')


### PR DESCRIPTION
Printing an empty SynapseCollection will no longer raise a `TypeError`, but print
```
 source   target   synapse model   weight   delay 
-------- -------- --------------- -------- -------
```
I'm also open for more explicit representations of an empty SynapseCollection.

Fixes #1884