### PR TITLE
Extended gitignore with specific excludes for various IDE config files, macOS-specific files and _build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,3 @@ cscope.out
 .project
 .cproject
 .pydevproject
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 __pycache__/
 build/
+_build/
 install/
 reports/
 
@@ -47,10 +48,20 @@ doc/pynestkernel_mock.py
 examples/microcircuit.png
 examples/reference_data/
 
+# macOS
+.DS_Store
+
 # IDEs / editors / Jupyter
 *.kdev4
 .ipynb_checkpoints/
 TAGS
 tags
 cscope.out
-.vscode/*
+.vscode/
+.idea/
+.settings/
+.project
+.cproject
+.pydevproject
+
+


### PR DESCRIPTION
A follow-up to #1958. Single reviewer should suffice for this PR.
