### PR TITLE
Add missing include file to CMakeLists

### DIFF
--- a/libnestutil/CMakeLists.txt
+++ b/libnestutil/CMakeLists.txt
@@ -29,8 +29,10 @@ set( nestutil_sources
     logging.h
     numerics.h numerics.cpp
     propagator_stability.h propagator_stability.cpp
+    regula_falsi.h
     sort.h
     stopwatch.h stopwatch.cpp
+    streamers.h
     string_utils.h
     vector_util.h
     )

--- a/libnestutil/CMakeLists.txt
+++ b/libnestutil/CMakeLists.txt
@@ -21,6 +21,7 @@ set( nestutil_sources
     beta_normalization_factor.h
     block_vector.h
     compose.hpp
+    dict_util.h
     enum_bitfield.h
     iterator_pair.h
     lockptr.h


### PR DESCRIPTION
This fixes an issue that we were running into with a NEST extension module not being able to ``#include "dict_util.h"``.

There are several other header files in the ``libnestutil`` directory; should these be added to the list as well for consistency? Or would this pollute the namespace too much?