### PR TITLE
Add Visual Studio Code settings directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ examples/reference_data/
 TAGS
 tags
 cscope.out
+.vscode/*


### PR DESCRIPTION
#1843 removed `.*` from `.gitignore`. This PR adds the vscode settings directory again.