### PR TITLE
Change Travis macOS build to MINIMAL to avoid timeouts (temporary).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       os: osx
       osx_image: xcode12.2   # Python 3.9.0 running on macOS 10.15.7
       language: shell      # language 'python' results in errors on macOS
-      env: CACHE_NAME=JOB xNEST_BUILD_TYPE=FULL_NO_EXTERNAL_FEATURES
+      env: CACHE_NAME=JOB xNEST_BUILD_TYPE=MINIMAL
       cache:
         directories:
           - $HOME/.cache


### PR DESCRIPTION
All macOS builds on Travis are currently failing due to timeouts. This PR temporarily changes the build config for macOS to `MINIMAL` to ensure that tests can complete again.

This should be reverted once we have a more powerful macOS setup.

I think a single reviewer on this one is ok.