### PR TITLE
Remove 'nest-' from setup.py version

### DIFF
--- a/cmake/NestVersionInfo.cmake
+++ b/cmake/NestVersionInfo.cmake
@@ -20,11 +20,11 @@
 # Determine NEST version based on git branch
 #
 # This module defines
-#  NEST_VERSION_BRANCH, the current git branch
-#  NEST_VERSION_SUFFIX, set using -Dwith-version-suffix=<suffix>.
-#  NEST_VERSION, the numeric version number plus the suffix
-#  NEST_VERSION_GITHASH, the current git revision hash (empty for tarballs)
-#  NEST_VERSION_STRING, the full NEST version string
+#  NEST_VERSION_BRANCH, the current git branch (nest-3.0)
+#  NEST_VERSION_SUFFIX, set using -Dwith-version-suffix=<suffix>. ("-pre")
+#  NEST_VERSION, the numeric version number plus the suffix  ("3.0-pre")
+#  NEST_VERSION_GITHASH, the current git revision hash (empty for tarballs) ("dd47c39ce")
+#  NEST_VERSION_STRING, the full NEST version string ("nest-3.0-pre@dd47c39ce")
 #
 # In release branches, the string "UNKNOWN" below has to be replaced
 # with the proper version (e.g. "nest-2.20") in order to get the
@@ -71,6 +71,5 @@ macro(get_version_info)
     set(NEST_VERSION_STRING "${NEST_VERSION_BRANCH}${versionsuffix}${githash}")
     unset(branchname)
     unset(versionsuffix)
-    unset(githash)
 
 endmacro()

--- a/pynest/setup.py.in
+++ b/pynest/setup.py.in
@@ -23,7 +23,7 @@ from distutils.core import setup
 
 setup(
     name='PyNEST',
-    version='@NEST_VERSION_STRING@',
+    version='@NEST_VERSION@@githash@',
     description='PyNEST provides Python bindings for NEST',
     author='The NEST Initiative',
     url='https://www.nest-simulator.org',


### PR DESCRIPTION
This removes the former "nest-" prefix from the version given in the pynest module. Note that the hash is empty for a release.