### PR TITLE
Format error messages in `jonke_synapse` and `stdp_dopamine_synapse`

### DIFF
--- a/models/jonke_synapse.h
+++ b/models/jonke_synapse.h
@@ -420,9 +420,9 @@ jonke_synapse< targetidentifierT >::check_synapse_params( const DictionaryDatum&
   {
     if ( syn_spec->known( param_arr[ n ] ) )
     {
-      throw NotImplemented(
-        "Connect doesn't support the setting of parameter param_arr[ n ]"
-        "in jonke_synapse. Use SetDefaults() or CopyModel()." );
+      std::string msg = "Connect doesn't support the setting of parameter " + param_arr[ n ]
+        + " in jonke_synapse. Use SetDefaults() or CopyModel().";
+      throw NotImplemented( msg );
     }
   }
 }

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -409,9 +409,9 @@ stdp_dopamine_synapse< targetidentifierT >::check_synapse_params( const Dictiona
   {
     if ( syn_spec->known( param_arr[ n ] ) )
     {
-      throw NotImplemented(
-        "Connect doesn't support the setting of parameter param_arr[ n ]"
-        "in stdp_dopamine_synapse. Use SetDefaults() or CopyModel()." );
+      std::string msg = "Connect doesn't support the setting of parameter " + param_arr[ n ]
+        + " in stdp_dopamine_synapse. Use SetDefaults() or CopyModel().";
+      throw NotImplemented( msg );
     }
   }
 }


### PR DESCRIPTION
This PR fixes #2044.

As far as I can see, the parameters still need to be set with `SetDefaults()` or `CopyModel()`, because they are part of their own class containing the common properties (`JonkeCommonProperties` and `STDPDopaCommonProperties`). This PR thus only change the formatting of the error messages.