### PR TITLE
Fix container access in corner cases and add _GLIBCXX_ASSERTIONS checks to all test configurations

### DIFF
--- a/extras/ci_build.sh
+++ b/extras/ci_build.sh
@@ -155,14 +155,14 @@ xPYTHON=0
 xREADLINE=0
 xSIONLIB=0
 
-CXX_FLAGS="-pedantic -Wextra -Wno-unknown-pragmas"
+CXX_FLAGS="-pedantic -Wextra -Wno-unknown-pragmas -D_GLIBCXX_ASSERTIONS"
 
 if [ "$xNEST_BUILD_TYPE" = "OPENMP_ONLY" ]; then
     xGSL=1
     xLIBBOOST=1
     xLTDL=1
     xOPENMP=1
-    CXX_FLAGS="-pedantic -Wextra"
+    CXX_FLAGS="-pedantic -Wextra -D_GLIBCXX_ASSERTIONS"
 fi
 
 if [ "$xNEST_BUILD_TYPE" = "MPI_ONLY" ]; then
@@ -183,7 +183,7 @@ if [ "$xNEST_BUILD_TYPE" = "FULL" ]; then
     xPYTHON=1
     xREADLINE=1
     xSIONLIB=1
-    CXX_FLAGS="-pedantic -Wextra"
+    CXX_FLAGS="-pedantic -Wextra -D_GLIBCXX_ASSERTIONS"
 fi
 
 if [ "$xNEST_BUILD_TYPE" = "FULL_NO_EXTERNAL_FEATURES" ]; then

--- a/libnestutil/block_vector.h
+++ b/libnestutil/block_vector.h
@@ -62,7 +62,8 @@ private:
   template < typename cv_value_type_ >
   using iter_ = bv_iterator< value_type_, cv_value_type_&, cv_value_type_* >;
 
-  const BlockVector< value_type_ >* block_vector_; //!< BlockVector to which this iterator points
+  //! BlockVector to which this iterator points
+  const BlockVector< value_type_ >* block_vector_;
   //! Iterator for the current block in the blockmap
   typename std::vector< std::vector< value_type_ > >::const_iterator block_vector_it_;
   //! Iterator pointing to the current element in the current block.

--- a/libnestutil/block_vector.h
+++ b/libnestutil/block_vector.h
@@ -328,6 +328,7 @@ inline BlockVector< value_type_ >::BlockVector( size_t n )
   {
     blockmap_.emplace_back( max_block_size );
   }
+  finish_ = begin(); // Because the blockmap has changed we need to recreate the iterator
   finish_ += n;
 }
 

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -314,7 +314,7 @@ nest::MPIManager::communicate( std::vector< long >& local_nodes, std::vector< lo
     displacements.at( i ) = displacements.at( i - 1 ) + num_nodes_per_rank.at( i - 1 );
   }
 
-  MPI_Allgatherv( &local_nodes[ 0 ],
+  MPI_Allgatherv( &( *local_nodes.begin() ),
     local_nodes.size(),
     MPI_Type< long >::type,
     &global_nodes[ 0 ],

--- a/nestkernel/mpi_manager_impl.h
+++ b/nestkernel/mpi_manager_impl.h
@@ -78,7 +78,7 @@ nest::MPIManager::communicate_Allgatherv( std::vector< T >& send_buffer,
   std::vector< int >& recv_counts )
 {
   // attempt Allgather
-  MPI_Allgatherv( &send_buffer[ 0 ],
+  MPI_Allgatherv( &( *send_buffer.begin() ),
     send_buffer.size(),
     MPI_Type< T >::type,
     &recv_buffer[ 0 ],


### PR DESCRIPTION
Partial fix of #2101, fixing the `BlockVector` iterator.

As reported in #2101, some C++ tests fail when compiling with `-D_GLIBCXX_ASSERTIONS`. The tests fail because iteration of  a `BlockVector` uses an index to keep track of the current block. When the iterator goes past the first or last block in the `BlockVector`, it then tries to access a non-existent block. See for example this line in `bv_iterator::operator--()`:
https://github.com/nest/nest-simulator/blob/bb9fab8a3a8796c03d08435815494b9397973107/libnestutil/block_vector.h#L614

This PR refactors the `BlockVector` iterator, `bv_iterator`, to not use an index, `block_index_`, but an iterator to keep track of which block `bv_iterator` is in.
