### PR TITLE
Fix broken colors in documentation

### DIFF
--- a/doc/colorize.rst
+++ b/doc/colorize.rst
@@ -1,0 +1,24 @@
+.. Color profiles for Sphinx.
+.. Has to be used with hacks.css (bitbucket.org/lbesson/web-sphinx/src/master/.static/hacks.css)
+.. role:: maroon
+.. role:: red
+.. role:: magenta
+.. role:: pink
+.. role:: orange
+.. role:: darkgreen
+.. role:: green
+.. role:: teal
+.. role:: cyan
+.. role:: aqua
+.. role:: blue
+.. role:: navy
+.. role:: purple
+.. role:: emph
+.. role:: under
+.. role:: over
+.. role:: blink
+.. role:: strike
+
+
+.. Based on: (c) Lilian Besson, 2011-2016, https://bitbucket.org/lbesson/web-sphinx/
+

--- a/doc/colorize.rst
+++ b/doc/colorize.rst
@@ -1,5 +1,4 @@
 .. Color profiles for Sphinx.
-.. Has to be used with hacks.css (bitbucket.org/lbesson/web-sphinx/src/master/.static/hacks.css)
 .. role:: maroon
 .. role:: red
 .. role:: magenta


### PR DESCRIPTION
Re-adding colorize.rst into the doc/ folder after removing in PR #1906. Without this file the color roles on Read the Docs do not work.