### PR TITLE
Remove SLI examples in model documentation

### DIFF
--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -51,34 +51,27 @@ Device to forward rates to remote applications using MUSIC
 Description
 +++++++++++
 
-A music_rate_out_proxy is used to send rates to a remote application that
+A `music_rate_out_proxy` is used to send rates to a remote application that
 also uses MUSIC.
 
-The music_rate_out_proxy represents a complete MUSIC rate output
+The `music_rate_out_proxy` represents a complete MUSIC rate output
 port. The channel on the port to which a source node forwards its
 events is determined during connection setup by using the parameter
-music_channel of the connection. The name of the port is set via
-SetStatus (see Parameters section below).
+`music_channel` of the connection. The name of the port is set via
+``SetStatus`` (see Parameters section below).
 
 Parameters
 ++++++++++
 
 The following properties are available in the status dictionary:
 
-port_name      - The name of the MUSIC output_port to forward events to
-                 (default: rate_out)
-port_width     - The width of the MUSIC input port
-published      - A bool indicating if the port has been already published
-                 with MUSIC
+port_name    - The name of the MUSIC output_port to forward events to (default: `rate_out`)
 
-The parameter port_name can be set using SetStatus.
+port_width   - The width of the MUSIC input port
 
-Examples
-++++++++
+published    - A bool indicating if the port has been already published with MUSIC
 
-/iaf_psc_alpha Create /n Set
-/music_rate_out_proxy Create /meop Set
-n meop << /music_channel 2 >> Connect
+The parameter port_name can be set using ``SetStatus``.
 
 Availability: Only when compiled with MUSIC
 

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -110,6 +110,7 @@ Example:
   3.0 milliseconds, relative to the device-timer origin.
 
 Example:
+
 Assume that NEST works with default resolution (step size) of 0.1 ms
 and default tic length of 0.001 ms. Then, spikes times not falling
 onto the grid will be handled as follows for different option settings:

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -99,6 +99,82 @@ will actually use, i.e., for grid-based simulation the spike times rounded
 to the appropriate point on the time grid. This means that ``GetStatus`` may
 return different `spike_times` values at different resolutions.
 
+Example:
+
+  ::
+
+     nest.SetStatus("spike_generator",
+                 params={"spike_times": [1.0, 2.0, 3.0]})
+
+  Instructs the spike generator to generate events at 1.0, 2.0, and
+  3.0 milliseconds, relative to the device-timer origin.
+
+Example:
+Assume that NEST works with default resolution (step size) of 0.1 ms
+and default tic length of 0.001 ms. Then, spikes times not falling
+onto the grid will be handled as follows for different option settings:
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [1.0, 1.9999, 3.0001]})
+
+  ---> spikes at steps 10 (==1.0 ms), 20 (==2.0 ms) and 30 (==3.0 ms)
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [1.0, 1.05, 3.0001]})
+
+  ---> **Error!** Spike time 1.05 not within tic/2 of step
+
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [1.0, 1.05, 3.0001],
+               "allow_offgrid_times": True})
+
+  ---> spikes at steps 10, 11 (mid-step time rounded up),
+         30 (time within tic/2 of step moved to step)
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [1.0, 1.05, 3.0001],
+               "precise_times": True})
+
+  ---> spikes at step 10, offset 0.0; step 11, offset -0.05;
+         step 31, offset -0.0999
+
+Assume we have simulated 10.0 ms and simulation times is thus 10.0 (step
+100). Then, any spike times set, at this time, must be later than step 100.
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [10.0001]})
+
+  ---> spike time is within tic/2 of step 100, rounded down to 100 thus
+         not in the future; **spike will not be emitted**
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [10.0001],
+               "precise_times": True})
+
+  ---> spike at step 101, offset -0.0999 is in the future
+
+  ::
+
+    nest.Create("spike_generator",
+               params={"spike_times": [10.0001, 11.0001],
+               "shift_now_spikes": True})
+
+  ---> spike at step 101, spike shifted into the future, and spike at step
+        110, not shifted, since it is in the future anyways
+
 Parameters
 ++++++++++
 

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -103,7 +103,7 @@ Example:
 
   ::
 
-     nest.SetStatus("spike_generator",
+     nest.Create("spike_generator",
                  params={"spike_times": [1.0, 2.0, 3.0]})
 
   Instructs the spike generator to generate events at 1.0, 2.0, and

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -64,13 +64,13 @@ do not coincide with a step are handled (see examples below):
 Multiple occurrences of the same time indicate that more than one
 event is to be generated at this particular time.
 
-Additionally, spike_weights can be set. This is an array as well.
+Additionally, `spike_weights` can be set. This is an array as well.
 It contains one weight value per spike time. If set, the spikes
 are delivered with the respective weight multiplied with the
 weight of the connection. To disable this functionality, the
 spike_weights array can be set to an empty array.
 
-    /precise_times   default: false
+    `precise_times`  default: false
 
 If false, spike times will be rounded to simulation steps, i.e., multiples
 of the resolution. The rounding is controlled by the two other flags.
@@ -79,14 +79,14 @@ combination of step and offset. This should only be used if all neurons
 receiving the spike train can handle precise timing information. In this
 case, the other two options are ignored.
 
-    /allow_offgrid_times   default: false
+    `allow_offgrid_times`   default: false
 
 If false, spike times will be rounded to the nearest step if they are
 less than tic/2 from the step, otherwise NEST reports an error.
 If true, spike times are rounded to the nearest step if within tic/2
 from the step, otherwise they are rounded up to the *end* of the step.
 
-    /shift_now_spikes   default: false
+    `shift_now_spikes`   default: false
 
 This option is mainly for use by the PyNN-NEST interface.
 If false, spike times rounded down to the current point in time will
@@ -94,57 +94,10 @@ be considered in the past and ignored.
 If true, spike times that are rounded down to the current time step
 are shifted one time step into the future.
 
-Note that GetStatus will report the spike times that the spike_generator
+Note that ``GetStatus`` will report the spike times that the spike_generator
 will actually use, i.e., for grid-based simulation the spike times rounded
-to the appropriate point on the time grid. This means that GetStatus may
-return different /spike_times values at different resolutions.
-
-Example:
-
-    spike_generator << /spike_times [1.0 2.0 3.0] >> SetStatus
-
-    Instructs the spike generator to generate events at 1.0, 2.0, and
-    3.0 milliseconds, relative to the device-timer origin.
-
-Example:
-
-Assume that NEST works with default resolution (step size) of 0.1ms
-and default tic length of 0.001ms. Then, spikes times not falling
-onto the grid will be handled as follows for different option settings:
-
-    /spike_generator << /spike_times [1.0 1.9999 3.0001] >> Create
-    ---> spikes at steps 10 (==1.0ms), 20 (==2.0ms) and 30 (==3.0ms)
-
-    /spike_generator << /spike_times [1.0 1.05 3.0001] >> Create
-    ---> error, spike time 1.05 not within tic/2 of step
-
-    /spike_generator << /spike_times [1.0 1.05 3.0001]
-                        /allow_offgrid_times true >> Create
-    ---> spikes at steps 10, 11 (mid-step time rounded up),
-         30 (time within tic/2 of step moved to step)
-
-    /spike_generator << /spike_times [1.0 1.05 3.0001]
-                        /precise_times true >> Create
-    ---> spikes at step 10, offset 0.0; step 11, offset -0.05;
-         step 31, offset -0.0999
-
-    Assume we have simulated 10.0ms and simulation times is thus 10.0 (step
-100).
-    Then, any spike times set, at this time, must be later than step 100.
-
-    /spike_generator << /spike_times [10.0001] >> Create
-    ---> spike time is within tic/2 of step 100, rounded down to 100 thus
-         not in the future, spike will not be emitted
-
-    /spike_generator << /spike_times [10.0001] /precise_times true >> Create
-    ---> spike at step 101, offset -0.0999 is in the future
-
-    /spike_generator
-      << /spike_times [10.0001 11.0001] /shift_now_spikes true >>
-    Create
-    ---> spike at step 101, spike shifted into the future, and spike at step
-110,
-         not shifted, since it is in the future anyways
+to the appropriate point on the time grid. This means that ``GetStatus`` may
+return different `spike_times` values at different resolutions.
 
 Parameters
 ++++++++++

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -148,7 +148,7 @@ onto the grid will be handled as follows for different option settings:
          step 31, offset -0.0999
 
 Assume we have simulated 10.0 ms and simulation times is thus 10.0 (step
-100). Then, any spike times set, at this time, must be later than step 100.
+100). Then, any spike times set at this time must be later than step 100.
 
   ::
 

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -148,7 +148,7 @@ onto the grid will be handled as follows for different option settings:
   ---> spikes at step 10, offset 0.0; step 11, offset -0.05;
          step 31, offset -0.0999
 
-Assume we have simulated 10.0 ms and simulation times is thus 10.0 (step
+Assume we have simulated 10.0 ms and simulation time is thus 10.0 (step
 100). Then, any spike times set at this time must be later than step 100.
 
   ::


### PR DESCRIPTION
I stumbled upon a couple of SLI examples that are still lingering in the model documentation - in spike_generator and music_rate_out_proxy specifically.
This PR simply removes them, and fixes up a bit of formatting.