### PR TITLE
Add checker for forbidden types

### DIFF
--- a/extras/check_forbidden_types.sh
+++ b/extras/check_forbidden_types.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 #
 # check_forbidden_types.sh
 #
@@ -25,7 +25,7 @@ forbidden_types="double_t"
 used_forbidden_types=""
 
 for t in $forbidden_types; do
-    scan_result=`grep $t -r -o --include '*.[h,cc,cpp]' $NEST_SOURCE | sed 's/:/: /'`
+    scan_result=`grep $t -r -o --include=*.{h,cc,cpp} $NEST_SOURCE | sed 's/:/: /'`
     if [ -n "$scan_result" ]; then
         used_forbidden_types=$used_forbidden_types$'\n'$scan_result
     fi

--- a/extras/check_forbidden_types.sh
+++ b/extras/check_forbidden_types.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+#
+# check_forbidden_types.sh
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+# This script scans for forbidden types and fails if any are used.
+
+forbidden_types="double_t"
+used_forbidden_types=""
+
+for t in $forbidden_types; do
+    scan_result=`grep $t -r -o --include '*.[h,cc,cpp]' $NEST_SOURCE | sed 's/:/: /'`
+    if [ -n "$scan_result" ]; then
+        used_forbidden_types=$used_forbidden_types$'\n'$scan_result
+    fi
+done
+
+echo "$used_forbidden_types"

--- a/extras/static_code_analysis.sh
+++ b/extras/static_code_analysis.sh
@@ -26,8 +26,8 @@
 # a local static code analysis.
 #
 # NOTE: This shell script is tightly coupled to Python script
-#       'extras/parse_travis_log.py'. 
-#       Any changes to message numbers (MSGBLDnnnn) have effects on 
+#       'extras/parse_travis_log.py'.
+#       Any changes to message numbers (MSGBLDnnnn) have effects on
 #       the build/test-log parsing process.
 #
 
@@ -118,6 +118,8 @@ print_msg "MSGBLD1050: " "Running check for copyright headers"
 copyright_check_errors=`python3 extras/check_copyright_headers.py`
 print_msg "MSGBLD1060: " "Running sanity check for Name definition and usage"
 unused_names_errors=`python3 extras/check_unused_names.py`
+print_msg "MSGBLD1070: " "Running check for forbidden type usage"
+forbidden_types_errors=`bash extras/check_forbidden_types.sh`
 
 
 # Perfom static code analysis.
@@ -128,7 +130,7 @@ for f in $FILE_NAMES; do
   if [[ $FILES_TO_IGNORE =~ .*$f.* ]]; then
     print_msg "MSGBLD0110: " "$f is explicitly ignored."
     continue
-  fi   
+  fi
   if [ ! -f "$f" ]; then
     print_msg "MSGBLD0110: " "$f is not a file or does not exist anymore."
     continue
@@ -185,7 +187,7 @@ for f in $FILE_NAMES; do
             print_msg "MSGBLD0155: " "[CPPC] $line"
             if $RUNS_ON_TRAVIS; then
               msg_count+=1
-              if [ ${msg_count} -ge ${MAX_CPPCHECK_MSG_COUNT} ]; then 
+              if [ ${msg_count} -ge ${MAX_CPPCHECK_MSG_COUNT} ]; then
                 print_msg "MSGBLD0156: " "[CPPC] MAX_CPPCHECK_MSG_COUNT (${MAX_CPPCHECK_MSG_COUNT}) reached for file: $f"
                 break
               fi
@@ -264,6 +266,7 @@ done
 nlines_copyright_check=`echo -e $copyright_check_errors | sed -e 's/^ *//' | wc -l`
 if [ $nlines_copyright_check \> 1 ] || \
    [ "x$unused_names_errors" != "x" ] || \
+   [ -n "$forbidden_types_errors" ] || \
    [ "x$c_files_with_errors" != "x" ] || \
    [ "x$python_files_with_errors" != "x" ]; then
 
@@ -292,7 +295,13 @@ if [ $nlines_copyright_check \> 1 ] || \
   if [ "x$unused_names_errors" != "x" ]; then
       print_msg "MSGBLD0220: " "Files with unused/ill-defined Name objects:"
       echo -e $unused_names_errors | sed -e 's/^ *//'
-      print_msg "" ""     
+      print_msg "" ""
+  fi
+
+  if [ -n "$forbidden_types_errors" ]; then
+      print_msg "MSGBLD0220: " "Files with forbidden types (hint: use types without _t suffix):"
+      echo -e $forbidden_types_errors | sed -e 's/^ *//'
+      print_msg "" ""
   fi
 
   if [ "x$python_files_with_errors" != "x" ]; then
@@ -305,7 +314,7 @@ if [ $nlines_copyright_check \> 1 ] || \
       print_msg "" ""
     fi
   fi
-  
+
   if ! $RUNS_ON_TRAVIS; then
       print_msg "" "For detailed problem descriptions, consult the tagged messages above."
       print_msg "" "Tags may be [VERA], [CPPC], [DIFF], [COPY], [NAME] and [PEP8]."
@@ -316,5 +325,5 @@ else
   print_msg "MSGBLD0220: " "+ + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +"
   print_msg "MSGBLD0220: " "+               STATIC CODE ANALYSIS TERMINATED SUCCESSFULLY !                +"
   print_msg "MSGBLD0220: " "+ + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +"
-  print_msg "" ""  
+  print_msg "" ""
 fi


### PR DESCRIPTION
This PR adds a checker for forbidden types (currently only `double_t`) to the static check phase of the CI and thereby fixes #1861.