### PR TITLE
Removed `object` base from class argument lists

### DIFF
--- a/doc/extractor_userdocs.py
+++ b/doc/extractor_userdocs.py
@@ -470,7 +470,7 @@ def CreateTagIndices(tags, outdir="userdocs/"):
     return indexfiles
 
 
-class JsonWriter(object):
+class JsonWriter:
     """
     Helper class to have a unified data output interface.
     """

--- a/doc/userdoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/userdoc/model_details/aeif_models_implementation.ipynb
@@ -482,7 +482,7 @@
     "    'w': 5., #! must be equal to 5.\n",
     "}\n",
     "\n",
-    "class Params(object):\n",
+    "class Params:\n",
     "    '''\n",
     "    Class giving access to the neuronal\n",
     "    parameters.\n",

--- a/examples/NESTServerClient/NESTServerClient.py
+++ b/examples/NESTServerClient/NESTServerClient.py
@@ -35,7 +35,7 @@ def encode(response):
         raise BadRequest(response.text)
 
 
-class NESTServerClient(object):
+class NESTServerClient:
 
     def __init__(self, host='localhost', port=5000):
         self.url = 'http://{}:{}/'.format(host, port)

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -411,7 +411,7 @@ def lambertwm1(x):
     return sp.lambertw(x, k=-1 if x < 0 else 0).real
 
 
-class Logger(object):
+class Logger:
     """Logger context manager used to properly log memory and timing
     information from network simulations.
 

--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -595,7 +595,7 @@ def get_parameters_hierarchical_addressing(nc, params):
     return result
 
 
-class SuppressedDeprecationWarning(object):
+class SuppressedDeprecationWarning:
     """
     Context manager turning off deprecation warnings for given methods.
 

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -119,7 +119,7 @@ def CreateParameter(parametertype, specs):
     return sli_func('CreateParameter', {parametertype: specs})
 
 
-class NodeCollectionIterator(object):
+class NodeCollectionIterator:
     """
     Iterator class for `NodeCollection`.
 
@@ -145,7 +145,7 @@ class NodeCollectionIterator(object):
         return val
 
 
-class NodeCollection(object):
+class NodeCollection:
     """
     Class for `NodeCollection`.
 
@@ -543,7 +543,7 @@ class NodeCollection(object):
             self.set({attr: value})
 
 
-class SynapseCollectionIterator(object):
+class SynapseCollectionIterator:
     """
     Iterator class for SynapseCollection.
     """
@@ -558,7 +558,7 @@ class SynapseCollectionIterator(object):
         return SynapseCollection(next(self._iter))
 
 
-class SynapseCollection(object):
+class SynapseCollection:
     """
     Class for Connections.
 
@@ -899,7 +899,7 @@ class SynapseCollection(object):
         sr('Transpose { arrayload pop SetStatus } forall')
 
 
-class CollocatedSynapses(object):
+class CollocatedSynapses:
     """
     Class for collocated synapse specifications.
 
@@ -929,7 +929,7 @@ class CollocatedSynapses(object):
         return len(self.syn_specs)
 
 
-class Mask(object):
+class Mask:
     """
     Class for spatial masks.
 

--- a/pynest/nest/spatial/hl_api_spatial.py
+++ b/pynest/nest/spatial/hl_api_spatial.py
@@ -86,7 +86,7 @@ class DistanceParameter(Parameter):
 distance = DistanceParameter()
 
 
-class pos(object):
+class pos:
     """
     Position of node in a specific dimension.
 
@@ -116,7 +116,7 @@ class pos(object):
         return CreateParameter('position', {'dimension': dimension})
 
 
-class source_pos(object):
+class source_pos:
     """
     Position of the source node in a specific dimension.
 
@@ -147,7 +147,7 @@ class source_pos(object):
                                {'dimension': dimension, 'synaptic_endpoint': 1})
 
 
-class target_pos(object):
+class target_pos:
     """
     Position of the target node in a specific dimension.
 
@@ -178,7 +178,7 @@ class target_pos(object):
                                {'dimension': dimension, 'synaptic_endpoint': 2})
 
 
-class grid(object):
+class grid:
     """
     Defines grid-based positions for nodes.
 
@@ -201,7 +201,7 @@ class grid(object):
         self.edge_wrap = edge_wrap
 
 
-class free(object):
+class free:
     """
     Defines positions for nodes based on a list of positions, or a Parameter object.
 

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -81,7 +81,7 @@ except ImportError:
     pass
 
 
-cdef class SLIDatum(object):
+cdef class SLIDatum:
 
     cdef Datum* thisptr
     cdef readonly unicode dtype
@@ -109,7 +109,7 @@ cdef class SLIDatum(object):
         self.thisptr = dat
 
 
-cdef class SLILiteral(object):
+cdef class SLILiteral:
 
     cdef readonly object name
     cdef object _hash
@@ -152,7 +152,7 @@ cdef class SLILiteral(object):
             return self.name >= obj
 
 
-cdef class NESTEngine(object):
+cdef class NESTEngine:
 
     cdef SLIInterpreter* pEngine
 

--- a/testsuite/pytests/test_regression_issue-1034.py
+++ b/testsuite/pytests/test_regression_issue-1034.py
@@ -30,7 +30,7 @@ import scipy.stats
 import unittest
 
 
-class PostTraceTester(object):
+class PostTraceTester:
     '''Test that postsynaptic trace values returned from NEST are consistent
     with reference values generated in Python.
 

--- a/testsuite/pytests/test_sp/test_growth_curves.py
+++ b/testsuite/pytests/test_sp/test_growth_curves.py
@@ -31,7 +31,7 @@ import sys
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
-class SynapticElementIntegrator(object):
+class SynapticElementIntegrator:
     """
     Generic class which describes how to compute the number of
     Synaptic Element based on Ca value

--- a/testsuite/pytests/test_spatial/test_spatial_distributions.py
+++ b/testsuite/pytests/test_spatial/test_spatial_distributions.py
@@ -63,7 +63,7 @@ P_MIN = 0.1
 SEED = 1234567
 
 
-class SpatialTester(object):
+class SpatialTester:
     """Tests for spatially structured networks."""
 
     def __init__(self, seed, dim, L, N, spatial_distribution, distribution_params=None,


### PR DESCRIPTION
In Python 3 all classes have `object` added into their bases implicitly. There is no need to declare it explicitly. I left it in in the `ConnPlotter` files as not to conflict with #2147 