### PR TITLE
Fix import nest in NEST Server

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -101,11 +101,6 @@ class NestModule(types.ModuleType):
     from . import spatial_distributions              # noqa
     from . import logic                              # noqa
 
-    try:
-        from . import server                         # noqa
-    except ImportError:
-        pass
-
     __version__ = ll_api.sli_func("statusdict /version get")
 
     # Lazy load the `spatial` module to avoid circular imports.

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -31,7 +31,6 @@ from flask_cors import CORS, cross_origin
 from werkzeug.exceptions import abort
 from werkzeug.wrappers import Response
 
-from nest import __version__    # noqa
 import nest
 
 import RestrictedPython

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -31,7 +31,9 @@ from flask_cors import CORS, cross_origin
 from werkzeug.exceptions import abort
 from werkzeug.wrappers import Response
 
+from nest import __version__    # noqa
 import nest
+
 import RestrictedPython
 import time
 
@@ -97,7 +99,7 @@ def do_exec(args, kwargs):
                     data[variable] = locals_.get(variable, None)
             else:
                 data = locals_.get(kwargs['return'], None)
-            response['data'] = nest.hl_api.serializable(data)
+            response['data'] = nest.serializable(data)
         return response
 
     except Exception as e:
@@ -148,7 +150,7 @@ def do_call(call_name, args=[], kwargs={}):
         log(call_name, f'local call, args={args}, kwargs={kwargs}')
         master_response = call(*args, **kwargs)
 
-    response = [nest.hl_api.serializable(master_response)]
+    response = [nest.serializable(master_response)]
     if mpi_comm is not None:
         log(call_name, 'waiting for response gather')
         response = mpi_comm.gather(response[0], root=0)


### PR DESCRIPTION
This PR fixes some requests error resulted from PR #2114.
I viewed some errors in requests:
- `localhost:5000` -> should show NEST Version but it shows error that `nest` doesn't provide `__version__`.
- `localhost:5000/api` -> showed a truncated list
- `localhost:5000/api/get` -> should show dict of KernelStatus (same as GetKernelStatus) 
                                             but it shows that `nest` doesn't provide `get`.
- `localhost:5000/api/set` -> same error as `localhost:5000/api/get`.
- `localhost:5000/api/<KernelKeywords>` e.g. `resolution` -> same as above.


For now, I fixed this bug by extra importing nest in hl_api_server.

Beat me if I am wrong. :smiley: 
