### PR TITLE
Clean up NEST Server and fix deadlock

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -182,16 +182,17 @@ html_show_copyright = False
 # With this local 'make html' is broken!
 github_doc_root = ''
 
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
-                      'nestml': ('https://nestml.readthedocs.io/en/latest/',
-                      None), 'pynn': ('http://neuralensemble.org/docs/PyNN/',
-                      None), 'elephant': ('https://elephant.readthedocs.io/en/latest/',
-                      None), 'desktop': ('https://nest-desktop.readthedocs.io/en/latest/',
-                      None), 'neuromorph': ('https://electronicvisions.github.io/hbp-sp9-guidebook/',
-                      None), 'arbor': ('https://arbor.readthedocs.io/en/latest/',
-                      None), 'tvb': ('http://docs.thevirtualbrain.org/',
-                      None), 'extmod': ('https://nest-extension-module.readthedocs.io/en/latest/',
-                      None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nestml': ('https://nestml.readthedocs.io/en/latest/', None),
+    'pynn': ('http://neuralensemble.org/docs/PyNN/', None),
+    'elephant': ('https://elephant.readthedocs.io/en/latest/', None),
+    'desktop': ('https://nest-desktop.readthedocs.io/en/latest/', None),
+    'neuromorph': ('https://electronicvisions.github.io/hbp-sp9-guidebook/', None),
+    'arbor': ('https://arbor.readthedocs.io/en/latest/', None),
+    'tvb': ('http://docs.thevirtualbrain.org/', None),
+    'extmod': ('https://nest-extension-module.readthedocs.io/en/latest/', None)
+}
 
 from doc.extractor_userdocs import ExtractUserDocs, relative_glob  # noqa
 

--- a/extras/nest-server-mpi
+++ b/extras/nest-server-mpi
@@ -32,15 +32,15 @@ rank = comm.Get_rank()
 
 def log(call_name, msg):
     global rank
-    print(f'==> WORKER {rank}/{time.time():.7f} ({call_name}): {msg}')
+    print(f'==> WORKER {rank}/{time.time():.7f} ({call_name}): {msg}', flush=True)
 
 
 if rank == 0:
-    print("==> Starting NEST Server Master on rank 0")
+    print("==> Starting NEST Server Master on rank 0", flush=True)
     nest.server.set_mpi_comm(comm)
     nest.server.run_mpi_app(host=opt['--host'], port=opt['--port'])
 else:
-    print(f"==> Starting NEST Server Worker on rank {rank}")
+    print(f"==> Starting NEST Server Worker on rank {rank}", flush=True)
     nest.server.set_mpi_comm(comm)
     while True:
         log('spinwait', 'waiting for call bcast')

--- a/extras/nest-server-mpi
+++ b/extras/nest-server-mpi
@@ -62,8 +62,9 @@ else:
 
             # The following exception handler is useful if an error
             # occurs simulataneously on all processes. If only a
-            # subset of processes throw, a deadlock due to mismatching
-            # MPI communication calls is inevitable on the next call.
+            # subset of processes raises an exception, a deadlock due
+            # to mismatching MPI communication calls is inevitable on
+            # the next call.
             try:
                 response = call(*args, **kwargs)
             except Exception:

--- a/extras/nest-server-mpi
+++ b/extras/nest-server-mpi
@@ -31,30 +31,43 @@ rank = comm.Get_rank()
 
 
 def log(call_name, msg):
-    global rank
-    print(f'==> WORKER {rank}/{time.time():.7f} ({call_name}): {msg}', flush=True)
+    msg = f'==> WORKER {rank}/{time.time():.7f} ({call_name}): {msg}'
+    print(msg, flush=True)
 
 
 if rank == 0:
     print("==> Starting NEST Server Master on rank 0", flush=True)
     nest.server.set_mpi_comm(comm)
     nest.server.run_mpi_app(host=opt['--host'], port=opt['--port'])
+
 else:
     print(f"==> Starting NEST Server Worker on rank {rank}", flush=True)
     nest.server.set_mpi_comm(comm)
     while True:
+
         log('spinwait', 'waiting for call bcast')
         call_name = comm.bcast(None, root=0)
+
         log(call_name, 'received call bcast, waiting for data bcast')
         data = comm.bcast(None, root=0)
+
         log(call_name, f'received data bcast, data={data}')
         args, kwargs = data
+
         if call_name == 'exec':
             response = nest.server.do_exec(args, kwargs)
         else:
-            call = getattr(nest, call_name)
-            args, kwargs = nest.server.NodeCollection(call, args, kwargs)
+            call, args, kwargs = nest.server.nestify(call_name, args, kwargs)
             log(call_name, f'local call, args={args}, kwargs={kwargs}')
-            response = nest.hl_api.serializable(call(*args, **kwargs))
+
+            # The following exception handler is useful if an error
+            # occurs simulataneously on all processes. If only a
+            # subset of processes throw, a deadlock due to mismatching
+            # MPI communication calls is inevitable on the next call.
+            try:
+                response = call(*args, **kwargs)
+            except Exception:
+                continue
+
         log(call_name, f'sending reponse gather, data={response}')
-        comm.gather(response, root=0)
+        comm.gather(nest.hl_api.serializable(response), root=0)

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -187,8 +187,11 @@ def route_api():
 def route_api_call(call):
     """ Route to call function in NEST.
     """
-    print("\n========================================\n")
+    print("\n========================================\n", flush=True)
     args, kwargs = get_arguments(request)
+    if mpi_comm is not None:
+        print(f"MPI RANK {mpi_comm.Get_rank()}: ", end="", flush=True)
+    print(f"Call to route /api/{call}, args={args}, kwargs={kwargs}", flush=True)
     response = api_client(call, args, kwargs)
     return jsonify(response)
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -102,12 +102,12 @@ def do_exec(args, kwargs):
 
     except Exception as e:
         for line in traceback.format_exception(*sys.exc_info()):
-            print(line)
+            print(line, flush=True)
         abort(Response(str(e), EXCEPTION_ERROR_STATUS))
 
 
 def log(call_name, msg):
-    print(f'==> MASTER 0/{time.time():.7f} ({call_name}): {msg}')
+    print(f'==> MASTER 0/{time.time():.7f} ({call_name}): {msg}', flush=True)
 
 
 def do_call(call_name, args=[], kwargs={}):
@@ -263,7 +263,7 @@ def get_or_error(func):
             return func(call, args, kwargs)
         except Exception as e:
             for line in traceback.format_exception(*sys.exc_info()):
-                print(line)
+                print(line, flush=True)
             abort(Response(str(e), EXCEPTION_ERROR_STATUS))
     return func_wrapper
 
@@ -438,7 +438,7 @@ def combine(call_name, response):
     if all(type(v) is list for v in response):
         return [item for lst in response for item in lst]
 
-    print(f"##\n## DATA COMBINATION ERROR: response={response}\n##\n")
+    print(f"##\n## DATA COMBINATION ERROR: response={response}\n##\n", flush=True)
     msg = "Cannot combine data because of unknown reason"
     raise Exception(msg)
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -120,12 +120,12 @@ def do_call(call_name, args=[], kwargs={}):
 
     If the server is run in MPI-enabled mode, this function will first
     communicate the call type (i.e., "exec" or API call) and the args
-    and kwargs to all worker processes and only then execute the call
+    and kwargs to all worker processes. Only then will it execute the call
     in the way described above for the serial case. After the call, the
-    worker responses are collected, combined and returned to the caller.
+    worker responses are collected, combined, and returned to the caller.
 
     Please note that this function must only be called on the master
-    process (i.e. the task with rank 0) in a distributed scenario.
+    process (i.e., the task with rank 0) in a distributed scenario.
 
     """
 
@@ -360,13 +360,12 @@ def run_mpi_app(host="127.0.0.1", port=5000):
 def combine(call_name, response):
     """Combine responses from different MPI processes.
 
-    If this function is run in a serial context, i.e., without MPI,
+    If this function is run in a serial context, that is, without MPI,
     it returns the only response immediately.
 
     In a distributed scenario, this function combines the responses of
     all MPI processes and returns a single response object. The type
-    of the result can vary depending on the call of the call that
-    produced it.
+    of the result can vary depending on the call that produced it.
 
     The combination of results is based on a cascade of heuristics
     based on the call that was issued and individual repsonse data:
@@ -416,7 +415,7 @@ def combine(call_name, response):
     if all(type(v) is list for v in response):
         return [item for lst in response for item in lst]
 
-    print(f"##\n## DATA COMBINATION ERROR: response={response}\n##\n", flush=True)
+    log("combine_data", f"ERROR: cannot combine response={response}")
     msg = "Cannot combine data because of unknown reason"
     raise Exception(msg)
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -421,7 +421,8 @@ def combine(call_name, response):
         return None
 
     # return the master response if all responses are known to be the same
-    if call_name in ('exec', 'Create', 'GetDefaults', 'GetKernelStatus'):
+    if call_name in ('exec', 'Create', 'GetDefaults', 'GetKernelStatus',
+                     'SetKernelStatus', 'SetStatus'):
         return response[0]
 
     # return a single response if there is only one which is not None

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -115,16 +115,16 @@ def do_call(call_name, args=[], kwargs={}):
     """Call a PYNEST function or execute a script within the server.
 
     If the server is run serially (i.e., without MPI), this function
-    will do one of two things: if call_name is "exec", it will execute
+    will do one of two things: If call_name is "exec", it will execute
     the script given in args via do_exec(). If call_name is the name
-    of a PyNEST API function, it will call that function with args and
-    kwargs as function arguments.
+    of a PyNEST API function, it will call that function and pass args
+    and kwargs to it.
 
-    If the server is run with MPI, this function will communicate the
-    call type ("exec" or API call) and the args and kwargs to all
-    worker processes before executing the call in the same way as
-    described above for the serial case. After the call, the worker
-    responses are collected, combined and returned to the caller.
+    If the server is run with MPI, this function will first communicate
+    the call type ("exec" or API call) and the args and kwargs to all
+    worker processes. Only then will it execute the call in the same
+    way as described above for the serial case. After the call, all
+    worker responses are collected, combined and returned.
 
     Please note that this function must only be called on the master
     process (i.e., the task with rank 0) in a distributed scenario.
@@ -190,7 +190,7 @@ def route_api():
 def route_api_call(call):
     """ Route to call function in NEST.
     """
-    print("\n========================================\n", flush=True)
+    print(f"\n{'='*40}\n", flush=True)
     args, kwargs = get_arguments(request)
     log("route_api_call", f"call={call}, args={args}, kwargs={kwargs}")
     response = api_client(call, args, kwargs)
@@ -313,7 +313,7 @@ def get_restricted_globals():
 
 
 def nestify(call_name, args, kwargs):
-    """Get the nest call and transform arguments.
+    """Get the NEST API call and convert arguments if neccessary.
     """
 
     call = getattr(nest, call_name)
@@ -356,7 +356,7 @@ def set_mpi_comm(comm):
 def run_mpi_app(host="127.0.0.1", port=5000):
     # NEST crashes with a segmentation fault if the number of threads
     # is changed from the outside. Calling run() with threaded=False
-    # prevents Flask from performing such changes
+    # prevents Flask from performing such changes.
     app.run(host=host, port=port, threaded=False)
 
 
@@ -422,7 +422,7 @@ def combine(call_name, response):
     if all(type(v) is list for v in response):
         return [item for lst in response for item in lst]
 
-    log("combine_data", f"ERROR: cannot combine response={response}")
+    log("combine()", f"ERROR: cannot combine response={response}")
     msg = "Cannot combine data because of unknown reason"
     raise Exception(msg)
 


### PR DESCRIPTION
This PR removes the serialization functionality from NEST Server, as this a) is not needed anymore since #2024 was merged and b) could lead to deadlocks in MPI-enabled scenarios. It also clarifies and extends several docstrings and cleans up the code structure a bit.

@babsey: can you please verify the changes in the context of NEST Desktop?
@jessica-mitchell: can you please have a look at the docstrings?