### PR TITLE
Add pygments in doc/requirements.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,6 +15,7 @@ numpy
 numpydoc
 path.py
 pathlib
+pygments>=2.6.1
 pytest
 recommonmark
 scipy


### PR DESCRIPTION
I tried to build docker image for NEST Simulator (Dockerfile adapted from nest/nest-docker). 

But it produces error during sphinx build (make html):
`AssertionError: wrong color format 'var(--jp-mirror-editor-variable-color)` 

According to the sphinx issue https://github.com/sphinx-doc/sphinx/issues/8198, 
the solution might be to add `pygments>=2.6.1` in doc/requirements.txt.

Aferwards, I was able to build Docker image with sphinx docs.