### PR TITLE
Add license to jupyter notebooks

### DIFF
--- a/doc/userdoc/model_details/HillTononiModels.ipynb
+++ b/doc/userdoc/model_details/HillTononiModels.ipynb
@@ -2030,13 +2030,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "License\n",
-    "-------\n",
+    "-----------------------------\n",
+    "### License\n",
     "\n",
-    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "This file is part of NEST. Copyright (C) 2004 The NEST Initiative\n",
     "\n",
-    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
-   ]
+    "NEST is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "NEST is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+    ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/HillTononiModels.ipynb
+++ b/doc/userdoc/model_details/HillTononiModels.ipynb
@@ -2019,13 +2019,6 @@
     "Gax.set_xlabel('Time [ms]');"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
  {
    "cell_type": "markdown",
    "metadata": {},

--- a/doc/userdoc/model_details/HillTononiModels.ipynb
+++ b/doc/userdoc/model_details/HillTononiModels.ipynb
@@ -2025,6 +2025,18 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "License\n",
+    "-------\n",
+    "\n",
+    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/IAF_neurons_singularity.ipynb
+++ b/doc/userdoc/model_details/IAF_neurons_singularity.ipynb
@@ -499,13 +499,6 @@
     "The maximum of the voltage traces show that the non-singular case nicely converges to the singular one and no numeric instabilities occur. "
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
  {
    "cell_type": "markdown",
    "metadata": {},

--- a/doc/userdoc/model_details/IAF_neurons_singularity.ipynb
+++ b/doc/userdoc/model_details/IAF_neurons_singularity.ipynb
@@ -505,6 +505,18 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "License\n",
+    "-------\n",
+    "\n",
+    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/IAF_neurons_singularity.ipynb
+++ b/doc/userdoc/model_details/IAF_neurons_singularity.ipynb
@@ -510,13 +510,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "License\n",
-    "-------\n",
+    "-----------------------------\n",
+    "### License\n",
     "\n",
-    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "This file is part of NEST. Copyright (C) 2004 The NEST Initiative\n",
     "\n",
-    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
-   ]
+    "NEST is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "NEST is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+    ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/userdoc/model_details/aeif_models_implementation.ipynb
@@ -824,13 +824,6 @@
     "plt.show();"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
  {
    "cell_type": "markdown",
    "metadata": {},

--- a/doc/userdoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/userdoc/model_details/aeif_models_implementation.ipynb
@@ -835,13 +835,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "License\n",
-    "-------\n",
+    "-----------------------------\n",
+    "### License\n",
     "\n",
-    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "This file is part of NEST. Copyright (C) 2004 The NEST Initiative\n",
     "\n",
-    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
-   ]
+    "NEST is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "NEST is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+    ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/userdoc/model_details/aeif_models_implementation.ipynb
@@ -830,6 +830,18 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "License\n",
+    "-------\n",
+    "\n",
+    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/noise_generator.ipynb
+++ b/doc/userdoc/model_details/noise_generator.ipynb
@@ -738,13 +738,6 @@
     "plt.ylabel(r'$\\langle V(t)V(t+\\tau)\\rangle$');"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
  {
    "cell_type": "markdown",
    "metadata": {},

--- a/doc/userdoc/model_details/noise_generator.ipynb
+++ b/doc/userdoc/model_details/noise_generator.ipynb
@@ -744,6 +744,18 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "License\n",
+    "-------\n",
+    "\n",
+    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/noise_generator.ipynb
+++ b/doc/userdoc/model_details/noise_generator.ipynb
@@ -749,12 +749,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "License\n",
-    "-------\n",
+    "-----------------------------\n",
+    "### License\n",
     "\n",
-    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "This file is part of NEST. Copyright (C) 2004 The NEST Initiative\n",
     "\n",
-    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+    "NEST is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "NEST is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
    ]
   }
  ],

--- a/doc/userdoc/model_details/siegert_neuron_integration.ipynb
+++ b/doc/userdoc/model_details/siegert_neuron_integration.ipynb
@@ -246,12 +246,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "License\n",
-    "-------\n",
-    "\n",
-    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
-    "\n",
-    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   "-----------------------------\n",
+   "### License\n",
+   "\n",
+   "This file is part of NEST. Copyright (C) 2004 The NEST Initiative\n",
+   "\n",
+   "NEST is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+   "\n",
+   "NEST is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
    ]
   }
  ],

--- a/doc/userdoc/model_details/siegert_neuron_integration.ipynb
+++ b/doc/userdoc/model_details/siegert_neuron_integration.ipynb
@@ -241,6 +241,18 @@
     "plt.title(r'Absolute error of first order asymptotics of $\\mathrm{erfcx}(s)$')\n",
     "plt.show()"
    ]
+  },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "License\n",
+    "-------\n",
+    "\n",
+    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/test_post_trace.ipynb
+++ b/doc/userdoc/model_details/test_post_trace.ipynb
@@ -622,13 +622,6 @@
     "            debug=False)\n"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
  {
    "cell_type": "markdown",
    "metadata": {},

--- a/doc/userdoc/model_details/test_post_trace.ipynb
+++ b/doc/userdoc/model_details/test_post_trace.ipynb
@@ -628,6 +628,18 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "License\n",
+    "-------\n",
+    "\n",
+    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+    "\n",
+    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   ]
   }
  ],
  "metadata": {

--- a/doc/userdoc/model_details/test_post_trace.ipynb
+++ b/doc/userdoc/model_details/test_post_trace.ipynb
@@ -633,12 +633,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "License\n",
-    "-------\n",
-    "\n",
-    "This notebook (and associated files) is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
-    "\n",
-    "This notebook (and associated files) is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+   "-----------------------------\n",
+   "### License\n",
+   "\n",
+   "This file is part of NEST. Copyright (C) 2004 The NEST Initiative\n",
+   "\n",
+   "NEST is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.\n",
+   "\n",
+   "NEST is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
    ]
   }
  ],


### PR DESCRIPTION
This PR adds the license information to the end of each Jupyter Notebook.

Resolves #1871 