### PR TITLE
Update links for live media image

### DIFF
--- a/doc/userdoc/download.rst
+++ b/doc/userdoc/download.rst
@@ -35,9 +35,9 @@ Download the NEST image for VMs
 The VM image of NEST is available in the OVA format, and is suitable, for example, for importing into VirtualBox.
 If you run **Windows**, this is the option for you OR if you just want to run NEST without installing it on your computer.
 
-* Download the `latest live media image  <https://nest-simulator.org/downloads/gplreleases/nest-3.1.ova>`_.
+* Download the `latest live media image  <https://nest-simulator.org/downloads/gplreleases/nest-latest.ova>`_.
 
-  `Checksum <https://nest-simulator.org/downloads/gplreleases/nest-3.1.ova.sha512sum>`_
+  `Checksum <https://nest-simulator.org/downloads/gplreleases/nest-latest.ova.sha512sum>`_
 
 * After downloading the virtual machine, check out the :doc:`install instructions for Live Media <installation/livemedia>`.
 
@@ -45,17 +45,15 @@ If you run **Windows**, this is the option for you OR if you just want to run NE
 Older versions of VM images
 ---------------------------
 
-`NEST Live Media 2.20.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.20.0.ova>`_
 
-`Checksum 2.20.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.20.0.ova.sha512sum>`_
+`NEST Live Media 3.1 <https://nest-simulator.org/downloads/gplreleases/nest-3.1.ova>`_
 
-`NEST Live Media 2.18.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.18.0.ova>`_
+`Checksum 3.1 <https://nest-simulator.org/downloads/gplreleases/nest-3.1.ova.sha512sum>`_
 
-`Checksum 2.18.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.18.0.ova.sha512sum>`_
+`NEST Live Media 2.20.2 <https://nest-simulator.org/downloads/gplreleases/nest-2.20.2.ova>`_
 
-`NEST Live Media 2.16.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.16.0.ova>`_
+`Checksum 2.20.2 <https://nest-simulator.org/downloads/gplreleases/nest-2.20.2.ova.sha512sum>`_
 
-`Checksum 2.16.0 <https://nest-simulator.org/downloads/gplreleases/lubuntu-18.04_nest-2.16.0.ova.sha512sum>`_
 
 We continuously aim to improve NEST, implement features, and fix bugs with every new version;
 thus, we encourage our users to use the **most recent version of NEST**.

--- a/doc/userdoc/installation/livemedia.rst
+++ b/doc/userdoc/installation/livemedia.rst
@@ -28,9 +28,9 @@ Windows users can follow instructions on the website (see above).
 NEST image setup
 ------------------
 
-* Download the `NEST live medium <https://www.nest-simulator.org/downloads/gplreleases/NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova>`_
+* Download the `NEST live medium <https://www.nest-simulator.org/downloads/gplreleases/nest-latest.ova>`_
 
-* Start Virtual Box and import the virtual machine image "NEST_2.20.0_Virtual_Box_lubuntu_18.04.ova" (**File** > **Import Appliance**)
+* Start Virtual Box and import the virtual machine image (**File** > **Import Appliance**)
 
 * Once imported, you can run the NEST image
 


### PR DESCRIPTION
This PR updates the links for the ova files. 
Older versions are removed and links to 2.20.2, 3.1 and latest (will be 3.2) are now available.

Reasoning is that we can always replace the file to nest-latest.ova to the most recent release without having to update the link.
We also wanted to keep only a couple of older versions, as we have capacity limits, and we want the versions that have the important fixes in the code. This means that now only these versions are available as ova.

