### PR TITLE
Fix catching build warnings in GitHub Actions

### DIFF
--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -367,7 +367,7 @@ def makebuild_summary(log_filename, msg_make_section_start,
     # with some warnings, this would be a good point to re-set the
     # expected_warnings variable conditionally for that build_type.
 
-    nest_warning_re = re.compile(f'.* ({build_dir}.*: warning:.*)')
+    nest_warning_re = re.compile(f'.*({build_dir}.*: warning:.*)')
     known_warnings = [
         f'{build_dir}/sli/scanner.cc:642:13: warning: this statement may fall through [-Wimplicit-fallthrough=]',
         f'{build_dir}/sli/scanner.cc:674:19: warning: this statement may fall through [-Wimplicit-fallthrough=]',

--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -412,10 +412,10 @@ def makebuild_summary(log_filename, msg_make_section_start,
 
     if in_make_section:
         # 'make' was not completed.
-        return False, None, None, None, None
+        return False, None, None, None, None, None
     else:
         # There is no 'make' section at all.
-        return None, None, None, None, None
+        return None, None, None, None, None, None
 
 
 def testsuite_results(log_filename, msg_testsuite_section_start,

--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -373,6 +373,18 @@ def makebuild_summary(log_filename, msg_make_section_start,
         f'{build_dir}/sli/scanner.cc:674:19: warning: this statement may fall through [-Wimplicit-fallthrough=]',
         f'{build_dir}/sli/scanner.cc:716:13: warning: this statement may fall through [-Wimplicit-fallthrough=]',
         f'{build_dir}/sli/scanner.cc:744:24: warning: this statement may fall through [-Wimplicit-fallthrough=]',
+        (f'{build_dir}/thirdparty/Random123/conventional/Engine.hpp:140:15: warning: implicitly-declared'
+         ' ‘r123::Engine<r123::Threefry4x64_R<20> >& r123::Engine<r123::Threefry4x64_R<20> >::operator='
+         '(const r123::Engine<r123::Threefry4x64_R<20> >&)’ is deprecated [-Wdeprecated-copy]'),
+        (f'{build_dir}/thirdparty/Random123/conventional/Engine.hpp:140:15: warning: implicitly-declared'
+         ' ‘r123::Engine<r123::Threefry4x32_R<20> >& r123::Engine<r123::Threefry4x32_R<20> >::operator='
+         '(const r123::Engine<r123::Threefry4x32_R<20> >&)’ is deprecated [-Wdeprecated-copy]'),
+        (f'{build_dir}/thirdparty/Random123/conventional/Engine.hpp:140:15: warning: implicitly-declared'
+         ' ‘r123::Engine<r123::Philox4x64_R<10> >& r123::Engine<r123::Philox4x64_R<10> >::operator='
+         '(const r123::Engine<r123::Philox4x64_R<10> >&)’ is deprecated [-Wdeprecated-copy]'),
+        (f'{build_dir}/thirdparty/Random123/conventional/Engine.hpp:140:15: warning: implicitly-declared'
+         ' ‘r123::Engine<r123::Philox4x32_R<10> >& r123::Engine<r123::Philox4x32_R<10> >::operator='
+         '(const r123::Engine<r123::Philox4x32_R<10> >&)’ is deprecated [-Wdeprecated-copy]'),
     ]
 
     with open(log_filename) as fh:

--- a/extras/parse_build_log.py
+++ b/extras/parse_build_log.py
@@ -352,6 +352,7 @@ def makebuild_summary(log_filename, msg_make_section_start,
     Number of error messages.
     Dictionary of file names and the number of errors within these files.
     Number of warning messages.
+    Number of expected warning messages.
     Dictionary of file names and the number of warnings within these file.
     """
 
@@ -424,9 +425,11 @@ def makebuild_summary(log_filename, msg_make_section_start,
 
     if in_make_section:
         # 'make' was not completed.
+        # See the docstring for explanation on the return values.
         return False, None, None, None, None, None
     else:
         # There is no 'make' section at all.
+        # See the docstring for explanation on the return values.
         return None, None, None, None, None, None
 
 

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -167,6 +167,16 @@ nest::aeif_cond_alpha::State_::State_( const State_& s )
   }
 }
 
+nest::aeif_cond_alpha::State_& nest::aeif_cond_alpha::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -295,6 +295,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -174,12 +174,6 @@ aeif_cond_alpha_multisynapse::State_::State_( const Parameters_& p )
   y_[ 0 ] = p.E_L;
 }
 
-aeif_cond_alpha_multisynapse::State_::State_( const State_& s )
-  : r_( s.r_ )
-{
-  y_ = s.y_;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -289,7 +289,6 @@ private:
     int r_;                   //!< number of refractory steps remaining
 
     State_( const Parameters_& ); //!< Default initialization
-    State_( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -174,12 +174,6 @@ aeif_cond_beta_multisynapse::State_::State_( const Parameters_& p )
   y_[ 0 ] = p.E_L;
 }
 
-aeif_cond_beta_multisynapse::State_::State_( const State_& s )
-  : r_( s.r_ )
-{
-  y_ = s.y_;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -292,7 +292,6 @@ private:
     int r_;                   //!< number of refractory steps remaining
 
     State_( const Parameters_& ); //!< Default initialization
-    State_( const State_& );
 
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -166,6 +166,16 @@ nest::aeif_cond_exp::State_::State_( const State_& s )
   }
 }
 
+nest::aeif_cond_exp::State_& nest::aeif_cond_exp::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -293,6 +293,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -161,6 +161,16 @@ nest::aeif_psc_alpha::State_::State_( const State_& s )
   }
 }
 
+nest::aeif_psc_alpha::State_& nest::aeif_psc_alpha::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -279,6 +279,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -115,6 +115,7 @@ nest::aeif_psc_delta_dynamics( double, const double y[], double f[], void* pnode
 nest::aeif_psc_delta::Parameters_::Parameters_()
   : V_peak_( 0.0 )    // mV
   , V_reset_( -60.0 ) // mV
+  , t_ref_( 0.0 )     // ms
   , g_L( 30.0 )       // nS
   , C_m( 281.0 )      // pF
   , E_L( -70.6 )      // mV
@@ -123,7 +124,6 @@ nest::aeif_psc_delta::Parameters_::Parameters_()
   , a( 4.0 )          // nS
   , b( 80.5 )         // pA
   , V_th( -50.4 )     // mV
-  , t_ref_( 0.0 )     // ms
   , I_e( 0.0 )        // pA
   , gsl_error_tol( 1e-6 )
   , with_refr_input_( false )

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -151,6 +151,17 @@ nest::aeif_psc_delta::State_::State_( const State_& s )
   }
 }
 
+nest::aeif_psc_delta::State_& nest::aeif_psc_delta::State_::operator=( const State_& s )
+{
+  refr_spikes_buffer_ = s.refr_spikes_buffer_;
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -275,6 +275,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -186,6 +186,17 @@ nest::aeif_psc_delta_clopath::State_::State_( const State_& s )
   }
 }
 
+nest::aeif_psc_delta_clopath::State_& nest::aeif_psc_delta_clopath::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  clamp_r_ = s.clamp_r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -315,6 +315,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -160,6 +160,16 @@ nest::aeif_psc_exp::State_::State_( const State_& s )
   }
 }
 
+nest::aeif_psc_exp::State_& nest::aeif_psc_exp::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Paramater and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -279,6 +279,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -164,6 +164,31 @@ nest::gif_cond_exp::State_::State_( const State_& s )
   }
 }
 
+nest::gif_cond_exp::State_& nest::gif_cond_exp::State_::operator=( const State_& s )
+{
+  I_stim_ = s.I_stim_;
+  sfa_ = s.sfa_;
+  stc_ = s.stc_;
+  r_ref_ = s.r_ref_;
+
+  sfa_elems_.resize( s.sfa_elems_.size(), 0.0 );
+  for ( size_t i = 0; i < sfa_elems_.size(); ++i )
+  {
+    sfa_elems_[ i ] = s.sfa_elems_[ i ];
+  }
+
+  stc_elems_.resize( s.stc_elems_.size(), 0.0 );
+  for ( size_t i = 0; i < stc_elems_.size(); ++i )
+  {
+    stc_elems_[ i ] = s.stc_elems_[ i ];
+  }
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    neuron_state_[ i ] = s.neuron_state_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -341,6 +341,8 @@ private:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum&, const Parameters_& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -145,27 +145,6 @@ nest::gif_cond_exp_multisynapse::State_::State_( const Parameters_& p )
   y_[ V_M ] = p.E_L_;
 }
 
-nest::gif_cond_exp_multisynapse::State_::State_( const State_& s )
-  : I_stim_( s.I_stim_ )
-  , sfa_( s.sfa_ )
-  , stc_( s.stc_ )
-  , r_ref_( s.r_ref_ )
-{
-  sfa_elems_.resize( s.sfa_elems_.size(), 0.0 );
-  for ( size_t i = 0; i < sfa_elems_.size(); ++i )
-  {
-    sfa_elems_[ i ] = s.sfa_elems_[ i ];
-  }
-
-  stc_elems_.resize( s.stc_elems_.size(), 0.0 );
-  for ( size_t i = 0; i < stc_elems_.size(); ++i )
-  {
-    stc_elems_[ i ] = s.stc_elems_[ i ];
-  }
-
-  y_ = s.y_;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -347,7 +347,6 @@ private:
     unsigned int r_ref_;
 
     State_( const Parameters_& ); //!< Default initialization
-    State_( const State_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -183,17 +183,6 @@ nest::glif_cond::State_::State_( const Parameters_& p )
   y_[ V_M ] = 0.0; // initialize to membrane potential
 }
 
-nest::glif_cond::State_::State_( const State_& s )
-{
-  threshold_ = s.threshold_;
-  threshold_spike_ = s.threshold_spike_;
-  threshold_voltage_ = s.threshold_voltage_;
-  ASCurrents_ = s.ASCurrents_;
-  ASCurrents_sum_ = s.ASCurrents_sum_;
-  refractory_steps_ = s.refractory_steps_;
-  y_ = s.y_;
-}
-
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -319,7 +319,6 @@ private:
     std::vector< double > y_; //!< neuron state
 
     State_( const Parameters_& );
-    State_( const State_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
     void set( const DictionaryDatum&, const Parameters_&, double );

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -212,6 +212,16 @@ nest::hh_cond_beta_gap_traub::State_::State_( const State_& s )
   }
 }
 
+nest::hh_cond_beta_gap_traub::State_& nest::hh_cond_beta_gap_traub::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -296,6 +296,8 @@ public:
     State_( const Parameters_& p );
     State_( const State_& s );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_& );
   };

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -173,6 +173,16 @@ nest::hh_cond_exp_traub::State_::State_( const State_& s )
   }
 }
 
+nest::hh_cond_exp_traub::State_& nest::hh_cond_exp_traub::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -252,6 +252,8 @@ public:
     State_( const Parameters_& p );
     State_( const State_& s );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -172,6 +172,16 @@ nest::hh_psc_alpha::State_::State_( const State_& s )
   }
 }
 
+nest::hh_psc_alpha::State_& nest::hh_psc_alpha::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -245,6 +245,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );
   };

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -186,6 +186,16 @@ nest::hh_psc_alpha_clopath::State_::State_( const State_& s )
   }
 }
 
+nest::hh_psc_alpha_clopath::State_& nest::hh_psc_alpha_clopath::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -289,6 +289,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );
   };

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -210,6 +210,16 @@ nest::hh_psc_alpha_gap::State_::State_( const State_& s )
   }
 }
 
+nest::hh_psc_alpha_gap::State_& nest::hh_psc_alpha_gap::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -271,6 +271,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, Node* node );
   };

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -307,6 +307,20 @@ nest::ht_neuron::State_::State_( const State_& s )
   }
 }
 
+nest::ht_neuron::State_& nest::ht_neuron::State_::operator=( const State_& s )
+{
+  ref_steps_ = s.ref_steps_;
+  I_NaP_ = s.I_NaP_;
+  I_KNa_ = s.I_KNa_;
+  I_T_ = s.I_T_;
+  I_h_ = s.I_h_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 nest::ht_neuron::State_::~State_()
 {
 }

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -359,6 +359,9 @@ public:
 
     State_( const ht_neuron&, const Parameters_& p );
     State_( const State_& s );
+
+    State_& operator=( const State_& s );
+
     ~State_();
 
     void get( DictionaryDatum& ) const;

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -158,6 +158,16 @@ nest::iaf_chxk_2008::State_::State_( const State_& s )
   }
 }
 
+nest::iaf_chxk_2008::State_& nest::iaf_chxk_2008::State_::operator=( const State_& s )
+{
+  r = s.r;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y[ i ] = s.y[ i ];
+  }
+  return *this;
+}
+
 nest::iaf_chxk_2008::Buffers_::Buffers_( iaf_chxk_2008& n )
   : logger_( n )
   , s_( 0 )

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -256,6 +256,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -146,6 +146,16 @@ nest::iaf_cond_alpha::State_::State_( const State_& s )
   }
 }
 
+nest::iaf_cond_alpha::State_& nest::iaf_cond_alpha::State_::operator=( const State_& s )
+{
+  r = s.r;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y[ i ] = s.y[ i ];
+  }
+  return *this;
+}
+
 nest::iaf_cond_alpha::Buffers_::Buffers_( iaf_cond_alpha& n )
   : logger_( n )
   , s_( 0 )

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -245,6 +245,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -277,6 +277,16 @@ nest::iaf_cond_alpha_mc::State_::State_( const State_& s )
   }
 }
 
+nest::iaf_cond_alpha_mc::State_& nest::iaf_cond_alpha_mc::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 nest::iaf_cond_alpha_mc::Buffers_::Buffers_( iaf_cond_alpha_mc& n )
   : logger_( n )
   , s_( 0 )

--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -349,6 +349,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
 

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -151,6 +151,16 @@ nest::iaf_cond_beta::State_::State_( const State_& s )
   }
 }
 
+nest::iaf_cond_beta::State_& nest::iaf_cond_beta::State_::operator=( const State_& s )
+{
+  r = s.r;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y[ i ] = s.y[ i ];
+  }
+  return *this;
+}
+
 nest::iaf_cond_beta::Buffers_::Buffers_( iaf_cond_beta& n )
   : logger_( n )
   , s_( 0 )

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -255,6 +255,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -130,6 +130,16 @@ nest::iaf_cond_exp::State_::State_( const State_& s )
   }
 }
 
+nest::iaf_cond_exp::State_& nest::iaf_cond_exp::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -214,6 +214,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -147,6 +147,16 @@ nest::iaf_cond_exp_sfa_rr::State_::State_( const State_& s )
   }
 }
 
+nest::iaf_cond_exp_sfa_rr::State_& nest::iaf_cond_exp_sfa_rr::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 /* ----------------------------------------------------------------
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -248,6 +248,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_&, Node* );
   };

--- a/models/music_cont_in_proxy.cpp
+++ b/models/music_cont_in_proxy.cpp
@@ -48,11 +48,6 @@ nest::music_cont_in_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_cont_in_proxy::Parameters_::Parameters_( const Parameters_& op )
-  : port_name_( op.port_name_ )
-{
-}
-
 nest::music_cont_in_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )

--- a/models/music_cont_in_proxy.h
+++ b/models/music_cont_in_proxy.h
@@ -128,8 +128,7 @@ private:
   {
     std::string port_name_; //!< the name of MUSIC port to connect to
 
-    Parameters_();                     //!< Sets default parameter values
-    Parameters_( const Parameters_& ); //!< Recalibrate all times
+    Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
     void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -52,12 +52,6 @@ nest::music_event_in_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_event_in_proxy::Parameters_::Parameters_( const Parameters_& op )
-  : port_name_( op.port_name_ )
-  , channel_( op.channel_ )
-{
-}
-
 nest::music_event_in_proxy::State_::State_()
   : registered_( false )
 {

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -136,8 +136,7 @@ private:
     std::string port_name_; //!< the name of MUSIC port to connect to
     int channel_;           //!< the MUSIC channel of the port
 
-    Parameters_();                     //!< Sets default parameter values
-    Parameters_( const Parameters_& ); //!< Recalibrate all times
+    Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;
 

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -50,11 +50,6 @@ nest::music_event_out_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_event_out_proxy::Parameters_::Parameters_( const Parameters_& op )
-  : port_name_( op.port_name_ )
-{
-}
-
 nest::music_event_out_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )

--- a/models/music_event_out_proxy.h
+++ b/models/music_event_out_proxy.h
@@ -142,8 +142,7 @@ private:
   {
     std::string port_name_; //!< the name of MUSIC port to connect to
 
-    Parameters_();                     //!< Sets default parameter values
-    Parameters_( const Parameters_& ); //!< Recalibrate all times
+    Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
     void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary

--- a/models/music_message_in_proxy.cpp
+++ b/models/music_message_in_proxy.cpp
@@ -49,13 +49,6 @@ nest::music_message_in_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_message_in_proxy::Parameters_::Parameters_( const Parameters_& op )
-  : port_name_( op.port_name_ )
-  , acceptable_latency_( op.acceptable_latency_ )
-
-{
-}
-
 nest::music_message_in_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -171,8 +171,7 @@ private:
     std::string port_name_;     //!< the name of MUSIC port to connect to
     double acceptable_latency_; //!< the acceptable latency of the port
 
-    Parameters_();                     //!< Sets default parameter values
-    Parameters_( const Parameters_& ); //!< Recalibrate all times
+    Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;
 

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -49,12 +49,6 @@ nest::music_rate_in_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_rate_in_proxy::Parameters_::Parameters_( const Parameters_& op )
-  : port_name_( op.port_name_ )
-  , channel_( op.channel_ )
-{
-}
-
 nest::music_rate_in_proxy::State_::State_()
   : registered_( false )
 {

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -152,8 +152,7 @@ private:
     std::string port_name_; //!< the name of MUSIC port to connect to
     int channel_;           //!< the MUSIC channel of the port
 
-    Parameters_();                     //!< Sets default parameter values
-    Parameters_( const Parameters_& ); //!< Recalibrate all times
+    Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
     void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -50,11 +50,6 @@ nest::music_rate_out_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_rate_out_proxy::Parameters_::Parameters_( const Parameters_& op )
-  : port_name_( op.port_name_ )
-{
-}
-
 nest::music_rate_out_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -140,8 +140,7 @@ private:
   {
     std::string port_name_; //!< the name of MUSIC port to connect to
 
-    Parameters_();                     //!< Sets default parameter values
-    Parameters_( const Parameters_& ); //!< Recalibrate all times
+    Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
     void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -291,6 +291,16 @@ nest::pp_cond_exp_mc_urbanczik::State_::State_( const State_& s )
   }
 }
 
+nest::pp_cond_exp_mc_urbanczik::State_& nest::pp_cond_exp_mc_urbanczik::State_::operator=( const State_& s )
+{
+  r_ = s.r_;
+  for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
+  {
+    y_[ i ] = s.y_[ i ];
+  }
+  return *this;
+}
+
 nest::pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( pp_cond_exp_mc_urbanczik& n )
   : logger_( n )
   , s_( 0 )

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -415,6 +415,8 @@ public:
     State_( const Parameters_& ); //!< Default initialization
     State_( const State_& );
 
+    State_& operator=( const State_& );
+
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum&, const Parameters_& );
 

--- a/nestkernel/ring_buffer.h
+++ b/nestkernel/ring_buffer.h
@@ -384,7 +384,7 @@ template < unsigned int num_channels >
 inline void
 MultiChannelInputBuffer< num_channels >::reset_values_all_channels( const index slot )
 {
-  assert( 0 <= slot and slot < buffer_.size() );
+  assert( slot < buffer_.size() );
   buffer_[ slot ].fill( 0.0 );
 }
 
@@ -399,7 +399,7 @@ template < unsigned int num_channels >
 inline const std::array< double, num_channels >&
 MultiChannelInputBuffer< num_channels >::get_values_all_channels( const index slot ) const
 {
-  assert( 0 <= slot and slot < buffer_.size() );
+  assert( slot < buffer_.size() );
   return buffer_[ slot ];
 }
 


### PR DESCRIPTION
Warnings when building in GitHub Actions are currently not caught. This has caused some additional warnings to slip through. This PR fixes the regex to catch the warnings. It also fixes warnings that have been building up and not been caught.