### PR TITLE
Warned about the removal of `nest.hl_api`

### DIFF
--- a/doc/userdoc/release_notes/v3.1/index.rst
+++ b/doc/userdoc/release_notes/v3.1/index.rst
@@ -64,3 +64,6 @@ Deprecation information
 * Model ``pp_pop_psc_delta`` has been deprecated since 2016 and
   will be removed in NEST 3.2. Please use model :doc:`gif_pop_psc_exp <gif_pop_psc_exp>`
   instead.
+* The `nest.hl_api` namespace contained the same members as `nest`
+  and is being removed in NEST 3.2. All imports from `nest.hl_api`
+  can be replaced by imports from `nest`.


### PR DESCRIPTION
#2135 removes the `nest.hl_api` namespace and we wouldn't want to upset our unicorn population so I added a note to the release notes.
![image](https://user-images.githubusercontent.com/28923979/133122191-8f09853e-bffb-46e1-8fc9-3e93fd1b7da0.png)
