### PR TITLE
Fix for failing Read the Docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ sphinx:
   configuration: doc/userdoc/conf.py
 
 python:
-  version 3.8
-  install:
-    - requirements: extras/nest-simulator-doc-requirements.txt
+   version: 3.8
+   install:
+   - requirements: extras/nest-simulator-doc-requirements.txt
 
 build:
   image: latest


### PR DESCRIPTION
This PR fixes a formatting issue in the .readthedocs.yml introduced in PR #1965  that causes the build to fail on ReadtheDocs.

