### PR TITLE
Undo link to PyNEST API in SLI documentation

### DIFF
--- a/doc/userdoc/sli_docs/neural-simulations.rst
+++ b/doc/userdoc/sli_docs/neural-simulations.rst
@@ -285,7 +285,7 @@ layer we have created above:
    --------------------------------------------------
    Total number of entries: 24
 
-Using the command SetStatus`, it is possible to change the entries of
+Using the command ``SetStatus``, it is possible to change the entries of
 this so called *status dictionary*. The following lines of code change
 the threshold value ``V_th`` to -60 mV:
 


### PR DESCRIPTION
Fixes #2120 

This PR removes the link in the reStructuredText to the PyNEST API in the neural_simulations SLI file.