### PR TITLE
Fall back to `Development` Python module in case of any errors

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -403,6 +403,7 @@ function( NEST_PROCESS_WITH_PYTHON )
       message( WARNING "${PYABI_WARN}")
     else()
       find_package( Python 3.8 REQUIRED Interpreter Development.Module )
+    endif()
 
     if ( Python_FOUND )
       if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -392,11 +392,9 @@ function( NEST_PROCESS_WITH_PYTHON )
   elseif ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter and ABI
-    if ( ${CMAKE_VERSION} VERSION_LESS "3.18.0")
+    find_package( Python 3.8 Interpreter Development.Module )
+    if ( NOT Python_FOUND )
       find_package( Python 3.8 REQUIRED Interpreter Development )
-      message( WARNING "CMake 3.18+ is recommended for more universal Python bindings. If you encounter missing Python header or library file errors, try upgrading CMake.")
-    else()
-      find_package( Python 3.8 REQUIRED Interpreter Development.Module )
     endif()
 
     if ( Python_FOUND )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -392,7 +392,7 @@ function( NEST_PROCESS_WITH_PYTHON )
   elseif ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter and ABI
-    find_package( Python 3.8 Interpreter Development.Module )
+    find_package( Python 3.8 COMPONENTS Interpreter Development.Module )
     if ( NOT Python_FOUND )
       find_package( Python 3.8 REQUIRED Interpreter Development )
       string( CONCAT PYABI_WARN "Could not locate Python ABI"

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -403,6 +403,8 @@ function( NEST_PROCESS_WITH_PYTHON )
       message( WARNING "${PYABI_WARN}")
     else()
       find_package( Python 3.8 REQUIRED Interpreter Development.Module )
+
+    if ( Python_FOUND )
       if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
         execute_process( COMMAND "${Python_EXECUTABLE}" "-c"
           "import sys, os; print(int(bool(os.environ.get('CONDA_DEFAULT_ENV', False)) or (sys.prefix != sys.base_prefix)))"

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -395,6 +395,13 @@ function( NEST_PROCESS_WITH_PYTHON )
     find_package( Python 3.8 Interpreter Development.Module )
     if ( NOT Python_FOUND )
       find_package( Python 3.8 REQUIRED Interpreter Development )
+      string( CONCAT PYABI_WARN "Could not locate Python ABI"
+        ", using shared libraries and header file instead."
+        " If you encounter missing `libpython.so` or `Python.h` file errors"
+        " please verify that CMake is up-to-date (3.18+) or that Python"
+        " development packages are installed."
+      )
+      message( WARNING "$PYABI_WARN")
     endif()
 
     if ( Python_FOUND )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -401,9 +401,8 @@ function( NEST_PROCESS_WITH_PYTHON )
         " is up-to-date (3.18+)."
       )
       message( WARNING "${PYABI_WARN}")
-    endif()
-
-    if ( Python_FOUND )
+    else()
+      find_package( Python 3.8 REQUIRED Interpreter Development.Module )
       if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
         execute_process( COMMAND "${Python_EXECUTABLE}" "-c"
           "import sys, os; print(int(bool(os.environ.get('CONDA_DEFAULT_ENV', False)) or (sys.prefix != sys.base_prefix)))"

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -392,16 +392,15 @@ function( NEST_PROCESS_WITH_PYTHON )
   elseif ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter and ABI
-    find_package( Python 3.8 COMPONENTS Interpreter Development.Module )
+    find_package( Python 3.8 QUIET COMPONENTS Interpreter Development.Module )
     if ( NOT Python_FOUND )
       find_package( Python 3.8 REQUIRED Interpreter Development )
       string( CONCAT PYABI_WARN "Could not locate Python ABI"
         ", using shared libraries and header file instead."
-        " If you encounter missing `libpython.so` or `Python.h` file errors"
-        " please verify that CMake is up-to-date (3.18+) or that Python"
-        " development packages are installed."
+        " Please clear your CMake cache and build folder and verify that CMake"
+        " is up-to-date (3.18+)."
       )
-      message( WARNING "$PYABI_WARN")
+      message( WARNING "${PYABI_WARN}")
     endif()
 
     if ( Python_FOUND )


### PR DESCRIPTION
Fixes #2209 and any other environment in which `Development.Module` might not work, but `Development` would. It was a bit optimistic to hope that only the CMake version would ever be a problem, and this PR makes sure that whatever happens we revert to the default behavior.