### PR TITLE
Fix failing assert when connecting spatial populations

### DIFF
--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -23,6 +23,8 @@
 #ifndef NTREE_IMPL_H
 #define NTREE_IMPL_H
 
+#include <limits>
+
 #include "ntree.h"
 
 // Includes from spatial:
@@ -391,7 +393,8 @@ Ntree< D, T, max_capacity, max_depth >::subquad_( const Position< D >& pos )
   int r = 0;
   for ( int i = 0; i < D; ++i )
   {
-    r += ( 1 << i ) * ( pos[ i ] < lower_left_[ i ] + extent_[ i ] / 2 ? 0 : 1 );
+    r += ( 1 << i )
+      * ( ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > std::numeric_limits< double >::epsilon() ? 0 : 1 );
   }
 
   return r;
@@ -478,7 +481,13 @@ Ntree< D, T, max_capacity, max_depth >::insert( Position< D > pos, const T& node
   if ( leaf_ )
   {
 
-    assert( ( pos >= lower_left_ ) && ( pos < lower_left_ + extent_ ) );
+#ifdef NDEBUG
+    for ( int i = 0; i < D; ++i )
+    {
+      assert( ( pos - lower_left_ )[ i ] > -std::numeric_limits< double >::epsilon()
+        && ( lower_left_ + extent_ - pos )[ i ] > -std::numeric_limits< double >::epsilon() );
+    }
+#endif
 
     nodes_.push_back( std::pair< Position< D >, T >( pos, node ) );
 

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -396,8 +396,8 @@ Ntree< D, T, max_capacity, max_depth >::subquad_( const Position< D >& pos )
     // Comparing against an epsilon value in case there are round-off errors.
     // Using a negative epsilon value because the round-off error may go both ways
     // and the difference we check against may therefore be +/- 10^-16.
-    r += ( 1 << i )
-      * ( ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > -std::numeric_limits< double >::epsilon() ? 0 : 1 );
+    const bool in_left_half = ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > -std::numeric_limits< double >::epsilon();
+    r += ( 1 << i ) * ( in_left_half ? 0 : 1 );
   }
 
   return r;
@@ -490,7 +490,7 @@ Ntree< D, T, max_capacity, max_depth >::insert( Position< D > pos, const T& node
       // Using a negative epsilon value because the round-off error may go both ways
       // and the difference we check against may therefore be +/- 10^-16.
       assert( ( pos - lower_left_ )[ i ] > -std::numeric_limits< double >::epsilon()
-        && ( lower_left_ + extent_ - pos )[ i ] > -std::numeric_limits< double >::epsilon() );
+        and ( lower_left_ + extent_ - pos )[ i ] > -std::numeric_limits< double >::epsilon() );
     }
 
     nodes_.push_back( std::pair< Position< D >, T >( pos, node ) );

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -394,8 +394,10 @@ Ntree< D, T, max_capacity, max_depth >::subquad_( const Position< D >& pos )
   for ( int i = 0; i < D; ++i )
   {
     // Comparing against an epsilon value in case there are round-off errors.
+    // Using a negative epsilon value because the round-off error may go both ways
+    // and the difference we check against may therefore be +/- 10^-16.
     r += ( 1 << i )
-      * ( ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > std::numeric_limits< double >::epsilon() ? 0 : 1 );
+      * ( ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > -std::numeric_limits< double >::epsilon() ? 0 : 1 );
   }
 
   return r;

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -393,6 +393,7 @@ Ntree< D, T, max_capacity, max_depth >::subquad_( const Position< D >& pos )
   int r = 0;
   for ( int i = 0; i < D; ++i )
   {
+    // Comparing against an epsilon value in case there are round-off errors.
     r += ( 1 << i )
       * ( ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > std::numeric_limits< double >::epsilon() ? 0 : 1 );
   }
@@ -483,6 +484,9 @@ Ntree< D, T, max_capacity, max_depth >::insert( Position< D > pos, const T& node
 
     for ( int i = 0; i < D; ++i )
     {
+      // Comparing against an epsilon value in case there are round-off errors.
+      // Using a negative epsilon value because the round-off error may go both ways
+      // and the difference we check against may therefore be +/- 10^-16.
       assert( ( pos - lower_left_ )[ i ] > -std::numeric_limits< double >::epsilon()
         && ( lower_left_ + extent_ - pos )[ i ] > -std::numeric_limits< double >::epsilon() );
     }

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -481,13 +481,11 @@ Ntree< D, T, max_capacity, max_depth >::insert( Position< D > pos, const T& node
   if ( leaf_ )
   {
 
-#ifdef NDEBUG
     for ( int i = 0; i < D; ++i )
     {
       assert( ( pos - lower_left_ )[ i ] > -std::numeric_limits< double >::epsilon()
         && ( lower_left_ + extent_ - pos )[ i ] > -std::numeric_limits< double >::epsilon() );
     }
-#endif
 
     nodes_.push_back( std::pair< Position< D >, T >( pos, node ) );
 

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -396,7 +396,8 @@ Ntree< D, T, max_capacity, max_depth >::subquad_( const Position< D >& pos )
     // Comparing against an epsilon value in case there are round-off errors.
     // Using a negative epsilon value because the round-off error may go both ways
     // and the difference we check against may therefore be +/- 10^-16.
-    const bool in_left_half = ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > -std::numeric_limits< double >::epsilon();
+    const bool in_left_half =
+      ( ( lower_left_[ i ] + extent_[ i ] / 2 ) - pos[ i ] ) > -std::numeric_limits< double >::epsilon();
     r += ( 1 << i ) * ( in_left_half ? 0 : 1 );
   }
 

--- a/testsuite/unittests/test_ntree_split.sli
+++ b/testsuite/unittests/test_ntree_split.sli
@@ -1,0 +1,96 @@
+/*
+ *  test_ntree_split.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+ /* BeginDocumentation
+Name: testsuite::test_ntree_split - test cornercases when splitting ntree
+
+Synopsis: (test_ntree_split) run
+
+
+Description:
+
+ This testscript connects spatial populations where the positions of nodes
+ are defined such that they cause roundoff errors when the ntree is split.
+*/
+
+M_PROGRESS setverbosity
+
+(unittest) run
+/unittest using
+
+{
+  << >> begin
+  ResetKernel
+
+  % Generate positions. The parameters pre_n_x and r should be defined such
+  % that we get roundoff errors. pre_n_x must be larger than 100 to make the
+  % ntree split.
+  /pre_n_x 110 def
+  /r 0.45 def
+  /positions [] def
+  /low_xy 0 r sub def
+  /high_xy r def
+  /dx high_xy low_xy sub pre_n_x 1 sub div def
+  /x_vals [low_xy high_xy dx] Range def
+  /y 0.0 def
+  /z 0.0 def
+
+  x_vals
+  {
+    /x Set
+    /positions positions [ x y z ] append def
+  } forall
+
+  % Create a source layer based on the positions generated.
+  <<
+    /positions positions
+    /elements /iaf_psc_alpha
+    /edge_wrap true
+  >>
+  CreateLayer /pre Set
+
+  % Create a target layer with a single position.
+  <<
+    /positions [ [ 1.0 0.0 0.0 ] ]
+    /elements /iaf_psc_alpha
+    /edge_wrap true
+  >>
+  CreateLayer /post Set
+
+  % We must specify a mask to make it generate a MaskedLayer, which splits the ntree.
+  /mask << /box << /lower_left [ -0.5 -0.5 -0.5 ]
+                   /upper_right [ 0.5 0.5 0.5 ] >> >> def
+
+  pre post
+  <<
+    /connection_type /pairwise_bernoulli_on_target
+    % Probability intentionally set to zero because we don't have to actually create the connections in this test.
+    /kernel 0.0
+    /mask mask
+    /allow_oversized_mask true
+  >>
+  ConnectLayers
+
+  end
+} pass_or_die
+
+end % using


### PR DESCRIPTION
When connecting spatial populations with a mask, in a corner case it would trigger an assert:
```
ntree_impl.h:486: nest::Ntree<D, T, max_capacity, max_depth>::iterator 
nest::Ntree<D, T, max_capacity, max_depth>::insert(nest::Position<D>, const T&) ... :
Assertion `( pos >= lower_left_ ) && ( pos < lower_left_ + extent_ )' failed.
```

When connecting using a mask on a population with more than 100 nodes, the population is split into 4 (in 2D) or 8 (in 3D) sub-regions. Each region is split recursively until each final region contains at most 100 nodes, or until it reaches a specified maximum depth.

The calculations performed when splitting a region may introduce round-off errors, which causes issues when trying to sort a position that is placed on one of the borders of the new sub-regions. Consequently this causes some nodes to be put in the wrong sub-regions, which triggers the assertion.

The round-off errors are handled by introducing an epsilon value when comparing positions.