### PR TITLE
Add additional reference to Izhikevich model documentation

### DIFF
--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -77,6 +77,13 @@ For all other purposes, it is recommended to use the standard technique for
 forward Euler integration. In this case, ``consistent_integration`` must be set
 to true (default).
 
+Note that the Izhikevich model in NEST differs from the origial publication [1]_.
+The Izhikevich model (as published by the author) has some numerical issues, which the Izhikevich model
+(in the NEST source) does not have. Also, the STDP model used in the original paper does not perfectly
+match the STDP synapse shipped with NEST. For further details see [2]_.
+
+
+
 Parameters
 ++++++++++
 
@@ -98,8 +105,12 @@ The following parameters can be set in the status dictionary.
 References
 ++++++++++
 
-.. [1] Izhikevich EM (2003). Simple model of spiking neurons. IEEE Transactions
+.. [1] Izhikevich EM. (2003). Simple model of spiking neurons. IEEE Transactions
        on Neural Networks, 14:1569-1572. DOI: https://doi.org/10.1109/TNN.2003.820440
+
+.. [2] Pauli R, Weidel P, Kunkel S, Morrison A (2018). Reproducing polychronization: A guide to maximizing
+       the reproducibility of spiking network models. Frontiers in Neuroinformatics, 12.
+       DOI: https://www.frontiersin.org/article/10.3389/fninf.2018.00046
 
 Sends
 +++++

--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -77,12 +77,7 @@ For all other purposes, it is recommended to use the standard technique for
 forward Euler integration. In this case, ``consistent_integration`` must be set
 to true (default).
 
-Note that the Izhikevich model in NEST differs from the origial publication [1]_.
-The Izhikevich model (as published by the author) has some numerical issues, which the Izhikevich model
-(in the NEST source) does not have. Also, the STDP model used in the original paper does not perfectly
-match the STDP synapse shipped with NEST. For further details see [2]_.
-
-
+For a detailed analysis and discussion of the numerical issues in the original publication, see [2]_.
 
 Parameters
 ++++++++++


### PR DESCRIPTION
This PR adds some text to the model doc mentioning differences between NEST and the original author's model. Includes reference to Pauli et al. paper. 2018.

Not sure if this needs a lot more detail in the documentation or if link suffices.

