### PR TITLE
Attribute assignment safeguards for `NestModule` and `SynapseCollection`

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -100,6 +100,7 @@ class NestModule(types.ModuleType):
         _api = list(k for k in self.__dict__ if not k.startswith("_"))
         _api.extend(k for k in dir(type(self)) if not k.startswith("_"))
         self.__all__ = list(set(_api))
+
         # Block setting of unknown attributes
         type(self).__setattr__ = _setattr_error
 
@@ -413,7 +414,6 @@ def _setattr_error(self, attr, val):
             cls_attr.__set__(self, val)
         else:
             raise err
-
 
 
 def _rel_import_star(module, import_module_name):

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -406,6 +406,16 @@ class NestModule(types.ModuleType):
 
 
 def _setattr_error(self, attr, val):
+    """
+    When attributes on the `nest` module instance are set, check if it exists on the
+    module type and try to call `__set__` on them. Without this explicit check `nest`s
+    `__setattr__` shadows class attributes and descriptors (such as `KernelAttribute`s).
+
+    Once this function exists on the `nest` module, new attributes can only be added using
+    `__dict__` manipulation. It is added onto the module at the end of `__init__`,
+    "freezing" the module.
+    """
+
     err = AttributeError(f"can't set attribute '{attr}' on module 'nest'")
     try:
         cls_attr = getattr(type(self), attr)

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -94,6 +94,9 @@ class NestModule(types.ModuleType):
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
         type(self).spatial = _lazy_module_property("spatial")
+        type(self).raster_plot = _lazy_module_property("raster_plot")
+        type(self).visualization = _lazy_module_property("visualization")
+        type(self).voltage_trace = _lazy_module_property("voltage_trace")
 
         self.__version__ = ll_api.sli_func("statusdict /version get")
         # Finalize the nest module with a public API.

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -403,7 +403,16 @@ class NestModule(types.ModuleType):
 
 
 def _setattr_error(self, attr, val):
-    raise AttributeError(f"module 'nest' has no attribute '{attr}'")
+    err = AttributeError(f"can't set attribute '{attr}' on module 'nest'")
+    try:
+        cls_attr = getattr(type(self), attr)
+    except AttributeError:
+        raise err from None
+    else:
+        if hasattr(cls_attr, "__set__"):
+            cls_attr.__set__(self, val)
+        else:
+            raise err
 
 
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -100,6 +100,9 @@ class NestModule(types.ModuleType):
         _api = list(k for k in self.__dict__ if not k.startswith("_"))
         _api.extend(k for k in dir(type(self)) if not k.startswith("_"))
         self.__all__ = list(set(_api))
+        # Block setting of unknown attributes
+        type(self).__setattr__ = _setattr_error
+
 
     def set(self, **kwargs):
         return self.SetKernelStatus(kwargs)
@@ -397,6 +400,11 @@ class NestModule(types.ModuleType):
     _readonly_kernel_attrs = builtins.set(
         k for k, v in vars().items() if isinstance(v, KernelAttribute) and v._readonly
     )
+
+
+def _setattr_error(self, attr, val):
+    raise AttributeError(f"module 'nest' has no attribute '{attr}'")
+
 
 
 def _rel_import_star(module, import_module_name):

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -104,7 +104,6 @@ class NestModule(types.ModuleType):
         # Block setting of unknown attributes
         type(self).__setattr__ = _setattr_error
 
-
     def set(self, **kwargs):
         return self.SetKernelStatus(kwargs)
 

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -715,7 +715,7 @@ class SynapseCollection(object):
     def __setattr__(self, attr, value):
         # `_datum` is the only property of SynapseCollection that should not be
         # interpreted as a property of the model
-        if attr == '_datum' or 'print_full':
+        if attr == '_datum' or attr == 'print_full':
             super().__setattr__(attr, value)
         else:
             self.set({attr: value})

--- a/testsuite/pytests/test_get_set.py
+++ b/testsuite/pytests/test_get_set.py
@@ -54,15 +54,15 @@ class TestNestGetSet(unittest.TestCase):
         kst = nest.get("keep_source_table")
         self.assertEqual(type(nest).keep_source_table._default, kst, "get value not equal to default after ResetKernel")
         self.assertEqual(kst, nest.keep_source_table, 'kernel attribute value not equal to get value')
-        with self.assertRaises(AttributeError, "no AttributeError for unknown attribute"):
+        with self.assertRaises(AttributeError, msg="no AttributeError for unknown attribute"):
             nest.accessAbsolutelyUnknownThingOnNestModule
-        with self.assertRaises(KeyError, "no KeyError for unknown get key"):
+        with self.assertRaises(KeyError, msg="no KeyError for unknown get key"):
             nest.get("accessAbsolutelyUnknownKernelAttribute")
 
     def test_set(self):
-        with self.assertRaises(AttributeError, "arbitrary attribute assignment passed"):
+        with self.assertRaises(AttributeError, msg="arbitrary attribute assignment passed"):
             nest.absolutelyUnknownThingOnNestModule = 5
-        with self.assertRaises(AttributeError, "known attribute assignment passed"):
+        with self.assertRaises(AttributeError, msg="known attribute assignment passed"):
             nest.get = 5
         nest.set(total_num_virtual_procs=2)
         self.assertEqual(2, nest.total_num_virtual_procs, 'set failed')

--- a/testsuite/pytests/test_get_set.py
+++ b/testsuite/pytests/test_get_set.py
@@ -49,19 +49,33 @@ class TestNestGetSet(unittest.TestCase):
         nest.ResetKernel()
 
     def test_get(self):
+        """
+        Test the `nest` module's `.get` function, `KernelAttribute` access and errors on
+        unknown attribute access.
+        """
+
         # TestCase.setUp calls ResetKernel so kernel attributes should be equal to their
-        # defaults. Test will error if there is a problem with the `.get` mechanism.
+        # defaults. Test should also error if there is a problem in general with the
+        # `.get` mechanism.
         kst = nest.get("keep_source_table")
         self.assertEqual(type(nest).keep_source_table._default, kst, "get value not equal to default after ResetKernel")
         self.assertEqual(kst, nest.keep_source_table, 'kernel attribute value not equal to get value')
+        # Getting the value of unknown attributes should error. Should error if there is
+        # a problem with possible `__getattr__` implementations.
         with self.assertRaises(AttributeError, msg="no AttributeError for unknown attribute"):
             nest.accessAbsolutelyUnknownThingOnNestModule
         with self.assertRaises(KeyError, msg="no KeyError for unknown get key"):
             nest.get("accessAbsolutelyUnknownKernelAttribute")
 
     def test_set(self):
+        """
+        Test the `nest` module's `.set` function, `KernelAttribute` assignment and errors
+        on unknown attribute assignment.
+        """
+        # Setting the value of unknown attributes should error. Prevents user errors.
         with self.assertRaises(AttributeError, msg="arbitrary attribute assignment passed"):
             nest.absolutelyUnknownThingOnNestModule = 5
+        # Don't allow non-KA to be replaced on the module.
         with self.assertRaises(AttributeError, msg="known attribute assignment passed"):
             nest.get = 5
         nest.set(total_num_virtual_procs=2)

--- a/testsuite/pytests/test_get_set.py
+++ b/testsuite/pytests/test_get_set.py
@@ -42,6 +42,35 @@ except ImportError:
 
 
 @nest.ll_api.check_stack
+class TestNestGetSet(unittest.TestCase):
+    """nest module get/set tests"""
+
+    def setUp(self):
+        nest.ResetKernel()
+
+    def test_get(self):
+        # TestCase.setUp calls ResetKernel so kernel attributes should be equal to their
+        # defaults. Test will error if there is a problem with the `.get` mechanism.
+        kst = nest.get("keep_source_table")
+        self.assertEqual(type(nest).keep_source_table._default, kst, "get value not equal to default after ResetKernel")
+        self.assertEqual(kst, nest.keep_source_table, 'kernel attribute value not equal to get value')
+        with self.assertRaises(AttributeError, "no AttributeError for unknown attribute"):
+            nest.accessAbsolutelyUnknownThingOnNestModule
+        with self.assertRaises(KeyError, "no KeyError for unknown get key"):
+            nest.get("accessAbsolutelyUnknownKernelAttribute")
+
+    def test_set(self):
+        with self.assertRaises(AttributeError, "arbitrary attribute assignment passed"):
+            nest.absolutelyUnknownThingOnNestModule = 5
+        with self.assertRaises(AttributeError, "known attribute assignment passed"):
+            nest.get = 5
+        nest.set(total_num_virtual_procs=2)
+        self.assertEqual(2, nest.total_num_virtual_procs, 'set failed')
+        nest.total_num_virtual_procs = 3
+        self.assertEqual(3, nest.total_num_virtual_procs, 'kernelattribute set failed')
+
+
+@nest.ll_api.check_stack
 class TestNodeCollectionGetSet(unittest.TestCase):
     """NodeCollection get/set tests"""
 

--- a/testsuite/pytests/test_get_set.py
+++ b/testsuite/pytests/test_get_set.py
@@ -60,7 +60,7 @@ class TestNestGetSet(unittest.TestCase):
         kst = nest.get("keep_source_table")
         self.assertEqual(type(nest).keep_source_table._default, kst, "get value not equal to default after ResetKernel")
         self.assertEqual(kst, nest.keep_source_table, 'kernel attribute value not equal to get value')
-        # Getting the value of unknown attributes should error. Should error if there is
+        # Getting the value of unknown attributes should error. The test should also error if there is
         # a problem with possible `__getattr__` implementations.
         with self.assertRaises(AttributeError, msg="no AttributeError for unknown attribute"):
             nest.accessAbsolutelyUnknownThingOnNestModule


### PR DESCRIPTION
* Settings unknown attributes on nest module raises an AttributError
* Fixed an always-true condition that allowed setting unknown attributes on SynapseCollection.

Closes #2219.

Just 1 remark: while the network or synapse collection is empty, you _can_ set unknown attributes. Any idea why this was implemented, should it remain that way?