### PR TITLE
Fixed `PYEXECDIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ nest_set_default_compiler_flags()
 #            of GNUInstallDirs defining CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir>.
 nest_process_with_python()
 include( GNUInstallDirs )
-set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION}/site-packages" )
+set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" )
 nest_process_with_optimize()
 nest_process_with_debug()
 nest_process_with_intel_compiler_flags()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set( target-bits-split "standard" CACHE STRING "Split of the 64-bit target neuro
 ################################################################################
 
 # In general use the CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir> vars from
-# GNUInstallDirs (included after calling nest_process_with_python()), but the 
+# GNUInstallDirs (included after calling nest_process_with_python()), but the
 # CMAKE_INSTALL_DATADIR is usually just CMAKE_INSTALL_DATAROOTDIR
 # and we want it to be CMAKE_INSTALL_DATAROOTDIR/PROJECT_NAME
 set( CMAKE_INSTALL_DATADIR "share/${PROJECT_NAME}" CACHE STRING "Relative directory, where NEST installs its data (share/nest)" )
@@ -130,7 +130,7 @@ nest_set_default_compiler_flags()
 #            of GNUInstallDirs defining CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir>.
 nest_process_with_python()
 include( GNUInstallDirs )
-set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" )
+set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION}/site-packages" )
 nest_process_with_optimize()
 nest_process_with_debug()
 nest_process_with_intel_compiler_flags()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ nest_set_default_compiler_flags()
 #            of GNUInstallDirs defining CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir>.
 nest_process_with_python()
 include( GNUInstallDirs )
+set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" )
 nest_process_with_optimize()
 nest_process_with_debug()
 nest_process_with_intel_compiler_flags()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ nest_set_default_compiler_flags()
 #            of GNUInstallDirs defining CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir>.
 nest_process_with_python()
 include( GNUInstallDirs )
-set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" )
+nest_post_process_with_python()
 nest_process_with_optimize()
 nest_process_with_debug()
 nest_process_with_intel_compiler_flags()

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -416,6 +416,8 @@ function( NEST_PROCESS_WITH_PYTHON )
       set( Python_EXECUTABLE ${Python_EXECUTABLE} PARENT_SCOPE )
       set( PYTHON ${Python_EXECUTABLE} PARENT_SCOPE )
       set( Python_VERSION ${Python_VERSION} PARENT_SCOPE )
+      set( Python_VERSION_MAJOR ${Python_VERSION_MAJOR} PARENT_SCOPE )
+      set( Python_VERSION_MINOR ${Python_VERSION_MINOR} PARENT_SCOPE )
       set( Python_INCLUDE_DIRS "${Python_INCLUDE_DIRS}" PARENT_SCOPE )
       set( Python_LIBRARIES "${Python_LIBRARIES}" PARENT_SCOPE )
 

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -410,14 +410,12 @@ function( NEST_PROCESS_WITH_PYTHON )
         set ( CMAKE_INSTALL_PREFIX "${Python_EnvRoot}" CACHE PATH "Default install prefix for the active Python interpreter" FORCE )
       endif ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
 
-      set( HAVE_PYTHON ON PARENT_SCOPE )
-
       # export found variables to parent scope
+      set( HAVE_PYTHON ON PARENT_SCOPE )
       set( Python_FOUND "${Python_FOUND}" PARENT_SCOPE )
       set( Python_EXECUTABLE ${Python_EXECUTABLE} PARENT_SCOPE )
       set( PYTHON ${Python_EXECUTABLE} PARENT_SCOPE )
       set( Python_VERSION ${Python_VERSION} PARENT_SCOPE )
-
       set( Python_INCLUDE_DIRS "${Python_INCLUDE_DIRS}" PARENT_SCOPE )
       set( Python_LIBRARIES "${Python_LIBRARIES}" PARENT_SCOPE )
 
@@ -431,7 +429,6 @@ function( NEST_PROCESS_WITH_PYTHON )
           set( CYTHON_VERSION "${CYTHON_VERSION}" PARENT_SCOPE )
         endif ()
       endif ()
-      set( PYEXECDIR "${Python_SITELIB}" PARENT_SCOPE )
     endif ()
   elseif ( ${with-python} STREQUAL "OFF" )
   else ()

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -438,6 +438,12 @@ function( NEST_PROCESS_WITH_PYTHON )
   endif ()
 endfunction()
 
+function( NEST_POST_PROCESS_WITH_PYTHON )
+  if ( Python_FOUND )
+    set( PYEXECDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" PARENT_SCOPE )
+  endif()
+endfunction()
+
 function( NEST_PROCESS_WITH_OPENMP )
   # Find OPENMP
   if ( with-openmp )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -399,12 +399,12 @@ function( NEST_PROCESS_WITH_PYTHON )
         execute_process( COMMAND "${Python_EXECUTABLE}" "-c"
           "import sys, os; print(int(bool(os.environ.get('CONDA_DEFAULT_ENV', False)) or (sys.prefix != sys.base_prefix)))"
           OUTPUT_VARIABLE Python_InVirtualEnv OUTPUT_STRIP_TRAILING_WHITESPACE )
-          
+
         if ( NOT Python_InVirtualEnv AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
           message( FATAL_ERROR "No virtual Python environment found and no installation prefix specified. "
             "Please either build and install NEST in a virtual Python environment or specify CMake option -DCMAKE_INSTALL_PREFIX=<nest_install_dir>.")
         endif()
-      
+
         # Setting CMAKE_INSTALL_PREFIX effects the inclusion of GNUInstallDirs defining CMAKE_INSTALL_<dir> and CMAKE_INSTALL_FULL_<dir>
         get_filename_component( Python_EnvRoot "${Python_SITELIB}/../../.." ABSOLUTE)
         set ( CMAKE_INSTALL_PREFIX "${Python_EnvRoot}" CACHE PATH "Default install prefix for the active Python interpreter" FORCE )
@@ -431,7 +431,7 @@ function( NEST_PROCESS_WITH_PYTHON )
           set( CYTHON_VERSION "${CYTHON_VERSION}" PARENT_SCOPE )
         endif ()
       endif ()
-      set( PYEXECDIR "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages" PARENT_SCOPE )
+      set( PYEXECDIR "${Python_SITELIB}" PARENT_SCOPE )
     endif ()
   elseif ( ${with-python} STREQUAL "OFF" )
   else ()


### PR DESCRIPTION
During #1959 I hardcoded `CMAKE_INSTALL_LIBDIR` to `lib` as it was unavailable during `nest_process_with_python` but this led to problems for several environments. Now `PYEXECDIR` is after the `GNUInstallDirs` have been included.

Closes #2075, closes #2079