### PR TITLE
Remove brackets around NodeCollections in tests

### DIFF
--- a/testsuite/regressiontests/issue-1242.sli
+++ b/testsuite/regressiontests/issue-1242.sli
@@ -27,7 +27,7 @@ Name: testsuite::issue-1242
 Synopsis: (issue-1242) run -> NEST exits if test fails
 
 Description:
-Tests that a connection from a node without proxies to 
+Tests that a connection from a node without proxies to
 a node without proxies that has global targets throws an error
 (instead of failing silently or resulting in inconsistent results).
 
@@ -46,7 +46,7 @@ M_ERROR setverbosity
 
   /spike_generator Create /sg Set
   /volume_transmitter Create /vt Set
-  [sg] [vt] Connect
+  sg vt Connect
 }
 fail_or_die
 

--- a/testsuite/regressiontests/issue-735.sli
+++ b/testsuite/regressiontests/issue-735.sli
@@ -63,17 +63,17 @@ M_ERROR setverbosity
     /syn_model /stdp_dopamine_synapse def
   }
   ifelse
-  
+
   param_on_connect
   {
-    [ n ] [ n ] 
-    << /rule /one_to_one >> 
+    n n
+    << /rule /one_to_one >>
     << /synapse_model syn_model /weight 2.0 pname 1.0 >>
     Connect
   }
   {
     n n syn_model Connect
-    << >> GetConnections 0 get 
+    << >> GetConnections 0 get
     << pname 1.0 /weight 2.0 >> SetStatus
   }
   ifelse

--- a/testsuite/regressiontests/issue-737-threads.sli
+++ b/testsuite/regressiontests/issue-737-threads.sli
@@ -50,7 +50,7 @@ skip_if_not_threaded
   /n /iaf_psc_alpha Create def
   /vt /volume_transmitter Create def
   /stdp_dopamine_synapse << /vt vt >> SetDefaults
-  [n] [n] << /rule /one_to_one >> << /synapse_model /stdp_dopamine_synapse /c 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /stdp_dopamine_synapse /c 2.0 >> Connect
 
 } fail_or_die
 
@@ -63,7 +63,7 @@ skip_if_not_threaded
   /node_id /iaf_psc_alpha Create def
   /vt /volume_transmitter Create def
   /stdp_dopamine_synapse << /vt vt >> SetDefaults
-  [node_id] [node_id] << /rule /one_to_one >> << /synapse_model /stdp_dopamine_synapse /n 2.0 >> Connect
+  node_id node_id << /rule /one_to_one >> << /synapse_model /stdp_dopamine_synapse /n 2.0 >> Connect
 
 } fail_or_die
 
@@ -76,7 +76,7 @@ skip_if_not_threaded
   /n /iaf_psc_alpha Create def
   /vt /volume_transmitter Create def
   /stdp_dopamine_synapse /mysyn << /vt vt >> CopyModel
-  [n] [n] << /rule /one_to_one >> << /synapse_model /mysyn /c 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /mysyn /c 2.0 >> Connect
 
 } fail_or_die
 
@@ -89,7 +89,7 @@ skip_if_not_threaded
   /node_id /iaf_psc_alpha Create def
   /vt /volume_transmitter Create def
   /stdp_dopamine_synapse /mysyn << /vt vt >> CopyModel
-  [node_id] [node_id] << /rule /one_to_one >> << /synapse_model /mysyn /n 2.0 >> Connect
+  node_id node_id << /rule /one_to_one >> << /synapse_model /mysyn /n 2.0 >> Connect
 
 } fail_or_die
 

--- a/testsuite/regressiontests/issue-737.sli
+++ b/testsuite/regressiontests/issue-737.sli
@@ -45,7 +45,7 @@ M_ERROR setverbosity
   ResetKernel
 
   /n /iaf_psc_alpha Create def
-  [n] [n] << /rule /one_to_one >> << /synapse_model /static_synapse_hom_w /weight 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /static_synapse_hom_w /weight 2.0 >> Connect
 
 } fail_or_die
 
@@ -55,7 +55,7 @@ M_ERROR setverbosity
 
   /n /iaf_psc_alpha Create def
   /static_synapse_hom_w /mysyn CopyModel
-  [n] [n] << /rule /one_to_one >> << /synapse_model /mysyn /weight 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /mysyn /weight 2.0 >> Connect
 
 } fail_or_die
 
@@ -64,7 +64,7 @@ M_ERROR setverbosity
   ResetKernel
 
   /node_id /iaf_psc_alpha Create def
-  [node_id] [node_id] << /rule /one_to_one >> << /synapse_model /quantal_stp_synapse /n 4.0 >> Connect
+  node_id node_id << /rule /one_to_one >> << /synapse_model /quantal_stp_synapse /n 4.0 >> Connect
 
 } fail_or_die
 
@@ -74,7 +74,7 @@ M_ERROR setverbosity
 
   /node_id /iaf_psc_alpha Create def
   /quantal_stp_synapse /mysyn CopyModel
-  [node_id] [node_id] << /rule /one_to_one >> << /synapse_model /mysyn /n 4.0 >> Connect
+  node_id node_id << /rule /one_to_one >> << /synapse_model /mysyn /n 4.0 >> Connect
 
 } fail_or_die
 
@@ -83,7 +83,7 @@ M_ERROR setverbosity
   ResetKernel
 
   /n /iaf_psc_alpha Create def
-  [n] [n] << /rule /one_to_one >> << /synapse_model /quantal_stp_synapse /a 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /quantal_stp_synapse /a 2.0 >> Connect
 
 } fail_or_die
 
@@ -93,7 +93,7 @@ M_ERROR setverbosity
 
   /n /iaf_psc_alpha Create def
   /quantal_stp_synapse /mysyn CopyModel
-  [n] [n] << /rule /one_to_one >> << /synapse_model /mysyn /a 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /mysyn /a 2.0 >> Connect
 
 } fail_or_die
 
@@ -102,7 +102,7 @@ M_ERROR setverbosity
   ResetKernel
 
   /n /iaf_psc_alpha Create def
-  [n] [n] << /rule /one_to_one >> << /synapse_model /stdp_dopamine_synapse /vt 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /stdp_dopamine_synapse /vt 2.0 >> Connect
 
 } fail_or_die
 
@@ -112,7 +112,7 @@ M_ERROR setverbosity
 
   /n /iaf_psc_alpha Create def
   /stdp_dopamine_synapse /mysyn CopyModel
-  [n] [n] << /rule /one_to_one >> << /synapse_model /mysyn /vt 2.0 >> Connect
+  n n << /rule /one_to_one >> << /synapse_model /mysyn /vt 2.0 >> Connect
 
 } fail_or_die
 

--- a/testsuite/regressiontests/ticket-451.sli
+++ b/testsuite/regressiontests/ticket-451.sli
@@ -39,56 +39,57 @@ Author: Hans Ekkehard Plesser, 2010-09-20
 
 M_INFO setverbosity
 
-/iaf_psc_alpha 3 Create ;
+/nodes /iaf_psc_alpha 3 Create def
+/first nodes [1 1] Take def
 
 {
-[1 2 3] [1] << /rule /fixed_indegree /indegree 4 /allow_multapses false /allow_autapses true >> Connect
+nodes first << /rule /fixed_indegree /indegree 4 /allow_multapses false /allow_autapses true >> Connect
 } fail_or_die
 
 {
-[1 2 3] [1] << /rule /fixed_indegree /indegree 3 /allow_multapses false /allow_autapses true >> Connect
+nodes first << /rule /fixed_indegree /indegree 3 /allow_multapses false /allow_autapses true >> Connect
 } pass_or_die
 
 {
-[1 2 3] [1] << /rule /fixed_indegree /indegree 2 /allow_multapses false /allow_autapses true >> Connect
+nodes first << /rule /fixed_indegree /indegree 2 /allow_multapses false /allow_autapses true >> Connect
 } pass_or_die
 
 {
-[1 2 3] [1] << /rule /fixed_indegree /indegree 4 /allow_multapses false /allow_autapses false >> Connect
+nodes first << /rule /fixed_indegree /indegree 4 /allow_multapses false /allow_autapses false >> Connect
 } fail_or_die
 
 {
-[1 2 3] [1] << /rule /fixed_indegree /indegree 2 /allow_multapses false /allow_autapses false >> Connect
+nodes first << /rule /fixed_indegree /indegree 2 /allow_multapses false /allow_autapses false >> Connect
 } pass_or_die
 
 {
-[1 2 3] [1] << /rule /fixed_indegree /indegree 1 /allow_multapses true /allow_autapses true >> Connect
+nodes first << /rule /fixed_indegree /indegree 1 /allow_multapses true /allow_autapses true >> Connect
 } pass_or_die
 
 % ---------------------
 
 {
-[1] [1 2 3] << /rule /fixed_outdegree /outdegree 4 /allow_multapses false /allow_autapses true >> Connect
+first nodes << /rule /fixed_outdegree /outdegree 4 /allow_multapses false /allow_autapses true >> Connect
 } fail_or_die
 
 {
-[1] [1 2 3] << /rule /fixed_outdegree /outdegree 3 /allow_multapses false /allow_autapses true >> Connect
+first nodes << /rule /fixed_outdegree /outdegree 3 /allow_multapses false /allow_autapses true >> Connect
 } pass_or_die
 
 {
-[1] [1 2 3] << /rule /fixed_outdegree /outdegree 2 /allow_multapses false /allow_autapses true >> Connect
+first nodes << /rule /fixed_outdegree /outdegree 2 /allow_multapses false /allow_autapses true >> Connect
 } pass_or_die
 
 {
-[1] [1 2 3] << /rule /fixed_outdegree /outdegree 4 /allow_multapses false /allow_autapses false >> Connect
+first nodes << /rule /fixed_outdegree /outdegree 4 /allow_multapses false /allow_autapses false >> Connect
 } fail_or_die
 
 {
-[1] [1 2 3] << /rule /fixed_outdegree /outdegree 2 /allow_multapses false /allow_autapses false >> Connect
+first nodes << /rule /fixed_outdegree /outdegree 2 /allow_multapses false /allow_autapses false >> Connect
 } pass_or_die
 
 {
-[1] [1 2 3] << /rule /fixed_outdegree /outdegree 1 /allow_multapses true /allow_autapses false >> Connect
+first nodes << /rule /fixed_outdegree /outdegree 1 /allow_multapses true /allow_autapses false >> Connect
 } pass_or_die
 
 endusing

--- a/testsuite/regressiontests/ticket-681.sli
+++ b/testsuite/regressiontests/ticket-681.sli
@@ -56,8 +56,8 @@ M_ERROR setverbosity
 
     ResetKernel
     0  << /local_num_threads 4 /overwrite_files false >> SetStatus
-    /n /iaf_psc_alpha 4 << /I_e 1500.0 >> Create ;
-    /sr /spike_recorder << /record_to /ascii >> Create ;
+    /n /iaf_psc_alpha 4 << /I_e 1500.0 >> Create def
+    /sr /spike_recorder << /record_to /ascii >> Create def
     n sr Connect
     1000 Simulate
 } failbutnocrash_or_die

--- a/testsuite/regressiontests/ticket-681.sli
+++ b/testsuite/regressiontests/ticket-681.sli
@@ -26,11 +26,11 @@ Name: testsuite::ticket-681 - Ensure that NEST handles errors during node prepar
 
 Synopsis: (ticket-681) run -> NEST exits if test fails
 
-Description: 
+Description:
 Ensures that NEST handles errors during calibration gracefully.
 
 This test will be run only if NEST is compiled without MPI but with Threads.
- 
+
 Author: Hans E Plesser, 2014-11-25, based on reproducer for #536.
  */
 
@@ -40,7 +40,7 @@ Author: Hans E Plesser, 2014-11-25, based on reproducer for #536.
 skip_if_not_threaded
 
 % preparatory work for proper test code in case NEST is complied with MPI support
-% For now we just ignore this test, this will later be replaced 
+% For now we just ignore this test, this will later be replaced
 % by a restart of NEST with a serial binary.
 skip_if_have_mpi
 
@@ -49,15 +49,15 @@ M_ERROR setverbosity
 {
     ResetKernel
     << /local_num_threads 4 /overwrite_files false >> SetKernelStatus
-    /iaf_psc_alpha 4 << /I_e 1500.0 >> Create ;
-    /spike_recorder << /record_to /ascii >> Create ;
-    [1 2 3 4] [5] Connect
+    /n /iaf_psc_alpha 4 << /I_e 1500.0 >> Create def
+    /sr /spike_recorder << /record_to /ascii >> Create def
+    n sr Connect
     1000 Simulate
-	
+
     ResetKernel
     0  << /local_num_threads 4 /overwrite_files false >> SetStatus
-    /iaf_psc_alpha 4 << /I_e 1500.0 >> Create ;
-    /spike_recorder << /record_to /ascii >> Create ;
-    [1 2 3 4] [5] Connect
+    /n /iaf_psc_alpha 4 << /I_e 1500.0 >> Create ;
+    /sr /spike_recorder << /record_to /ascii >> Create ;
+    n sr Connect
     1000 Simulate
 } failbutnocrash_or_die

--- a/testsuite/unittests/test_bernoulli_synapse.sli
+++ b/testsuite/unittests/test_bernoulli_synapse.sli
@@ -105,9 +105,9 @@ forall
 /parrot_neuron Create /post Set
 
 {
-  [pre] [post] << /rule /all_to_all >> << /synapse_model /bernoulli_synapse /p_transmit -0.1 >> Connect
+  pre post << /rule /all_to_all >> << /synapse_model /bernoulli_synapse /p_transmit -0.1 >> Connect
 } fail_or_die
 
 {
-  [pre] [post] << /rule /all_to_all >> << /synapse_model /bernoulli_synapse /p_transmit 1.1 >> Connect
+  pre post << /rule /all_to_all >> << /synapse_model /bernoulli_synapse /p_transmit 1.1 >> Connect
 } fail_or_die

--- a/testsuite/unittests/test_gap_junction.sli
+++ b/testsuite/unittests/test_gap_junction.sli
@@ -99,14 +99,6 @@ M_ERROR setverbosity
 % Check that illegal gap-junction connections cannot be created
 {
   setup
-  neuron_gap neuron_gap
-  << /rule /one_to_one /make_symmetric true >> 
-  << /synapse_model /gap_junction >>
-  Connect
-} fail_or_die
-
-{
-  setup
   neuron_no_gap neuron_no_gap
   << /rule /one_to_one /make_symmetric true >> 
   << /synapse_model /gap_junction >>

--- a/testsuite/unittests/test_gap_junction.sli
+++ b/testsuite/unittests/test_gap_junction.sli
@@ -82,7 +82,7 @@ M_ERROR setverbosity
 % Check that delay cannot be set for gap-junction connections
 {
   setup
-  neuron_gap  neuron_gap
+  neuron_gap neuron_gap
   << /rule /one_to_one /make_symmetric true >> 
   << /synapse_model /gap_junction /delay 2.0 >>
   Connect
@@ -99,7 +99,7 @@ M_ERROR setverbosity
 % Check that illegal gap-junction connections cannot be created
 {
   setup
-  neuron_gap 0 get neuron_gap 0 get
+  neuron_gap neuron_gap
   << /rule /one_to_one /make_symmetric true >> 
   << /synapse_model /gap_junction >>
   Connect


### PR DESCRIPTION
This fixes #2034.

Remove brackets around NodeCollections when connecting to make tests fail from the actual mistake.

The removed test should actually pass, so I have removed it. It used to fail because we got the node id's and tried to connect them, and this does not work. Connecting two `hh_psc_alpha_gap` neurons does and should work though.