### PR TITLE
Enforce Python and Cython version requirements during configuration

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -398,7 +398,7 @@ function( NEST_PROCESS_WITH_PYTHON )
   elseif ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter
-    find_package( PythonInterp 3 REQUIRED )
+    find_package( PythonInterp 3.6 REQUIRED )
 
     if ( PYTHONINTERP_FOUND )
       set( PYTHONINTERP_FOUND "${PYTHONINTERP_FOUND}" PARENT_SCOPE )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -417,16 +417,16 @@ function( NEST_PROCESS_WITH_PYTHON )
         set( PYTHON_LIBRARIES "${PYTHON_LIBRARIES}" PARENT_SCOPE )
 
         if ( cythonize-pynest )
-          find_package( Cython )
+          if ( ${PYTHON_VERSION_STRING} VERSION_GREATER_EQUAL "3.7" )
+            # Need updated Cython because of a change in the C api in Python 3.7
+            find_package( Cython 0.28.3 REQUIRED )
+          else ()
+              # confirmed not working: 0.15.1
+              # confirmed working: 0.19.2+
+              # in between unknown
+            find_package( Cython 0.19.2 REQUIRED )
+          endif ()
           if ( CYTHON_FOUND )
-            # confirmed not working: 0.15.1
-            # confirmed working: 0.19.2+
-            # in between unknown
-            if ( CYTHON_VERSION VERSION_LESS "0.19.2" )
-              message( FATAL_ERROR "Your Cython version is too old. Please install "
-                                   "newer version (0.19.2+)" )
-            endif ()
-
             # export found variables to parent scope
             set( CYTHON_FOUND "${CYTHON_FOUND}" PARENT_SCOPE )
             set( CYTHON_EXECUTABLE "${CYTHON_EXECUTABLE}" PARENT_SCOPE )

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -450,7 +450,7 @@ echo "Phase 7: Running PyNEST tests"
 echo "-----------------------------"
 if test "${PYTHON}"; then
     # Find the path to PyNEST without actually importing it
-    PYNEST_TEST_DIR="$("${PYTHON}" -c "import importlib; print(importlib.util.find_spec('nest').submodule_search_locations[0])")/tests"
+    PYNEST_TEST_DIR="$("${PYTHON}" -c "import importlib.util; print(importlib.util.find_spec('nest').submodule_search_locations[0])")/tests"
     XUNIT_FILE="${REPORTDIR}/07_pynesttests.xml"
     "${PYTHON}" "${NOSE}" -v --with-xunit --xunit-testsuite-name="07_pynesttests" --xunit-file="${XUNIT_FILE}" "${PYNEST_TEST_DIR}" 2>&1 \
         | tee -a "${TEST_LOGFILE}" | grep -i --line-buffered "\.\.\. ok\|fail\|skip\|error" | sed 's/^/  /'


### PR DESCRIPTION
Because of f-strings, NEST now requires Python version >=3.6. This PR enforces this requirement during configuration. 

Additionally, if Python version >=3.7 is used, a suitably recent Cython version must also be used. This is because the C api is changed with Python 3.7 (see also #1928). 

@jessica-mitchell @sarakonradi Should the Cython version requirement also be mentioned in the installation guide?