### PR TITLE
Use `Development.Module` to be compatible with static Python interpreter

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -392,7 +392,12 @@ function( NEST_PROCESS_WITH_PYTHON )
   elseif ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter and ABI
-    find_package( Python 3.8 REQUIRED Interpreter Development.Module )
+    if ( ${CMAKE_VERSION} VERSION_LESS "3.18.0")
+      find_package( Python 3.8 REQUIRED Interpreter Development )
+      message( WARNING "CMake 3.18+ is recommended for more universal Python bindings. If you encounter missing Python header or library file errors, try upgrading CMake.")
+    else()
+      find_package( Python 3.8 REQUIRED Interpreter Development.Module )
+    endif()
 
     if ( Python_FOUND )
       if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -391,8 +391,8 @@ function( NEST_PROCESS_WITH_PYTHON )
     message( FATAL_ERROR "Python 2 is not supported anymore, please use Python 3 by setting CMake option -Dwith-python=ON." )
   elseif ( ${with-python} STREQUAL "ON" )
 
-    # Localize the Python interpreter and lib/header files
-    find_package( Python 3.8 REQUIRED Interpreter Development )
+    # Localize the Python interpreter and ABI
+    find_package( Python 3.8 REQUIRED Interpreter Development.Module )
 
     if ( Python_FOUND )
       if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )


### PR DESCRIPTION
The current CMake build requires Python's shared library and header files to be available (`libpython.so` and `Python.h`). These aren't always available, and appearantly NEST builds perfectly fine without them. 

Let's drop this requirement (one line change from `find_package(Python3 Development)` to `Development.Module`) so that NEST can also build and be deployed to environments where Python is built in static mode.

Many non-Ubuntu non-system Python installations do not have these shared libraries. The most relevant use cases where we bump into this issue is on lightweight containers and the manylinux wheel images where these files have been [intentionally removed](https://github.com/pypa/manylinux/issues/255#issuecomment-450761634).

(And another one, often relevant to me and 15% of Python users, is that `pyenv` also builds without shared libraries ;) )