### PR TITLE
Automatically flag issues and pull-requests as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,3 +20,4 @@ jobs:
         stale-pr-message: 'Pull request automatically marked stale!'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
+        days-before-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '31 8 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Issue automatically marked stale!'
+        stale-pr-message: 'Pull request automatically marked stale!'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'


### PR DESCRIPTION
This adds a GitHub Action that automatically marks stale issues and pull request.

See https://github.com/actions/stale for details on (possible) configuration settings.