### PR TITLE
Parse build output of GitHub Actions

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -13,7 +13,7 @@ jobs:
          os: ["ubuntu-20.04", macos-latest]
          cpp_compiler: ["gcc", "clang"]
          xNEST_BUILD_TYPE: ["MINIMAL", "MPI_ONLY", "OPENMP_ONLY", "FULL"]
-         exclude: 
+         exclude:
            - xNEST_BUILD_TYPE: "MPI_ONLY"
              cpp_compiler: "clang"
              os: macos-latest
@@ -47,34 +47,34 @@ jobs:
            - xNEST_BUILD_TYPE: "FULL"
              os: macos-latest
              cpp_compiler: "clang"
-                                                 
+
      steps:
-                       
+
        # Steps represent a sequence of tasks that will be executed as part of the job
-       - name: Checkout repo content 
+       - name: Checkout repo content
          #uses: actions/checkout@v2 # checkout the repository content to github runner.
          uses: actions/checkout@master
-         
+
        - name: Check Python path
          run: echo $PYTHONPATH
-       
+
        - name: Check path
          run: |
            echo $PATH
            echo $PWD
          shell: bash
-         
+
        - name: Set up Python 3.x
          uses: actions/setup-python@v2
          with:
            python-version: 3.9
-                     
+
        - name: Dependencies MacOS
          if: runner.os =='macOS'
          run: |
             brew install coreutils gsl open-mpi automake autoconf libtool
             brew info python
-            
+
        - name: Dependencies Linux
          if: contains(matrix.os, 'ubuntu')
          run: |
@@ -83,7 +83,7 @@ jobs:
            sudo apt-get install libltdl-dev libreadline6-dev libncurses5-dev libgsl0-dev python3-all-dev jq pep8 libpcre3 libpcre3-dev python2-dev libboost-all-dev
            sudo apt-get install openmpi-bin libopenmpi-dev libgsl0-dev tcl8.6 tcl8.6-dev tk8.6-dev
            sudo apt-get install libboost-filesystem-dev libboost-regex-dev libboost-wave-dev libboost-python-dev libboost-program-options-dev libboost-test-dev
-                      
+
        - name: Install dependencies
          #uses: actions/cache@master
          run: |
@@ -93,11 +93,11 @@ jobs:
             pip list
             g++ --version
             set -o pipefail
-            
+
        - name: Update shared library cache
          if: contains(matrix.os, 'ubuntu')
-         run: sudo ldconfig    
-                         
+         run: sudo ldconfig
+
        - name: Minimal Build
          if: ${{ matrix.xNEST_BUILD_TYPE == 'MINIMAL' }}
          run: |

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -103,33 +103,37 @@ jobs:
          run: |
            echo "Minimal Build"
            chmod +x extras/gha_build.sh
-           ./extras/gha_build.sh
+           ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
+           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
          env:
-           xNEST_BUILD_TYPE: "MINIMAL"     
-         
+           xNEST_BUILD_TYPE: "MINIMAL"
+
        - name: MPI Only
          if: ${{ matrix.xNEST_BUILD_TYPE == 'MPI_ONLY' }}
          run: |
            echo "MPI Only Build"
            chmod +x extras/gha_build.sh
-           ./extras/gha_build.sh
+           ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
+           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
          env:
            xNEST_BUILD_TYPE: MPI_ONLY
-           
+
        - name: OpenMP Only
          if: ${{ matrix.xNEST_BUILD_TYPE == 'OPENMP_ONLY' }}
          run: |
            echo "OpenMP Only Build"
            chmod +x extras/gha_build.sh
-           ./extras/gha_build.sh
+           ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
+           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
          env:
-          xNEST_BUILD_TYPE: OPENMP_ONLY 
-           
+          xNEST_BUILD_TYPE: OPENMP_ONLY
+
        - name: Full Build
          if: ${{ matrix.xNEST_BUILD_TYPE == 'FULL' }}
          run: |
            echo "FULL Build"
            chmod +x extras/gha_build.sh
-           ./extras/gha_build.sh   
+           ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
+           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
          env:
            xNEST_BUILD_TYPE: FULL

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -104,7 +104,7 @@ jobs:
            echo "Minimal Build"
            chmod +x extras/gha_build.sh
            ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
-           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
+           python extras/parse_build_log.py gha_build.sh.log ${{ github.workspace }}
          env:
            xNEST_BUILD_TYPE: "MINIMAL"
 
@@ -114,7 +114,7 @@ jobs:
            echo "MPI Only Build"
            chmod +x extras/gha_build.sh
            ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
-           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
+           python extras/parse_build_log.py gha_build.sh.log ${{ github.workspace }}
          env:
            xNEST_BUILD_TYPE: MPI_ONLY
 
@@ -124,7 +124,7 @@ jobs:
            echo "OpenMP Only Build"
            chmod +x extras/gha_build.sh
            ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
-           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
+           python extras/parse_build_log.py gha_build.sh.log ${{ github.workspace }}
          env:
           xNEST_BUILD_TYPE: OPENMP_ONLY
 
@@ -134,6 +134,6 @@ jobs:
            echo "FULL Build"
            chmod +x extras/gha_build.sh
            ./extras/gha_build.sh 2>&1 | tee gha_build.sh.log
-           python extras/parse_travis_log.py gha_build.sh.log ${{ github.workspace }}
+           python extras/parse_build_log.py gha_build.sh.log ${{ github.workspace }}
          env:
            xNEST_BUILD_TYPE: FULL

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ before_install:
          pip install --upgrade pip setuptools
          # Installing additional packages using pip as they only have
          # outdated versions in the Travis package whitelist.
-         # terminaltables is required by parse_travis_log.py to create
+         # terminaltables is required by parse_build_log.py to create
          # the build summary.
          pip install scipy junitparser mpi4py
          if [ "$TRAVIS_OS_NAME" != "osx" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - MAKEFLAGS="-j 2"
 stages:
    - Static-Code-Analysis
-   
+
 jobs:
   # list of build stages to run. Stages with the same name get run in parallel.
   include:
@@ -134,7 +134,7 @@ before_install:
            # nose must be installed user-only to avoid permissions conflict for man-pages
            wget https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl
            pip3 install --user nose-1.3.7-py3-none-any.whl
-         fi  
+         fi
          pip list
      fi
 
@@ -148,4 +148,3 @@ before_script:
 script:
    - set -o pipefail
    - ./extras/travis_build.sh 2>&1 | tee travis_build.sh.log
-   

--- a/doc/userdoc/contribute/ci.rst
+++ b/doc/userdoc/contribute/ci.rst
@@ -34,7 +34,7 @@ The current CI implementation is defined in `.travis.yml <https://github.com/nes
 
 #. Build of NEST Simulator
 
-   To ensure that changes in the code do not increase the number of compiler warnings generated during the build, warnings are counted and compared to a hardcoded number in the function ``makebuild_summary()`` in `extras/parse_travis_log.py <https://github.com/nest/nest-simulator/blob/master/extras/parse_travis_log.py>`_. The number of counted and expected warnings is printed in the "Build report" table printed at the end of the stage. For changes that legitimately increase the number of warnings, these values should be changed as part of the pull request.
+   To ensure that changes in the code do not increase the number of compiler warnings generated during the build, warnings are counted and compared to a hardcoded number in the function ``makebuild_summary()`` in `extras/parse_build_log.py <https://github.com/nest/nest-simulator/blob/master/extras/parse_build_log.py>`_. The number of counted and expected warnings is printed in the "Build report" table printed at the end of the stage. For changes that legitimately increase the number of warnings, these values should be changed as part of the pull request.
 
    The CI builds cover both the gcc and clang compilers.
 

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -282,7 +282,7 @@ fi
 
 # Verify the PEP8 installation.
 if $PERFORM_PEP8; then
-  $PEP8 --ignore="E121,E501" ./extras/parse_travis_log.py || error_exit "Failed to verify the PEP8 installation. Executable: $PEP8"
+  $PEP8 --ignore="E121,E501" ./extras/parse_build_log.py || error_exit "Failed to verify the PEP8 installation. Executable: $PEP8"
 fi
 
 # Extracting changed files between two commits.

--- a/extras/check_code_style.sh
+++ b/extras/check_code_style.sh
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-# This script performs a static code analysis and can be used to verify 
+# This script performs a static code analysis and can be used to verify
 # if a source file fulfills the NEST coding style guidelines.
 # Run ./extras/check_code_style.sh --help for more detailed information.
 
@@ -33,7 +33,7 @@ CPPCHECK=cppcheck                #    CPPCHECK version 1.69 or later is required
 CLANG_FORMAT=clang-format-3.6    #    CLANG-FORMAT version 3.6 and only this version is required !
 PEP8=pep8
 
-PERFORM_VERA=true                # Perform VERA++ analysis. 
+PERFORM_VERA=true                # Perform VERA++ analysis.
 PERFORM_CPPCHECK=false           # Skip CPPCHECK analysis.
 PERFORM_CLANG_FORMAT=true        # Perform CLANG-FORMAT analysis.
 PERFORM_PEP8=true                # Perform PEP8 analysis.
@@ -77,15 +77,15 @@ Usage: ./extras/check_code_style.sh [options ...]
 
 This script processes C/C++ and Python source code files to verify compliance with the NEST
 coding  style  guidelines.  The  checks are performed the same way as in the NEST Travis CI
-build and test environment. If no file is specified, a local 'git diff' is issued to obtain 
-the changed files in the commit range '<git-sha-start>..<git-sha-end>'. By default, this is 
+build and test environment. If no file is specified, a local 'git diff' is issued to obtain
+the changed files in the commit range '<git-sha-start>..<git-sha-end>'. By default, this is
 'master..head'.
 
 The script expects to be run from the base directory of the NEST sources,
 i.e. all executions should start like:
     ./extras/check_code_style.sh ...
 
-The setup of the tooling is explained here: 
+The setup of the tooling is explained here:
     https://nest-simulator.readthedocs.io/en/latest/contribute/coding_guidelines_cpp.html
 
 Options:
@@ -270,7 +270,7 @@ if $PERFORM_CPPCHECK; then
 fi
 
 # Verify the CLANG-FORMAT installation. CLANG-FORMAT version 3.6 and only 3.6 is required.
-# The CLANG-FORMAT versions up to and including 3.5 do not support all configuration options required for NEST. 
+# The CLANG-FORMAT versions up to and including 3.5 do not support all configuration options required for NEST.
 # Version 3.7 introduced a different formatting. NEST relies on the formatting of version 3.6.
 if $PERFORM_CLANG_FORMAT; then
   $CLANG_FORMAT -style=./.clang-format ./nest/main.cpp >/dev/null 2>&1 || error_exit "Failed to verify the CLANG-FORMAT installation. Executable: $CLANG_FORMAT"

--- a/extras/gha_build.sh
+++ b/extras/gha_build.sh
@@ -23,7 +23,7 @@
 # This shell script is part of the NEST Travis CI build and test environment.
 # It is invoked by the top-level Travis script '.travis.yml'.
 #
-# NOTE: This shell script is tightly coupled to 'extras/parse_travis_log.py'.
+# NOTE: This shell script is tightly coupled to 'extras/parse_build_log.py'.
 #       Any changes to message numbers (MSGBLDnnnn) or the variable name
 #      'file_names' have effects on the build/test-log parsing process.
 

--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# parse_travis_log.py
+# parse_build_log.py
 #
 # This file is part of NEST.
 #

--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -874,7 +874,7 @@ def printable_summary(list_of_changed_files,
          convert_bool_value_to_status_string(status_cmake_configure)],
         ['Make', convert_bool_value_to_status_string(status_make) + '\n' +
          '\nErrors  : ' + str(number_of_errors) +
-         '\nWarnings: ' + str(number_of_warnings) + f' ({expected_warnings} expected)'],
+         '\nWarnings: ' + str(number_of_warnings)],
         ['Make install',
          convert_bool_value_to_status_string(status_make_install)],
         ['Make installcheck',

--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -20,26 +20,26 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-This Python script is part of the NEST Travis CI build and test environment.
-It parses the Travis CI build log file 'travis_build.sh.log' (The name is
-hard-wired in '.travis.yml'.) and creates the 'NEST Travis CI Build Summary'.
+This Python script is part of the NEST GitHub Actions CI build and test environment.
+It parses the GitHub Actions build log file 'gha_build.sh.log' (The name is
+hard-wired in '.nestbuildmatrix.yml'.) and creates the 'NEST GitHub Actions Build Summary'.
 
 NOTE: Please note that the parsing process is coupled to shell script
-      'travis_build.sh' and relies on the message numbers "MSGBLDnnnn'.
+      'gha_build.sh' and relies on the message numbers "MSGBLDnnnn'.
       It does not rely on the messages texts itself except for file names.
 """
 
 
 def is_message_pair_in_logfile(log_filename, msg_start_of_section,
                                msg_end_of_section):
-    """Read the NEST Travis CI build log file and return 'True' in case both
+    """Read the NEST GitHub Actions build log file and return 'True' in case both
     messages are found in correct order. Return 'False' if only the first
     message was found. Return 'None' in case the first or both messages
     are not contained in the file.
 
     Parameters
     ----------
-    log_filename:         NEST Travis CI build log file name.
+    log_filename:         NEST GitHub Actions build log file name.
     msg_start_of_section: Message number string, e.g. "MSGBLD1234".
     msg_end_of_section:   Message number string, e.g. "MSGBLD1234".
 
@@ -60,12 +60,12 @@ def is_message_pair_in_logfile(log_filename, msg_start_of_section,
 
 
 def is_message_in_logfile(log_filename, msg_number):
-    """Read the NEST Travis CI build log file. Return 'True' if the message is
+    """Read the NEST GitHub Actions build log file. Return 'True' if the message is
     contained in the log file.
 
     Parameters
     ----------
-    log_filename: NEST Travis CI build log file name.
+    log_filename: NEST GitHub Actions build log file name.
     msg_number:   Message number string, e.g. "MSGBLD1234".
 
     Returns
@@ -102,12 +102,12 @@ def is_message(line, msg_number):
 
 def list_of_changed_files(log_filename, msg_changed_files_section_start,
                           msg_changed_files_section_end, msg_changed_files):
-    """Read the NEST Travis CI build log file, find the 'changed files' section
+    """Read the NEST GitHub Actions build log file, find the 'changed files' section
     and return a list of the changed files or an empty list, respectively.
 
     Parameters
     ----------
-    log_filename:                    NEST Travis CI build log file name.
+    log_filename:                    NEST GitHub Actions build log file name.
     msg_changed_files_section_start: Message number string, e.g. "MSGBLD1234".
     msg_changed_files_section_end:   Message number string, e.g. "MSGBLD1234".
     msg_changed_files:               Message number string, e.g. "MSGBLD1234".
@@ -146,13 +146,13 @@ def list_of_changed_files(log_filename, msg_changed_files_section_start,
 
 def msg_summary_vera(log_filename, msg_vera_section_start,
                      msg_vera_section_end, msg_vera):
-    """Read the NEST Travis CI build log file, find the VERA++ sections,
+    """Read the NEST GitHub Actions build log file, find the VERA++ sections,
     extract the VERA messages per file and return a dictionary containing an
     overall summary of the VERA++ code analysis.
 
     Parameters
     ----------
-    log_filename:           NEST Travis CI build log file name.
+    log_filename:           NEST GitHub Actions build log file name.
     msg_vera_section_start: Message number string, e.g. "MSGBLD1234".
     msg_vera_section_end:   Message number string, e.g. "MSGBLD1234".
     msg_vera:               Message number string, e.g. "MSGBLD1234".
@@ -192,13 +192,13 @@ def msg_summary_vera(log_filename, msg_vera_section_start,
 
 def msg_summary_cppcheck(log_filename, msg_cppcheck_section_start,
                          msg_cppcheck_section_end, msg_cppcheck):
-    """Read the NEST Travis CI build log file, find the cppcheck sections,
+    """Read the NEST GitHub Actions build log file, find the cppcheck sections,
     extract the cppcheck messages per file and return a dictionary containing
     an overall summary of the cppcheck code analysis.
 
     Parameters
     ---------
-    log_filename:               NEST Travis CI build log file name.
+    log_filename:               NEST GitHub Actions build log file name.
     msg_cppcheck_section_start: Message number string, e.g. "MSGBLD1234".
     msg_cppcheck_section_end:   Message number string, e.g. "MSGBLD1234".
     msg_cppcheck:               Message number string, e.g. "MSGBLD1234".
@@ -245,13 +245,13 @@ def msg_summary_cppcheck(log_filename, msg_cppcheck_section_start,
 
 def msg_summary_format(log_filename, msg_format_section_start,
                        msg_format_section_end, msg_format):
-    """Read the NEST Travis CI build log file, find the clang-format sections,
+    """Read the NEST GitHub Actions build log file, find the clang-format sections,
     extract the 'diff-messages' per file and return a dictionary containing an
     overall summary of the clang-format code analysis.
 
     Parameters
     ----------
-    log_filename:             NEST Travis CI build log file name.
+    log_filename:             NEST GitHub Actions build log file name.
     msg_format_section_start: Message number string, e.g. "MSGBLD1234".
     msg_format_section_end:   Message number string, e.g. "MSGBLD1234".
     msg_format:               Message number string, e.g. "MSGBLD1234".
@@ -291,13 +291,13 @@ def msg_summary_format(log_filename, msg_format_section_start,
 
 def msg_summary_pep8(log_filename, msg_pep8_section_start,
                      msg_pep8_section_end, msg_pep8):
-    """Read the NEST Travis CI build log file, find the PEP8 sections, extract
+    """Read the NEST GitHub Actions build log file, find the PEP8 sections, extract
     the PEP8 messages per file and return a dictionary containing an overall
     summary.
 
     Parameters:
     ----------
-    log_filename:           NEST Travis CI build log file name.
+    log_filename:           NEST GitHub Actions build log file name.
     msg_pep8_section_start: Message number string, e.g. "MSGBLD1234".
     msg_pep8_section_end:   Message number string, e.g. "MSGBLD1234".
     msg_pep8:               Message number string, e.g. "MSGBLD1234".
@@ -336,13 +336,13 @@ def msg_summary_pep8(log_filename, msg_pep8_section_start,
 
 def makebuild_summary(log_filename, msg_make_section_start,
                       msg_make_section_end):
-    """Read the NEST Travis CI build log file and return the number of build
+    """Read the NEST GitHub Actions build log file and return the number of build
     error and warning messages as well as dictionaries summarizing their
     occurrences.
 
     Parameters
     ----------
-    log_filename:           NEST Travis CI build log file name.
+    log_filename:           NEST GitHub Actions build log file name.
     msg_make_section_start: Message number string, e.g. "MSGBLD1234".
     msg_make_section_end:   Message number string, e.g. "MSGBLD1234".
 
@@ -420,7 +420,7 @@ def makebuild_summary(log_filename, msg_make_section_start,
 
 def testsuite_results(log_filename, msg_testsuite_section_start,
                       msg_testsuite_end_message):
-    """Read the NEST Travis CI build log file, find the 'make-installcheck'
+    """Read the NEST GitHub Actions build log file, find the 'make-installcheck'
     section which runs the NEST test suite. Extract the total number of tests
     and the number of tests failed. Return True if all tests passed
     successfully and False in case one or more tests failed. Additionally the
@@ -429,7 +429,7 @@ def testsuite_results(log_filename, msg_testsuite_section_start,
 
     Parameters
     ----------
-    log_filename:                NEST Travis CI build log file name.
+    log_filename:                NEST GitHub Actions build log file name.
     msg_testsuite_section_start: Message number string, e.g. "MSGBLD1234".
     msg_testsuite_end_message:   Message number string, e.g. "MSGBLD1234".
 
@@ -625,8 +625,8 @@ def code_analysis_per_file_tables(summary_vera, summary_cppcheck,
        summary_format is not None:
 
         # Keys, i.e. file names, are identical in these dictionaries.
-        # If this assertion raises an exception, please check travis_build.sh
-        # which runs the Travis CI build.
+        # If this assertion raises an exception, please check gha_build.sh
+        # which runs the GitHub Actions build.
         assert (summary_format.keys() == summary_cppcheck.keys())
         assert (summary_format.keys() == summary_vera.keys())
 
@@ -818,7 +818,7 @@ def printable_summary(list_of_changed_files,
     header = """
     + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
     +                                                                         +
-    +        N E S T   T r a v i s   C I   B u i l d   S u m m a r y          +
+    +    N E S T   G i t H u b   A c t i o n s   B u i l d   S u m m a r y    +
     +                                                                         +
     + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
     \n\n"""
@@ -990,7 +990,7 @@ if __name__ == '__main__':
     skip_code_analysis = is_message_in_logfile(log_filename, "MSGBLD0225")
     skip_installcheck = is_message_in_logfile(log_filename, "MSGBLD0305")
 
-    # The NEST Travis CI build consists of several steps and sections.
+    # The NEST GitHub Actions build consists of several steps and sections.
     # Each section is enclosed in a start- and an end-message.
     # By checking these message-pairs it can be verified whether a section
     # passed through successfully, failed or was skipped.
@@ -1028,7 +1028,7 @@ if __name__ == '__main__':
      number_of_tests_skipped, failed_tests, test_time) = \
         testsuite_results(log_filename, "MSGBLD0290", "MSGBLD0300")
 
-    # Determine the build result to tell Travis CI whether the build was
+    # Determine the build result to tell GitHub Actions whether the build was
     # successful or not.
     exit_code = build_return_code(status_cmake_configure,
                                   status_make,
@@ -1045,7 +1045,7 @@ if __name__ == '__main__':
                                   skip_code_analysis,
                                   skip_installcheck)
 
-    # Only after a successful build, Travis CI will upload the build artifacts
+    # Only after a successful build, GitHub Actions will upload the build artifacts
     # to Amazon S3.
     status_amazon_s3_upload = \
         (not is_message_in_logfile(log_filename, "MSGBLD0330") and

--- a/extras/parse_travis_log.py
+++ b/extras/parse_travis_log.py
@@ -981,7 +981,7 @@ if __name__ == '__main__':
     from terminaltables import AsciiTable
     from textwrap import wrap
 
-    this_script_filename, log_filename, build_type, build_dir = argv
+    this_script_filename, log_filename, build_dir = argv
 
     changed_files = \
         list_of_changed_files(log_filename, "MSGBLD0070",

--- a/extras/static_code_analysis.sh
+++ b/extras/static_code_analysis.sh
@@ -26,7 +26,7 @@
 # a local static code analysis.
 #
 # NOTE: This shell script is tightly coupled to Python script
-#       'extras/parse_travis_log.py'.
+#       'extras/parse_build_log.py'.
 #       Any changes to message numbers (MSGBLDnnnn) have effects on
 #       the build/test-log parsing process.
 #

--- a/extras/travis_build.sh
+++ b/extras/travis_build.sh
@@ -23,7 +23,7 @@
 # This shell script is part of the NEST Travis CI build and test environment.
 # It is invoked by the top-level Travis script '.travis.yml'.
 #
-# NOTE: This shell script is tightly coupled to 'extras/parse_travis_log.py'.
+# NOTE: This shell script is tightly coupled to 'extras/parse_build_log.py'.
 #       Any changes to message numbers (MSGBLDnnnn) or the variable name
 #      'file_names' have effects on the build/test-log parsing process.
 


### PR DESCRIPTION
GitHub actions will now parse the output of the build, give a proper summary, and fail if there are new compiler warnings raised, like it used to with Travis. This fixes #2005.

Also, the `parse_travis_log.py` script is renamed to `parse_build_log.py`, and trailing whitespace is cleaned up in the modified files.