### PR TITLE
Tidy up SLI startup, especially opening of sli-init.sli.

### DIFF
--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -30,6 +30,9 @@
 // Generated includes:
 #include "config.h"
 
+// Includes from libnestutil:
+#include "compose.hpp"
+
 // Includes from sli:
 #include "arraydatum.h"
 #include "booldatum.h"
@@ -55,32 +58,8 @@ extern char** environ;
 2.  Locate startup file and prepare the start symbol
     to run the startup script.
 3.  If startup-script cannot be located, issue meaningful diagnostic
-    messages and exit gracefuly.
+    messages and exit gracefully.
 */
-
-/**
- * Returns true, if the interpreter startup file sli-init.sli
- * is in the supplied path and false otherwise.
- */
-bool
-SLIStartup::checkpath( std::string const& path, std::string& result ) const
-{
-  const std::string fullpath = path + slilibpath;
-  const std::string fullname = fullpath + "/" + startupfilename;
-
-  std::ifstream in( fullname.c_str() );
-
-  if ( in.good() )
-  {
-    result = fullname;
-    return true;
-  }
-  else
-  {
-    result.erase();
-    return false;
-  }
-}
 
 
 /** @BeginDocumentation
@@ -154,58 +133,12 @@ SLIStartup::GetenvFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 }
 
-/**
- * Checks if the environment variable envvar contains a directory. If yes, the
- * path is returned, else an empty string is returned.
- */
-std::string
-SLIStartup::checkenvpath( std::string const& envvar, SLIInterpreter* i, std::string defaultval = "" ) const
-{
-  const std::string envpath = getenv( envvar );
-
-  if ( envpath != "" )
-  {
-    DIR* dirptr = opendir( envpath.c_str() );
-    if ( dirptr != NULL )
-    {
-      closedir( dirptr );
-      return envpath;
-    }
-    else
-    {
-      std::string msg;
-      switch ( errno )
-      {
-      case ENOTDIR:
-        msg = String::compose( "'%1' is not a directory.", envpath );
-        break;
-      case ENOENT:
-        msg = String::compose( "Directory '%1' does not exist.", envpath );
-        break;
-      default:
-        msg = String::compose( "Errno %1 received when trying to open '%2'", errno, envpath );
-        break;
-      }
-
-      i->message( SLIInterpreter::M_ERROR, "SLIStartup", String::compose( "%1 is not usable:", envvar ).c_str() );
-      i->message( SLIInterpreter::M_ERROR, "SLIStartup", msg.c_str() );
-      if ( defaultval != "" )
-      {
-        i->message(
-          SLIInterpreter::M_ERROR, "SLIStartup", String::compose( "I'm using the default: %1", defaultval ).c_str() );
-      }
-    }
-  }
-  return std::string();
-}
-
 
 SLIStartup::SLIStartup( int argc, char** argv )
-  : startupfilename( "sli-init.sli" )
-  , slilibpath( "/sli" )
-  , slilibdir( NEST_INSTALL_PREFIX "/" NEST_INSTALL_DATADIR )
-  , slidocdir( NEST_INSTALL_PREFIX "/" NEST_INSTALL_DOCDIR )
-  , sliprefix( NEST_INSTALL_PREFIX )
+  : sliprefix( NEST_INSTALL_PREFIX )
+  , slilibdir( sliprefix + "/" + NEST_INSTALL_DATADIR )
+  , slidocdir( sliprefix + "/" + NEST_INSTALL_DOCDIR )
+  , startupfile( slilibdir + "/sli/sli-init.sli" )
   , verbosity_( SLIInterpreter::M_INFO ) // default verbosity level
   , debug_( false )
   , argv_name( "argv" )
@@ -255,7 +188,7 @@ SLIStartup::SLIStartup( int argc, char** argv )
   , exitcode_unknownerror_name( "unknownerror" )
   , environment_name( "environment" )
 {
-  ArrayDatum ad;
+  ArrayDatum args_array;
 
   // argv[0] is the name of the program that was given to the shell.
   // This name must be given to SLI, otherwise initialization fails.
@@ -266,7 +199,7 @@ SLIStartup::SLIStartup( int argc, char** argv )
   for ( int i = 0; i < argc; ++i )
   {
     StringDatum* sd = new StringDatum( argv[ i ] );
-    ad.push_back( Token( sd ) );
+    args_array.push_back( Token( sd ) );
 
     if ( *sd == "-d" || *sd == "--debug" )
     {
@@ -274,7 +207,6 @@ SLIStartup::SLIStartup( int argc, char** argv )
       verbosity_ = SLIInterpreter::M_ALL; // make the interpreter verbose.
       continue;
     }
-
     if ( *sd == "--verbosity=ALL" )
     {
       verbosity_ = SLIInterpreter::M_ALL;
@@ -321,7 +253,7 @@ SLIStartup::SLIStartup( int argc, char** argv )
       continue;
     }
   }
-  targs = ad;
+  commandline_args_ = args_array;
 }
 
 void
@@ -330,36 +262,12 @@ SLIStartup::init( SLIInterpreter* i )
   i->verbosity( verbosity_ );
 
   i->createcommand( getenv_name, &getenvfunction );
-  std::string fname;
-
-  // check for sli-init.sli
-  if ( not checkpath( slilibdir, fname ) )
-  {
-    i->message( SLIInterpreter::M_FATAL, "SLIStartup", "Your NEST installation seems broken. \n" );
-    i->message( SLIInterpreter::M_FATAL, "SLIStartup", "I could not find the startup file that" );
-    i->message( SLIInterpreter::M_FATAL, "SLIStartup", ( std::string( "should have been in " ) + slilibdir ).c_str() );
-    i->message( SLIInterpreter::M_FATAL, "SLIStartup", "Please re-build NEST and try again." );
-    i->message( SLIInterpreter::M_FATAL, "SLIStartup", "Bye." );
-
-    // We cannot call i->terminate() here because the interpreter is not
-    // fully configured yet. If running PyNEST, the Python process will
-    // terminate.
-    std::exit( EXITCODE_FATAL );
-  }
-  else
-  {
-    std::string fname_msg = std::string( "Initialising from file: " ) + fname;
-    i->message( SLIInterpreter::M_DEBUG, "SLIStartup", fname_msg.c_str() );
-  }
-
-  Token cin_token( new XIstreamDatum( std::cin ) );
-  Token start_token( new NameDatum( start_name ) );
 
   DictionaryDatum statusdict( new Dictionary() );
   i->statusdict = &( *statusdict );
   assert( statusdict.valid() );
 
-  statusdict->insert_move( argv_name, targs );
+  statusdict->insert_move( argv_name, commandline_args_ );
   statusdict->insert( version_name, Token( new StringDatum( NEST_VERSION_STRING ) ) );
   statusdict->insert( exitcode_name, Token( new IntegerDatum( EXIT_SUCCESS ) ) );
   statusdict->insert( prgbuilt_name, Token( new StringDatum( String::compose( "%1 %2", __DATE__, __TIME__ ) ) ) );
@@ -371,42 +279,15 @@ SLIStartup::init( SLIInterpreter* i )
   statusdict->insert( hostvendor_name, Token( new StringDatum( NEST_HOSTVENDOR ) ) );
   statusdict->insert( hostcpu_name, Token( new StringDatum( NEST_HOSTCPU ) ) );
 
-  // expose platform model for code branching without assuming
-  // configure leads to a unique setting
-  std::string platform;
+  // Value other than default were defined for BlueGene models. Keep for backward compatibility.
+  statusdict->insert( platform_name, Token( new StringDatum( "default" ) ) );
 
-#ifdef IS_BLUEGENE_L
-  platform += "bg/l";
-#endif
-
-#ifdef IS_BLUEGENE_P
-  platform += "bg/p";
-#endif
-
-#ifdef IS_BLUEGENE_Q
-  platform += "bg/q";
-#endif
-
-  if ( platform == "" )
-  {
-    platform = "default";
-  }
-
-  statusdict->insert( platform_name, Token( new StringDatum( platform ) ) );
-
-  // expose threading model without assuming configure leads to a
-  // unique setting
-  std::string threading;
 
 #ifdef _OPENMP
-  threading += "openmp";
+  statusdict->insert( threading_name, Token( new StringDatum( "openmp" ) ) );
+#else
+  statusdict->insert( threading_name, Token( new StringDatum( "no" ) ) );
 #endif
-  if ( threading == "" )
-  {
-    threading = "no";
-  }
-
-  statusdict->insert( threading_name, Token( new StringDatum( threading ) ) );
 
 #ifdef HAVE_MPI
   statusdict->insert( have_mpi_name, Token( new BoolDatum( true ) ) );
@@ -506,14 +387,33 @@ SLIStartup::init( SLIInterpreter* i )
 
   i->def( statusdict_name, statusdict );
 
-  if ( not fname.empty() )
-  {
-    std::ifstream* input = new std::ifstream( fname.c_str() );
-    Token input_token( new XIstreamDatum( input ) );
 
-    i->EStack.push_move( input_token );
-    i->EStack.push( i->baselookup( i->iparse_name ) );
+  // Check that startup file is readable before pushing it to stack.
+  char c;
+  std::ifstream su_test( startupfile.c_str() );
+  su_test.get( c );
+  if ( not su_test.good() )
+  {
+    i->message( SLIInterpreter::M_FATAL,
+      "SLIStartup",
+      String::compose(
+        "SLI initialisation file not found at %1.\n"
+        "Please check your NEST installation.",
+        startupfile ).c_str() );
+
+    // We cannot call i->terminate() here because the interpreter is not fully configured yet.
+    // If running PyNEST, the Python process will terminate.
+    std::exit( EXITCODE_FATAL );
   }
+
+  i->message(
+    SLIInterpreter::M_DEBUG, "SLIStartup", String::compose( "Initialising from file: %1", startupfile ).c_str() );
+
+  // Push open sli-init.sli stream and Parse command to stack
+  std::ifstream* input = new std::ifstream( startupfile.c_str() );
+  Token input_token( new XIstreamDatum( input ) );
+  i->EStack.push_move( input_token );
+  i->EStack.push( i->baselookup( i->iparse_name ) );
 
   // If we start with debug option, we set the debugging mode, but disable
   // stepmode. This way, the debugger is entered only on error.

--- a/sli/slistartup.h
+++ b/sli/slistartup.h
@@ -59,18 +59,15 @@
 
 class SLIStartup : public SLIModule
 {
-  const std::string startupfilename;
-  const std::string slilibpath;
-  std::string slilibdir;
-  std::string slidocdir;
-  std::string sliprefix;
+  const std::string sliprefix;
+  const std::string slilibdir;
+  const std::string slidocdir;
+  const std::string startupfile;
 
-  std::string locateSLIInstallationPath( void );
-  bool checkpath( std::string const&, std::string& ) const;
+  std::string find_startup_file( const std::string& ) const;
   std::string getenv( const std::string& ) const;
-  std::string checkenvpath( std::string const&, SLIInterpreter*, std::string ) const;
 
-  Token targs;
+  Token commandline_args_;
   int verbosity_;
   bool debug_;
 


### PR DESCRIPTION
This PR tidies `slistartup.[h,cc]`, removing unused code, renaming some variables and in particular making the check for the `sli-init.sli` file more robust by not only checking for its existence, but also for readability. This might address confusing problems observed by @steffengraber during container construction.