### PR TITLE
Fix access of first element of an empty vector in pynestkernel

### DIFF
--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -620,7 +620,9 @@ cdef inline object sli_vector_to_object(sli_vector_ptr_t dat, vector_value_t _ =
     else:
         raise NESTErrors.PyNESTError("unsupported specialization")
 
-    memcpy(array_data, &vector_ptr.front(), vector_ptr.size() * sizeof(vector_value_t))
+    # skip when vector_ptr points to an ampty vector
+    if vector_ptr.size() > 0:
+        memcpy(array_data, &vector_ptr.front(), vector_ptr.size() * sizeof(vector_value_t))
 
     if HAVE_NUMPY:
         if vector_ptr.size() > 0:

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -620,7 +620,7 @@ cdef inline object sli_vector_to_object(sli_vector_ptr_t dat, vector_value_t _ =
     else:
         raise NESTErrors.PyNESTError("unsupported specialization")
 
-    # skip when vector_ptr points to an ampty vector
+    # skip when vector_ptr points to an empty vector
     if vector_ptr.size() > 0:
         memcpy(array_data, &vector_ptr.front(), vector_ptr.size() * sizeof(vector_value_t))
 

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -99,7 +99,7 @@ fi
 
 if test "${PYTHON}"; then
       TIME_LIMIT=120  # seconds, for each of the Python tests
-      PYTEST_VERSION="$(${PYTHON} -m pytest --version --timeout ${TIME_LIMIT} --numprocesses=auto 2>&1)" || {
+      PYTEST_VERSION="$(${PYTHON} -m pytest --version --timeout ${TIME_LIMIT} --numprocesses=1 2>&1)" || {
         echo "Error: PyNEST testing requested, but 'pytest' cannot be run."
         echo "       Testing also requires the 'pytest-xdist' and 'pytest-timeout' extensions."
         exit 1
@@ -471,7 +471,7 @@ if test "${PYTHON}"; then
     
     # Run all tests except those in the mpi and non_concurrent subdirectories
     XUNIT_FILE="${REPORTDIR}/${XUNIT_NAME}.xml"
-    "${PYTHON}" -m pytest --verbose --timeout $TIME_LIMIT --junit-xml="${XUNIT_FILE}" --numprocesses=auto \
+    "${PYTHON}" -m pytest --verbose --timeout $TIME_LIMIT --junit-xml="${XUNIT_FILE}" --numprocesses=1 \
           --ignore="${PYNEST_TEST_DIR}/mpi" --ignore="${PYNEST_TEST_DIR}/non_concurrent" \
           "${PYNEST_TEST_DIR}" 2>&1 | tee -a "${TEST_LOGFILE}" 
 


### PR DESCRIPTION
This PR fix out of bound access in pynestkernel, reported in #2101.
With this fix, the two pynest examples (recording_demo.py and balancedneuron.py) reported in #2101 now succeed.