### PR TITLE
Remove all mentions of spike multiplicity from user documentation

### DIFF
--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -68,7 +68,7 @@ namespace nest
  * state makes an up-transition it sends a spike with multiplicity 2,
  * if a down transition occurs, it sends a spike with multiplicity 1.
  * The decoding scheme relies on the feature that spikes with multiplicity
- * larger 1 are delivered consecutively, also in a parallel setting.
+ * larger than 1 are delivered consecutively, also in a parallel setting.
  * The creation of double connections between binary neurons will
  * destroy the decoding scheme, as this effectively duplicates
  * every event. Using random connection routines it is therefore

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -61,7 +61,22 @@ namespace nest
  * This class is a base class that needs to be instantiated with a gain
  * function.
  *
- * @see ginzburg_neuron, mccullogh_pitts_neuron
+ * @note
+ * This neuron has a special use for spike events to convey the
+ * binary state of the neuron to the target. The neuron model
+ * only sends a spike if a transition of its state occurs. If the
+ * state makes an up-transition it sends a spike with multiplicity 2,
+ * if a down transition occurs, it sends a spike with multiplicity 1.
+ * The decoding scheme relies on the feature that spikes with multiplicity
+ * larger 1 are delivered consecutively, also in a parallel setting.
+ * The creation of double connections between binary neurons will
+ * destroy the decoding scheme, as this effectively duplicates
+ * every event. Using random connection routines it is therefore
+ * advisable to set the property 'allow_multapses' to false.
+ * The neuron accepts several sources of currents, e.g. from a
+ * noise_generator.
+ *
+ * @see ginzburg_neuron, mccullogh_pitts_neuron, erfc_neuron
  */
 template < class TGainfunction >
 class binary_neuron : public ArchivingNode
@@ -525,8 +540,8 @@ binary_neuron< TGainfunction >::handle( SpikeEvent& e )
   // correct.
 
 
-  long m = e.get_multiplicity();
-  long node_id = e.get_sender_node_id();
+  const long m = e.get_multiplicity();
+  const long node_id = e.get_sender_node_id();
   const Time& t_spike = e.get_stamp();
 
   if ( m == 1 )
@@ -547,8 +562,7 @@ binary_neuron< TGainfunction >::handle( SpikeEvent& e )
         e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), -e.get_weight() );
     }
   }
-  else // multiplicity != 1
-    if ( m == 2 )
+  else if ( m == 2 )
   {
     // count this event positively, transition 0->1
     B_.spikes_.add_value( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), e.get_weight() );

--- a/models/erfc_neuron.h
+++ b/models/erfc_neuron.h
@@ -40,49 +40,35 @@ activation function
 Description
 +++++++++++
 
-The erfc_neuron is an implementation of a binary neuron that
+The ``erfc_neuron`` is an implementation of a binary neuron that
 is irregularly updated at Poisson time points. At each update
-point, the total synaptic input h into the neuron is summed up,
-passed through a gain function g whose output is interpreted as
+point, the total synaptic input :math:`h` into the neuron is summed up,
+passed through a gain function :math:`g` whose output is interpreted as
 the probability of the neuron to be in the active (1) state.
 
-The gain function g used here is
+The gain function used here is
 
 .. math::
 
- g(h) = 0.5 * erfc (( h - \theta ) / ( \sqrt( 2. ) * \sigma)).
+ g(h) = \frac{1}{2} \mathrm{erfc} \frac{h - \theta}{\sqrt{2}\sigma}\;.
 
 This corresponds to a McCulloch-Pitts neuron receiving additional
-Gaussian noise with mean 0 and standard deviation sigma.  The time
-constant tau_m is defined as the mean of the inter-update-interval
+Gaussian noise with mean 0 and standard deviation :math:`\sigma`.  The time
+constant :math:`\tau_m` is defined as the mean of the inter-update-interval
 that is drawn from an exponential distribution with this
 parameter. Using this neuron to reproduce simulations with
-asynchronous update (similar to [1,2]_), the time constant needs to be
-chosen as tau_m = dt*N, where dt is the simulation time step and N the
-number of neurons in the original simulation with asynchronous
-update. This ensures that a neuron is updated on average every tau_m
-ms. Since in the original papers [1,2]_ neurons are coupled with zero
+asynchronous update (similar to [1]_ [2]_), the time constant needs to be
+chosen as :math:`\tau_m = dt \times N`, where :math:`dt` is the simulation
+time step and :math:`N` the number of neurons in the original simulation with asynchronous
+update. This ensures that a neuron is updated on average every :math:`\tau_m`
+ms. Since in the original papers [1]_ [2]_ neurons are coupled with zero
 delay, this implementation follows that definition. It uses the update
 scheme described in [3]_ to maintain causality: The incoming events in
 time step t_i are taken into account at the beginning of the time step
 to calculate the gain function and to decide upon a transition.  In
-order to obtain delayed coupling with delay d, the user has to specify
-the delay d+h upon connection, where h is the simulation time step.
+order to obtain delayed coupling with delay :math:`d`, the user has to specify
+the delay :math:`d+h` upon connection, where :math:`h` is the simulation time step.
 
-Remarks:
-
-This neuron has a special use for spike events to convey the binary
-state of the neuron to the target. The neuron model only sends a spike
-if a transition of its state occurs. If the state makes an
-up-transition it sends a spike with multiplicity 2, if a down
-transition occurs, it sends a spike with multiplicity 1.  The decoding
-scheme relies on the feature that spikes with multiplicity larger 1
-are delivered consecutively, also in a parallel setting.  The creation
-of double connections between binary neurons will destroy the decoding
-scheme, as this effectively duplicates every event. Using random
-connection routines it is therefore advisable to set the property
-'allow_multapses' to false.  The neuron accepts several sources of
-currents, e.g. from a noise_generator.
 
 Parameters
 ++++++++++
@@ -93,11 +79,32 @@ Parameters
  sigma  mV      1/sqrt(2pi) x inverse of maximal slope
 ======  ======  =========================================================
 
+.. admonition:: Special requirements for binary neurons
+
+   As a binary neuron, the ``erfc_neuron``, the user must
+   ensure that the following requirements are observed. NEST does not
+   enforce them. Breaching the requirements can lead to meaningless
+   results.
+
+   1. Binary neurons must only be connected to other binary neurons.
+
+   #. At most one connection must be created between any pair of
+      binary neurons. When using probabilistic connection rules, specify
+      ``'allow_autapses': False`` to avoid accidental creation of
+      multiple connections between a pair of neurons.
+
+   #. Binary neurons can be driven by current-injecting devices, but
+      *not* by spike generators.
+
+   #. Activity of binary neurons can only be recored using a `spin_detector`
+      or `correlospinmatrix_detector`.
+
+
 References
 ++++++++++
 
 .. [1] Ginzburg I, Sompolinsky H (1994). Theory of correlations in stochastic
-       neural networks. PRE 50(4) p. 3171
+       neural networks. PRE 50(4) p. 3171.
        DOI: https://doi.org/10.1103/PhysRevE.50.3171
 .. [2] McCulloch W, Pitts W (1943). A logical calculus of the ideas
        immanent in nervous activity. Bulletin of Mathematical Biophysics,
@@ -107,20 +114,16 @@ References
        p. 267. Peter beim Graben, Changsong Zhou, Marco Thiel, Juergen Kurths
        (Eds.), Springer. DOI: https://doi.org/10.1007/978-3-540-73159-7_10
 
-Sends
-+++++
-
-SpikeEvent
 
 Receives
 ++++++++
 
-SpikeEvent, PotentialRequest
+CurrentEvent
 
 See also
 ++++++++
 
-mcculloch_pitts_neuron, ginzburg_neuron
+mcculloch_pitts_neuron, ginzburg_neuron, spin_detector, correlospinmatrix_detector
 
 EndUserDocs */
 

--- a/models/erfc_neuron.h
+++ b/models/erfc_neuron.h
@@ -96,8 +96,8 @@ Parameters
    #. Binary neurons can be driven by current-injecting devices, but
       *not* by spike generators.
 
-   #. Activity of binary neurons can only be recored using a `spin_detector`
-      or `correlospinmatrix_detector`.
+   #. Activity of binary neurons can only be recored using a ``spin_detector``
+      or ``correlospinmatrix_detector``.
 
 
 References
@@ -123,7 +123,6 @@ CurrentEvent
 See also
 ++++++++
 
-mcculloch_pitts_neuron, ginzburg_neuron, spin_detector, correlospinmatrix_detector
 
 EndUserDocs */
 

--- a/models/erfc_neuron.h
+++ b/models/erfc_neuron.h
@@ -88,7 +88,7 @@ Parameters
 
    1. Binary neurons must only be connected to other binary neurons.
 
-   #. At most one connection must be created between any pair of
+   #. No more than one connection must be created between any pair of
       binary neurons. When using probabilistic connection rules, specify
       ``'allow_autapses': False`` to avoid accidental creation of
       multiple connections between a pair of neurons.

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -52,42 +52,29 @@ Description
 
 This model simulates a population of spike-response model neurons with
 multi-timescale adaptation and exponential postsynaptic currents, as
-described in Schwalger et al. (2017) [1]_.
+described by Schwalger et al. (2017) [1]_.
 
-The single neuron model is defined by the hazard function:
+The single neuron model is defined by the hazard function
 
 .. math::
 
- \lambda_0 * \exp\left(( V_m - E_{sfa} ) / \Delta_V\right)
+ h(t) = \lambda_0  \exp\frac{V_m(t) - E_{\text{sfa}}(t)}{\Delta_V}
 
-After each spike, the membrane potential V_m is reset to V_reset. Spike
-frequency
+After each spike, the membrane potential :math:`V_m` is reset to
+:math:`V_{\text{reset}}`. Spike frequency
 adaptation is implemented by a set of exponentially decaying traces, the
-sum of which is E_sfa. Upon a spike, all adaptation traces are incremented
-by the respective q_sfa each and decay with the respective time constant
+sum of which is :math:`E_{\text{sfa}}`. Upon a spike, all adaptation traces are incremented
+by the respective :math:`q_{\text{sfa}}` each and decay with the respective time constant
 tau_sfa.
 
-The corresponding single neuron model is available in NEST as gif_psc_exp.
+The corresponding single neuron model is available in NEST as ``gif_psc_exp``.
 The default parameters, although some are named slightly different, are not
-matched in both models due to historical reasons. See below for the parameter
+matched in both models for historical reasons. See below for the parameter
 translation.
-
-As gif_pop_psc_exp represents many neurons in one node, it may send a lot
-of spikes. In each time step, it sends at most one spike though, the
-multiplicity of which is set to the number of emitted spikes. Postsynaptic
-neurons and devices in NEST understand this as several spikes, but
-communication effort is reduced in simulations.
-
-This model uses a new algorithm to directly simulate the population activity
-(sum of all spikes) of the population of neurons, without explicitly
-representing each single neuron. The computational cost is largely
-independent of the number N of neurons represented. The algorithm used
-here is fundamentally different from and likely much faster than the one
-used in the previously added population model pp_pop_psc_delta.
 
 Connecting two population models corresponds to full connectivity of every
 neuron in each population. An approximation of random connectivity can be
-implemented by connecting populations through a spike_dilutor.
+implemented by connecting populations through a ``spike_dilutor``.
 
 
 Parameters
@@ -124,7 +111,7 @@ The following parameters can be set in the status dictionary.
 -----------------------------------------------------------
 gif_pop_psc_exp  gif_psc_exp  relation
 tau_m            g_L          tau_m = C_m / g_L
-N                ---          use N gif_psc_exp
+N                ---          use N gif_psc_exp neurons
 =============== ============  =============================
 
 
@@ -154,6 +141,22 @@ gif_psc_exp, pp_pop_psc_delta, spike_dilutor
 
 EndUserDocs */
 
+
+/**
+ * @note
+ * As gif_pop_psc_exp represents many neurons in one node, it may send a lot
+ * of spikes. In each time step, it sends at most one spike though, the
+ * multiplicity of which is set to the number of emitted spikes. Postsynaptic
+ * neurons and devices in NEST understand this as several spikes, but
+ * communication effort is reduced in simulations.
+ *
+ * This model uses a new algorithm to directly simulate the population activity
+ * (sum of all spikes) of the population of neurons, without explicitly
+ * representing each single neuron. The computational cost is largely
+ * independent of the number N of neurons represented. The algorithm used
+ * here is fundamentally different from and likely much faster than the one
+ * used in the previously added population model pp_pop_psc_delta.
+ */
 class gif_pop_psc_exp : public Node
 {
 

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -65,7 +65,7 @@ After each spike, the membrane potential :math:`V_m` is reset to
 adaptation is implemented by a set of exponentially decaying traces, the
 sum of which is :math:`E_{\text{sfa}}`. Upon a spike, each of the adaptation traces is
 incremented by the respective :math:`q_{\text{sfa}}` and decays with the respective time constant
-tau_sfa.
+:math:`\tau_{\text{sfa}}`.
 
 The corresponding single neuron model is available in NEST as ``gif_psc_exp``.
 The default parameters, although some are named slightly different, are not

--- a/models/ginzburg_neuron.h
+++ b/models/ginzburg_neuron.h
@@ -39,7 +39,7 @@ Binary stochastic neuron with sigmoidal activation function
 Description
 +++++++++++
 
-The `ginzburg_neuron` is an implementation of a binary neuron that
+The ``ginzburg_neuron`` is an implementation of a binary neuron that
 is irregularly updated as Poisson time points. At each update
 point, the total synaptic input h into the neuron is summed up,
 passed through a gain function g whose output is interpreted as
@@ -100,8 +100,8 @@ c_3    1/mV          Slope factor of sigmoidal gain
    #. Binary neurons can be driven by current-injecting devices, but
       *not* by spike generators.
 
-   #. Activity of binary neurons can only be recored using a `spin_detector`
-      or `correlospinmatrix_detector`.
+   #. Activity of binary neurons can only be recored using a ``spin_detector``
+      or ``correlospinmatrix_detector``.
 
 
 References
@@ -127,7 +127,6 @@ CurrentEvent
 See also
 ++++++++
 
-mcculloch_pitts_neuron, erfc_neuron, spin_detector, correlospinmatrix_detector
 
 EndUserDocs */
 

--- a/models/ginzburg_neuron.h
+++ b/models/ginzburg_neuron.h
@@ -92,7 +92,7 @@ c_3    1/mV          Slope factor of sigmoidal gain
 
    1. Binary neurons must only be connected to other binary neurons.
 
-   #. At most one connection must be created between any pair of
+   #. No more than connection must be created between any pair of
       binary neurons. When using probabilistic connection rules, specify
       ``'allow_autapses': False`` to avoid accidental creation of
       multiple connections between a pair of neurons.

--- a/models/ginzburg_neuron.h
+++ b/models/ginzburg_neuron.h
@@ -39,26 +39,27 @@ Binary stochastic neuron with sigmoidal activation function
 Description
 +++++++++++
 
-The ginzburg_neuron is an implementation of a binary neuron that
+The `ginzburg_neuron` is an implementation of a binary neuron that
 is irregularly updated as Poisson time points. At each update
 point, the total synaptic input h into the neuron is summed up,
 passed through a gain function g whose output is interpreted as
 the probability of the neuron to be in the active (1) state.
 
-The gain function g used here is :math:`g(h) = c_1*h + c_2 * 0.5*(1 +
-\tanh(c_3*(h-\theta)))` (output clipped to [0,1]). This allows to
-obtain affine-linear (:math:`c_1\neq0, c_2\neq0, c_3=0`) or sigmoidal (:math:`c_1=0,
-c_2=1, c_3\neq0`) shaped gain functions. The latter choice
+The gain function used here is :math:`g(h) = c_1 h + c_2 (1 +
+\tanh(c_3 (h-\theta)))/2` (output clipped to :math:`[0, 1]`). This permits
+affine-linear (:math:`c_1\neq0, c_2\neq0, c_3=0`) or sigmoidally shaped
+(:math:`c_1=0, c_2=1, c_3\neq0`) gain functions. The latter choice
 corresponds to the definition in [1]_, giving the name to this
 neuron model.
+
 The choice :math:`c_1=0, c_2=1, c_3=\beta/2` corresponds to the Glauber
 dynamics [2]_, :math:`g(h) = 1 / (1 + \exp(-\beta (h-\theta)))`.
 The time constant :math:`\tau_m` is defined as the mean
 inter-update-interval that is drawn from an exponential
 distribution with this parameter. Using this neuron to reproduce
 simulations with asynchronous update [1]_, the time constant needs
-to be chosen as :math:`\tau_m = dt*N`, where dt is the simulation time
-step and N the number of neurons in the original simulation with
+to be chosen as :math:`\tau_m = dt \times N`, where :math:`dt` is the simulation time
+step and :math:`N` the number of neurons in the original simulation with
 asynchronous update. This ensures that a neuron is updated on
 average every :math:`\tau_m` ms. Since in the original paper [1]_ neurons
 are coupled with zero delay, this implementation follows this
@@ -66,24 +67,9 @@ definition. It uses the update scheme described in [3]_ to
 maintain causality: The incoming events in time step :math:`t_i` are
 taken into account at the beginning of the time step to calculate
 the gain function and to decide upon a transition.  In order to
-obtain delayed coupling with delay d, the user has to specify the
-delay d+h upon connection, where h is the simulation time step.
+obtain delayed coupling with delay :math:`d`, the user has to specify the
+delay :math:`d+h` upon connection, where :math:`h` is the simulation time step.
 
-Remarks:
-
-This neuron has a special use for spike events to convey the
-binary state of the neuron to the target. The neuron model
-only sends a spike if a transition of its state occurs. If the
-state makes an up-transition it sends a spike with multiplicity 2,
-if a down transition occurs, it sends a spike with multiplicity 1.
-The decoding scheme relies on the feature that spikes with multiplicity
-larger 1 are delivered consecutively, also in a parallel setting.
-The creation of double connections between binary neurons will
-destroy the deconding scheme, as this effectively duplicates
-every event. Using random connection routines it is therefore
-advisable to set the property 'allow_multapses' to false.
-The neuron accepts several sources of currents, e.g. from a
-noise_generator.
 
 Parameters
 ++++++++++
@@ -97,11 +83,32 @@ c_2    probability   Prefactor of sigmoidal gain
 c_3    1/mV          Slope factor of sigmoidal gain
 ====== ============= ===========================================================
 
+.. admonition:: Special requirements for binary neurons
+
+   As a binary neuron, the ``ginzburg_neuron``, the user must
+   ensure that the following requirements are observed. NEST does not
+   enforce them. Breaching the requirements can lead to meaningless
+   results.
+
+   1. Binary neurons must only be connected to other binary neurons.
+
+   #. At most one connection must be created between any pair of
+      binary neurons. When using probabilistic connection rules, specify
+      ``'allow_autapses': False`` to avoid accidental creation of
+      multiple connections between a pair of neurons.
+
+   #. Binary neurons can be driven by current-injecting devices, but
+      *not* by spike generators.
+
+   #. Activity of binary neurons can only be recored using a `spin_detector`
+      or `correlospinmatrix_detector`.
+
+
 References
 ++++++++++
 
 .. [1] Ginzburg I, Sompolinsky H (1994). Theory of correlations in stochastic
-       neural networks. PRE 50(4) p. 3171
+       neural networks. PRE 50(4) p. 3171.
        DOI: https://doi.org/10.1103/PhysRevE.50.3171
 .. [2] Hertz J, Krogh A, Palmer R (1991). Introduction to the theory of neural
        computation. Addison-Wesley Publishing Conmpany.
@@ -111,20 +118,16 @@ References
        (Eds.), Springer.
        DOI: https://doi.org/10.1007/978-3-540-73159-7_10
 
-Sends
-+++++
-
-SpikeEvent
 
 Receives
 ++++++++
 
-SpikeEvent, PotentialRequest
+CurrentEvent
 
 See also
 ++++++++
 
-pp_psc_delta
+mcculloch_pitts_neuron, erfc_neuron, spin_detector, correlospinmatrix_detector
 
 EndUserDocs */
 

--- a/models/mcculloch_pitts_neuron.h
+++ b/models/mcculloch_pitts_neuron.h
@@ -39,43 +39,28 @@ Binary deterministic neuron with Heaviside activation function
 Description
 +++++++++++
 
-The mcculloch_pitts_neuron is an implementation of a binary
+The `mcculloch_pitts_neuron` is an implementation of a binary
 neuron that is irregularly updated as Poisson time points [1]_. At
 each update point the total synaptic input h into the neuron is
-summed up, passed through a Heaviside gain function g(h) = H(h-theta),
+summed up, passed through a Heaviside gain function :math:`g(h) = H(h-\theta)`,
 whose output is either 1 (if input is above) or 0 (if input is below
 threshold theta).
-The time constant tau_m is defined as the
+The time constant :math:`\tau_m` is defined as the
 mean inter-update-interval that is drawn from an exponential
 distribution with this parameter. Using this neuron to reproduce
 simulations with asynchronous update [1]_, the time constant needs
-to be chosen as tau_m = dt*N, where dt is the simulation time
-step and N the number of neurons in the original simulation with
+to be chosen as :math:`\tau_m = dt \times N`, where :math:`dt` is the simulation time
+step and :math:`N` the number of neurons in the original simulation with
 asynchronous update. This ensures that a neuron is updated on
-average every tau_m ms. Since in the original paper [1]_ neurons
+average every :math:`\tau_m` ms. Since in the original paper [1]_ neurons
 are coupled with zero delay, this implementation follows this
 definition. It uses the update scheme described in [3]_ to
-maintain causality: The incoming events in time step t_i are
+maintain causality: The incoming events in time step :math:`t_i` are
 taken into account at the beginning of the time step to calculate
 the gain function and to decide upon a transition.  In order to
-obtain delayed coupling with delay d, the user has to specify the
-delay d+h upon connection, where h is the simulation time step.
+obtain delayed coupling with delay :math:`d`, the user has to specify the
+delay :math:`d+h` upon connection, where :math:`h` is the simulation time step.
 
-Remarks:
-
-This neuron has a special use for spike events to convey the
-binary state of the neuron to the target. The neuron model
-only sends a spike if a transition of its state occurs. If the
-state makes an up-transition it sends a spike with multiplicity 2,
-if a down transition occurs, it sends a spike with multiplicity 1.
-The decoding scheme relies on the feature that spikes with multiplicity
-larger 1 are delivered consecutively, also in a parallel setting.
-The creation of double connections between binary neurons will
-destroy the decoding scheme, as this effectively duplicates
-every event. Using random connection routines it is therefore
-advisable to set the property 'allow_multapses' to false.
-The neuron accepts several sources of currents, e.g. from a
-noise_generator.
 
 Parameters
 ++++++++++
@@ -84,6 +69,28 @@ Parameters
  tau_m   ms      Membrane time constant (mean inter-update-interval)
  theta   mV      Threshold for sigmoidal activation function
 ======= =======  ====================================================
+
+
+.. admonition:: Special requirements for binary neurons
+
+   As a binary neuron, the ``mcculloch_pitts_neuron``, the user must
+   ensure that the following requirements are observed. NEST does not
+   enforce them. Breaching the requirements can lead to meaningless
+   results.
+
+   1. Binary neurons must only be connected to other binary neurons.
+
+   #. At most one connection must be created between any pair of
+      binary neurons. When using probabilistic connection rules, specify
+      ``'allow_autapses': False`` to avoid accidental creation of
+      multiple connections between a pair of neurons.
+
+   #. Binary neurons can be driven by current-injecting devices, but
+      *not* by spike generators.
+
+   #. Activity of binary neurons can only be recored using a `spin_detector`
+      or `correlospinmatrix_detector`.
+
 
 References
 ++++++++++
@@ -99,20 +106,17 @@ References
        (Eds.), Springer.
        DOI: https://doi.org/10.1007/978-3-540-73159-7_10
 
-Sends
-+++++
-
-SpikeEvent
 
 Receives
 ++++++++
 
-SpikeEvent, PotentialRequest
+CurrentEvent
+
 
 See also
 ++++++++
 
-pp_psc_delta
+ginzburg_neuron, erfc_neuron, spin_detector, correlospinmatrix_detector
 
 EndUserDocs */
 

--- a/models/mcculloch_pitts_neuron.h
+++ b/models/mcculloch_pitts_neuron.h
@@ -80,7 +80,7 @@ Parameters
 
    1. Binary neurons must only be connected to other binary neurons.
 
-   #. At most one connection must be created between any pair of
+   #. No more than one connection must be created between any pair of
       binary neurons. When using probabilistic connection rules, specify
       ``'allow_autapses': False`` to avoid accidental creation of
       multiple connections between a pair of neurons.

--- a/models/mcculloch_pitts_neuron.h
+++ b/models/mcculloch_pitts_neuron.h
@@ -88,8 +88,8 @@ Parameters
    #. Binary neurons can be driven by current-injecting devices, but
       *not* by spike generators.
 
-   #. Activity of binary neurons can only be recored using a `spin_detector`
-      or `correlospinmatrix_detector`.
+   #. Activity of binary neurons can only be recored using a ``spin_detector``
+      or ``correlospinmatrix_detector``.
 
 
 References
@@ -116,7 +116,6 @@ CurrentEvent
 See also
 ++++++++
 
-ginzburg_neuron, erfc_neuron, spin_detector, correlospinmatrix_detector
 
 EndUserDocs */
 

--- a/models/parrot_neuron.h
+++ b/models/parrot_neuron.h
@@ -45,27 +45,25 @@ Description
 
 The parrot neuron simply emits one spike for every incoming spike.
 An important application is to provide identical poisson spike
-trains to a group of neurons. The poisson_generator sends a different
+trains to a group of neurons. The ``poisson_generator`` sends a different
 spike train to each of its target neurons. By connecting one
-poisson_generator to a parrot_neuron and then that parrot_neuron to
+``poisson_generator`` to a ``parrot_neuron`` and then that ``parrot_neuron`` to
 a group of neurons, all target neurons will receive the same poisson
 spike train.
 
-Remarks:
+Remarks
+.......
 
-- Weights on connection to the parrot_neuron are ignored.
-- Weights on connections from the parrot_neuron are handled as usual.
+- Weights of connections *to* the ``parrot_neuron`` are ignored.
+- Weights on connections *from* the ``parrot_neuron`` are handled as usual.
 - Delays are honored on incoming and outgoing connections.
-- Multiplicity may be used to indicate number of spikes in a single
-  time step. Instead of the accumulated weigths of the incoming spikes, the
-  number of the spikes is stored within a ring buffer.
 
 Only spikes arriving on connections to port 0 will be repeated.
 Connections onto port 1 will be accepted, but spikes incoming
 through port 1 will be ignored. This allows setting exact pre-
 and postsynaptic spike times for STDP protocols by connecting
 two parrot neurons spiking at desired times by, e.g., a
-stdp_synapse onto port 1 on the postsynaptic parrot neuron.
+`stdp_synapse` onto port 1 on the postsynaptic parrot neuron.
 
 Receives
 ++++++++

--- a/models/pp_pop_psc_delta.h
+++ b/models/pp_pop_psc_delta.h
@@ -47,53 +47,46 @@ Population of point process neurons with leaky integration of delta-shaped PSCs
 Description
 +++++++++++
 
-pp_pop_psc_delta is an effective model of a population of neurons. The
-N component neurons are assumed to be spike response models with escape
+``pp_pop_psc_delta`` is an effective model of a population of neurons. The
+:math:`N` component neurons are assumed to be spike-response models with escape
 noise, also known as generalized linear models. We follow closely the
 nomenclature of [1]_. The component neurons are a special case of
-pp_psc_delta (with purely exponential rate function, no reset and no
-random dead_time). All neurons in the population share the inputs that it
+``pp_psc_delta`` (with purely exponential rate function, no reset and no
+random deadtime). All neurons in the population share the inputs that it
 receives, and the output is the pooled spike train.
 
-The instantaneous firing rate of the N component neurons is defined as
+The instantaneous firing rate of the :math:`N` component neurons is defined as
 
 .. math::
 
- rate(t) = \rho_0 * \exp( (h(t) - \eta(t))/\delta_u ),
+ r(t) = \rho_0  \exp \frac{h(t) - \eta(t)}{\delta_u}\;,
 
-where h(t) is the input potential (synaptic delta currents convolved with
-an exponential kernel with time constant tau_m), eta(t) models the effect
+where :math:`h(t)` is the input potential (synaptic delta currents convolved with
+an exponential kernel with time constant :math:`tau_m`), :math:`\eta(t)` models the effect
 of refractoriness and adaptation (the neuron's own spike train convolved with
-a sum of exponential kernels with time constants tau_eta), and delta_u
+a sum of exponential kernels with time constants :math:`\tau_{\eta}`), and :math:`\delta_u`
 sets the scale of the voltages.
 
-To represent a (homogeneous) population of N inhomogeneous renewal process
+To represent a (homogeneous) population of :math:`N` inhomogeneous renewal process
 neurons, we can keep track of the numbers of neurons that fired a certain
 number of time steps in the past. These neurons will have the same value of
 the hazard function (instantaneous rate), and we draw a binomial random
 number for each of these groups. This algorithm is thus very similar to
-ppd_sup_generator and gamma_sup_generator, see also [2]_.
+``ppd_sup_generator`` and ``gamma_sup_generator``, see also [2]_.
 
-However, the adapting threshold eta(t) of the neurons generally makes the
+However, the adapting threshold :math:`\eta(t)` of the neurons generally makes the
 neurons non-renewal processes. We employ the quasi-renewal approximation
 [1]_, to be able to use the above algorithm. For the extension of [1] to
 coupled populations see [3]_.
 
 In effect, in each simulation time step, a binomial random number for each
 of the groups of neurons has to be drawn, independent of the number of
-represented neurons. For large N, it should be much more efficient than
-simulating N individual pp_psc_delta models.
+represented neurons. For large :math:`N`, it should be much more efficient than
+simulating :math:`N` individual ``pp_psc_delta`` models.
 
-pp_pop_psc_delta emits spike events like other neuron models, but no more
-than one per time step. If several component neurons spike in the time step,
-the multiplicity of the spike event is set accordingly. Thus, to monitor
-its output, the multiplicity of the spike events has to be taken into
-account. Alternatively, the internal variable n_events gives the number of
-spikes emitted in a time step, and can be monitored using a multimeter.
+The internal variable ``n_events`` gives the number of
+spikes emitted in a time step, and can be monitored using a ``multimeter``.
 
-EDIT Nov 2016: pp_pop_psc_delta is now deprecated, because a new and
-presumably much faster population model implementation is now available, see
-gif_pop_psc_exp.
 
 Parameters
 ++++++++++
@@ -128,6 +121,12 @@ The parameters correspond to the ones of pp_psc_delta as follows.
  with_reset         False
  t_ref_remaining    0.0
 ==================  ============================
+
+.. admonition:: Deprecated model
+
+   ``pp_pop_psc_delta`` is deprecated because a new and presumably much faster
+   population model implementation is now available, see ``gif_pop_psc_exp``.
+
 
 References
 ++++++++++

--- a/models/pp_pop_psc_delta.h
+++ b/models/pp_pop_psc_delta.h
@@ -157,7 +157,6 @@ SpikeEvent, CurrentEvent, DataLoggingRequest
 See also
 ++++++++
 
-gif_pop_psc_exp, pp_psc_delta, ppd_sup_generator, gamma_sup_generator
 
 EndUserDocs */
 

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -118,7 +118,7 @@ and exponential input filters) (see [5,6]_).
 This model has been adapted from iaf_psc_delta. The default parameters are
 set to the mean values given in [2]_, which have been matched to spike-train
 recordings. Due to the many features of pp_psc_delta and its versatility,
-parameters should be set carefully and conciously.
+parameters should be set carefully and consciously.
 
 Parameters
 ++++++++++


### PR DESCRIPTION
Spike multiplicity is an internal implementation detail of NEST and should thus not be mentioned in user-facing documentation. In some cases, this PR moves such documentation to developer docs (doxygen docstrings) or removes it entirely where that seemed the better choice.

The PR also adds user-directed admonitions to documentation for binary neurons and improves docstring formatting.

@ddahmen Could you look at the binary neuron and population generator documentation and check it for correctness of content?