### PR TITLE
Fix missing state variable initialisation in iaf_chxk_2008

### DIFF
--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -143,7 +143,7 @@ nest::iaf_chxk_2008::State_::State_( const Parameters_& p )
   : r( 0 )
 {
   y[ V_M ] = p.E_L; // initialize to reversal potential
-  for ( size_t i = 1; i < STATE_VEC_SIZE; ++i )
+  for ( size_t i = DG_EXC ; i < STATE_VEC_SIZE ; ++i )
   {
     y[ i ] = 0;
   }

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -143,7 +143,7 @@ nest::iaf_chxk_2008::State_::State_( const Parameters_& p )
   : r( 0 )
 {
   y[ V_M ] = p.E_L; // initialize to reversal potential
-  for ( size_t i = 2; i < STATE_VEC_SIZE; ++i )
+  for ( size_t i = 1; i < STATE_VEC_SIZE; ++i )
   {
     y[ i ] = 0;
   }

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -143,7 +143,7 @@ nest::iaf_chxk_2008::State_::State_( const Parameters_& p )
   : r( 0 )
 {
   y[ V_M ] = p.E_L; // initialize to reversal potential
-  for ( size_t i = DG_EXC ; i < STATE_VEC_SIZE ; ++i )
+  for ( size_t i = DG_EXC; i < STATE_VEC_SIZE; ++i )
   {
     y[ i ] = 0;
   }


### PR DESCRIPTION
This fixes the second element (with index 1, corresponding to ``DG_EXC``) not being initialised.

```C++
    //! Symbolic indices to the elements of the state vector y
    enum StateVecElems
    {
      V_M = 0,
      DG_EXC,
      G_EXC,
      DG_INH,
      G_INH,
      DG_AHP,
      G_AHP,
      STATE_VEC_SIZE
    };

    //! state vector, must be C-array for GSL solver
    double y[ STATE_VEC_SIZE ];
```