### PR TITLE
Fix version warning in documentation

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -184,7 +184,7 @@ if os.environ.get("READTHEDOCS") == "True":
                      You can change versions on the bottom left of the screen."
         rst_epilog = ""
 else:
-    version = "3.1"
+    version = "latest"
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
Problem:
The documentation contains a warning prologue that should only appear in the "latest" version.

Solution: 
Readthedocs contains an environment variable "READTHEDOCS_VERSION" at build time which contains the version number that is currently being built. Only if this is "latest" the warning is displayed.

Note: for locally built documentation no warning is shown anymore.