### PR TITLE
Fix issue with building Sphinx documentation with recent Jinja version

### DIFF
--- a/extras/conda-nest-simulator-dev.yml
+++ b/extras/conda-nest-simulator-dev.yml
@@ -32,12 +32,12 @@
 name: nest-simulator-dev
 channels:
   - conda-forge
-  
+
 dependencies:
   # Basics ------------------
   - python >= 3.8
   - pip
-  
+
   # Building NEST -----------
   - cmake >= 3.12
   - cython
@@ -78,6 +78,7 @@ dependencies:
   - sphinx-tabs
   - sphinx >= 2
   - sphinx_rtd_theme
+  - jinja2 < 3
   - tqdm
   - yamllint
 

--- a/extras/nest-simulator-doc-requirements.txt
+++ b/extras/nest-simulator-doc-requirements.txt
@@ -23,6 +23,7 @@ sphinx>=2
 sphinx_autobuild
 sphinx_gallery
 sphinx_rtd_theme
+jinja2<3
 statsmodels
 tqdm
 yamllint


### PR DESCRIPTION
Fixes #2038 by adding a requirement to keep Jinja version below 3 when creating a Conda environment. Also adds the requirement for Read the Docs.