### PR TITLE
Update Python version check in __init__.py to check for minor version, and to report correct minimum required version (>= 3.8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,11 @@ configure_file(
     "${PROJECT_BINARY_DIR}/doc/fulldoc.conf" @ONLY
 )
 
+configure_file(
+    "${PROJECT_SOURCE_DIR}/pynest/nest/__init__.py.in"
+    "${PROJECT_BINARY_DIR}/pynest/nest/__init__.py" @ONLY
+)
+
 
 ################################################################################
 ##################            Install Extra Files             ##################

--- a/pynest/CMakeLists.txt
+++ b/pynest/CMakeLists.txt
@@ -74,8 +74,9 @@ if ( HAVE_PYTHON )
       -D_IS_PYNEST
       )
 
-  install(DIRECTORY  nest/
+  install(DIRECTORY  nest/ ${PROJECT_BINARY_DIR}/pynest/nest/
       DESTINATION ${CMAKE_INSTALL_PREFIX}/${PYEXECDIR}/nest
+      PATTERN "__init__.py.in" EXCLUDE
   )
   install( TARGETS pynestkernel DESTINATION ${PYEXECDIR}/nest/ )
   install( CODE "

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -39,11 +39,6 @@ For more information visit https://www.nest-simulator.org.
 
 """
 
-import sys
-if sys.version_info[0] == 2:
-    msg = "Python 2 is no longer supported. Please use Python >= 3.6."
-    raise Exception(msg)
-
 from . import ll_api                  # noqa
 from .ll_api import set_communicator  # noqa
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -39,6 +39,11 @@ For more information visit https://www.nest-simulator.org.
 
 """
 
+import sys
+if ( sys.version_info[0] == 2 ) or ( sys.version_info[0] == 3 and sys.version_info[1] < 8 ):
+    msg = "Unsupported Python version. Please use Python >= 3.8."
+    raise Exception(msg)
+
 from . import ll_api                  # noqa
 from .ll_api import set_communicator  # noqa
 
@@ -59,3 +64,17 @@ except ImportError:
     pass
 
 __version__ = ll_api.sli_func("statusdict /version get")
+
+
+def test():
+    """Runs all PyNEST unit tests."""
+    from . import tests
+    import unittest
+
+    debug = ll_api.get_debug()
+    ll_api.set_debug(True)
+
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(tests.suite())
+
+    ll_api.set_debug(debug)

--- a/pynest/nest/__init__.py.in
+++ b/pynest/nest/__init__.py.in
@@ -40,8 +40,8 @@ For more information visit https://www.nest-simulator.org.
 """
 
 import sys
-if ( sys.version_info.major < @Python_VERSION_MAJOR@ ) or ( sys.version_info.major == @Python_VERSION_MAJOR@ and sys.version_info.minor < @Python_VERSION_MINOR@ ):
-    msg = "Python runtime version is older than compiletime version. Please use Python >= @Python_VERSION_MAJOR@.@Python_VERSION_MINOR@."
+if sys.version_info.major != @Python_VERSION_MAJOR@ or sys.version_info.minor != @Python_VERSION_MINOR@ :
+    msg = "Python runtime version does not match 'nest' compiletime version. Please use Python @Python_VERSION_MAJOR@.@Python_VERSION_MINOR@."
     raise Exception(msg)
 
 from . import ll_api                  # noqa

--- a/pynest/nest/__init__.py.in
+++ b/pynest/nest/__init__.py.in
@@ -40,8 +40,8 @@ For more information visit https://www.nest-simulator.org.
 """
 
 import sys
-if ( sys.version_info[0] == 2 ) or ( sys.version_info[0] == 3 and sys.version_info[1] < 8 ):
-    msg = "Unsupported Python version. Please use Python >= 3.8."
+if ( sys.version_info.major < @Python_VERSION_MAJOR@ ) or ( sys.version_info.major == @Python_VERSION_MAJOR@ and sys.version_info.minor < @Python_VERSION_MINOR@ ):
+    msg = "Python runtime version is older than compiletime version. Please use Python >= @Python_VERSION_MAJOR@.@Python_VERSION_MINOR@."
     raise Exception(msg)
 
 from . import ll_api                  # noqa
@@ -64,17 +64,3 @@ except ImportError:
     pass
 
 __version__ = ll_api.sli_func("statusdict /version get")
-
-
-def test():
-    """Runs all PyNEST unit tests."""
-    from . import tests
-    import unittest
-
-    debug = ll_api.get_debug()
-    ll_api.set_debug(True)
-
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(tests.suite())
-
-    ll_api.set_debug(debug)


### PR DESCRIPTION
As commented on #2122, remove Python version check in `__init__.py` as minimum requirement is already enforced to be >= 3.8 (#1954)