### PR TITLE
Fix failing Read the docs build 

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -84,6 +84,8 @@ sys.modules["nest.kernel"] = pynestkernel_mock
 # autoclass `nest.NestModule` to generate the documentation of the properties
 import nest  # noqa
 
+vars(nest)["NestModule"] = type(nest)
+
 # -- General configuration ------------------------------------------------
 extensions = [
     'sphinx_gallery.gen_gallery',

--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -84,7 +84,7 @@ sys.modules["nest.kernel"] = pynestkernel_mock
 # autoclass `nest.NestModule` to generate the documentation of the properties
 import nest  # noqa
 
-vars(nest)["NestModule"] = type(nest)
+vars(nest)["NestModule"] = type(nest)        # direct write to nest.NestModule is suppressed as unknown attribute 
 
 # -- General configuration ------------------------------------------------
 extensions = [

--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -83,7 +83,6 @@ sys.modules["nest.kernel"] = pynestkernel_mock
 # to autodoc properties the way the `autoclass` directive would. We can then
 # autoclass `nest.NestModule` to generate the documentation of the properties
 import nest  # noqa
-nest.NestModule = type(nest)
 
 # -- General configuration ------------------------------------------------
 extensions = [

--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -84,7 +84,7 @@ sys.modules["nest.kernel"] = pynestkernel_mock
 # autoclass `nest.NestModule` to generate the documentation of the properties
 import nest  # noqa
 
-vars(nest)["NestModule"] = type(nest)        # direct write to nest.NestModule is suppressed as unknown attribute 
+vars(nest)["NestModule"] = type(nest)        # direct write to nest.NestModule is suppressed as unknown attribute
 
 # -- General configuration ------------------------------------------------
 extensions = [


### PR DESCRIPTION
This PR fixes the build on Read the docs, that fails due changes when #2220 was merged.

Thanks to @Helveg for the fix