### PR TITLE
Improve NodeCollection iterator dereferencing performance when using composite NodeCollections with metadata

### DIFF
--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -637,7 +637,10 @@ inline NodeIDTriple nc_const_iterator::operator*() const
     gt.lid = 0;
     for ( const auto& part : composite_collection_->parts_ )
     {
-      if ( part == composite_collection_->parts_[ part_idx_ ] )
+      // Using a stripped-down comparison of Primitives to avoid redundant and potentially expensive comparisons of
+      // metadata.
+      const auto& current_part = composite_collection_->parts_[ part_idx_ ];
+      if ( part.first_ == current_part.first_ and part.last_ == current_part.last_ )
       {
         break;
       }


### PR DESCRIPTION
With multiple processes, using `GetLocalNodeCollection(layer)` on a spatial NodeCollection returns a stepped composite NodeCollection. Then, if this is used with functions like `GetPosition(nodes)`, getting the position of each node involves iterating this composite NodeCollection. However, when dereferencing the iterator, the `operator*()` at some point compares two of the primitive NodeCollections contained in the composite (for the local NodeCollection it will only be compared with itself). This comparison involves comparing the metadata, which is expensive. For `GetPosition()` this comparison is done for every node, which can take a long time. When not using multiple processes this is not a problem because `GetPosition()` would then be called on a primitive NodeCollection.

This PR strips down the comparison to avoid comparing metadata of the primitives when dereferencing an iterator of a composite, thus improves the preformance.

Fixes #1892