### PR TITLE
Clean up t_ref parameter in aeif models

### DIFF
--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -251,7 +251,6 @@ private:
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA
     double V_th;       //!< Spike threshold in mV
-    double t_ref;      //!< Refractory period in ms
     double tau_syn_ex; //!< Excitatory synaptic rise time
     double tau_syn_in; //!< Excitatory synaptic rise time
     double I_e;        //!< Intrinsic current in pA

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -265,7 +265,7 @@ nest::aeif_cond_exp::Parameters_::set( const DictionaryDatum& d, Node* node )
 
   if ( t_ref_ < 0 )
   {
-    throw BadProperty( "Ensure that t_ref >= 0" );
+    throw BadProperty( "Refractory time cannot be negative." );
   }
 
   if ( tau_syn_ex <= 0 || tau_syn_in <= 0 || tau_w <= 0 )

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -251,7 +251,6 @@ private:
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA
     double V_th;       //!< Spike threshold in mV
-    double t_ref;      //!< Refractory period in ms
     double tau_syn_ex; //!< Excitatory synaptic kernel decay time in ms
     double tau_syn_in; //!< Inhibitory synaptic kernel decay time in ms
     double I_e;        //!< Intrinsic current in pA

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -235,7 +235,6 @@ private:
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA
     double V_th;       //!< Spike threshold in mV
-    double t_ref;      //!< Refractory period in ms
     double tau_syn_ex; //!< Excitatory synaptic rise time
     double tau_syn_in; //!< Excitatory synaptic rise time
     double I_e;        //!< Intrinsic current in pA

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -241,7 +241,7 @@ nest::aeif_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* node )
 
   if ( t_ref_ < 0 )
   {
-    throw BadProperty( "Ensure that t_ref >= 0" );
+    throw BadProperty( "Refractory time cannot be negative." );
   }
 
   if ( tau_w <= 0 )

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef AEIF_PSC_delta_H
-#define AEIF_PSC_delta_H
+#ifndef AEIF_PSC_DELTA_H
+#define AEIF_PSC_DELTA_H
 
 // Generated includes:
 #include "config.h"
@@ -231,7 +231,6 @@ private:
     double a;       //!< Subthreshold adaptation in nS
     double b;       //!< Spike-triggered adaptation in pA
     double V_th;    //!< Spike threshold in mV
-    double t_ref;   //!< Refractory period in ms
     double I_e;     //!< Intrinsic current in pA
 
     double gsl_error_tol;  //!< Error bound for GSL integrator
@@ -435,4 +434,4 @@ aeif_psc_delta::set_status( const DictionaryDatum& d )
 } // namespace
 
 #endif // HAVE_GSL
-#endif // AEIF_PSC_delta_H
+#endif // AEIF_PSC_DELTA_H

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -302,7 +302,7 @@ nest::aeif_psc_delta_clopath::Parameters_::set( const DictionaryDatum& d, Node* 
 
   if ( t_ref_ < 0 )
   {
-    throw BadProperty( "Ensure that t_ref >= 0" );
+    throw BadProperty( "Refractory time cannot be negative." );
   }
 
   if ( t_clamp_ < 0 )

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -543,7 +543,7 @@ nest::aeif_psc_delta_clopath::update( const Time& origin, const long from, const
       {
         S_.y_[ State_::V_M ] = P_.V_clamp_;
         S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
-        S_.y_[ State_::Z ] = P_.I_sp;
+        S_.y_[ State_::Z ] = P_.I_sp; // depolarizing spike afterpotential current
         S_.y_[ State_::V_TH ] = P_.V_th_max;
 
         /* Initialize clamping step counter.

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -542,7 +542,7 @@ nest::aeif_psc_delta_clopath::update( const Time& origin, const long from, const
       if ( S_.y_[ State_::V_M ] >= V_.V_peak_ && S_.clamp_r_ == 0 )
       {
         S_.y_[ State_::V_M ] = P_.V_clamp_;
-        S_.y_[ State_::W ] += P_.b; // spike-driven adaptation
+        S_.y_[ State_::W ] += P_.b;   // spike-driven adaptation
         S_.y_[ State_::Z ] = P_.I_sp; // depolarizing spike afterpotential current
         S_.y_[ State_::V_TH ] = P_.V_th_max;
 

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -129,6 +129,8 @@ a          nS      Subthreshold adaptation
 b          pA      Spike-triggered adaptation
 Delta_T    mV      Slope factor
 tau_w      ms      Adaptation time constant
+tau_z      ms      Spike afterpotential current time constant
+I_sp       pA      Depolarizing spike afterpotential current magnitude
 V_peak     mV      Spike detection threshold
 V_th_max   mV      Value of V_th afer a spike
 V_th_rest  mV      Resting value of V_th
@@ -254,9 +256,9 @@ private:
     double C_m;         //!< Membrane Capacitance in pF
     double E_L;         //!< Leak reversal Potential (aka resting potential) in mV
     double Delta_T;     //!< Slope factor in ms
-    double tau_w;       //!< Adaptation time-constant in ms
-    double tau_z;       //!< Adaptation time-constant in ms
-    double tau_V_th;    //!< Adaptive threshold time-constant in ms
+    double tau_w;       //!< Adaptation time constant in ms
+    double tau_z;       //!< Spike afterpotential current time constant in ms
+    double tau_V_th;    //!< Adaptive threshold time constant in ms
     double V_th_max;    //!< Value of V_th afer a spike in mV
     double V_th_rest;   //!< Resting value of V_th in mV
     double tau_plus;    //!< Time constant of u_bar_plus in ms
@@ -264,8 +266,8 @@ private:
     double tau_bar_bar; //!< Time constant of u_bar_bar in ms
     double a;           //!< Subthreshold adaptation in nS
     double b;           //!< Spike-triggered adaptation in pA
-    double I_sp;
-    double I_e;   //!< Intrinsic current in pA
+    double I_sp;        //!< Depolarizing spike afterpotential current in pA
+    double I_e;         //!< Intrinsic current in pA
 
     double gsl_error_tol; //!< Error bound for GSL integrator
 

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -265,7 +265,6 @@ private:
     double a;           //!< Subthreshold adaptation in nS
     double b;           //!< Spike-triggered adaptation in pA
     double I_sp;
-    double t_ref; //!< Refractory period in ms
     double I_e;   //!< Intrinsic current in pA
 
     double gsl_error_tol; //!< Error bound for GSL integrator

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -255,7 +255,7 @@ nest::aeif_psc_exp::Parameters_::set( const DictionaryDatum& d, Node* node )
 
   if ( t_ref_ < 0 )
   {
-    throw BadProperty( "Ensure that t_ref >= 0" );
+    throw BadProperty( "Refractory time cannot be negative." );
   }
 
   if ( tau_syn_ex <= 0 || tau_syn_in <= 0 || tau_w <= 0 )

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -237,7 +237,6 @@ private:
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA
     double V_th;       //!< Spike threshold in mV
-    double t_ref;      //!< Refractory period in ms
     double tau_syn_ex; //!< Excitatory synaptic kernel decay time in ms
     double tau_syn_in; //!< Inhibitory synaptic kernel decay time in ms
     double I_e;        //!< Intrinsic current in pA


### PR DESCRIPTION
Remove unused ``t_ref`` parameters and unify error messages when it is set < 0.

Fixes #1968.