### PR TITLE
Only call `set_connections_have_changed()` from thread 0

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -848,8 +848,6 @@ nest::ConnectionManager::disconnect( const thread tid,
   const index snode_id,
   const index tnode_id )
 {
-  set_connections_have_changed();
-
   assert( syn_id != invalid_synindex );
 
   const index lcid = find_connection( tid, syn_id, snode_id, tnode_id );

--- a/testsuite/pytests/test_regression_issue-2125.py
+++ b/testsuite/pytests/test_regression_issue-2125.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# test_regression_issue-2125.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import nest
+import numpy as np
+import unittest
+
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+class ThreadedDisconnectTestCase(unittest.TestCase):
+
+    def test_threaded_disconnect(self):
+        """Test that threaded disconnect does not produce segmentation fault"""
+        nest.ResetKernel()
+        nest.SetKernelStatus({'local_num_threads': 2})
+
+        neurons = nest.Create('iaf_psc_alpha', 3)
+
+        nest.Connect(neurons[0], neurons[2])
+
+        conns = nest.GetConnections()
+        self.assertEqual(len(conns), 1)
+
+         # Make sure we are able to call Disconnect when we have number of threads more than one
+        nest.Disconnect(neurons[0], neurons[2])
+
+        conns = nest.GetConnections()
+        self.assertEqual(len(conns), 0)
+
+
+def suite():
+    suite = unittest.makeSuite(ThreadedDisconnectTestCase, 'test')
+    return suite
+
+
+def run():
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(suite())
+
+
+if __name__ == "__main__":
+    run()

--- a/testsuite/pytests/test_regression_issue-2125.py
+++ b/testsuite/pytests/test_regression_issue-2125.py
@@ -22,7 +22,7 @@
 import nest
 import unittest
 
-HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+HAVE_OPENMP = nest.ll_api.sli_func('is_threaded')
 
 
 @unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')

--- a/testsuite/pytests/test_regression_issue-2125.py
+++ b/testsuite/pytests/test_regression_issue-2125.py
@@ -32,6 +32,7 @@ class ThreadedDisconnectTestCase(unittest.TestCase):
     def test_threaded_disconnect(self):
         """Test that threaded disconnect does not produce segmentation fault"""
         nest.ResetKernel()
+        nest.set_verbosity('M_ERROR')
         nest.SetKernelStatus({'local_num_threads': 2})
 
         neurons = nest.Create('iaf_psc_alpha', 3)

--- a/testsuite/pytests/test_regression_issue-2125.py
+++ b/testsuite/pytests/test_regression_issue-2125.py
@@ -58,5 +58,5 @@ def run():
     runner.run(suite())
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     run()

--- a/testsuite/pytests/test_regression_issue-2125.py
+++ b/testsuite/pytests/test_regression_issue-2125.py
@@ -20,7 +20,6 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 import nest
-import numpy as np
 import unittest
 
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
@@ -42,7 +41,7 @@ class ThreadedDisconnectTestCase(unittest.TestCase):
         conns = nest.GetConnections()
         self.assertEqual(len(conns), 1)
 
-         # Make sure we are able to call Disconnect when we have number of threads more than one
+        # Make sure we are able to call Disconnect when we have number of threads more than one
         nest.Disconnect(neurons[0], neurons[2])
 
         conns = nest.GetConnections()


### PR DESCRIPTION
Remove `set_connections_have_changed()` from `nest::ConnectionManager::disconnect` as  `set_connections_have_changed()` has already been called.

 `nest::ConnectionManager::disconnect()` is (by going backwards in the call-graph) called from two functions. The first is `SPManager::disconnect`, which already calls `set_connections_have_changed()` before going into the different threads:
https://github.com/nest/nest-simulator/blob/8c16625f39737318fceb97989e37fe6ab2b01342/nestkernel/sp_manager.cpp#L317-L319

The second is `SPmanager::update_structural_plasticity`, which calls `set_connections_have_changed()` if we either connect or disconnect, again from thread 0:
https://github.com/nest/nest-simulator/blob/8c16625f39737318fceb97989e37fe6ab2b01342/nestkernel/sp_manager.cpp#L413-L416

We therefore do not need to call `set_connections_have_changed()` in `nest::ConnectionManager::disconnect`.

This PR fixes #2125.