### PR TITLE
Update NEST 2.20.x CMake configuration to support OpenMP fully on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>
 
-cmake_minimum_required( VERSION 3.1 )
+# Version range from minimum required (3.12 for macOS OpenMP)
+# up to newest version tested, see https://cliutils.gitlab.io/modern-cmake/chapters/basics.html
+cmake_minimum_required( VERSION 3.12...3.19 )
 
 # add cmake modules: for all `include(...)` first look here
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )

--- a/sli/CMakeLists.txt
+++ b/sli/CMakeLists.txt
@@ -84,7 +84,7 @@ set( sli_sources
     )
 
 add_library( sli_lib ${sli_sources} )
-target_link_libraries( sli_lib nestutil )
+target_link_libraries( sli_lib nestutil OpenMP::OpenMP_CXX )
 
 # Make a separate target for linking against readline, so that
 # pynestkernel does not need to link against readline and make
@@ -92,11 +92,11 @@ target_link_libraries( sli_lib nestutil )
 # pull request for more information:
 # https://github.com/nest/nest-simulator/pull/323
 add_library( sli_readline gnureadline.cc gnureadline.h )
-target_link_libraries( sli_readline sli_lib nestutil ${READLINE_LIBRARIES} )
+target_link_libraries( sli_readline sli_lib nestutil ${READLINE_LIBRARIES} OpenMP::OpenMP_CXX )
 
 # add the executable
 add_executable( sli puresli.cc )
-target_link_libraries( sli sli_lib sli_readline ${GSL_LIBRARIES} )
+target_link_libraries( sli sli_lib sli_readline ${GSL_LIBRARIES} OpenMP::OpenMP_CXX )
 
 target_include_directories( sli PRIVATE
     ${PROJECT_SOURCE_DIR}/libnestutil


### PR DESCRIPTION
This is a backport from NEST3 to make sure threaded NEST compiles fine with Clang on macOS.