### PR TITLE
Fix pycodestyle

### DIFF
--- a/testsuite/pytests/test_sp/test_sp_manager.py
+++ b/testsuite/pytests/test_sp/test_sp_manager.py
@@ -145,8 +145,7 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                     assert 10 == st_neuron['SE1']['z_connected']
                     assert 10 == st_neuron['SE2']['z_connected']
 
-                assert 20 == len(
-                    nest.GetConnections(neurons, neurons, syn_model))
+                assert 20 == len(nest.GetConnections(neurons, neurons, syn_model))
                 break
 
 

--- a/testsuite/pytests/test_sp/test_sp_manager.py
+++ b/testsuite/pytests/test_sp/test_sp_manager.py
@@ -142,10 +142,10 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                 nest.Simulate(10.0)
                 status = nest.GetStatus(neurons, 'synaptic_elements')
                 for st_neuron in status:
-                    assert 10 == st_neuron['SE1']['z_connected']
-                    assert 10 == st_neuron['SE2']['z_connected']
+                    assert st_neuron['SE1']['z_connected'] == 10
+                    assert st_neuron['SE2']['z_connected'] == 10
 
-                assert 20 == len(nest.GetConnections(neurons, neurons, syn_model))
+                assert len(nest.GetConnections(neurons, neurons, syn_model)) == 20
                 break
 
 

--- a/testsuite/pytests/test_sp/test_sp_manager.py
+++ b/testsuite/pytests/test_sp/test_sp_manager.py
@@ -64,8 +64,7 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                 nest.structural_plasticity_synapses = {'syn1': syn_dict}
                 kernel_status = nest.structural_plasticity_synapses
                 assert 'syn1' in kernel_status
-                assert kernel_status['syn1'] == extract_dict_a_from_b(
-                    kernel_status['syn1'], syn_dict)
+                assert kernel_status['syn1'] == extract_dict_a_from_b(kernel_status['syn1'], syn_dict)
 
     def test_min_max_delay_using_default_delay(self):
         nest.ResetKernel()

--- a/testsuite/pytests/test_sp/test_sp_manager.py
+++ b/testsuite/pytests/test_sp/test_sp_manager.py
@@ -24,8 +24,10 @@ import unittest
 
 __author__ = 'naveau'
 
+
 def extract_dict_a_from_b(a, b):
     return dict((k, b[k]) for k in a.keys() if k in b.keys())
+
 
 class TestStructuralPlasticityManager(unittest.TestCase):
 
@@ -61,9 +63,9 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                 nest.set(min_delay=0.1, max_delay=1.0)
                 nest.structural_plasticity_synapses = {'syn1': syn_dict}
                 kernel_status = nest.structural_plasticity_synapses
-                self.assertIn('syn1', kernel_status)
-                self.assertEqual(kernel_status['syn1'], extract_dict_a_from_b(
-                    kernel_status['syn1'], syn_dict))
+                assert 'syn1' in kernel_status
+                assert kernel_status['syn1'] == extract_dict_a_from_b(
+                    kernel_status['syn1'], syn_dict)
 
     def test_min_max_delay_using_default_delay(self):
         nest.ResetKernel()
@@ -76,8 +78,8 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                 'post_synaptic_element': 'SE2',
             }
         }
-        self.assertLessEqual(nest.min_delay, delay)
-        self.assertGreaterEqual(nest.max_delay, delay)
+        assert nest.min_delay <= delay
+        assert nest.max_delay >= delay
 
     def test_getting_kernel_status(self):
         neuron_model = 'iaf_psc_alpha'
@@ -114,12 +116,12 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                             )
 
         sp_synapses = nest.structural_plasticity_synapses['syn1']
-        assert ('pre_synaptic_element' in sp_synapses)
-        assert ('post_synaptic_element' in sp_synapses)
-        assert (sp_synapses['pre_synaptic_element'] == 'Axon_ex')
-        assert (sp_synapses['post_synaptic_element'] == 'Den_ex')
+        assert 'pre_synaptic_element' in sp_synapses
+        assert 'post_synaptic_element' in sp_synapses
+        assert sp_synapses['pre_synaptic_element'] == 'Axon_ex'
+        assert sp_synapses['post_synaptic_element'] == 'Den_ex'
 
-        assert (nest.structural_plasticity_update_interval == 10000.)
+        assert nest.structural_plasticity_update_interval == 10000.
 
     def test_synapse_creation(self):
         for syn_model in nest.Models('synapses'):
@@ -141,11 +143,11 @@ class TestStructuralPlasticityManager(unittest.TestCase):
                 nest.Simulate(10.0)
                 status = nest.GetStatus(neurons, 'synaptic_elements')
                 for st_neuron in status:
-                    self.assertEqual(10, st_neuron['SE1']['z_connected'])
-                    self.assertEqual(10, st_neuron['SE2']['z_connected'])
+                    assert 10 == st_neuron['SE1']['z_connected']
+                    assert 10 == st_neuron['SE2']['z_connected']
 
-                self.assertEqual(
-                    20, len(nest.GetConnections(neurons, neurons, syn_model)))
+                assert 20 == len(
+                    nest.GetConnections(neurons, neurons, syn_model))
                 break
 
 

--- a/testsuite/pytests/test_sp/test_sp_manager.py
+++ b/testsuite/pytests/test_sp/test_sp_manager.py
@@ -120,7 +120,7 @@ class TestStructuralPlasticityManager(unittest.TestCase):
         assert sp_synapses['pre_synaptic_element'] == 'Axon_ex'
         assert sp_synapses['post_synaptic_element'] == 'Den_ex'
 
-        assert nest.structural_plasticity_update_interval == 10000.
+        assert nest.structural_plasticity_update_interval == 10000.0
 
     def test_synapse_creation(self):
         for syn_model in nest.Models('synapses'):


### PR DESCRIPTION
This fixes the static code check failure that is completely unrelated to but suddenly cropping up in https://github.com/nest/nest-simulator/pull/2058.

Also remove some unittest assertions in favour of plain Python assertions (as recommended for unittest → pytest migration).