### PR TITLE
Fix failing build on ReadtheDocs due to key error

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -41,7 +41,9 @@ else:
 
 doc_build_dir = Path(os.environ['OLDPWD']) / 'doc/userdoc'
 
-if os.environ.get('READTHEDOCS', 'False') == 'True':
+read_the_docs_build = os.environ.get('READTHEDOCS') == 'True'
+
+if read_the_docs_build:
     doc_build_dir = source_dir / 'doc/userdoc'
 
 print("doc_build_dir", str(doc_build_dir))

--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -39,12 +39,13 @@ if source_dir:
 else:
     source_dir = Path(__file__).resolve().parent.parent.parent.resolve()
 
-doc_build_dir = Path(os.environ['OLDPWD']) / 'doc/userdoc'
 
 read_the_docs_build = os.environ.get('READTHEDOCS') == 'True'
 
 if read_the_docs_build:
     doc_build_dir = source_dir / 'doc/userdoc'
+else:
+    doc_build_dir = Path(os.environ['OLDPWD']) / 'doc/userdoc'
 
 print("doc_build_dir", str(doc_build_dir))
 print("source_dir", str(source_dir))

--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -40,12 +40,10 @@ else:
     source_dir = Path(__file__).resolve().parent.parent.parent.resolve()
 
 
-read_the_docs_build = os.environ.get('READTHEDOCS') == 'True'
-
-if read_the_docs_build:
-    doc_build_dir = source_dir / 'doc/userdoc'
+if os.environ.get("READTHEDOCS") == "True":
+    doc_build_dir = source_dir / "doc/userdoc"
 else:
-    doc_build_dir = Path(os.environ['OLDPWD']) / 'doc/userdoc'
+    doc_build_dir = Path(os.environ["OLDPWD"]) / "doc/userdoc"
 
 print("doc_build_dir", str(doc_build_dir))
 print("source_dir", str(source_dir))


### PR DESCRIPTION
Fixes #2053

After a bit of testing, it seems we can get a working build both locally and on ReadtheDocs by moving the line `doc_build_dir = Path(os.environ['OLDPWD']) / 'doc/userdoc'`into an if else statement.
See issue #2053 for details.