### PR TITLE
Warn users they are using lastest on ReadtheDocs 

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -166,8 +166,9 @@ html_theme_options = {'logo_only': True,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = [str(doc_build_dir / 'static')]
 
-rst_prolog = ".. warning:: \n  This is A PREVIEW for NEST 3.0 and NOT an OFFICIAL RELEASE! \
-             Some functionality may not be available and information may be incomplete!"
+rst_prolog = ".. warning:: \n   This version of the documentation is NOT an official release. \
+             You are looking at 'latest', which is in active and ongoing development. \
+             You can change versions on the bottom left of the screen."
 rst_epilog = ""
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
This PR alters the text in the Warning that appears above each page to warn users they are in the latest version of NEST.

Resolves #2083 