### PR TITLE
Remove erroneous check in stimulation device base class

### DIFF
--- a/nestkernel/stimulation_device.cpp
+++ b/nestkernel/stimulation_device.cpp
@@ -123,10 +123,6 @@ void
 nest::StimulationDevice::set_status( const DictionaryDatum& d )
 {
 
-  if ( kernel().simulation_manager.has_been_prepared() )
-  {
-    throw BadProperty( "Input parameters cannot be changed while inside a Prepare/Run/Cleanup context." );
-  }
   Parameters_ ptmp = P_; // temporary copy in case of errors
   ptmp.set( d );         // throws if BadProperty
 


### PR DESCRIPTION
This PR solves issue 83 from EBRAINS-cosim. A control had been added by mistake to the stimulation devices during the integration of the current version of NEST I/O. This control did not allow changing the status of the device once it had been initialized. 