### PR TITLE
Fix compiler warning issued by newest Clang

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -201,27 +201,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        cpp_compiler: ["gcc", "clang"]
-        xNEST_BUILD_TYPE: ["MINIMAL", "MPI_ONLY", "OPENMP_ONLY", "FULL"]
-        exclude:
-          - xNEST_BUILD_TYPE: "MPI_ONLY"
-            cpp_compiler: "clang"
-            os: macos-latest
-          - xNEST_BUILD_TYPE: "OPENMP_ONLY"
-            cpp_compiler: "clang"
-            os: macos-latest
-          - xNEST_BUILD_TYPE: "MINIMAL"
-            os: macos-latest
-            cpp_compiler: "gcc"
-          - xNEST_BUILD_TYPE: "MPI_ONLY"
-            cpp_compiler: "gcc"
-            os: macos-latest
-          - xNEST_BUILD_TYPE: "OPENMP_ONLY"
-            cpp_compiler: "gcc"
-            os: macos-latest
-          - xNEST_BUILD_TYPE: "FULL"
-            os: macos-latest
-            cpp_compiler: "gcc"
+        cpp_compiler: ["clang"]
+        xNEST_BUILD_TYPE: ["MINIMAL"]
 
     steps:
       - name: "Checkout repository content"

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -107,8 +107,8 @@ jobs:
             cpp_compiler: "clang"
             os: "ubuntu-20.04"
           - xNEST_BUILD_TYPE: "FULL"
-            os: "ubuntu-20.04"
             cpp_compiler: "clang"
+            os: "ubuntu-20.04"
 
     steps:
       - name: "Checkout repository content"
@@ -210,9 +210,6 @@ jobs:
           - xNEST_BUILD_TYPE: "OPENMP_ONLY"
             cpp_compiler: "clang"
             os: macos-latest
-          - xNEST_BUILD_TYPE: "FULL"
-            os: macos-latest
-            cpp_compiler: "clang"
           - xNEST_BUILD_TYPE: "MINIMAL"
             os: macos-latest
             cpp_compiler: "gcc"

--- a/nestkernel/connection_creator_impl.h
+++ b/nestkernel/connection_creator_impl.h
@@ -118,7 +118,7 @@ ConnectionCreator::PoolWrapper_< D >::PoolWrapper_()
 }
 
 template < int D >
-ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_()
+ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_< D >()
 {
   if ( masked_layer_ )
   {


### PR DESCRIPTION
This PR fixes a compiler warning introduced by the last version of Clang (see https://windowsquestions.com/2021/08/12/is-the-class-name-in-same-scope-as-the-out-of-line-definition-of-class-templates-destructor/), which made all macOS tests fail (zero warnings expected).

I am setting this to critical with Milestone 3.2 because all tests will fail in macOS until this is fixed.