### PR TITLE
Restructure recorder documentation to contain all properties.

### DIFF
--- a/doc/extractor_userdocs.py
+++ b/doc/extractor_userdocs.py
@@ -372,6 +372,9 @@ def rst_index(hierarchy, current_tags=[], underlines='=-~', top=True):
             underlines = underlines[1:]
 
     for tags, items in sorted(hierarchy.items()):
+
+        if "NOINDEX" in tags:
+            continue
         if isinstance(tags, str):
             title = tags
         else:

--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -1,4 +1,4 @@
-.. _connection_mgnt:
+.. _connection_management:
 
 Connection Management
 =====================

--- a/doc/guides/recording_from_simulations.rst
+++ b/doc/guides/recording_from_simulations.rst
@@ -7,11 +7,11 @@ from neurons and synapses.
 
 To determine what happens to recorded data, each recording device can
 specify a *recording backend* in its ``record_to`` property. The
-default backend is *memory*, which just stores the recorded data in
-memory for later retrieval. Other backends write the data to file or
-to the screen. The different backends and their usage is explained in
-detail in the section about :ref:`Recording Backends
-<recording_backends>`.
+default backend is *memory*, which stores the recorded data in memory
+for later retrieval. Other backends write the data to file or to the
+screen, or stream it to other applications via the network. The
+different backends and their usage are explained in detail in the
+section about :ref:`Recording Backends <recording_backends>`.
 
 Recording devices can fundamentally be subdivided into two groups:
 
@@ -111,11 +111,11 @@ Recorders for every-day situations
 Where does data end up?
 -----------------------
 
-After a recording device has sampled or collected data, the *recording backends* are
-responsible for how the data are processed.
+After a recording device has sampled or collected data, the data is
+handed to a dedicated *recording backend*, set for each recorder.
+These are responsible for how the data are processed.
 
-
-Theoretically, recording backends are not restricted in what they do
+Theoretically, recording backends are completely free in what they do
 with the data. The ones included in NEST can collect data in memory,
 display it on the terminal, or write it to files.
 

--- a/doc/guides/recording_from_simulations.rst
+++ b/doc/guides/recording_from_simulations.rst
@@ -35,67 +35,9 @@ temporal aspects of the simulation loop.
    of thread execution, events are not necessarily recorded in
    chronological order.
 
-The time span in which a recorder is actually recording, can be specified
-using the additional properties ``start`` and ``stop``. These define
-activation and inactivation times of the device in ms. An additional
-property ``origin`` is available to shift the recording window by a
-certain amount, which can be useful in simulation protocols with
-repeated simulations. The following rules apply:
-
-- Collectors collect all events with timestamps `T` that fulfill
-
-  ::
-
-     start < T <= stop.
-
-  Events with timestamp `T == start` are not recorded.
 
 
-- Sampling devices sample at times *t = nh* (*h* being the simulation
-  resolution) with
 
-  ::
-
-     start < t <= stop
-     (t-start) mod interval == 0
-
-
-Common recorder properties
---------------------------
-
-All recorders have a set of common properties that can be set using
-``SetDefaults`` on the model class or ``SetStatus`` on a device
-instance:
-
-.. glossary::
-
- label
-   A string (default: `""`) specifying an arbitrary textual label for
-   the device.  Recording backends might use the label to generate
-   device specific identifiers like filenames and such.
-
- n_events
-   The number of events that were collected by the recorder can be
-   read out of the `n_events` entry. The number of events can be reset
-   to 0. Other values cannot be set.
-
- origin
-   A positive floating point number (default : `0.0`) used as the
-   reference time for `start` and `stop`.
-
- record_to
-   A string (default: `"memory"`) containing the name of the recording
-   backend where to write data to. An empty string turns all recording
-   of individual events off.
-
- start
-   A positive floating point number (default: `0.0`) specifying the
-   activation time in ms, relative to `origin`.
-
- stop
-   A floating point number (default: `infinity`) specifying the
-   deactication time in ms, relative to `origin`. The value of `stop`
-   must be greater than or equal to `start`
 
 Recorders for every-day situations
 ----------------------------------

--- a/doc/guides/recording_from_simulations.rst
+++ b/doc/guides/recording_from_simulations.rst
@@ -13,17 +13,6 @@ screen, or stream it to other applications via the network. The
 different backends and their usage are explained in detail in the
 section about :ref:`Recording Backends <recording_backends>`.
 
-Recording devices can fundamentally be subdivided into two groups:
-
-- **Collectors** collect events sent to them. Neurons are connected to
-  collectors and the collector collects the events emitted by the
-  neurons connected to it.
-
-- **Samplers** actively interrogate their targets at given time
-  intervals. This means that the sampler must be connected to the
-  neuron (not the neuron to the sampler), and that the neuron must
-  support the particular type of sampling.
-
 Recording devices can only reliably record data that was generated
 during the previous simulation time step interval. See the guide about
 :doc:`running simulations <running_simulations>` for details about the
@@ -35,8 +24,16 @@ temporal aspects of the simulation loop.
    of thread execution, events are not necessarily recorded in
    chronological order.
 
+Recording devices can fundamentally be subdivided into two groups:
 
+- **Collectors** collect events sent to them. Neurons are connected to
+  collectors and the collector collects the events emitted by the
+  neurons connected to it.
 
+- **Samplers** actively interrogate their targets at given time
+  intervals. This means that the sampler must be connected to the
+  neuron (not the neuron to the sampler), and that the neuron must
+  support the particular type of sampling.
 
 
 Recorders for every-day situations

--- a/doc/guides/recording_from_simulations.rst
+++ b/doc/guides/recording_from_simulations.rst
@@ -100,11 +100,9 @@ instance:
 Recorders for every-day situations
 ----------------------------------
 
-.. include:: ../models/multimeter.rst
-
-.. include:: ../models/spike_recorder.rst
-
-.. include:: ../models/weight_recorder.rst
+- :ref:`multimeter`
+- :ref:`spike_recorder`
+- :ref:`weight_recorder`
 
 .. _recording_backends:
 
@@ -174,10 +172,10 @@ dictionary to ``SetKernelStatus``.
 
     nest.SetKernelStatus({"recording_backends": {'sionlib': {'buffer_size': 512}}})
 
-.. include:: ../models/recording_backend_memory.rst
+Following is a list of built-in recording backends that come with
+NEST:
 
-.. include:: ../models/recording_backend_ascii.rst
-
-.. include:: ../models/recording_backend_screen.rst
-
-.. include:: ../models/recording_backend_sionlib.rst
+- :ref:`recording_backend_memory`
+- :ref:`recording_backend_ascii`
+- :ref:`recording_backend_screen`
+- :ref:`recording_backend_sionlib`

--- a/doc/guides/running_simulations.rst
+++ b/doc/guides/running_simulations.rst
@@ -35,6 +35,8 @@ The simulation loop. Light gray boxes denote thread parallel parts, dark
 gray boxes denote MPI parallel parts. U(St) is the update operator that
 propagates the internal state of a neuron or device.
 
+.. _simulation_resolution:
+
 Simulation resolution and update interval
 -----------------------------------------
 

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -112,6 +112,8 @@ fail if carried out in the wrong direction, i.e., trying to connect the
    ``record_from`` property is already set to record the variable ``V_m``
    from the neurons it is connected to.
 
+.. include:: ../models/recording_device.rst
+
 EndUserDocs */
 
 namespace nest

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -114,6 +114,17 @@ fail if carried out in the wrong direction, i.e., trying to connect the
 
 .. include:: ../models/recording_device.rst
 
+.. glossary::
+
+ record_from
+   A list (default: `[]`) of parameters and state variables to sample
+   from the nodes, the multimeter is connected to. Potential
+   recordables are given in the corresponding model documentation.
+
+ interval
+   A float (default: `1.0`) specifying the interval in ms, at which
+   data is collected from the nodes, the multimeter is connected to.
+
 EndUserDocs */
 
 namespace nest

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -98,7 +98,7 @@ it should record from by using the standard ``Connect`` routine.
     nest.Connect(mm, neurons)
 
 To learn more about possible connection patterns and additional
-options when using ``Connect``, see the guide on :doc:`connection
+options when using ``Connect``, see the guide on :ref:`connection
 management <connection_management>`.
 
 The above call to ``Connect`` would fail if the neurons would not

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -40,6 +40,8 @@
 
 /* BeginUserDocs: device, recorder
 
+.. _multimeter:
+
 Short description
 +++++++++++++++++
 

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -80,8 +80,8 @@ using the ``multimeter`` parameter `interval`. The default value of
    nest.SetStatus(mm, 'interval': 0.1})
 
 The recording interval must be greater than or equal to the
-:doc:`simulation resolution <running_simulations>`, which defaults to
-0.1 ms.
+:ref:`simulation resolution <simulation_resolution>`, which defaults
+to 0.1 ms.
 
 .. warning::
 

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -35,6 +35,8 @@
 
 /* BeginUserDocs: device, recorder, spike
 
+.. _spike_recorder:
+
 Short description
 +++++++++++++++++
 

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -66,6 +66,8 @@ spike creation rather than that of their arrival.
 The call to ``Connect`` will fail if the connection direction is
 reversed (i.e., connecting *sr* to *neurons*).
 
+.. include:: ../models/recording_device.rst
+
 EndUserDocs */
 
 namespace nest

--- a/models/weight_recorder.h
+++ b/models/weight_recorder.h
@@ -36,6 +36,8 @@
 
 /* BeginUserDocs: device, recorder
 
+.. _weight_recorder:
+
 Short description
 +++++++++++++++++
 

--- a/models/weight_recorder.h
+++ b/models/weight_recorder.h
@@ -73,6 +73,8 @@ synapses that fulfill the given criteria.
 
    >>> nest.Connect(pre, post, syn_spec="stdp_synapse_rec")
 
+.. include:: ../models/recording_device.rst
+
 EndUserDocs */
 
 namespace nest

--- a/nestkernel/recording_backend_ascii.h
+++ b/nestkernel/recording_backend_ascii.h
@@ -32,8 +32,11 @@
 
 .. _recording_backend_ascii:
 
-Write data to plain text files
-##############################
+ascii - Write data to plain text files
+######################################
+
+Description
++++++++++++
 
 The `ascii` recording backend writes collected data persistently to a
 plain text ASCII file. It can be used for small to medium sized

--- a/nestkernel/recording_backend_ascii.h
+++ b/nestkernel/recording_backend_ascii.h
@@ -28,7 +28,7 @@
 
 #include "recording_backend.h"
 
-/* BeginUserDocs: recording backend
+/* BeginUserDocs: NOINDEX
 
 .. _recording_backend_ascii:
 

--- a/nestkernel/recording_backend_memory.h
+++ b/nestkernel/recording_backend_memory.h
@@ -26,7 +26,7 @@
 // Includes from nestkernel:
 #include "recording_backend.h"
 
-/* BeginUserDocs: recording backend
+/* BeginUserDocs: NOINDEX
 
 .. _recording_backend_memory:
 

--- a/nestkernel/recording_backend_memory.h
+++ b/nestkernel/recording_backend_memory.h
@@ -28,6 +28,8 @@
 
 /* BeginUserDocs: recording backend
 
+.. _recording_backend_memory:
+
 Store data in main memory
 #########################
 

--- a/nestkernel/recording_backend_memory.h
+++ b/nestkernel/recording_backend_memory.h
@@ -30,8 +30,11 @@
 
 .. _recording_backend_memory:
 
-Store data in main memory
-#########################
+memory - Store data in main memory
+##################################
+
+Description
++++++++++++
 
 When a recording device sends data to the ``memory`` backend, it is
 stored internally in efficient vectors. These vectors are made available to the

--- a/nestkernel/recording_backend_screen.h
+++ b/nestkernel/recording_backend_screen.h
@@ -28,6 +28,8 @@
 
 /* BeginUserDocs: recording backend
 
+.. _recording_backend_screen:
+
 Write data to the terminal
 ##########################
 

--- a/nestkernel/recording_backend_screen.h
+++ b/nestkernel/recording_backend_screen.h
@@ -30,8 +30,11 @@
 
 .. _recording_backend_screen:
 
-Write data to the terminal
-##########################
+screen - Write data to the terminal
+###################################
+
+Description
++++++++++++
 
 When initially conceiving and debugging simulations, it can be useful
 to check recordings in a more ad hoc fashion. The recording backend

--- a/nestkernel/recording_backend_screen.h
+++ b/nestkernel/recording_backend_screen.h
@@ -26,7 +26,7 @@
 #include "recording_backend.h"
 #include <set>
 
-/* BeginUserDocs: recording backend
+/* BeginUserDocs: NOINDEX
 
 .. _recording_backend_screen:
 

--- a/nestkernel/recording_backend_sionlib.h
+++ b/nestkernel/recording_backend_sionlib.h
@@ -29,7 +29,7 @@
 
 #include "recording_backend.h"
 
-/* BeginUserDocs: recording backend
+/* BeginUserDocs: NOINDEX
 
 .. _recording_backend_sionlib:
 

--- a/nestkernel/recording_backend_sionlib.h
+++ b/nestkernel/recording_backend_sionlib.h
@@ -33,8 +33,11 @@
 
 .. _recording_backend_sionlib:
 
-Store data to an efficient binary format
-########################################
+sionlib - Store data to an efficient binary format
+##################################################
+
+Description
++++++++++++
 
 .. admonition:: Availability
 

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -42,6 +42,62 @@
 namespace nest
 {
 
+/* BeginUserDocs: NOINDEX
+
+Recording time window
++++++++++++++++++++++
+
+The time span during which the recorder actually records, can be
+specified using the properties ``start`` and ``stop``. These define
+the activation period of the device in ms. An additional property
+``origin`` allows to shift the recording window by a certain time,
+which can be useful in experimental protocols with :ref:`repeated
+simulations <stepped_simulations>`. Please note that events with
+timestamp `t = start` are not recorded.
+
+Data handling
++++++++++++++
+
+All recorded data is handed over to the recording backend, selected
+via the ``record_to`` property. More details on available backends and
+their properties can be found in the :ref:`guide to recording from
+simulations <recording_backends>`.
+
+Recorder properties
++++++++++++++++++++
+
+.. glossary::
+
+ label
+   A string (default: `""`) specifying an arbitrary textual label for
+   the device.  Recording backends might use the label to generate
+   device specific identifiers like filenames and such.
+
+ n_events
+   The number of events that were collected by the recorder can be
+   read out of the `n_events` entry. The number of events can be reset
+   to 0. Other values cannot be set.
+
+ origin
+   A positive floating point number (default : `0.0`) used as the
+   reference time for `start` and `stop`.
+
+ record_to
+   A string (default: `"memory"`) containing the name of the recording
+   backend where to write data to. An empty string turns all recording
+   of individual events off.
+
+ start
+   A positive floating point number (default: `0.0`) specifying the
+   activation time in ms, relative to `origin`.
+
+ stop
+   A floating point number (default: `infinity`) specifying the
+   deactication time in ms, relative to `origin`. The value of `stop`
+   must be greater than or equal to `start`
+
+EndUserDocs */
+
 /**
  * Base class for all recording devices.
  *

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -201,7 +201,7 @@ def Connect(pre, post, conn_spec=None, syn_spec=None,
 
     See Also
     ---------
-    :ref:`connection_mgnt`
+    :ref:`connection_management`
     """
     use_connect_arrays, pre, post = _process_input_nodes(pre, post, conn_spec)
 


### PR DESCRIPTION
This PR is a replacement for #1819 and in essence adds the complete table of recorder properties to each recorder by including a documentation snippet extracted from `nestkernel/recording_device.h`, where the `RecordingBackend` base class is defined.

On the infrastructure side, I have added a line of code to handle a new magic `NOINDEX` keyword to the user doc extractor, which excludes the generated documentation from any indices in the model directory, and replaced the direct inclusion of recorder and recording backend documentation into the guide on recording from simulations by links to get the size of that page down.

This PR implements the changes discussed amongst the author and the suggested reviewers on December 12, 2020.

@jhnnsnk: please feel free to send me the example for switching recording backends you have presented at that meeting as a PR against my branch.