### PR TITLE
Fix encode error of help text.

### DIFF
--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -404,7 +404,7 @@ def load_help(obj):
     """
 
     help_fname = get_help_fname(obj)
-    with open(help_fname, 'r', encoding="utf-8") as help_file:
+    with open(help_fname, 'r', encoding='utf-8') as help_file:
         help_text = help_file.read()
     return help_text
 

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -404,7 +404,7 @@ def load_help(obj):
     """
 
     help_fname = get_help_fname(obj)
-    with open(help_fname, 'r') as help_file:
+    with open(help_fname, 'r', encoding="utf-8") as help_file:
         help_text = help_file.read()
     return help_text
 


### PR DESCRIPTION
After merging PR #1926 I tested getting help via nest-server and I got error:
`'ascii' codec can't decode byte 0xe2 in position 13: ordinal not in range(128)`

This PR should fix this encoding error.

