### PR TITLE
Fix build log parser failed test list

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -88,7 +88,7 @@ jobs:
          #uses: actions/cache@master
          run: |
             python -m pip install --upgrade pip setuptools
-            python -m pip install scipy junitparser numpy nose cython matplotlib terminaltables pandoc
+            python -m pip install scipy junitparser>=2 numpy nose cython matplotlib terminaltables pandoc
             python -m pip install nose
             pip list
             g++ --version

--- a/extras/conda-nest-simulator-dev.yml
+++ b/extras/conda-nest-simulator-dev.yml
@@ -92,7 +92,7 @@ dependencies:
   # PIP dependencies -- do not delete
   - pip:
     # For testsuite
-    - junitparser
+    - junitparser >= 2
     # For documentation
     - example
     - Image

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -33,6 +33,9 @@ import os
 import sys
 
 
+assert int(jp.version.split('.')[0]) >= 2, 'junitparser version must be >= 2'
+
+
 def parse_result_file(fname):
 
     results = jp.JUnitXml.fromfile(fname)

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -38,7 +38,7 @@ def parse_result_file(fname):
     results = jp.JUnitXml.fromfile(fname)
 
     failed_tests = ['.'.join((case.classname, case.name)) for case in results
-                    if case.result and not isinstance(case.result, jp.junitparser.Skipped)]
+                    if case.result and not isinstance(case.result[0], jp.junitparser.Skipped)]
 
     return {'Tests': results.tests,
             'Skipped': results.skipped,

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -39,7 +39,7 @@ assert int(jp.version.split('.')[0]) >= 2, 'junitparser version must be >= 2'
 def parse_result_file(fname):
 
     results = jp.JUnitXml.fromfile(fname)
-
+    assert all(len(case.result) == 1 for case in results if case.result), 'Case result has unexpected length > 1'
     failed_tests = ['.'.join((case.classname, case.name)) for case in results
                     if case.result and not isinstance(case.result[0], jp.junitparser.Skipped)]
 


### PR DESCRIPTION
Resolves #1945 by updating the `summarize_tests.py` script for `junitparser` version 2.0. With version 2.0 of `junitparser` [`case.result` is changed to a list](https://junitparser.readthedocs.io/en/latest/#note-on-version-2). This caused skipped tests to not be detected as skipped, and therefore added to the list of failing tests which is printed if any other tests fail.