### PR TITLE
Fix out of bound access on pp_pop_psc_delta and pulsepacket_generator

### DIFF
--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -229,7 +229,7 @@ ModelsModule::init( SLIInterpreter* )
   kernel().model_manager.register_node_model< parrot_neuron >( "parrot_neuron" );
   kernel().model_manager.register_node_model< parrot_neuron_ps >( "parrot_neuron_ps" );
   kernel().model_manager.register_node_model< pp_psc_delta >( "pp_psc_delta" );
-  kernel().model_manager.register_node_model< pp_pop_psc_delta >( "pp_pop_psc_delta" );
+  kernel().model_manager.register_node_model< pp_pop_psc_delta >( "pp_pop_psc_delta", /*private_model*/ false, /*deprecation_info*/ "a future version of NEST" );
   kernel().model_manager.register_node_model< gif_psc_exp >( "gif_psc_exp" );
   kernel().model_manager.register_node_model< gif_psc_exp_multisynapse >( "gif_psc_exp_multisynapse" );
   kernel().model_manager.register_node_model< glif_psc >( "glif_psc" );

--- a/models/modelsmodule.cpp
+++ b/models/modelsmodule.cpp
@@ -229,7 +229,8 @@ ModelsModule::init( SLIInterpreter* )
   kernel().model_manager.register_node_model< parrot_neuron >( "parrot_neuron" );
   kernel().model_manager.register_node_model< parrot_neuron_ps >( "parrot_neuron_ps" );
   kernel().model_manager.register_node_model< pp_psc_delta >( "pp_psc_delta" );
-  kernel().model_manager.register_node_model< pp_pop_psc_delta >( "pp_pop_psc_delta", /*private_model*/ false, /*deprecation_info*/ "a future version of NEST" );
+  kernel().model_manager.register_node_model< pp_pop_psc_delta >(
+    "pp_pop_psc_delta", /*private_model*/ false, /*deprecation_info*/ "a future version of NEST" );
   kernel().model_manager.register_node_model< gif_psc_exp >( "gif_psc_exp" );
   kernel().model_manager.register_node_model< gif_psc_exp_multisynapse >( "gif_psc_exp_multisynapse" );
   kernel().model_manager.register_node_model< glif_psc >( "glif_psc" );

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -296,7 +296,7 @@ nest::pp_pop_psc_delta::calibrate()
       temp = 0;
     }
 
-    for ( int j = 0; j < V_.len_eta_; j++ )
+    for ( int j = 0; j < V_.len_eta_ - 1; j++ )
     {
       S_.age_occupations_.push_back( 0 );
       S_.thetas_ages_.push_back( 0 );

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -319,7 +319,7 @@ nest::pp_pop_psc_delta::calibrate()
 void
 nest::pp_pop_psc_delta::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 && ( delay ) from < kernel().connection_manager.get_min_delay() );
+  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
   assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -296,6 +296,7 @@ nest::pp_pop_psc_delta::calibrate()
       temp = 0;
     }
 
+    // Set all except last state vector elements to zero, then fill last element with initial value
     for ( int j = 0; j < V_.len_eta_ - 1; j++ )
     {
       S_.age_occupations_.push_back( 0 );

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -220,7 +220,7 @@ nest::pulsepacket_generator::update( Time const& T, const long from, const long 
     long prev_spike = B_.spiketimes_.front();
     B_.spiketimes_.pop_front();
 
-    if ( n_spikes > 0 and not B_.spiketimes_.empty() and prev_spike != B_.spiketimes_.front() )
+    if ( n_spikes > 0 and ( B_.spiketimes_.empty() or prev_spike != B_.spiketimes_.front() ) )
     {
       SpikeEvent se;
       se.set_multiplicity( n_spikes );

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -78,7 +78,7 @@ nest::pulsepacket_generator::Parameters_::set( const DictionaryDatum& d, pulsepa
   // We cannot use a single line here since short-circuiting may stop evaluation
   // prematurely. Therefore, neednewpulse must be second arg on second line.
   bool neednewpulse = updateValueParam< long >( d, names::activity, a_, node );
-  neednewpulse = updateValueParam< double >( d, names::sdev, sdev_, node ) || neednewpulse;
+  neednewpulse = updateValueParam< double >( d, names::sdev, sdev_, node ) or neednewpulse;
   if ( a_ < 0 )
   {
     throw BadProperty( "The activity cannot be negative." );
@@ -89,7 +89,7 @@ nest::pulsepacket_generator::Parameters_::set( const DictionaryDatum& d, pulsepa
   }
 
 
-  if ( updateValue< std::vector< double > >( d, "pulse_times", pulse_times_ ) || neednewpulse )
+  if ( updateValue< std::vector< double > >( d, "pulse_times", pulse_times_ ) or neednewpulse )
   {
     std::sort( pulse_times_.begin(), pulse_times_.end() );
     ppg.B_.spiketimes_.clear();
@@ -152,7 +152,7 @@ nest::pulsepacket_generator::calibrate()
   // determine pulse-center times that lie within
   // a window sdev*sdev_tolerance around the current time
   while (
-    V_.stop_center_idx_ < P_.pulse_times_.size() && P_.pulse_times_.at( V_.stop_center_idx_ ) - now <= V_.tolerance )
+    V_.stop_center_idx_ < P_.pulse_times_.size() and P_.pulse_times_.at( V_.stop_center_idx_ ) - now <= V_.tolerance )
   {
     if ( std::abs( P_.pulse_times_.at( V_.stop_center_idx_ ) - now ) > V_.tolerance )
     {
@@ -179,7 +179,7 @@ nest::pulsepacket_generator::update( Time const& T, const long from, const long 
   if ( V_.stop_center_idx_ < P_.pulse_times_.size() )
   {
     while ( V_.stop_center_idx_ < P_.pulse_times_.size()
-      && ( Time( Time::ms( P_.pulse_times_.at( V_.stop_center_idx_ ) ) ) - T ).get_ms() <= V_.tolerance )
+      and ( Time( Time::ms( P_.pulse_times_.at( V_.stop_center_idx_ ) ) ) - T ).get_ms() <= V_.tolerance )
     {
       V_.stop_center_idx_++;
     }
@@ -214,13 +214,13 @@ nest::pulsepacket_generator::update( Time const& T, const long from, const long 
 
   // Since we have an ordered list of spiketimes,
   // we can compute the histogram on the fly.
-  while ( not B_.spiketimes_.empty() && B_.spiketimes_.front() < ( T.get_steps() + to ) )
+  while ( not B_.spiketimes_.empty() and B_.spiketimes_.front() < ( T.get_steps() + to ) )
   {
     n_spikes++;
     long prev_spike = B_.spiketimes_.front();
     B_.spiketimes_.pop_front();
 
-    if ( n_spikes > 0 && ( not B_.spiketimes_.empty() && prev_spike != B_.spiketimes_.front() ) )
+    if ( n_spikes > 0 and not B_.spiketimes_.empty() and prev_spike != B_.spiketimes_.front() )
     {
       SpikeEvent se;
       se.set_multiplicity( n_spikes );

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -220,7 +220,7 @@ nest::pulsepacket_generator::update( Time const& T, const long from, const long 
     long prev_spike = B_.spiketimes_.front();
     B_.spiketimes_.pop_front();
 
-    if ( n_spikes > 0 && prev_spike != B_.spiketimes_.front() )
+    if ( n_spikes > 0 && ( not B_.spiketimes_.empty() && prev_spike != B_.spiketimes_.front() ) )
     {
       SpikeEvent se;
       se.set_multiplicity( n_spikes );

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -70,7 +70,9 @@ __all__ = [
 _deprecation_warning = {'deprecated_model': {'deprecation_issued': False,
                                              'replacement': 'replacement_mod'},
                         'iaf_psc_alpha_canon': {'deprecation_issued': False,
-                                                'replacement': 'iaf_psc_alpha_ps'}}
+                                                'replacement': 'iaf_psc_alpha_ps'},
+                        'pp_pop_psc_delta': {'deprecation_issued': False,
+                                             'replacement': 'gif_pop_psc_exp'}}
 
 
 def format_Warning(message, category, filename, lineno, line=None):


### PR DESCRIPTION
This fix part of #2101 

Installcheck with `-D_GLIBCXX_ASSERTIONS` flag reported out of bound access in pp_pop_psc_delta and pulsepacket_generator (see #2101)

-pp_pop_psc_delta case:
calibration in pp_pop_psc_delta created rhos_ages_ vector 1 unit larger than eta_kernel_ vector.
This caused theta_ages_ vector to be created 1 unit smaller than rhos_ages_ vector in line 348.
This causes out of bound access of theta_ages_ vector in the loop in line 361.

-pulsepacket_generator case:
line 223 was accessing the first element of an empty deque (spiketimes_) due to pop_front in line 221.
This was fixed by checking if spiketimes_ is not empty first (same as line 217)