### PR TITLE
Make sure `init_state_` is called for models that need it, and remove redundant ones

### DIFF
--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -163,11 +163,9 @@ nest::ac_generator::ac_generator( const ac_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::ac_generator::init_state_( const Node& proto )
+nest::ac_generator::init_state_()
 {
-  const ac_generator& pr = downcast< ac_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -163,15 +163,6 @@ nest::ac_generator::ac_generator( const ac_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::ac_generator::init_state_( const Node& proto )
-{
-  const ac_generator& pr = downcast< ac_generator >( proto );
-
-  device_.init_state( pr.device_ );
-  S_ = pr.S_;
-}
-
-void
 nest::ac_generator::init_buffers_()
 {
   device_.init_buffers();

--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -163,6 +163,14 @@ nest::ac_generator::ac_generator( const ac_generator& n )
  * ---------------------------------------------------------------- */
 
 void
+nest::ac_generator::init_state_( const Node& proto )
+{
+  const ac_generator& pr = downcast< ac_generator >( proto );
+
+  device_.init_state( pr.device_ );
+}
+
+void
 nest::ac_generator::init_buffers_()
 {
   device_.init_buffers();

--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -129,6 +129,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
+  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -129,7 +129,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -129,7 +129,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -167,17 +167,6 @@ nest::aeif_cond_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_cond_alpha::State_& nest::aeif_cond_alpha::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -367,13 +356,6 @@ nest::aeif_cond_alpha::~aeif_cond_alpha()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::aeif_cond_alpha::init_state_( const Node& proto )
-{
-  const aeif_cond_alpha& pr = downcast< aeif_cond_alpha >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::aeif_cond_alpha::init_buffers_()

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -215,7 +215,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -296,7 +295,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -267,8 +267,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -180,15 +180,6 @@ aeif_cond_alpha_multisynapse::State_::State_( const State_& s )
   y_ = s.y_;
 }
 
-aeif_cond_alpha_multisynapse::State_& aeif_cond_alpha_multisynapse::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-
-  y_ = s.y_;
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -414,13 +405,6 @@ aeif_cond_alpha_multisynapse::~aeif_cond_alpha_multisynapse()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-aeif_cond_alpha_multisynapse::init_state_( const Node& proto )
-{
-  const aeif_cond_alpha_multisynapse& pr = downcast< aeif_cond_alpha_multisynapse >( proto );
-  S_ = pr.S_;
-}
 
 void
 aeif_cond_alpha_multisynapse::init_buffers_()

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -205,7 +205,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -292,7 +291,6 @@ private:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -261,8 +261,7 @@ private:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style arrays.
+   * @note Copy constructor required because of C-style arrays.
    */
   struct State_
   {

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -180,15 +180,6 @@ aeif_cond_beta_multisynapse::State_::State_( const State_& s )
   y_ = s.y_;
 }
 
-aeif_cond_beta_multisynapse::State_& aeif_cond_beta_multisynapse::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-
-  y_ = s.y_;
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -421,13 +412,6 @@ aeif_cond_beta_multisynapse::~aeif_cond_beta_multisynapse()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-aeif_cond_beta_multisynapse::init_state_( const Node& proto )
-{
-  const aeif_cond_beta_multisynapse& pr = downcast< aeif_cond_beta_multisynapse >( proto );
-  S_ = pr.S_;
-}
 
 void
 aeif_cond_beta_multisynapse::init_buffers_()

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -264,8 +264,7 @@ private:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style arrays.
+   * @note Copy constructor required because of C-style arrays.
    */
   struct State_
   {

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -208,7 +208,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -295,7 +294,6 @@ private:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -166,17 +166,6 @@ nest::aeif_cond_exp::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_cond_exp::State_& nest::aeif_cond_exp::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -362,13 +351,6 @@ nest::aeif_cond_exp::~aeif_cond_exp()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::aeif_cond_exp::init_state_( const Node& proto )
-{
-  const aeif_cond_exp& pr = downcast< aeif_cond_exp >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::aeif_cond_exp::init_buffers_()

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -215,7 +215,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( const Time&, const long, const long );
@@ -294,7 +293,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -267,8 +267,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -161,17 +161,6 @@ nest::aeif_psc_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_alpha::State_& nest::aeif_psc_alpha::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -357,13 +346,6 @@ nest::aeif_psc_alpha::~aeif_psc_alpha()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::aeif_psc_alpha::init_state_( const Node& proto )
-{
-  const aeif_psc_alpha& pr = downcast< aeif_psc_alpha >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::aeif_psc_alpha::init_buffers_()

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -251,8 +251,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -201,7 +201,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -280,7 +279,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -151,18 +151,6 @@ nest::aeif_psc_delta::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_delta::State_& nest::aeif_psc_delta::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -335,13 +323,6 @@ nest::aeif_psc_delta::~aeif_psc_delta()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::aeif_psc_delta::init_state_( const Node& proto )
-{
-  const aeif_psc_delta& pr = downcast< aeif_psc_delta >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::aeif_psc_delta::init_buffers_()

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -246,8 +246,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -196,7 +196,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( const Time&, const long, const long );
@@ -276,7 +275,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -186,19 +186,6 @@ nest::aeif_psc_delta_clopath::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_delta_clopath::State_& nest::aeif_psc_delta_clopath::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  clamp_r_ = s.clamp_r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -402,13 +389,6 @@ nest::aeif_psc_delta_clopath::~aeif_psc_delta_clopath()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::aeif_psc_delta_clopath::init_state_( const Node& proto )
-{
-  const aeif_psc_delta_clopath& pr = downcast< aeif_psc_delta_clopath >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::aeif_psc_delta_clopath::init_buffers_()

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -285,8 +285,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -226,7 +226,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( const Time&, const long, const long );
@@ -316,7 +315,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -160,17 +160,6 @@ nest::aeif_psc_exp::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_exp::State_& nest::aeif_psc_exp::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -352,13 +341,6 @@ nest::aeif_psc_exp::~aeif_psc_exp()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::aeif_psc_exp::init_state_( const Node& proto )
-{
-  const aeif_psc_exp& pr = downcast< aeif_psc_exp >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::aeif_psc_exp::init_buffers_()

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -203,7 +203,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( const Time&, const long, const long );
@@ -280,7 +279,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -253,8 +253,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -248,13 +248,6 @@ nest::amat2_psc_exp::amat2_psc_exp( const amat2_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::amat2_psc_exp::init_state_( const Node& proto )
-{
-  const amat2_psc_exp& pr = downcast< amat2_psc_exp >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::amat2_psc_exp::init_buffers_()
 {
   ArchivingNode::clear_history();

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -184,7 +184,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -114,7 +114,6 @@ public:
 
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 
@@ -421,14 +420,6 @@ binary_neuron< TGainfunction >::binary_neuron( const binary_neuron& n )
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-template < class TGainfunction >
-void
-binary_neuron< TGainfunction >::init_state_( const Node& proto )
-{
-  const binary_neuron& pr = downcast< binary_neuron >( proto );
-  S_ = pr.S_;
-}
 
 template < class TGainfunction >
 void

--- a/models/correlation_detector.cpp
+++ b/models/correlation_detector.cpp
@@ -235,8 +235,6 @@ nest::correlation_detector::init_state_( const Node& proto )
   const correlation_detector& pr = downcast< correlation_detector >( proto );
 
   device_.init_state( pr.device_ );
-  S_ = pr.S_;
-  set_state_buffers_initialized( false ); // force recreation of buffers
 }
 
 void

--- a/models/correlation_detector.cpp
+++ b/models/correlation_detector.cpp
@@ -236,7 +236,7 @@ nest::correlation_detector::init_state_( const Node& proto )
 
   device_.init_state( pr.device_ );
   S_ = pr.S_;
-  set_buffers_initialized( false ); // force recreation of buffers
+  set_state_buffers_initialized( false ); // force recreation of buffers
 }
 
 void

--- a/models/correlation_detector.cpp
+++ b/models/correlation_detector.cpp
@@ -230,11 +230,9 @@ nest::correlation_detector::correlation_detector( const correlation_detector& n 
  * ---------------------------------------------------------------- */
 
 void
-nest::correlation_detector::init_state_( const Node& proto )
+nest::correlation_detector::init_state_()
 {
-  const correlation_detector& pr = downcast< correlation_detector >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/correlation_detector.h
+++ b/models/correlation_detector.h
@@ -199,7 +199,7 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 private:
-  void init_state_( Node const& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -266,8 +266,6 @@ nest::correlomatrix_detector::init_state_( const Node& proto )
   const correlomatrix_detector& pr = downcast< correlomatrix_detector >( proto );
 
   device_.init_state( pr.device_ );
-  S_ = pr.S_;
-  set_state_buffers_initialized( false ); // force recreation of buffers
 }
 
 void

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -261,11 +261,9 @@ nest::correlomatrix_detector::correlomatrix_detector( const correlomatrix_detect
  * ---------------------------------------------------------------- */
 
 void
-nest::correlomatrix_detector::init_state_( const Node& proto )
+nest::correlomatrix_detector::init_state_()
 {
-  const correlomatrix_detector& pr = downcast< correlomatrix_detector >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -267,7 +267,7 @@ nest::correlomatrix_detector::init_state_( const Node& proto )
 
   device_.init_state( pr.device_ );
   S_ = pr.S_;
-  set_buffers_initialized( false ); // force recreation of buffers
+  set_state_buffers_initialized( false ); // force recreation of buffers
 }
 
 void

--- a/models/correlomatrix_detector.h
+++ b/models/correlomatrix_detector.h
@@ -185,7 +185,7 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 private:
-  void init_state_( Node const& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -277,8 +277,6 @@ nest::correlospinmatrix_detector::init_state_( const Node& proto )
   const correlospinmatrix_detector& pr = downcast< correlospinmatrix_detector >( proto );
 
   device_.init_state( pr.device_ );
-  S_ = pr.S_;
-  set_state_buffers_initialized( false ); // force recreation of buffers
 }
 
 void

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -272,11 +272,9 @@ nest::correlospinmatrix_detector::correlospinmatrix_detector( const correlospinm
  * ---------------------------------------------------------------- */
 
 void
-nest::correlospinmatrix_detector::init_state_( const Node& proto )
+nest::correlospinmatrix_detector::init_state_()
 {
-  const correlospinmatrix_detector& pr = downcast< correlospinmatrix_detector >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -278,7 +278,7 @@ nest::correlospinmatrix_detector::init_state_( const Node& proto )
 
   device_.init_state( pr.device_ );
   S_ = pr.S_;
-  set_buffers_initialized( false ); // force recreation of buffers
+  set_state_buffers_initialized( false ); // force recreation of buffers
 }
 
 void

--- a/models/correlospinmatrix_detector.h
+++ b/models/correlospinmatrix_detector.h
@@ -171,7 +171,7 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 private:
-  void init_state_( Node const& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/dc_generator.cpp
+++ b/models/dc_generator.cpp
@@ -134,6 +134,11 @@ nest::dc_generator::dc_generator( const dc_generator& n )
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
+void
+nest::dc_generator::init_state_()
+{
+  device_.init_state();
+}
 
 void
 nest::dc_generator::init_buffers_()

--- a/models/dc_generator.cpp
+++ b/models/dc_generator.cpp
@@ -136,15 +136,6 @@ nest::dc_generator::dc_generator( const dc_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::dc_generator::init_state_( const Node& proto )
-{
-  const dc_generator& pr = downcast< dc_generator >( proto );
-
-  device_.init_state( pr.device_ );
-  S_ = pr.S_;
-}
-
-void
 nest::dc_generator::init_buffers_()
 {
   device_.init_buffers();

--- a/models/dc_generator.h
+++ b/models/dc_generator.h
@@ -117,6 +117,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/dc_generator.h
+++ b/models/dc_generator.h
@@ -117,7 +117,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/gamma_sup_generator.cpp
+++ b/models/gamma_sup_generator.cpp
@@ -195,11 +195,9 @@ nest::gamma_sup_generator::gamma_sup_generator( const gamma_sup_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::gamma_sup_generator::init_state_( const Node& proto )
+nest::gamma_sup_generator::init_state_()
 {
-  const gamma_sup_generator& pr = downcast< gamma_sup_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/gamma_sup_generator.h
+++ b/models/gamma_sup_generator.h
@@ -110,7 +110,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -164,34 +164,6 @@ nest::gif_cond_exp::State_::State_( const State_& s )
   }
 }
 
-nest::gif_cond_exp::State_& nest::gif_cond_exp::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    neuron_state_[ i ] = s.neuron_state_[ i ];
-  }
-
-  sfa_elems_.resize( s.sfa_elems_.size(), 0.0 );
-  for ( size_t i = 0; i < sfa_elems_.size(); ++i )
-  {
-    sfa_elems_[ i ] = s.sfa_elems_[ i ];
-  }
-
-  stc_elems_.resize( s.stc_elems_.size(), 0.0 );
-  for ( size_t i = 0; i < stc_elems_.size(); ++i )
-  {
-    stc_elems_[ i ] = s.stc_elems_[ i ];
-  }
-
-  I_stim_ = s.I_stim_;
-  sfa_ = s.sfa_;
-  stc_ = s.stc_;
-  r_ref_ = s.r_ref_;
-
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -394,13 +366,6 @@ nest::gif_cond_exp::~gif_cond_exp()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::gif_cond_exp::init_state_( const Node& proto )
-{
-  const gif_cond_exp& pr = downcast< gif_cond_exp >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::gif_cond_exp::init_buffers_()

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -246,7 +246,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 
@@ -341,7 +340,6 @@ private:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -166,32 +166,6 @@ nest::gif_cond_exp_multisynapse::State_::State_( const State_& s )
   y_ = s.y_;
 }
 
-nest::gif_cond_exp_multisynapse::State_& nest::gif_cond_exp_multisynapse::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-
-  sfa_elems_.resize( s.sfa_elems_.size(), 0.0 );
-  for ( size_t i = 0; i < sfa_elems_.size(); ++i )
-  {
-    sfa_elems_[ i ] = s.sfa_elems_[ i ];
-  }
-
-  stc_elems_.resize( s.stc_elems_.size(), 0.0 );
-  for ( size_t i = 0; i < stc_elems_.size(); ++i )
-  {
-    stc_elems_[ i ] = s.stc_elems_[ i ];
-  }
-
-  y_ = s.y_;
-
-  I_stim_ = s.I_stim_;
-  sfa_ = s.sfa_;
-  r_ref_ = s.r_ref_;
-  stc_ = s.stc_;
-
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -440,13 +414,6 @@ nest::gif_cond_exp_multisynapse::~gif_cond_exp_multisynapse()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::gif_cond_exp_multisynapse::init_state_( const Node& proto )
-{
-  const gif_cond_exp_multisynapse& pr = downcast< gif_cond_exp_multisynapse >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::gif_cond_exp_multisynapse::init_buffers_()

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -243,7 +243,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 
@@ -349,7 +348,6 @@ private:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -262,13 +262,6 @@ nest::gif_pop_psc_exp::gif_pop_psc_exp( const gif_pop_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_pop_psc_exp::init_state_( const Node& proto )
-{
-  const gif_pop_psc_exp& pr = downcast< gif_pop_psc_exp >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::gif_pop_psc_exp::init_buffers_()
 {
   B_.ex_spikes_.clear(); //!< includes resize

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -186,7 +186,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -269,14 +269,6 @@ nest::gif_psc_exp::gif_psc_exp( const gif_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_psc_exp::init_state_( const Node& proto )
-{
-  const gif_psc_exp& pr = downcast< gif_psc_exp >( proto );
-  S_ = pr.S_;
-  // sfa_elems_ and stc_elems_ are initialized in calibrate()
-}
-
-void
 nest::gif_psc_exp::init_buffers_()
 {
   B_.spikes_ex_.clear(); // includes resize

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -228,7 +228,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -284,13 +284,6 @@ nest::gif_psc_exp_multisynapse::gif_psc_exp_multisynapse( const gif_psc_exp_mult
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_psc_exp_multisynapse::init_state_( const Node& proto )
-{
-  const gif_psc_exp_multisynapse& pr = downcast< gif_psc_exp_multisynapse >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::gif_psc_exp_multisynapse::init_buffers_()
 {
   B_.spikes_.clear();   //!< includes resize

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -233,7 +233,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -194,25 +194,6 @@ nest::glif_cond::State_::State_( const State_& s )
   y_ = s.y_;
 }
 
-nest::glif_cond::State_& nest::glif_cond::State_::operator=( const State_& s )
-{
-
-  if ( this == &s ) // avoid assignment to self
-  {
-    return *this;
-  }
-
-  threshold_ = s.threshold_;
-  threshold_spike_ = s.threshold_spike_;
-  threshold_voltage_ = s.threshold_voltage_;
-  ASCurrents_ = s.ASCurrents_;
-  refractory_steps_ = s.refractory_steps_;
-  y_ = s.y_;
-
-  return *this;
-}
-
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -544,13 +525,6 @@ nest::glif_cond::~glif_cond()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::glif_cond::init_state_( const Node& proto )
-{
-  const glif_cond& pr = downcast< glif_cond >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::glif_cond::init_buffers_()

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -222,9 +222,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  //! Reset state of neuron.
-  void init_state_( const Node& proto );
-
   //! Reset internal buffers of neuron.
   void init_buffers_();
 
@@ -323,7 +320,6 @@ private:
 
     State_( const Parameters_& );
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
     void set( const DictionaryDatum&, const Parameters_&, double );

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -385,13 +385,6 @@ nest::glif_psc::glif_psc( const glif_psc& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc::init_state_( const Node& proto )
-{
-  const glif_psc& pr = downcast< glif_psc >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::glif_psc::init_buffers_()
 {
   B_.spikes_.clear();   // includes resize

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -217,9 +217,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  //! Reset state of neuron.
-  void init_state_( const Node& proto );
-
   //! Reset internal buffers of neuron.
   void init_buffers_();
 

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -212,17 +212,6 @@ nest::hh_cond_beta_gap_traub::State_::State_( const State_& s )
   }
 }
 
-nest::hh_cond_beta_gap_traub::State_& nest::hh_cond_beta_gap_traub::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -374,13 +363,6 @@ nest::hh_cond_beta_gap_traub::~hh_cond_beta_gap_traub()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::hh_cond_beta_gap_traub::init_state_( const Node& proto )
-{
-  const hh_cond_beta_gap_traub& pr = downcast< hh_cond_beta_gap_traub >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::hh_cond_beta_gap_traub::init_buffers_()

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -212,7 +212,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   double get_normalisation_factor( double, double );
   void calibrate();
@@ -296,8 +295,6 @@ public:
 
     State_( const Parameters_& p );
     State_( const State_& s );
-
-    State_& operator=( const State_& s );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_& );

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -173,17 +173,6 @@ nest::hh_cond_exp_traub::State_::State_( const State_& s )
   }
 }
 
-nest::hh_cond_exp_traub::State_& nest::hh_cond_exp_traub::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -324,13 +313,6 @@ nest::hh_cond_exp_traub::~hh_cond_exp_traub()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::hh_cond_exp_traub::init_state_( const Node& proto )
-{
-  const hh_cond_exp_traub& pr = downcast< hh_cond_exp_traub >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::hh_cond_exp_traub::init_buffers_()

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -176,7 +176,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 
@@ -252,8 +251,6 @@ public:
 
     State_( const Parameters_& p );
     State_( const State_& s );
-
-    State_& operator=( const State_& s );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -172,17 +172,6 @@ nest::hh_psc_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::hh_psc_alpha::State_& nest::hh_psc_alpha::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -320,13 +309,6 @@ nest::hh_psc_alpha::~hh_psc_alpha()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::hh_psc_alpha::init_state_( const Node& proto )
-{
-  const hh_psc_alpha& pr = downcast< hh_psc_alpha >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::hh_psc_alpha::init_buffers_()

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -214,8 +214,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -170,7 +170,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -246,7 +245,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -186,17 +186,6 @@ nest::hh_psc_alpha_clopath::State_::State_( const State_& s )
   }
 }
 
-nest::hh_psc_alpha_clopath::State_& nest::hh_psc_alpha_clopath::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -346,13 +335,6 @@ nest::hh_psc_alpha_clopath::~hh_psc_alpha_clopath()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::hh_psc_alpha_clopath::init_state_( const Node& proto )
-{
-  const hh_psc_alpha_clopath& pr = downcast< hh_psc_alpha_clopath >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::hh_psc_alpha_clopath::init_buffers_()

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -255,8 +255,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -208,7 +208,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -290,7 +289,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -210,17 +210,6 @@ nest::hh_psc_alpha_gap::State_::State_( const State_& s )
   }
 }
 
-nest::hh_psc_alpha_gap::State_& nest::hh_psc_alpha_gap::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -364,13 +353,6 @@ nest::hh_psc_alpha_gap::~hh_psc_alpha_gap()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::hh_psc_alpha_gap::init_state_( const Node& proto )
-{
-  const hh_psc_alpha_gap& pr = downcast< hh_psc_alpha_gap >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::hh_psc_alpha_gap::init_buffers_()

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -240,8 +240,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -188,7 +188,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 
@@ -272,7 +271,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -307,27 +307,6 @@ nest::ht_neuron::State_::State_( const State_& s )
   }
 }
 
-nest::ht_neuron::State_& nest::ht_neuron::State_::operator=( const State_& s )
-{
-  if ( this == &s )
-  {
-    return *this;
-  }
-
-  ref_steps_ = s.ref_steps_;
-  I_NaP_ = s.I_NaP_;
-  I_KNa_ = s.I_KNa_;
-  I_T_ = s.I_T_;
-  I_h_ = s.I_h_;
-
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-
-  return *this;
-}
-
 nest::ht_neuron::State_::~State_()
 {
 }
@@ -649,13 +628,6 @@ nest::ht_neuron::~ht_neuron()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::ht_neuron::init_state_( const Node& proto )
-{
-  const ht_neuron& pr = downcast< ht_neuron >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::ht_neuron::init_buffers_()

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -226,7 +226,6 @@ private:
     SUP_SPIKE_RECEPTOR
   };
 
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 
@@ -361,8 +360,6 @@ public:
     State_( const ht_neuron&, const Parameters_& p );
     State_( const State_& s );
     ~State_();
-
-    State_& operator=( const State_& s );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const ht_neuron&, Node* node );

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -185,14 +185,6 @@ nest::iaf_chs_2007::iaf_chs_2007( const iaf_chs_2007& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_chs_2007::init_node_( const Node& proto )
-{
-  const iaf_chs_2007& pr = downcast< iaf_chs_2007 >( proto );
-  P_ = pr.P_;
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_chs_2007::init_buffers_()
 {
   B_.spikes_ex_.clear(); // includes resize

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -193,13 +193,6 @@ nest::iaf_chs_2007::init_node_( const Node& proto )
 }
 
 void
-nest::iaf_chs_2007::init_state_( const Node& proto )
-{
-  const iaf_chs_2007& pr = downcast< iaf_chs_2007 >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_chs_2007::init_buffers_()
 {
   B_.spikes_ex_.clear(); // includes resize

--- a/models/iaf_chs_2007.h
+++ b/models/iaf_chs_2007.h
@@ -134,7 +134,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_node_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_chs_2007.h
+++ b/models/iaf_chs_2007.h
@@ -135,7 +135,6 @@ public:
 
 private:
   void init_node_( const Node& proto );
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -158,21 +158,6 @@ nest::iaf_chxk_2008::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_chxk_2008::State_& nest::iaf_chxk_2008::State_::operator=( const State_& s )
-{
-  if ( this == &s ) // avoid assignment to self
-  {
-    return *this;
-  }
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y[ i ] = s.y[ i ];
-  }
-
-  r = s.r;
-  return *this;
-}
-
 nest::iaf_chxk_2008::Buffers_::Buffers_( iaf_chxk_2008& n )
   : logger_( n )
   , s_( 0 )
@@ -294,13 +279,6 @@ nest::iaf_chxk_2008::~iaf_chxk_2008()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::iaf_chxk_2008::init_state_( const Node& proto )
-{
-  const iaf_chxk_2008& pr = downcast< iaf_chxk_2008 >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::iaf_chxk_2008::init_buffers_()

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -229,8 +229,7 @@ private:
    * dynamics and the refractory count. The state vector must be a
    * C-style array to be compatible with GSL ODE solvers.
    *
-   * @note Copy constructor and assignment operator are required because
-   *       of the C-style array.
+   * @note Copy constructor required because  of the C-style array.
    */
 public:
   struct State_

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -178,7 +178,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -257,7 +256,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -146,21 +146,6 @@ nest::iaf_cond_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_alpha::State_& nest::iaf_cond_alpha::State_::operator=( const State_& s )
-{
-  if ( this == &s ) // avoid assignment to self
-  {
-    return *this;
-  }
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y[ i ] = s.y[ i ];
-  }
-
-  r = s.r;
-  return *this;
-}
-
 nest::iaf_cond_alpha::Buffers_::Buffers_( iaf_cond_alpha& n )
   : logger_( n )
   , s_( 0 )
@@ -300,13 +285,6 @@ nest::iaf_cond_alpha::~iaf_cond_alpha()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::iaf_cond_alpha::init_state_( const Node& proto )
-{
-  const iaf_cond_alpha& pr = downcast< iaf_cond_alpha >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::iaf_cond_alpha::init_buffers_()

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -172,7 +172,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -246,7 +245,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -220,8 +220,7 @@ private:
    * dynamics and the refractory count. The state vector must be a
    * C-style array to be compatible with GSL ODE solvers.
    *
-   * @note Copy constructor and assignment operator are required because
-   *       of the C-style array.
+   * @note Copy constructor required because of the C-style array.
    */
 public:
   struct State_

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -277,17 +277,6 @@ nest::iaf_cond_alpha_mc::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_alpha_mc::State_& nest::iaf_cond_alpha_mc::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 nest::iaf_cond_alpha_mc::Buffers_::Buffers_( iaf_cond_alpha_mc& n )
   : logger_( n )
   , s_( 0 )
@@ -467,13 +456,6 @@ nest::iaf_cond_alpha_mc::~iaf_cond_alpha_mc()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::iaf_cond_alpha_mc::init_state_( const Node& proto )
-{
-  const iaf_cond_alpha_mc& pr = downcast< iaf_cond_alpha_mc >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::iaf_cond_alpha_mc::init_buffers_()

--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -200,7 +200,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -350,7 +349,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -318,8 +318,7 @@ private:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
 public:
   struct State_

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -151,21 +151,6 @@ nest::iaf_cond_beta::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_beta::State_& nest::iaf_cond_beta::State_::operator=( const State_& s )
-{
-  if ( this == &s ) // avoid assignment to self
-  {
-    return *this;
-  }
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y[ i ] = s.y[ i ];
-  }
-
-  r = s.r;
-  return *this;
-}
-
 nest::iaf_cond_beta::Buffers_::Buffers_( iaf_cond_beta& n )
   : logger_( n )
   , s_( 0 )
@@ -309,13 +294,6 @@ nest::iaf_cond_beta::~iaf_cond_beta()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::iaf_cond_beta::init_state_( const Node& proto )
-{
-  const iaf_cond_beta& pr = downcast< iaf_cond_beta >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::iaf_cond_beta::init_buffers_()

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -230,8 +230,7 @@ private:
    * dynamics and the refractory count. The state vector must be a
    * C-style array to be compatible with GSL ODE solvers.
    *
-   * @note Copy constructor and assignment operator are required because
-   *       of the C-style array.
+   * @note Copy constructor required because of the C-style array.
    */
 public:
   struct State_

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -179,7 +179,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   double get_normalisation_factor( double, double );
   void calibrate();
@@ -256,7 +255,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -130,17 +130,6 @@ nest::iaf_cond_exp::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_exp::State_& nest::iaf_cond_exp::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -275,13 +264,6 @@ nest::iaf_cond_exp::~iaf_cond_exp()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::iaf_cond_exp::init_state_( const Node& proto )
-{
-  const iaf_cond_exp& pr = downcast< iaf_cond_exp >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::iaf_cond_exp::init_buffers_()

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -150,7 +150,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -215,7 +214,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -194,8 +194,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -147,17 +147,6 @@ nest::iaf_cond_exp_sfa_rr::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_exp_sfa_rr::State_& nest::iaf_cond_exp_sfa_rr::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
@@ -310,13 +299,6 @@ nest::iaf_cond_exp_sfa_rr::~iaf_cond_exp_sfa_rr()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::iaf_cond_exp_sfa_rr::init_state_( const Node& proto )
-{
-  const iaf_cond_exp_sfa_rr& pr = downcast< iaf_cond_exp_sfa_rr >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::iaf_cond_exp_sfa_rr::init_buffers_()

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -173,7 +173,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -249,7 +248,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -226,8 +226,7 @@ public:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
   struct State_
   {

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -237,13 +237,6 @@ iaf_psc_alpha::iaf_psc_alpha( const iaf_psc_alpha& n )
  * ---------------------------------------------------------------- */
 
 void
-iaf_psc_alpha::init_state_( const Node& proto )
-{
-  const iaf_psc_alpha& pr = downcast< iaf_psc_alpha >( proto );
-  S_ = pr.S_;
-}
-
-void
 iaf_psc_alpha::init_buffers_()
 {
   B_.input_buffer_.clear(); // includes resize

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -177,7 +177,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -252,13 +252,6 @@ nest::iaf_psc_alpha_canon::iaf_psc_alpha_canon( const iaf_psc_alpha_canon& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_alpha_canon::init_state_( const Node& proto )
-{
-  const iaf_psc_alpha_canon& pr = downcast< iaf_psc_alpha_canon >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_alpha_canon::init_buffers_()
 {
   B_.events_.resize();

--- a/models/iaf_psc_alpha_canon.h
+++ b/models/iaf_psc_alpha_canon.h
@@ -214,7 +214,6 @@ private:
    * only through a Node*.
    */
   //@{
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -275,13 +275,6 @@ iaf_psc_alpha_multisynapse::iaf_psc_alpha_multisynapse( const iaf_psc_alpha_mult
  * ---------------------------------------------------------------- */
 
 void
-iaf_psc_alpha_multisynapse::init_state_( const Node& proto )
-{
-  const iaf_psc_alpha_multisynapse& pr = downcast< iaf_psc_alpha_multisynapse >( proto );
-  S_ = pr.S_;
-}
-
-void
 iaf_psc_alpha_multisynapse::init_buffers_()
 {
   B_.spikes_.clear();   // includes resize

--- a/models/iaf_psc_alpha_multisynapse.h
+++ b/models/iaf_psc_alpha_multisynapse.h
@@ -111,7 +111,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -246,13 +246,6 @@ nest::iaf_psc_alpha_ps::iaf_psc_alpha_ps( const iaf_psc_alpha_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_alpha_ps::init_state_( const Node& proto )
-{
-  const iaf_psc_alpha_ps& pr = downcast< iaf_psc_alpha_ps >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_alpha_ps::init_buffers_()
 {
   B_.events_.resize();

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -212,7 +212,6 @@ private:
    * only through a Node*.
    */
   //@{
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -221,13 +221,6 @@ nest::iaf_psc_delta::iaf_psc_delta( const iaf_psc_delta& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_delta::init_state_( const Node& proto )
-{
-  const iaf_psc_delta& pr = downcast< iaf_psc_delta >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_delta::init_buffers_()
 {
   B_.spikes_.clear();   // includes resize

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -172,7 +172,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_delta_ps.cpp
+++ b/models/iaf_psc_delta_ps.cpp
@@ -227,13 +227,6 @@ nest::iaf_psc_delta_ps::iaf_psc_delta_ps( const iaf_psc_delta_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_delta_ps::init_state_( const Node& proto )
-{
-  const iaf_psc_delta_ps& pr = downcast< iaf_psc_delta_ps >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_delta_ps::init_buffers_()
 {
   B_.events_.resize();

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -208,7 +208,6 @@ private:
    * only through a Node*.
    */
   //@{
-  void init_state_( const Node& proto );
   void init_buffers_();
 
   void calibrate();

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -235,13 +235,6 @@ nest::iaf_psc_exp::iaf_psc_exp( const iaf_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp::init_state_( const Node& proto )
-{
-  const iaf_psc_exp& pr = downcast< iaf_psc_exp >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_exp::init_buffers_()
 {
   B_.input_buffer_.clear(); // includes resize

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -190,7 +190,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -220,13 +220,6 @@ nest::iaf_psc_exp_htum::iaf_psc_exp_htum( const iaf_psc_exp_htum& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_htum::init_state_( const Node& proto )
-{
-  const iaf_psc_exp_htum& pr = downcast< iaf_psc_exp_htum >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_exp_htum::init_buffers_()
 {
   B_.spikes_ex_.clear(); // includes resize

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -174,7 +174,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -262,13 +262,6 @@ iaf_psc_exp_multisynapse::iaf_psc_exp_multisynapse( const iaf_psc_exp_multisynap
  * ---------------------------------------------------------------- */
 
 void
-iaf_psc_exp_multisynapse::init_state_( const Node& proto )
-{
-  const iaf_psc_exp_multisynapse& pr = downcast< iaf_psc_exp_multisynapse >( proto );
-  S_ = pr.S_;
-}
-
-void
 iaf_psc_exp_multisynapse::init_buffers_()
 {
   B_.spikes_.clear();   // includes resize

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -117,7 +117,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -236,14 +236,6 @@ nest::iaf_psc_exp_ps::iaf_psc_exp_ps( const iaf_psc_exp_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps::init_state_( const Node& proto )
-{
-  const iaf_psc_exp_ps& pr = downcast< iaf_psc_exp_ps >( proto );
-
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_exp_ps::init_buffers_()
 {
   B_.events_.resize();

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -206,7 +206,6 @@ private:
    * only through a Node*.
    */
   //@{
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -264,14 +264,6 @@ nest::iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless( const iaf_psc_exp_ps_los
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps_lossless::init_state_( const Node& proto )
-{
-  const iaf_psc_exp_ps_lossless& pr = downcast< iaf_psc_exp_ps_lossless >( proto );
-
-  S_ = pr.S_;
-}
-
-void
 nest::iaf_psc_exp_ps_lossless::init_buffers_()
 {
   B_.events_.resize();

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -201,7 +201,6 @@ private:
    * only through a Node*.
    */
   //@{
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -215,11 +215,9 @@ nest::inhomogeneous_poisson_generator::inhomogeneous_poisson_generator( const in
  * Node initialization functions
  * ---------------------------------------------------------------- */
 void
-nest::inhomogeneous_poisson_generator::init_state_( const Node& proto )
+nest::inhomogeneous_poisson_generator::init_state_()
 {
-  const inhomogeneous_poisson_generator& pr = downcast< inhomogeneous_poisson_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/inhomogeneous_poisson_generator.h
+++ b/models/inhomogeneous_poisson_generator.h
@@ -122,7 +122,7 @@ public:
 
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -170,13 +170,6 @@ nest::izhikevich::izhikevich( const izhikevich& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::izhikevich::init_state_( const Node& proto )
-{
-  const izhikevich& pr = downcast< izhikevich >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::izhikevich::init_buffers_()
 {
   B_.spikes_.clear();   // includes resize

--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -150,7 +150,6 @@ private:
   friend class RecordablesMap< izhikevich >;
   friend class UniversalDataLogger< izhikevich >;
 
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -227,13 +227,6 @@ nest::mat2_psc_exp::mat2_psc_exp( const mat2_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::mat2_psc_exp::init_state_( const Node& proto )
-{
-  const mat2_psc_exp& pr = downcast< mat2_psc_exp >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::mat2_psc_exp::init_buffers_()
 {
   ArchivingNode::clear_history();

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -172,7 +172,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );

--- a/models/mip_generator.cpp
+++ b/models/mip_generator.cpp
@@ -92,11 +92,9 @@ nest::mip_generator::mip_generator( const mip_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::mip_generator::init_state_( const Node& proto )
+nest::mip_generator::init_state_()
 {
-  const mip_generator& pr = downcast< mip_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/mip_generator.h
+++ b/models/mip_generator.h
@@ -123,7 +123,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/music_cont_in_proxy.cpp
+++ b/models/music_cont_in_proxy.cpp
@@ -119,14 +119,6 @@ nest::music_cont_in_proxy::music_cont_in_proxy( const music_cont_in_proxy& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::music_cont_in_proxy::init_state_( const Node& proto )
-{
-  const music_cont_in_proxy& pr = downcast< music_cont_in_proxy >( proto );
-
-  S_ = pr.S_;
-}
-
-void
 nest::music_cont_in_proxy::init_buffers_()
 {
 }

--- a/models/music_cont_in_proxy.h
+++ b/models/music_cont_in_proxy.h
@@ -112,7 +112,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -206,11 +206,6 @@ nest::music_cont_out_proxy::music_cont_out_proxy( const music_cont_out_proxy& n 
 }
 
 void
-nest::music_cont_out_proxy::init_state_( const Node& /* np */ )
-{
-}
-
-void
 nest::music_cont_out_proxy::init_buffers_()
 {
   B_.data_.clear();

--- a/models/music_cont_out_proxy.h
+++ b/models/music_cont_out_proxy.h
@@ -152,7 +152,6 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 protected:
-  void init_state_( Node const& );
   void init_buffers_();
   void calibrate();
   void finalize();

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -122,14 +122,6 @@ nest::music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n 
  * ---------------------------------------------------------------- */
 
 void
-nest::music_event_in_proxy::init_state_( const Node& proto )
-{
-  const music_event_in_proxy& pr = downcast< music_event_in_proxy >( proto );
-
-  S_ = pr.S_;
-}
-
-void
 nest::music_event_in_proxy::init_buffers_()
 {
 }

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -120,7 +120,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -125,13 +125,6 @@ nest::music_event_out_proxy::~music_event_out_proxy()
 }
 
 void
-nest::music_event_out_proxy::init_state_( const Node& /* np */ )
-{
-  // const music_event_out_proxy& sd = dynamic_cast<const
-  // music_event_out_proxy&>(np);
-}
-
-void
 nest::music_event_out_proxy::init_buffers_()
 {
 }

--- a/models/music_event_out_proxy.h
+++ b/models/music_event_out_proxy.h
@@ -126,7 +126,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( Node const& );
   void init_buffers_();
   void calibrate();
 

--- a/models/music_message_in_proxy.cpp
+++ b/models/music_message_in_proxy.cpp
@@ -121,14 +121,6 @@ nest::music_message_in_proxy::music_message_in_proxy( const music_message_in_pro
  * ---------------------------------------------------------------- */
 
 void
-nest::music_message_in_proxy::init_state_( const Node& proto )
-{
-  const music_message_in_proxy& pr = downcast< music_message_in_proxy >( proto );
-
-  S_ = pr.S_;
-}
-
-void
 nest::music_message_in_proxy::init_buffers_()
 {
 }

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -155,7 +155,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -121,14 +121,6 @@ nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::music_rate_in_proxy::init_state_( const Node& proto )
-{
-  const music_rate_in_proxy& pr = downcast< music_rate_in_proxy >( proto );
-
-  S_ = pr.S_;
-}
-
-void
 nest::music_rate_in_proxy::init_buffers_()
 {
 }

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -138,7 +138,6 @@ public:
   }
 
 private:
-  void init_state_( const Node& );
   void init_buffers_();
   void calibrate();
 

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -134,11 +134,6 @@ nest::music_rate_out_proxy::~music_rate_out_proxy()
 }
 
 void
-nest::music_rate_out_proxy::init_state_( const Node& /* np */ )
-{
-}
-
-void
 nest::music_rate_out_proxy::init_buffers_()
 {
 }

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -124,7 +124,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( Node const& );
   void init_buffers_();
   void calibrate();
 

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -209,11 +209,9 @@ nest::noise_generator::noise_generator( const noise_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::noise_generator::init_state_( const Node& proto )
+nest::noise_generator::init_state_()
 {
-  const noise_generator& pr = downcast< noise_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -182,7 +182,7 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
 
   /**

--- a/models/parrot_neuron.h
+++ b/models/parrot_neuron.h
@@ -104,10 +104,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void
-  init_state_( const Node& )
-  {
-  } // no state
   void init_buffers_();
   void
   calibrate()

--- a/models/parrot_neuron_ps.h
+++ b/models/parrot_neuron_ps.h
@@ -106,11 +106,6 @@ public:
   }
 
 private:
-  void
-  init_state_( Node const& )
-  {
-  } // no state
-
   void init_buffers_();
 
   void

--- a/models/poisson_generator.cpp
+++ b/models/poisson_generator.cpp
@@ -90,11 +90,9 @@ nest::poisson_generator::poisson_generator( const poisson_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator::init_state_( const Node& proto )
+nest::poisson_generator::init_state_()
 {
-  const poisson_generator& pr = downcast< poisson_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/poisson_generator.h
+++ b/models/poisson_generator.h
@@ -110,7 +110,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/poisson_generator_ps.cpp
+++ b/models/poisson_generator_ps.cpp
@@ -111,11 +111,9 @@ nest::poisson_generator_ps::poisson_generator_ps( const poisson_generator_ps& n 
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator_ps::init_state_( const Node& proto )
+nest::poisson_generator_ps::init_state_()
 {
-  const poisson_generator_ps& pr = downcast< poisson_generator_ps >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/poisson_generator_ps.h
+++ b/models/poisson_generator_ps.h
@@ -120,7 +120,7 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -291,17 +291,6 @@ nest::pp_cond_exp_mc_urbanczik::State_::State_( const State_& s )
   }
 }
 
-nest::pp_cond_exp_mc_urbanczik::State_& nest::pp_cond_exp_mc_urbanczik::State_::operator=( const State_& s )
-{
-  assert( this != &s ); // would be bad logical error in program
-  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
-  {
-    y_[ i ] = s.y_[ i ];
-  }
-  r_ = s.r_;
-  return *this;
-}
-
 nest::pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( pp_cond_exp_mc_urbanczik& n )
   : logger_( n )
   , s_( 0 )
@@ -493,13 +482,6 @@ nest::pp_cond_exp_mc_urbanczik::~pp_cond_exp_mc_urbanczik()
 /* ----------------------------------------------------------------
  * Node initialization functions
  * ---------------------------------------------------------------- */
-
-void
-nest::pp_cond_exp_mc_urbanczik::init_state_( const Node& proto )
-{
-  const pp_cond_exp_mc_urbanczik& pr = downcast< pp_cond_exp_mc_urbanczik >( proto );
-  S_ = pr.S_;
-}
 
 void
 nest::pp_cond_exp_mc_urbanczik::init_buffers_()

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -383,8 +383,7 @@ private:
 
   /**
    * State variables of the model.
-   * @note Copy constructor and assignment operator required because
-   *       of C-style array.
+   * @note Copy constructor required because of C-style array.
    */
 public:
   struct State_

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -276,7 +276,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
   void update( Time const&, const long, const long );
@@ -416,7 +415,6 @@ public:
 
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
-    State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_& );

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -221,13 +221,6 @@ nest::pp_pop_psc_delta::pp_pop_psc_delta( const pp_pop_psc_delta& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_pop_psc_delta::init_state_( const Node& proto )
-{
-  const pp_pop_psc_delta& pr = downcast< pp_pop_psc_delta >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::pp_pop_psc_delta::init_buffers_()
 {
   B_.spikes_.clear();   //!< includes resize

--- a/models/pp_pop_psc_delta.h
+++ b/models/pp_pop_psc_delta.h
@@ -187,7 +187,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -277,8 +277,6 @@ nest::pp_psc_delta::pp_psc_delta( const pp_psc_delta& n )
 void
 nest::pp_psc_delta::init_state_( const Node& proto )
 {
-  const pp_psc_delta& pr = downcast< pp_psc_delta >( proto );
-  S_ = pr.S_;
   S_.r_ = Time( Time::ms( P_.t_ref_remaining_ ) ).get_steps();
 }
 

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -275,7 +275,7 @@ nest::pp_psc_delta::pp_psc_delta( const pp_psc_delta& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_psc_delta::init_state_( const Node& proto )
+nest::pp_psc_delta::init_state_()
 {
   S_.r_ = Time( Time::ms( P_.t_ref_remaining_ ) ).get_steps();
 }

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -220,7 +220,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -191,11 +191,9 @@ nest::ppd_sup_generator::ppd_sup_generator( const ppd_sup_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::ppd_sup_generator::init_state_( const Node& proto )
+nest::ppd_sup_generator::init_state_()
 {
-  const ppd_sup_generator& pr = downcast< ppd_sup_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/ppd_sup_generator.h
+++ b/models/ppd_sup_generator.h
@@ -122,7 +122,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -120,11 +120,9 @@ nest::pulsepacket_generator::pulsepacket_generator( const pulsepacket_generator&
  * ---------------------------------------------------------------- */
 
 void
-nest::pulsepacket_generator::init_state_( const Node& proto )
+nest::pulsepacket_generator::init_state_()
 {
-  const pulsepacket_generator& pr = downcast< pulsepacket_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/pulsepacket_generator.h
+++ b/models/pulsepacket_generator.h
@@ -111,7 +111,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/rate_neuron_ipn.h
+++ b/models/rate_neuron_ipn.h
@@ -140,7 +140,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -213,14 +213,6 @@ nest::rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn( const rate_neuron_ipn
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::init_state_( const Node& proto )
-{
-  const rate_neuron_ipn& pr = downcast< rate_neuron_ipn >( proto );
-  S_ = pr.S_;
-}
-
-template < class TNonlinearities >
-void
 nest::rate_neuron_ipn< TNonlinearities >::init_buffers_()
 {
   B_.delayed_rates_ex_.clear(); // includes resize

--- a/models/rate_neuron_opn.h
+++ b/models/rate_neuron_opn.h
@@ -143,7 +143,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -197,14 +197,6 @@ nest::rate_neuron_opn< TNonlinearities >::rate_neuron_opn( const rate_neuron_opn
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::init_state_( const Node& proto )
-{
-  const rate_neuron_opn& pr = downcast< rate_neuron_opn >( proto );
-  S_ = pr.S_;
-}
-
-template < class TNonlinearities >
-void
 nest::rate_neuron_opn< TNonlinearities >::init_buffers_()
 {
   B_.delayed_rates_ex_.clear(); // includes resize

--- a/models/rate_transformer_node.h
+++ b/models/rate_transformer_node.h
@@ -141,7 +141,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -150,14 +150,6 @@ nest::rate_transformer_node< TNonlinearities >::rate_transformer_node( const rat
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::init_state_( const Node& proto )
-{
-  const rate_transformer_node& pr = downcast< rate_transformer_node >( proto );
-  S_ = pr.S_;
-}
-
-template < class TNonlinearities >
-void
 nest::rate_transformer_node< TNonlinearities >::init_buffers_()
 {
   B_.delayed_rates_.clear(); // includes resize

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -279,13 +279,6 @@ nest::siegert_neuron::siegert( double mu, double sigma_square )
  * ---------------------------------------------------------------- */
 
 void
-nest::siegert_neuron::init_state_( const Node& proto )
-{
-  const siegert_neuron& pr = downcast< siegert_neuron >( proto );
-  S_ = pr.S_;
-}
-
-void
 nest::siegert_neuron::init_buffers_()
 {
   // resize buffers

--- a/models/siegert_neuron.h
+++ b/models/siegert_neuron.h
@@ -170,7 +170,6 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& proto );
   void init_buffers_();
   void calibrate();
 

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -241,11 +241,9 @@ nest::sinusoidal_gamma_generator::sinusoidal_gamma_generator( const sinusoidal_g
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_gamma_generator::init_state_( const Node& proto )
+nest::sinusoidal_gamma_generator::init_state_()
 {
-  const sinusoidal_gamma_generator& pr = downcast< sinusoidal_gamma_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -246,7 +246,6 @@ nest::sinusoidal_gamma_generator::init_state_( const Node& proto )
   const sinusoidal_gamma_generator& pr = downcast< sinusoidal_gamma_generator >( proto );
 
   device_.init_state( pr.device_ );
-  S_ = pr.S_;
 }
 
 void

--- a/models/sinusoidal_gamma_generator.h
+++ b/models/sinusoidal_gamma_generator.h
@@ -211,7 +211,7 @@ public:
   }
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
   void event_hook( DSSpikeEvent& );

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -196,11 +196,9 @@ nest::sinusoidal_poisson_generator::sinusoidal_poisson_generator( const sinusoid
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_poisson_generator::init_state_( const Node& proto )
+nest::sinusoidal_poisson_generator::init_state_()
 {
-  const sinusoidal_poisson_generator& pr = downcast< sinusoidal_poisson_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -201,7 +201,6 @@ nest::sinusoidal_poisson_generator::init_state_( const Node& proto )
   const sinusoidal_poisson_generator& pr = downcast< sinusoidal_poisson_generator >( proto );
 
   device_.init_state( pr.device_ );
-  S_ = pr.S_;
 }
 
 void

--- a/models/sinusoidal_poisson_generator.h
+++ b/models/sinusoidal_poisson_generator.h
@@ -149,7 +149,7 @@ public:
   }
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
   void event_hook( DSSpikeEvent& );

--- a/models/spike_dilutor.cpp
+++ b/models/spike_dilutor.cpp
@@ -86,11 +86,9 @@ nest::spike_dilutor::spike_dilutor( const spike_dilutor& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_dilutor::init_state_( const Node& proto )
+nest::spike_dilutor::init_state_()
 {
-  const spike_dilutor& pr = downcast< spike_dilutor >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -114,7 +114,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/spike_generator.cpp
+++ b/models/spike_generator.cpp
@@ -298,11 +298,9 @@ nest::spike_generator::spike_generator( const spike_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_generator::init_state_( const Node& proto )
+nest::spike_generator::init_state_()
 {
-  const spike_generator& pr = downcast< spike_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/spike_generator.cpp
+++ b/models/spike_generator.cpp
@@ -303,7 +303,6 @@ nest::spike_generator::init_state_( const Node& proto )
   const spike_generator& pr = downcast< spike_generator >( proto );
 
   device_.init_state( pr.device_ );
-  S_ = pr.S_;
 }
 
 void

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -244,7 +244,7 @@ public:
   }
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -55,12 +55,6 @@ nest::spin_detector::spin_detector( const spin_detector& n )
 }
 
 void
-nest::spin_detector::init_state_( const Node& )
-{
-  init_buffers_();
-}
-
-void
 nest::spin_detector::init_buffers_()
 {
 }

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -138,7 +138,6 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 private:
-  void init_state_( Node const& );
   void init_buffers_();
   void calibrate();
 

--- a/models/step_current_generator.cpp
+++ b/models/step_current_generator.cpp
@@ -248,11 +248,9 @@ nest::step_current_generator::step_current_generator( const step_current_generat
  * ---------------------------------------------------------------- */
 
 void
-nest::step_current_generator::init_state_( const Node& proto )
+nest::step_current_generator::init_state_()
 {
-  const step_current_generator& pr = downcast< step_current_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/step_current_generator.h
+++ b/models/step_current_generator.h
@@ -126,7 +126,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/step_rate_generator.cpp
+++ b/models/step_rate_generator.cpp
@@ -248,11 +248,9 @@ nest::step_rate_generator::step_rate_generator( const step_rate_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::step_rate_generator::init_state_( const Node& proto )
+nest::step_rate_generator::init_state_()
 {
-  const step_rate_generator& pr = downcast< step_rate_generator >( proto );
-
-  device_.init_state( pr.device_ );
+  device_.init_state();
 }
 
 void

--- a/models/step_rate_generator.h
+++ b/models/step_rate_generator.h
@@ -138,7 +138,7 @@ public:
   }
 
 private:
-  void init_state_( const Node& );
+  void init_state_();
   void init_buffers_();
   void calibrate();
 

--- a/models/volume_transmitter.cpp
+++ b/models/volume_transmitter.cpp
@@ -84,11 +84,6 @@ nest::volume_transmitter::volume_transmitter( const volume_transmitter& n )
 }
 
 void
-nest::volume_transmitter::init_state_( const Node& )
-{
-}
-
-void
 nest::volume_transmitter::init_buffers_()
 {
   B_.neuromodulatory_spikes_.clear();

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -152,7 +152,6 @@ public:
   const std::vector< spikecounter >& deliver_spikes();
 
 private:
-  void init_state_( Node const& );
   void init_buffers_();
   void calibrate();
 

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -87,10 +87,6 @@ class ConnTestDummyNodeBase : public Node
   {
   }
   void
-  init_node_( const nest::Node& )
-  {
-  }
-  void
   init_state_( const nest::Node& )
   {
   }

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -87,7 +87,7 @@ class ConnTestDummyNodeBase : public Node
   {
   }
   void
-  init_state_( const nest::Node& )
+  init_state_()
   {
   }
   void

--- a/nestkernel/device.h
+++ b/nestkernel/device.h
@@ -69,7 +69,7 @@ public:
 
   /** Reset dynamic state to that of model. */
   virtual void
-  init_state( const Device& )
+  init_state()
   {
   }
 

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -46,7 +46,7 @@ Node::Node()
   , thread_( 0 )
   , vp_( invalid_thread_ )
   , frozen_( false )
-  , buffers_initialized_( false )
+  , state_buffers_initialized_( false )
   , node_uses_wfr_( false )
 {
 }
@@ -60,7 +60,7 @@ Node::Node( const Node& n )
   , vp_( n.vp_ )
   , frozen_( n.frozen_ )
   // copy must always initialized its own buffers
-  , buffers_initialized_( false )
+  , state_buffers_initialized_( false )
   , node_uses_wfr_( n.node_uses_wfr_ )
 {
 }
@@ -70,29 +70,25 @@ Node::~Node()
 }
 
 void
-Node::init_state()
-{
-  Model const* const model = kernel().model_manager.get_model( model_id_ );
-  assert( model );
-  init_state_( model->get_prototype() );
-}
-
-void
 Node::init_state_( Node const& )
 {
 }
 
 void
-Node::init_buffers()
+Node::init()
 {
-  if ( buffers_initialized_ )
+  if ( state_buffers_initialized_ )
   {
     return;
   }
 
+  Model const* const model = kernel().model_manager.get_model( model_id_ );
+  assert( model );
+  init_state_( model->get_prototype() );
+
   init_buffers_();
 
-  buffers_initialized_ = true;
+  state_buffers_initialized_ = true;
 }
 
 void

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -46,7 +46,7 @@ Node::Node()
   , thread_( 0 )
   , vp_( invalid_thread_ )
   , frozen_( false )
-  , state_buffers_initialized_( false )
+  , initialized_( false )
   , node_uses_wfr_( false )
 {
 }
@@ -60,7 +60,7 @@ Node::Node( const Node& n )
   , vp_( n.vp_ )
   , frozen_( n.frozen_ )
   // copy must always initialized its own buffers
-  , state_buffers_initialized_( false )
+  , initialized_( false )
   , node_uses_wfr_( n.node_uses_wfr_ )
 {
 }
@@ -77,7 +77,7 @@ Node::init_state_( Node const& )
 void
 Node::init()
 {
-  if ( state_buffers_initialized_ )
+  if ( initialized_ )
   {
     return;
   }
@@ -88,7 +88,7 @@ Node::init()
 
   init_buffers_();
 
-  state_buffers_initialized_ = true;
+  initialized_ = true;
 }
 
 void
@@ -100,7 +100,6 @@ void
 Node::set_initialized()
 {
   set_initialized_();
-  initialized_ = true;
 }
 
 void

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -70,7 +70,7 @@ Node::~Node()
 }
 
 void
-Node::init_state_( Node const& )
+Node::init_state_()
 {
 }
 
@@ -82,10 +82,7 @@ Node::init()
     return;
   }
 
-  Model const* const model = kernel().model_manager.get_model( model_id_ );
-  assert( model );
-  init_state_( model->get_prototype() );
-
+  init_state_();
   init_buffers_();
 
   initialized_ = true;

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -915,12 +915,11 @@ private:
    */
   int model_id_;
 
-  thread thread_;                  //!< thread node is assigned to
-  thread vp_;                      //!< virtual process node is assigned to
-  bool frozen_;                    //!< node shall not be updated if true
-  bool state_buffers_initialized_; //!< Buffers have been initialized
-  bool node_uses_wfr_;             //!< node uses waveform relaxation method
-  bool initialized_;               //!< set true once a node is fully initialized
+  thread thread_;      //!< thread node is assigned to
+  thread vp_;          //!< virtual process node is assigned to
+  bool frozen_;        //!< node shall not be updated if true
+  bool initialized_;   //!< state and buffers have been initialized
+  bool node_uses_wfr_; //!< node uses waveform relaxation method
 
   NodeCollectionPTR nc_ptr_;
 };

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -915,12 +915,12 @@ private:
    */
   int model_id_;
 
-  thread thread_;            //!< thread node is assigned to
-  thread vp_;                //!< virtual process node is assigned to
-  bool frozen_;              //!< node shall not be updated if true
+  thread thread_;                  //!< thread node is assigned to
+  thread vp_;                      //!< virtual process node is assigned to
+  bool frozen_;                    //!< node shall not be updated if true
   bool state_buffers_initialized_; //!< Buffers have been initialized
-  bool node_uses_wfr_;       //!< node uses waveform relaxation method
-  bool initialized_;         //!< set true once a node is fully initialized
+  bool node_uses_wfr_;             //!< node uses waveform relaxation method
+  bool initialized_;               //!< set true once a node is fully initialized
 
   NodeCollectionPTR nc_ptr_;
 };

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -238,27 +238,12 @@ public:
   void set_node_uses_wfr( const bool );
 
   /**
-   * Set state variables to the default values for the model and initialize
-   * buffers of the node.
+   * Initialize node prior to first simulation after node has been created.
    *
-   * Dynamic variables are all observable state variables of a node
-   * that change during Node::update(). After calling init(), the state
-   * variables should have the same values that they had after the node
-   * was created. In practice, they will be initialized to the values
-   * of the prototype node (model), unless the parameters of the model
-   * have been changed since the node was created. The node will then be
-   * initialized to the present values set in the model.
-   *
-   * The function also initializes the Buffers of a Node, e.g., ring buffers
-   * for incoming events, or buffers for logging potentials.
-   * init() is called before Simulate is called for the first time
-   * on a node, but not upon resumption of a simulation.
-   *
-   * This is a wrapper function, which calls the overloaded functions
-   * Node::init_state_(const Node&) and Node::init_buffers_()
-   * only if the state and buffers of the node have not been
-   * initialized yet. The private functions must be implemented by the
-   * derived classes if they are needed.
+   * init() allows the node to configure internal data structures prior to
+   * being simulated. The method has an effect only the first time it is
+   * called on a given node, otherwise it returns immediately. init() calls
+   * virtual functions init_state_() and init_buffers_().
    */
   void init();
 
@@ -854,23 +839,19 @@ private:
 
 protected:
   /**
-   * Private function to initialize the state of a node to model defaults.
-   * This function, which must be overloaded by all derived classes, provides
-   * the implementation for initializing the state of a node to the model
-   * defaults; the state is the set of observable dynamic variables.
-   * @param Reference to model prototype object.
-   * @see Node::init_state()
-   * @note To provide a reasonable behavior during the transition to the new
-   *       scheme, init_state_() has a default implementation calling
-   *       init_dynamic_state_().
+   * Configure state variables depending on runtime information.
+   *
+   * Overload this method if the node needs to adapt state variables prior to
+   * first simulation to runtime information, e.g., the number of incoming
+   * connections.
    */
   virtual void init_state_( Node const& );
 
   /**
-   * Private function to initialize the buffers of a node.
-   * This function, which must be overloaded by all derived classes, provides
-   * the implementation for initializing the buffers of a node.
-   * @see Node::init_buffers()
+   * Configure persistent internal data structures.
+   *
+   * Let node configure persistent internal data structures, such as input
+   * buffers or ODE solvers, to runtime information prior to first simulation.
    */
   virtual void init_buffers_();
 

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -238,33 +238,29 @@ public:
   void set_node_uses_wfr( const bool );
 
   /**
-   * Set state variables to the default values for the model.
+   * Set state variables to the default values for the model and initialize
+   * buffers of the node.
+   *
    * Dynamic variables are all observable state variables of a node
-   * that change during Node::update().
-   * After calling init_state(), the state variables
-   * should have the same values that they had after the node was
-   * created. In practice, they will be initialized to the values
-   * of the prototype node (model).
-   * @note If the parameters of the model have been changed since the node
-   *       was created, the node will be initialized to the present values
-   *       set in the model.
-   * @note This function is the public interface to the private function
-   *       Node::init_state_(const Node&) that must be implemented by
-   *       derived classes.
-   */
-  void init_state();
-
-  /**
-   * Initialize buffers of a node.
-   * This function initializes the Buffers of a Node, e.g., ring buffers
-   * for incoming events, buffers for logging potentials.
-   * This function is called before Simulate is called for the first time
+   * that change during Node::update(). After calling init(), the state
+   * variables should have the same values that they had after the node
+   * was created. In practice, they will be initialized to the values
+   * of the prototype node (model), unless the parameters of the model
+   * have been changed since the node was created. The node will then be
+   * initialized to the present values set in the model.
+   *
+   * The function also initializes the Buffers of a Node, e.g., ring buffers
+   * for incoming events, or buffers for logging potentials.
+   * init() is called before Simulate is called for the first time
    * on a node, but not upon resumption of a simulation.
-   * This is a wrapper function, which calls the overloaded
-   * Node::init_buffers_() worker only if the buffers of the node have not been
-   * initialized yet.
+   *
+   * This is a wrapper function, which calls the overloaded functions
+   * Node::init_state_(const Node&) and Node::init_buffers_()
+   * only if the state and buffers of the node have not been
+   * initialized yet. The private functions must be implemented by the
+   * derived classes if they are needed.
    */
-  void init_buffers();
+  void init();
 
   /**
    * Re-calculate dependent parameters of the node.
@@ -822,17 +818,17 @@ public:
    */
   index get_thread_lid() const;
 
-  //! True if buffers have been initialized.
+  //! True if state and buffers have been initialized.
   bool
-  buffers_initialized() const
+  state_buffers_initialized() const
   {
-    return buffers_initialized_;
+    return state_buffers_initialized_;
   }
 
   void
-  set_buffers_initialized( bool initialized )
+  set_state_buffers_initialized( bool initialized )
   {
-    buffers_initialized_ = initialized;
+    state_buffers_initialized_ = initialized;
   }
 
   /**
@@ -935,7 +931,7 @@ private:
   thread thread_;            //!< thread node is assigned to
   thread vp_;                //!< virtual process node is assigned to
   bool frozen_;              //!< node shall not be updated if true
-  bool buffers_initialized_; //!< Buffers have been initialized
+  bool state_buffers_initialized_; //!< Buffers have been initialized
   bool node_uses_wfr_;       //!< node uses waveform relaxation method
   bool initialized_;         //!< set true once a node is fully initialized
 

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -818,19 +818,6 @@ public:
    */
   index get_thread_lid() const;
 
-  //! True if state and buffers have been initialized.
-  bool
-  state_buffers_initialized() const
-  {
-    return state_buffers_initialized_;
-  }
-
-  void
-  set_state_buffers_initialized( bool initialized )
-  {
-    state_buffers_initialized_ = initialized;
-  }
-
   /**
    * Sets the local device id.
    * Throws an error if used on a non-device node.

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -845,7 +845,7 @@ protected:
    * first simulation to runtime information, e.g., the number of incoming
    * connections.
    */
-  virtual void init_state_( Node const& );
+  virtual void init_state_();
 
   /**
    * Configure persistent internal data structures.

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -389,18 +389,6 @@ NodeManager::get_nodes( const DictionaryDatum& params, const bool local_only )
   return std::move( nodecollection );
 }
 
-void
-NodeManager::init_state( index node_id )
-{
-  Node* n = get_node_or_proxy( node_id );
-  if ( n == 0 )
-  {
-    throw UnknownNode( node_id );
-  }
-
-  n->init_state();
-}
-
 bool
 NodeManager::is_local_node( Node* n ) const
 {
@@ -633,7 +621,7 @@ NodeManager::prepare_node_( Node* n )
 {
   // Frozen nodes are initialized and calibrated, so that they
   // have ring buffers and can accept incoming spikes.
-  n->init_buffers();
+  n->init();
   n->calibrate();
 }
 

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -102,12 +102,6 @@ public:
   NodeCollectionPTR get_nodes( const DictionaryDatum& dict, const bool local_only );
 
   /**
-   * Set the state (observable dynamic variables) of a node to model defaults.
-   * @see Node::init_state()
-   */
-  void init_state( index );
-
-  /**
    * Return total number of network nodes.
    */
   index size() const;

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -119,7 +119,7 @@ public:
 
 private:
   void
-  init_state_( const Node& )
+  init_state_()
   {
   }
   void


### PR DESCRIPTION
This PR makes sure `init_state_` is called for models that need it. At the moment, the function is not called at all.

I have refactored the `init_state()` and `init_buffers()` functions in `node.cpp` to be one function, `init()`, which first calls `init_state_()` and then `init_buffers_()`.

I have removed `init_state_()` in the models which only copies the state from the prototypes, as this really does nothing. I have then also removed alot of `State_& operator=( const State_& )`.

As far as I can see, all the detectors and generators still have a `init_state_`, and they just call `device_.init_state( pr.device_ );` This function is a virtual function, so it might be overloaded. I have therefore kept them.
See for instance:
https://github.com/nest/nest-simulator/blob/794d7ebb3ddfd3b2ab4cf5c6ef79954f90058e44/models/correlation_detector.cpp#L233-L237
