### PR TITLE
Clarify the post-pre convention used in plot-weight-matrices example documentation

### DIFF
--- a/pynest/examples/plot_weight_matrices.py
+++ b/pynest/examples/plot_weight_matrices.py
@@ -50,7 +50,11 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 # number of elements in each population.
 # Since in this example, we have 2 populations (E/I), :math:`2^2` possible
 # synaptic connections exist (EE, EI, IE, II).
-
+#
+# Note the use of "post-pre" notation when referring to synaptic connections.
+# As a matter of convention in computational neuroscience, we refer to the
+# connection from inhibitory to excitatory neurons (I->E) as EI (post-pre) and
+# connections from excitatory to inhibitory neurons (E->I) as IE (post-pre).
 
 def plot_weight_matrices(E_neurons, I_neurons):
 

--- a/pynest/examples/plot_weight_matrices.py
+++ b/pynest/examples/plot_weight_matrices.py
@@ -56,6 +56,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 # connection from inhibitory to excitatory neurons (I->E) as EI (post-pre) and
 # connections from excitatory to inhibitory neurons (E->I) as IE (post-pre).
 
+
 def plot_weight_matrices(E_neurons, I_neurons):
 
     W_EE = np.zeros([len(E_neurons), len(E_neurons)])


### PR DESCRIPTION
This PR is in response to a mailing list question asking to clarify the notation in the weight matrices example. I basically took what Renato said and added that to the documentation.