### PR TITLE
Add functions to access information about simulation time

### DIFF
--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -150,19 +150,19 @@ public:
    * Get the number of total cycles in the current run.
    * Can be used to calculate the simulation time of the current run.
    */
-  delay get_number_of_cycles_in_run() const;
+  delay get_number_of_steps_in_run() const;
 
   /**
    * Get the start cycle of the current run.
    * Can be used to calculate the start time of the current run.
    */
-  delay get_start_cycle_in_run() const;
+  delay get_start_step_in_run() const;
 
   /**
    * Get the number of cycles that the current simulation will have been simulated for.
    * Can be used to calculate the end time of the simulation (only considering the runs that have be called so far).
    */
-  delay get_end_cycle_in_simulation() const;
+  delay get_end_step_in_simulation() const;
 
   //! Return start of current time slice, in steps.
   // TODO: rename / precisely how defined?

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -146,6 +146,24 @@ public:
   // TODO: Precisely how defined? Rename!
   Time const& get_clock() const;
 
+  /**
+   * Get the number of total cycles in the current run.
+   * Can be used to calculate the simulation time of the current run.
+   */
+  delay get_number_of_cycles_in_run() const;
+
+  /**
+   * Get the start cycle of the current run.
+   * Can be used to calculate the start time of the current run.
+   */
+  delay get_start_cycle_in_run() const;
+
+  /**
+   * Get the number of cycles that the current simulation will have been simulated for.
+   * Can be used to calculate the end time of the simulation (only considering the runs that have be called so far). 
+   */
+  delay get_end_cycle_in_simulation() const;
+
   //! Return start of current time slice, in steps.
   // TODO: rename / precisely how defined?
   delay get_from_step() const;
@@ -247,6 +265,26 @@ inline Time const&
 SimulationManager::get_clock() const
 {
   return clock_;
+}
+
+inline delay 
+SimulationManager::get_number_of_cycles_in_run() const
+{
+  return to_do_total_;
+}
+
+inline delay 
+SimulationManager::get_start_cycle_in_run() const
+{
+  assert( not simulating_ ); //implicit due to using get_time()
+  return get_time().get_steps() - (to_do_total_ - to_do_);
+}
+
+inline delay 
+SimulationManager::get_end_cycle_in_simulation() const
+{
+  assert( not simulating_ ); //implicit due to using get_time()
+  return get_time().get_steps() + to_do_;
 }
 
 inline delay

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -160,7 +160,7 @@ public:
 
   /**
    * Get the number of cycles that the current simulation will have been simulated for.
-   * Can be used to calculate the end time of the simulation (only considering the runs that have be called so far). 
+   * Can be used to calculate the end time of the simulation (only considering the runs that have be called so far).
    */
   delay get_end_cycle_in_simulation() const;
 
@@ -267,23 +267,23 @@ SimulationManager::get_clock() const
   return clock_;
 }
 
-inline delay 
+inline delay
 SimulationManager::get_number_of_cycles_in_run() const
 {
   return to_do_total_;
 }
 
-inline delay 
+inline delay
 SimulationManager::get_start_cycle_in_run() const
 {
-  assert( not simulating_ ); //implicit due to using get_time()
-  return get_time().get_steps() - (to_do_total_ - to_do_);
+  assert( not simulating_ ); // implicit due to using get_time()
+  return get_time().get_steps() - ( to_do_total_ - to_do_ );
 }
 
-inline delay 
+inline delay
 SimulationManager::get_end_cycle_in_simulation() const
 {
-  assert( not simulating_ ); //implicit due to using get_time()
+  assert( not simulating_ ); // implicit due to using get_time()
   return get_time().get_steps() + to_do_;
 }
 

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -147,22 +147,19 @@ public:
   Time const& get_clock() const;
 
   /**
-   * Get the number of total cycles in the current run.
-   * Can be used to calculate the simulation time of the current run.
+   * Get the simulation duration in the current call to run().
    */
-  delay get_number_of_steps_in_run() const;
+  Time run_duration() const;
 
   /**
-   * Get the start cycle of the current run.
-   * Can be used to calculate the start time of the current run.
+   * Get the start time of the current call to run().
    */
-  delay get_start_step_in_run() const;
+  Time run_start_time() const;
 
   /**
-   * Get the number of cycles that the current simulation will have been simulated for.
-   * Can be used to calculate the end time of the simulation (only considering the runs that have be called so far).
+   * Get the simulation's time at the end of the current call to run().
    */
-  delay get_end_step_in_simulation() const;
+  Time run_end_time() const;
 
   //! Return start of current time slice, in steps.
   // TODO: rename / precisely how defined?
@@ -267,24 +264,24 @@ SimulationManager::get_clock() const
   return clock_;
 }
 
-inline delay
-SimulationManager::get_number_of_steps_in_run() const
+inline Time
+SimulationManager::run_duration() const
 {
-  return to_do_total_;
+  return to_do_total_ * Time::get_resolution();
 }
 
-inline delay
-SimulationManager::get_start_step_in_run() const
+inline Time
+SimulationManager::run_start_time() const
 {
   assert( not simulating_ ); // implicit due to using get_time()
-  return get_time().get_steps() - ( to_do_total_ - to_do_ );
+  return get_time() - ( to_do_total_ - to_do_ ) * Time::get_resolution();
 }
 
-inline delay
-SimulationManager::get_end_step_in_simulation() const
+inline Time
+SimulationManager::run_end_time() const
 {
   assert( not simulating_ ); // implicit due to using get_time()
-  return get_time().get_steps() + to_do_;
+  return ( get_time().get_steps() + to_do_ ) * Time::get_resolution();
 }
 
 inline delay

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -191,8 +191,8 @@ private:
 
   Time clock_;                     //!< SimulationManager clock, updated once per slice
   delay slice_;                    //!< current update slice
-  delay to_do_;                    //!< number of pending cycles.
-  delay to_do_total_;              //!< number of requested cycles in current simulation.
+  delay to_do_;                    //!< number of pending steps.
+  delay to_do_total_;              //!< number of requested steps in current simulation.
   delay from_step_;                //!< update clock_+from_step<=T<clock_+to_step_
   delay to_step_;                  //!< update clock_+from_step<=T<clock_+to_step_
   timeval t_slice_begin_;          //!< Wall-clock time at the begin of a time slice

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -191,8 +191,8 @@ private:
 
   Time clock_;                     //!< SimulationManager clock, updated once per slice
   delay slice_;                    //!< current update slice
-  delay to_do_;                    //!< number of pending steps.
-  delay to_do_total_;              //!< number of requested steps in current simulation.
+  delay to_do_;                    //!< number of pending steps
+  delay to_do_total_;              //!< number of requested steps in current simulation
   delay from_step_;                //!< update clock_+from_step<=T<clock_+to_step_
   delay to_step_;                  //!< update clock_+from_step<=T<clock_+to_step_
   timeval t_slice_begin_;          //!< Wall-clock time at the begin of a time slice

--- a/nestkernel/simulation_manager.h
+++ b/nestkernel/simulation_manager.h
@@ -268,20 +268,20 @@ SimulationManager::get_clock() const
 }
 
 inline delay
-SimulationManager::get_number_of_cycles_in_run() const
+SimulationManager::get_number_of_steps_in_run() const
 {
   return to_do_total_;
 }
 
 inline delay
-SimulationManager::get_start_cycle_in_run() const
+SimulationManager::get_start_step_in_run() const
 {
   assert( not simulating_ ); // implicit due to using get_time()
   return get_time().get_steps() - ( to_do_total_ - to_do_ );
 }
 
 inline delay
-SimulationManager::get_end_cycle_in_simulation() const
+SimulationManager::get_end_step_in_simulation() const
 {
   assert( not simulating_ ); // implicit due to using get_time()
   return get_time().get_steps() + to_do_;


### PR DESCRIPTION
This PR adds three new functions to expose information about the simulation time of the current simulation.
Thus, it will allow to access information about the end of the current run, the time when the current run was started and the end of the overall simulation (multiple runs accumulated).

Example: A simulation run in the following way:
```
with nest.RunManager():
   i = 10
   for _ in range(3):
      nest.Run(i)
      i = i + 10
```

would return ( Run(10) / Run(20) / Run(30) ):
```
get_number_of_cycles_in_run():	100 / 200 / 300
get_start_cycle_in_run():	0 / 100 / 300
get_end_cycle_in_simulation():	100 / 300 / 600
```

We would like to use this information in the [insite-pipeline](https://github.com/VRGroupRWTH/insite) to give users the ability to access information about the start and end time of the current simulation to allow for a) buffer pre-allocation b) incorporating this information into visualization clients.

Refactored approach of PR #2006.