### PR TITLE
Update refguide_nest2_nest3.rst

### DIFF
--- a/doc/userdoc/guides/nest2_to_nest3/refguide_nest2_nest3.rst
+++ b/doc/userdoc/guides/nest2_to_nest3/refguide_nest2_nest3.rst
@@ -304,14 +304,15 @@ divergent *and* num_connections        fixed_outdegree
 Functions related to simulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+-------------------------------+-------------------------------------------------------+
-| NEST 2.x                      | NEST 3.0                                              |
-+===============================+=======================================================+
-| nest.ResetNetwork()           | Use nest.ResetKernel() instead                        |
-+-------------------------------+-------------------------------------------------------+
-| nest.GetKernelStatus('time'), | nest.GetKernelStatus(':green:`biological_time`'),     |
-| nest.SetKernelStatus('time')  | nest.SetKernelStatus(':green:`biological_time`')      |
-+-------------------------------+-------------------------------------------------------+
++-------------------------------------+--------------------------------------------------------+
+| NEST 2.x                            | NEST 3.0                                               |
++=====================================+========================================================+
+| nest.ResetNetwork()                 | Use nest.ResetKernel() instead                         |
++-------------------------------------+--------------------------------------------------------+
+| nest.GetKernelStatus('time'),       | nest.GetKernelStatus(':green:`biological_time`'),      |
+| nest.SetKernelStatus({'time': 0.})  | nest.SetKernelStatus({':green:`biological_time`': 0.}) |
++-------------------------------------+--------------------------------------------------------+
+
 
    .. note::
 


### PR DESCRIPTION
This is related to PR #2059. Setting a value using `SetKernelStatus` requires passing a dictionary, this PR introduces this.