### PR TITLE
Remove unused function communicate_Allreduce_max_in_place()

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -720,12 +720,6 @@ nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate_Allreduce_max_in_place( std::vector< long >& buffer )
-{
-  MPI_Allreduce( MPI_IN_PLACE, &buffer[ 0 ], 1, MPI_LONG, MPI_MAX, comm );
-}
-
-void
 nest::MPIManager::communicate_Allgather( std::vector< long >& buffer )
 {
   // avoid aliasing, see http://www.mpi-forum.org/docs/mpi-11-html/node10.html
@@ -1096,13 +1090,6 @@ void
 nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer )
 {
   recv_buffer.swap( send_buffer );
-}
-
-void
-nest::MPIManager::communicate_Allreduce_max_in_place( std::vector< long >& )
-{
-  // Null operator for ranks == 1
-  // Max already is the input
 }
 
 void

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -161,11 +161,6 @@ public:
   void communicate_Allreduce_sum_in_place( std::vector< int >& buffer );
   void communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer );
 
-  /*
-   * Maximum across all ranks
-   */
-  void communicate_Allreduce_max_in_place( std::vector< long >& buffer );
-
   std::string get_processor_name();
 
   bool is_mpi_used();


### PR DESCRIPTION
Resolves #1924 by removing the unused function `communicate_Allreduce_max_in_place()`.