### PR TITLE
Fix broken images in documentation

### DIFF
--- a/doc/userdoc/documentation_workflow/user_documentation_workflow.rst
+++ b/doc/userdoc/documentation_workflow/user_documentation_workflow.rst
@@ -21,7 +21,7 @@ with each release of NEST having its own documentation.
 
 This workflow aims for the concept of **user-correctable documentation**.
 
-.. image:: ../_static/img/documentation_workflow.png
+.. image:: ../static/img/documentation_workflow.png
   :width: 500
   :alt: Alternative text
 

--- a/doc/userdoc/getting_started.rst
+++ b/doc/userdoc/getting_started.rst
@@ -71,7 +71,7 @@ Display the voltage graph from the voltmeter:
 
 You should see the following image as the output:
 
-.. image:: _static/img/output_getting_started.png
+.. image:: static/img/output_getting_started.png
    :align: center
 
 **And that's it! You have performed your first neuronal simulation in NEST!**

--- a/doc/userdoc/guides/connection_management.rst
+++ b/doc/userdoc/guides/connection_management.rst
@@ -96,7 +96,7 @@ all connection rules available in NEST is available below.
 all-to-all
 ~~~~~~~~~~
 
-.. image:: ../_static/img/All_to_all.png
+.. image:: ../static/img/All_to_all.png
      :width: 200px
      :align: center
 
@@ -161,7 +161,7 @@ Generator Interface and randomly connects 10% of the neurons from
 fixed indegree
 ~~~~~~~~~~~~~~
 
-.. image:: ../_static/img/Fixed_indegree.png
+.. image:: ../static/img/Fixed_indegree.png
      :width: 200px
      :align: center
 
@@ -179,7 +179,7 @@ that each node in ``B`` has a fixed `indegree` of ``N``.
 fixed outdegree
 ~~~~~~~~~~~~~~~
 
-.. image:: ../_static/img/Fixed_outdegree.png
+.. image:: ../static/img/Fixed_outdegree.png
      :width: 200px
      :align: center
 
@@ -211,7 +211,7 @@ such that the total number of connections equals ``N``.
 one-to-one
 ~~~~~~~~~~
 
-.. image:: ../_static/img/One_to_one.png
+.. image:: ../static/img/One_to_one.png
      :width: 200px
      :align: center
 
@@ -632,7 +632,7 @@ different compartments of a multi-compartment integrate-and-fire
 neuron (``iaf_cond_alpha_mc``) that are represented by different
 receptors.
 
-.. image:: ../_static/img/Receptor_types.png
+.. image:: ../static/img/Receptor_types.png
      :width: 200px
      :align: center
 

--- a/doc/userdoc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
+++ b/doc/userdoc/guides/nest2_to_nest3/nest2_to_nest3_overview.rst
@@ -732,7 +732,7 @@ distribution.
     ax[0].set_ylabel('V_m');
 
 
-.. image:: ../../_static/img/NEST3_13_0.png
+.. image:: ../../static/img/NEST3_13_0.png
 
 
 .. _spatial_ex:
@@ -766,7 +766,7 @@ use ``nest.spatial.grid()`` or ``nest.spatial.free``.
     grid_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[10, 8]))
     nest.PlotLayer(grid_nodes);
 
-.. image:: ../../_static/img/NEST3_23_0.png
+.. image:: ../../static/img/NEST3_23_0.png
   :width: 500px
 
 .. code-block:: ipython
@@ -776,7 +776,7 @@ use ``nest.spatial.grid()`` or ``nest.spatial.free``.
                                                          num_dimensions=2))
     nest.PlotLayer(free_nodes);
 
-.. image:: ../../_static/img/NEST3_24_0.png
+.. image:: ../../static/img/NEST3_24_0.png
   :width: 500px
 
 After you have created your spatially distributed nodes, you can use `spatial` property to set
@@ -836,7 +836,7 @@ node or connection parameters.
     ax.set_xlabel('Node position on x-axis')
     ax.set_ylabel('V_m');
 
-  .. image:: ../../_static/img/NEST3_25_0.png
+  .. image:: ../../static/img/NEST3_25_0.png
 
   NEST provides some functions to help create distributions based on for
   example the distance between two neurons.
@@ -918,7 +918,7 @@ parameter:
     ax.set_xlabel('Target NodeID')
     ax.set_ylabel('Num. connections');
 
-.. image:: ../../_static/img/NEST3_34_0.png
+.. image:: ../../static/img/NEST3_34_0.png
 
 
 
@@ -970,7 +970,7 @@ given as argument.
 
 
 
-.. image:: ../../_static/img/NEST3_27_0.png
+.. image:: ../../static/img/NEST3_27_0.png
 
 .. _logic:
 
@@ -1062,7 +1062,7 @@ statement. Three arguments are required:
 
 
 
-.. image:: ../../_static/img/NEST3_26_0.png
+.. image:: ../../static/img/NEST3_26_0.png
 
 
 .. _combine_ex:

--- a/doc/userdoc/guides/parallel_computing.rst
+++ b/doc/userdoc/guides/parallel_computing.rst
@@ -43,7 +43,7 @@ Virtual processes are distributed round-robin (i.e. each VP is allocated equal
 time slices, without any given a priority) onto the MPI processes and
 counted continuously over all processes.
 
-.. figure:: ../_static/img/Process_vp_thread.png
+.. figure:: ../static/img/Process_vp_thread.png
 
  Basic scheme showing how threads (T) and virtual
  processes (VP) reside in MPI processes (P) in NEST
@@ -59,7 +59,7 @@ In the figure below, a node distribution for a small network consisting of ``spi
 four ``iaf_psc_alpha`` neurons, and a ``spike_recorder``
 in a scenario with two processes with two threads each.
 
-.. figure:: ../_static/img/Node_distribution.png
+.. figure:: ../static/img/Node_distribution.png
 
  sg=spike_generator, iaf=iaf_psc_alpha, sr=spike_recorder. Numbers to
  the left and right indicate node IDs.

--- a/doc/userdoc/guides/running_simulations.rst
+++ b/doc/userdoc/guides/running_simulations.rst
@@ -26,7 +26,7 @@ simulation and allow the efficient use of computer clusters, NEST uses a
 following figure shows the basic loop that is run upon a call to
 ``Simulate``:
 
-.. figure:: ../_static/img/simulation_loop-241x300.png
+.. figure:: ../static/img/simulation_loop-241x300.png
    :alt: Simulation Loop
 
    Simulation Loop
@@ -45,7 +45,7 @@ the largest delay in the network. From this definition follows that no
 node can influence another node during at least a time of *dmin*, i.e.
 the elements are effectively decoupled for this interval.
 
-.. figure:: ../_static/img/time_definitions-300x61.png
+.. figure:: ../static/img/time_definitions-300x61.png
    :alt: Definitions of the minimimum delay and the simulation resolution
 
    Definitions of minimum delay (*dmin*) and simulation resolution (*h*).

--- a/doc/userdoc/guides/simulations_with_precise_spike_times.rst
+++ b/doc/userdoc/guides/simulations_with_precise_spike_times.rst
@@ -23,7 +23,7 @@ due in the current time step from its spike buffers and updates its
 state variables such as the membrane potential.
 
 
-.. figure:: ../_static/img/precise1-300x175.png
+.. figure:: ../static/img/precise1-300x175.png
 
  Propagation of membrane potential in case of grid-constrained spiking.
  Filled dots indicate update of membrane potential; black cross indicates
@@ -41,7 +41,7 @@ represented by an integer time stamp and a double precision offset. As
 the incoming spikes divide the *h*-steps into substeps, a neuron needs
 to update its state variables for each substep.
 
-.. figure:: ../_static/img/precise1-300x175.png
+.. figure:: ../static/img/precise1-300x175.png
 
  Propagation of membrane potential in case of off-grid spiking.
  Dashed red line indicates precise time of threshold crossing.

--- a/doc/userdoc/index.rst
+++ b/doc/userdoc/index.rst
@@ -140,9 +140,9 @@ Forschungsgemeinschaft [S.J. van Albada: AL 2041/1-1], the Helmholtz young inves
 multi-scale neuronal networks", and compute time provided by UNINETT Sigma2 - the National Infrastructure for High
 Performance Computing and Data Storage in Norway and its predecessors.
 
-.. image:: _static/img/HBP.png
+.. image:: static/img/HBP.png
   :width: 55 %
   :target: https://www.humanbrainproject.eu/
-.. image:: _static/img/EBRAINS.svg
+.. image:: static/img/EBRAINS.svg
   :width: 25 %
   :target: https://ebrains.eu/

--- a/doc/userdoc/installation/index.rst
+++ b/doc/userdoc/installation/index.rst
@@ -217,7 +217,7 @@ provide containerized versions of NEST in several formats:
           generated, as shown below. You can then copy and paste the
           link into your browser.
 
-           .. image:: ../_static/img/docker_link.png
+           .. image:: ../static/img/docker_link.png
               :align: center
               :width: 1000px
 
@@ -280,7 +280,7 @@ Once in Python you can type:
 
 If installation was successful, you should see the NEST splash screen in the terminal:
 
-.. figure:: ../_static/img/import_nest.png
+.. figure:: ../static/img/import_nest.png
    :scale: 50%
    :alt: import nest
 

--- a/doc/userdoc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/userdoc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -34,7 +34,7 @@ PyNEST - an interface to the NEST simulator
 
 .. _Python-Interface:
 
-.. figure:: ../../_static/img/python_interface.png
+.. figure:: ../../static/img/python_interface.png
    :alt: Python Interface
    :width: 600px
 
@@ -229,7 +229,7 @@ to form a small network.
 
 .. _VM-neuron:
 
-.. figure:: ../../_static/img/vm_one_neuron.pdf.png
+.. figure:: ../../static/img/vm_one_neuron.pdf.png
    :alt: Membrane potential of integrate-and-fire neuron with constant input current
    :width: 400px
 
@@ -239,7 +239,7 @@ to form a small network.
 
 .. _spikes-one-neuron:
 
-.. figure:: ../../_static/img/spikes_one_neuron.pdf.png
+.. figure:: ../../static/img/spikes_one_neuron.pdf.png
    :alt: Spikes of the neuron.
    :width: 400px
 
@@ -397,7 +397,7 @@ the synaptic model.
 
 .. _vm_one_neuron_noise:
 
-.. figure:: ../../_static/img/vm_one_neuron_noise.pdf.png
+.. figure:: ../../static/img/vm_one_neuron_noise.pdf.png
    :alt: Membrane potential of integrate-and-fire neuron with Poisson noise as input.
    :width: 400px
 
@@ -407,7 +407,7 @@ the synaptic model.
 
 .. _spikes_one_neuron_noise:
 
-.. figure:: ../../_static/img/spikes_one_neuron_noise.pdf.png
+.. figure:: ../../static/img/spikes_one_neuron_noise.pdf.png
    :alt: Spikes of the neuron with noise.
    :width: 400px
 
@@ -426,7 +426,7 @@ Two connected neurons
 
 .. _vm_psp_two_neurons:
 
-.. figure:: ../../_static/img/vm_psp_two_neurons.pdf-w400.png
+.. figure:: ../../static/img/vm_psp_two_neurons.pdf-w400.png
    :alt: Postsynaptic potentials in neuron2 evoked by the spikes of neuron1
 
    Postsynaptic potentials in neuron2 evoked by the spikes of neuron1

--- a/doc/userdoc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
+++ b/doc/userdoc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
@@ -108,7 +108,7 @@ be located?".
 
 .. _grid:
 
-.. figure:: ../../_static/img/grid.png
+.. figure:: ../../static/img/grid.png
    :alt: Example of on-grid, in which the neurons are positioned as grid.
 
    Example of on-grid, in which the neurons are
@@ -116,7 +116,7 @@ be located?".
 
 .. _free:
 
-.. figure:: ../../_static/img/free.png
+.. figure:: ../../static/img/free.png
    :alt: Example of off-grid, in which the neurons are positioned as grid+jitter.
 
    Example of off-grid, in which the neurons are
@@ -209,7 +209,7 @@ following table lists the parameters that can be used.
 
 .. _cirgauss:
 
-.. figure:: ../../_static/img/sample1_circgauss.png
+.. figure:: ../../static/img/sample1_circgauss.png
    :alt: Examples of connectivity for each of the connectivity dictionaries mentioned in the following Python code snippet.
 
    Examples of connectivity for each of the connectivity dictionaries
@@ -217,7 +217,7 @@ following table lists the parameters that can be used.
 
 .. _rectanchor:
 
-.. figure:: ../../_static/img/sample2_rectanchor.png
+.. figure:: ../../static/img/sample2_rectanchor.png
    :alt: Examples of connectivity for each of the connectivity dictionaries mentioned in the following Python code snippet.
 
    Examples of connectivity for each of the connectivity dictionaries
@@ -225,7 +225,7 @@ following table lists the parameters that can be used.
 
 .. _doughnutlinear:
 
-.. figure:: ../../_static/img/sample3_doughnutlinear.png
+.. figure:: ../../static/img/sample3_doughnutlinear.png
    :alt: Examples of connectivity for each of the connectivity dictionaries mentioned in the following Python code snippet.
 
    Examples of connectivity for each of the connectivity dictionaries
@@ -233,7 +233,7 @@ following table lists the parameters that can be used.
 
 .. _gaussweights:
 
-.. figure:: ../../_static/img/sample4_gaussweights.png
+.. figure:: ../../static/img/sample4_gaussweights.png
    :alt: Examples of connectivity for each of the connectivity dictionaries mentioned in the following Python code snippet.
 
    Examples of connectivity for each of the connectivity dictionaries


### PR DESCRIPTION
This PR fixes the broken images in the documentation by updating ``_static`` to ``static`` in the corresponding paths. It is a follow-up to #1843.