### PR TITLE
Explain neuron models in documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,9 +41,11 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
     You can find a list of all models implemented in NEST in our
     :doc:`model directory <models/index>`.
 
-    Each neuron model is one entity. Check out
-    `NESTML <https://nestml.readthedocs.io/en/latest/>`_ if you want to combine
-    aspects of different models or create a new model.
+    Please note that each neuron or synapse model available in NEST is a single
+    entity. If your research demands a combination of features that are available
+    in `different` models, our built-in models may not be for you. In this case you
+    should check out `NESTML <https://nestml.readthedocs.io/en/latest/>`_ to
+    learn about how to create your own.
 
 .. raw:: html
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,14 +38,9 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
 
 **Know which model you need?**
-    You can find a list of all models implemented in NEST in our
-    :doc:`model directory <models/index>`.
-
-    Please note that each neuron or synapse model available in NEST is a single
-    entity. If your research demands a combination of features that are available
-    in `different` models, our built-in models may not be for you. In this case you
-    should check out `NESTML <https://nestml.readthedocs.io/en/latest/>`_ to
-    learn about how to create your own.
+    NEST comes packaged with a large collection of neuron and synaptic plasticity models.
+    You can find a list of all available models in our :doc:`model directory <models/index>`,
+    or select a model category by clicking one of the images:
 
 .. raw:: html
 
@@ -74,6 +69,10 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
   </embed>
 
+
+**Need a different model?**
+    To customize or combine features of neuron and synapse models, we recommend
+    using the `NESTML modeling language <https://nestml.readthedocs.io/>`_.
 
 **Have a question or issue with NEST?**
     See our :doc:`Getting Help <getting_help>` page.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,7 +38,8 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
 
 **Have an idea of the type of model you need?**
-    Click on one of the images to access our :doc:`model directory <models/index>`:
+
+    You can find a list of all models implemented in NEST in our model directory.
 
 .. raw:: html
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,10 +65,7 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
   <a href="microcircuit/index.html">
     <img src="_images/microcircuit.png" alt="Microcircuit" style="width:150px;height:150px;border:0;">
   </a>
-
-
   </embed>
-
 
 **Need a different model?**
     To customize or combine features of neuron and synapse models, we recommend

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -46,13 +46,13 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
  <embed>
 
- <a href="models/neurons.html">
+ <a href="models/index_neuron.html">
     <img src="_static/img/neuron.png" alt="Neuron Models" style="width:150px;height:150px;border:0;">
   </a>
-  <a href="models/synapses.html">
+  <a href="models/index_synapse.html">
     <img src="_static/img/synapse1.png" alt="Synapse Models" style="width:150px;height:150px;border:0;">
   </a>
-  <a href="models/devices.html">
+  <a href="models/index_device.html">
     <img src="_static/img/oscilloscope.png" alt="Devices" style="width:150px;height:150px;border:0;">
   </a>
   </embed>
@@ -62,7 +62,7 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 .. raw:: html
 
   <embed>
-  <a href="microcircuit/index.html">
+  <a href="examples/cortical_microcircuit_index.html">
     <img src="_images/microcircuit.png" alt="Microcircuit" style="width:150px;height:150px;border:0;">
   </a>
   </embed>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,9 +37,13 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
     Start here at our :doc:`Getting Started <getting_started>` page
 
 
-**Have an idea of the type of model you need?**
+**Know which model you need?**
     You can find a list of all models implemented in NEST in our
     :doc:`model directory <models/index>`.
+
+    Each model is one entity. Check out
+    `NESTML <https://nestml.readthedocs.io/en/latest/>`_ if you want to combine
+    aspects of different models or create a new model.
 
 .. raw:: html
 
@@ -68,11 +72,6 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
   </embed>
 
-
-**Need a different or combined model?**
-    A model in NEST is one entity. Check out
-    `NESTML <https://nestml.readthedocs.io/en/latest/>`_ if you want to combine
-    aspects of different models or create a new model.
 
 **Have a question or issue with NEST?**
     See our :doc:`Getting Help <getting_help>` page.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,8 +38,8 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
 
 **Have an idea of the type of model you need?**
-
-    You can find a list of all models implemented in NEST in our model directory.
+    You can find a list of all models implemented in NEST in our
+    :doc:`model directory <models/index>`.
 
 .. raw:: html
 
@@ -70,7 +70,8 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
 
 
 **Need a different or combined model?**
-    A model in NEST is one entity. Check out NESTML if you want to combine
+    A model in NEST is one entity. Check out
+    `NESTML <https://nestml.readthedocs.io/en/latest/>`_ if you want to combine
     aspects of different models or create a new model.
 
 **Have a question or issue with NEST?**

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,8 +69,9 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
   </embed>
 
 
-**Need a different model?**
-    Check out how you can :doc:`create you own model <models/create_model>` here.
+**Need a different or combined model?**
+    A model in NEST is one entity. Check out NESTML if you want to combine
+    aspects of different models or create a new model.
 
 **Have a question or issue with NEST?**
     See our :doc:`Getting Help <getting_help>` page.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,7 +41,7 @@ NEST is a simulator for **spiking neural network models**, ideal for networks of
     You can find a list of all models implemented in NEST in our
     :doc:`model directory <models/index>`.
 
-    Each model is one entity. Check out
+    Each neuron model is one entity. Check out
     `NESTML <https://nestml.readthedocs.io/en/latest/>`_ if you want to combine
     aspects of different models or create a new model.
 


### PR DESCRIPTION
This PR clarifies that neuron models in NEST are one entity. It fixes #1866.