### PR TITLE
Change `time` to `biological_time` in SetKernelStatus doc as the variable name has been changed

### DIFF
--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -222,7 +222,7 @@ def SetKernelStatus(params):
 
     resolution : float, default: 0.1
         The resolution of the simulation (in ms)
-    time : float
+    biological_time : float
         The current simulation time (in ms)
     to_do : int, read only
         The number of steps yet to be simulated


### PR DESCRIPTION
`time` has been renamed to `biological_time`. The error prevents `sensitivity_to_perturbation.py` from running, this is now fixed.