### PR TITLE
Add -Woverloaded-virtual to CI compiler flags

### DIFF
--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -166,14 +166,14 @@ xPYTHON=0
 xREADLINE=0
 xSIONLIB=0
 
-CXX_FLAGS="-pedantic -Wextra -Wno-unknown-pragmas"
+CXX_FLAGS="-pedantic -Wextra -Woverloaded-virtual -Wno-unknown-pragmas"
 
 if [ "$xNEST_BUILD_TYPE" = "OPENMP_ONLY" ]; then
     xGSL=1
     xLIBBOOST=1
     xLTDL=1
     xOPENMP=1
-    CXX_FLAGS="-pedantic -Wextra"
+    CXX_FLAGS="-pedantic -Wextra -Woverloaded-virtual"
 fi
 
 if [ "$xNEST_BUILD_TYPE" = "MPI_ONLY" ]; then
@@ -194,7 +194,7 @@ if [ "$xNEST_BUILD_TYPE" = "FULL" ]; then
     xPYTHON=1
     xREADLINE=1
     xSIONLIB=1
-    CXX_FLAGS="-pedantic -Wextra"
+    CXX_FLAGS="-pedantic -Wextra -Woverloaded-virtual"
 fi
 
 if [ "$xNEST_BUILD_TYPE" = "FULL_NO_EXTERNAL_FEATURES" ]; then


### PR DESCRIPTION
The `-Woverloaded-virtual` flag is added to CI compiler flags to ensure that no function declaration hides virtual functions from a base class (see #1377). This fixes #1315 and resolves #1433.