### PR TITLE
fix citation for NEST 2.20.1 and add citation for NEST 2.20.2

### DIFF
--- a/doc/citing-nest.rst
+++ b/doc/citing-nest.rst
@@ -11,7 +11,9 @@ For the full citation and additional formats follow the doi Zenodo link.
 
 Cite the version you used in your work:
 
-Fardet, Tanguy et al. (2019). **NEST 2.20.0** Zenodo. https://doi.org/10.5281/zenodo.3605514
+Fardet, Tanguy et al. (2020). **NEST 2.20.1** Zenodo. https://doi.org/10.5281/zenodo.4018718
+
+Fardet, Tanguy et al. (2020). **NEST 2.20.0** Zenodo. https://doi.org/10.5281/zenodo.3605514
 
 Jordan, Jakob et al. (2019). **NEST 2.18.0** Zenodo. https://doi.org/10.5281/zenodo.2605422
 


### PR DESCRIPTION
Fix one citation and add another.

This is already shown correctly in the 2.20.1 docs (https://nest-simulator.readthedocs.io/en/nest-2.20.1/citing-nest.html) but not yet on the 3.0 docs (https://nest-simulator.readthedocs.io/en/latest/citing-nest.html); this PR simply updates the latter to the former.

@jougs, @terhorstd: could you include this step in the release pipeline?

I assume we will not update ``citing-nest.rst`` in older release versions of the documentation (for example, the 2.20.0 docs will never be updated to include citations for later—2.20.1 and up—releases).