### PR TITLE
Modify and improve colors in style sheet for ReadtheDocs

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -29,6 +29,8 @@ import subprocess
 from pathlib import Path
 from shutil import copyfile
 
+import sphinx_rtd_theme
+
 from subprocess import check_output, CalledProcessError
 from mock import Mock as MagicMock
 
@@ -89,7 +91,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
     'sphinx_tabs.tabs',
-    'nbsphinx'
+    'nbsphinx',
+    'sphinx_rtd_theme'
 ]
 
 mathjax_path = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML"  # noqa
@@ -153,7 +156,7 @@ numfig_format = {'figure': 'Figure %s', 'table': 'Table %s',
 html_theme = 'sphinx_rtd_theme'
 html_logo = str(doc_build_dir / 'static/img/nest_logo.png')
 html_theme_options = {'logo_only': True,
-                      'display_version': False}
+                      'display_version': True}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -9,31 +9,7 @@
 .rst-content dl:not(.docutils) code.descclassname {
     display: none;
 }
-/*html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
-    background: none;
 
-}
-html.writer-html4 .rst-content dl:not(.docutils) dl:not(.field-list) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
-	margin-bottom: 6px;
-	border: none;
-	border-left: 3px solid #ccc;
-	background: none;
-	color: #555;
-}
-
-html.writer-html4 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
-	display: table;
-	margin: 6px 0;
-	font-size: medium;
-	line-height: normal;
-	background: none;
-	color: #717171;
-	border-left: solid 3px;
-	border-top: none;
-	padding: 6px;
-	position: relative;
-}
-*/
 .rst-content dl:not(.docutils) dt {
 	display: table;
 	margin: 6px 0;

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -6,26 +6,45 @@
    background-color: #272525;
 }
 
-code.descclassname {
+.rst-content dl:not(.docutils) code.descclassname {
     display: none;
 }
-html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
+/*html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
     background: none;
 
 }
+html.writer-html4 .rst-content dl:not(.docutils) dl:not(.field-list) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
+	margin-bottom: 6px;
+	border: none;
+	border-left: 3px solid #ccc;
+	background: none;
+	color: #555;
+}
 
-html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
-    display: table;
-    margin: 6px 0;
-        margin-top: 6px;
-    font-size: large;
-    line-height: normal;
-    background: none;
-    color: #717171;
-    border-top: none;
-    border-left: solid;
-    padding: 6px;
-    position: relative;
+html.writer-html4 .rst-content dl:not(.docutils) > dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
+	display: table;
+	margin: 6px 0;
+	font-size: medium;
+	line-height: normal;
+	background: none;
+	color: #717171;
+	border-left: solid 3px;
+	border-top: none;
+	padding: 6px;
+	position: relative;
+}
+*/
+.rst-content dl:not(.docutils) dt {
+	display: table;
+	margin: 6px 0;
+	font-size: medium;
+	line-height: normal;
+	background: none;
+	color: #717171;
+	border-left: solid 3px;
+	border-top: none;
+	padding: 6px;
+	position: relative;
 }
 
 .rst-content dl:not(.docutils) dl dt {
@@ -33,7 +52,6 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
     color: #333;
     background: none;
 }
-
 
 .rst-content code, .rst-content tt, code {
     border: none;

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -10,7 +10,15 @@
     display: none;
 }
 
-.rst-content dl:not(.docutils) dt, .rst-content dl:not(.docutils) dt[class^="sig sig-object py"] {
+.rst-content dl:not(.docutils) dt {
+    color: #272727;
+    background: none;
+    border-left: none;
+    border-top: none;
+
+}
+
+.rst-content dl:not(.docutils) dt[class^="sig sig-object py"] {
 	margin: 6px 0;
 	font-size: medium;
 	line-height: normal;
@@ -24,7 +32,7 @@
 
 .rst-content dl:not(.docutils) dl dt {
     border-left: none;
-    color: #333;
+    color: #272727;
     background: none;
 }
 
@@ -174,10 +182,6 @@ a:hover {
     padding: 0.5em;
     border: 1px solid #ff6633;
     border-radius: 5px;
-}
-
-.rst-content kbd {
-    background-color: lightgray;
 }
 
 .rst-content .admonition {

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -153,17 +153,18 @@ a:hover {
 }
 
 .rst-content .danger .admonition-title {
-    background: #ff3333;
+    background: #ff1133;
 }
-.rst-content .note .admonition-title {
-    background: #ff9933;
+
+.rst-content .seealso .admonition-title, .rst-content .note .admonition-title {
+    background: #ffbb33;
 }
-.rst-content .seealso .admonition-title {
-    background: #ff9933;
-}
+
 .rst-content .warning .admonition-title {
     background: #ff6633;
+
 }
+
 .wy-plain-list-disc, .rst-content .section ul, .rst-content .toctree-wrapper ul, article ul {
     margin-bottom: 12px;
 }
@@ -180,7 +181,7 @@ a:hover {
 }
 
 .rst-content .admonition {
-    background: #e0e0e0;
+    background: #e9e9e9;
 
 }
 

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -6,6 +6,35 @@
    background-color: #272525;
 }
 
+code.descclassname {
+    display: none;
+}
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list) > dt {
+    background: none;
+
+}
+
+html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) > dt {
+    display: table;
+    margin: 6px 0;
+        margin-top: 6px;
+    font-size: large;
+    line-height: normal;
+    background: none;
+    color: #717171;
+    border-top: none;
+    border-left: solid;
+    padding: 6px;
+    position: relative;
+}
+
+.rst-content dl:not(.docutils) dl dt {
+    border-left: none;
+    color: #333;
+    background: none;
+}
+
+
 .rst-content code, .rst-content tt, code {
     border: none;
     font-size: 85%;
@@ -14,7 +43,7 @@
     padding-right: 2px;
 }
 
-  t.rst-content tt.literal, .rst-content tt.literal, .rst-content code.literal { 
+t.rst-content tt.literal, .rst-content tt.literal, .rst-content code.literal { 
     color: #111;
 
 }
@@ -110,10 +139,6 @@ a:hover {
     text-decoration: underline;
 }
 
-code.descclassname {
-    display: none;
-}
-
 .rst-content dl:not(.docutils) dt  em[class^='property']{
      display:none;
 }
@@ -131,18 +156,23 @@ code.descclassname {
 }
 
 .rst-content .admonition-title {
-    background: #ffae18;
-
+    background: #333333;
 }
 
+.rst-content .danger .admonition-title {
+    background: #ff3333;
+}
+.rst-content .note .admonition-title {
+    background: #ff9933;
+}
+.rst-content .seealso .admonition-title {
+    background: #ff9933;
+}
+.rst-content .warning .admonition-title {
+    background: #ff6633;
+}
 .wy-plain-list-disc, .rst-content .section ul, .rst-content .toctree-wrapper ul, article ul {
     margin-bottom: 12px;
-}
-
-.rst-content dl:not(.docutils) dt {
-    background: #ff663336;
-    border-top: solid 3px #ff6633;
-    color: black;
 }
 
 .rst-content .pull-quote {

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -6,7 +6,7 @@
    background-color: #272525;
 }
 
-.rst-content dl:not(.docutils) code.descclassname {
+.rst-content dl:not(.docutils) code.descclassname, .rst-content dl:not(.docutils) tt.descclassname {
     display: none;
 }
 

--- a/doc/userdoc/static/css/custom.css
+++ b/doc/userdoc/static/css/custom.css
@@ -1,23 +1,22 @@
 .wy-breadcrumbs-aside {
-   display: none !important;
+    display: none !important;
 }
 
 .keep-us-sustainable {
-   background-color: #272525;
+    background-color: #272525;
 }
 
-.rst-content dl:not(.docutils) code.descclassname, .rst-content dl:not(.docutils) tt.descclassname {
+.rst-content dl:not(.docutils) [class^="sig-prename descclassname"] {
     display: none;
 }
 
-.rst-content dl:not(.docutils) dt {
-	display: table;
+.rst-content dl:not(.docutils) dt, .rst-content dl:not(.docutils) dt[class^="sig sig-object py"] {
 	margin: 6px 0;
 	font-size: medium;
 	line-height: normal;
-	background: none;
-	color: #717171;
-	border-left: solid 3px;
+	background: #ff663329;
+	color: #272727;
+	border-left: solid 3px #ff663385;
 	border-top: none;
 	padding: 6px;
 	position: relative;


### PR DESCRIPTION
This PR modifies the CSS to change the color/highlighting of different items on ReadtheDocs. 
These changes remove the default blue theme color that crept in our docs in some places, and tries to improve the clarity by removing background colors. 

It also hides the entire name of python objects (so instead of `nest.lib.hl_api_simulation.Simulate()` being shown only `Simulate()` is visible) in the PyNEST API. 

* Only python classes, functions, and methods have a background  highlight, and the top border is changed for a left border 
* Parameters, Returns, Raises  etc have no highlighting (See https://nest-test.readthedocs.io/en/fix-css-docs/ref_material/pynest_apis.html)
* RestructuredText definition lists and glossary also have no color highlighting (See section Run NEST server: https://nest-test.readthedocs.io/en/fix-css-docs/nest_server.html)
* There are currently 4 colors used for admonition titles, based off of the NEST orange:
     * Note and See Also use a light yellowy orange
     *  Warnings use NEST orange (At top of every page)
     * Danger uses red (See https://nest-test.readthedocs.io/en/fix-css-docs/nest_server.html)
     * Custom admonitions use dark gray (See https://nest-test.readthedocs.io/en/fix-css-docs/guides/random_numbers.html#)

Of course, these changes can be discussed and modified.

Resolves #2031 


