### PR TITLE
Bump sphinx version to >=4.0.2 to remove jinja<3 requirement

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,11 +19,10 @@ recommonmark
 scipy
 seaborn
 sphinx-tabs
-sphinx>=2
+sphinx>=4.0.2
 sphinx_autobuild
 sphinx_gallery
 sphinx_rtd_theme
-jinja2<3
 statsmodels
 tqdm
 yamllint

--- a/environment.yml
+++ b/environment.yml
@@ -75,10 +75,8 @@ dependencies:
   - path.py
   - pydot
   - recommonmark
-  - sphinx-tabs
-  - sphinx >= 2
+  - sphinx >= 4.0.2
   - sphinx_rtd_theme
-  - jinja2 < 3
   - tqdm
   - yamllint
 
@@ -98,3 +96,4 @@ dependencies:
     - Image
     - sphinx_autobuild
     - sphinx_gallery
+    - sphinx-tabs


### PR DESCRIPTION
Also moving sphinx-tabs to be pip installed because the conda-forge version currently only supports sphinx <= 3. Fixes #2041.