### PR TITLE
Re-Import nest server

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -92,12 +92,13 @@ class NestModule(types.ModuleType):
         _rel_import_star(self, ".lib.hl_api_spatial")
         _rel_import_star(self, ".lib.hl_api_types")
         try:
-            _rel_import_star(self, ".server.hl_api_server")
+            _rel_import_star(self, ".server")
         except ImportError:
             pass
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
         type(self).raster_plot = _lazy_module_property("raster_plot")
+        type(self).server = _lazy_module_property("server")
         type(self).spatial = _lazy_module_property("spatial")
         type(self).visualization = _lazy_module_property("visualization")
         type(self).voltage_trace = _lazy_module_property("voltage_trace")
@@ -466,6 +467,9 @@ def _lazy_module_property(module_name, optional=False, optional_hint=""):
         cls = type(self)
         delattr(cls, module_name)
         try:
+            module = importlib.import_module("." + module_name, __name__)
+        except AttributeError as e:
+            # retry importing module.
             module = importlib.import_module("." + module_name, __name__)
         except ImportError as e:
             if optional:

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -75,6 +75,11 @@ class NestModule(types.ModuleType):
     from . import logic                              # noqa
     from .ll_api import set_communicator
 
+    try:
+        from . import server                         # noqa
+    except ImportError:
+        pass
+
     def __init__(self, name):
         super().__init__(name)
         # Copy over the original module attributes to preserve all interpreter-given

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -74,7 +74,6 @@ class NestModule(types.ModuleType):
     from . import spatial_distributions              # noqa
     from . import logic                              # noqa
     from .ll_api import set_communicator
-    
     try:
         from . import server                         # noqa
     except ImportError:

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -97,8 +97,8 @@ class NestModule(types.ModuleType):
             pass
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
-        type(self).spatial = _lazy_module_property("spatial")
         type(self).raster_plot = _lazy_module_property("raster_plot")
+        type(self).spatial = _lazy_module_property("spatial")
         type(self).visualization = _lazy_module_property("visualization")
         type(self).voltage_trace = _lazy_module_property("voltage_trace")
 

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -74,7 +74,6 @@ class NestModule(types.ModuleType):
     from . import spatial_distributions              # noqa
     from . import logic                              # noqa
     from .ll_api import set_communicator
-
     try:
         from . import server                         # noqa
     except ImportError:

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -75,11 +75,6 @@ class NestModule(types.ModuleType):
     from . import logic                              # noqa
     from .ll_api import set_communicator
 
-    try:
-        from . import server                         # noqa
-    except ImportError:
-        pass
-
     def __init__(self, name):
         super().__init__(name)
         # Copy over the original module attributes to preserve all interpreter-given
@@ -98,10 +93,16 @@ class NestModule(types.ModuleType):
         _rel_import_star(self, ".lib.hl_api_types")
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
-        type(self).spatial = _lazy_module_property("spatial")
         type(self).raster_plot = _lazy_module_property("raster_plot")
+        type(self).spatial = _lazy_module_property("spatial")
         type(self).visualization = _lazy_module_property("visualization")
         type(self).voltage_trace = _lazy_module_property("voltage_trace")
+
+        try:
+            _rel_import_star(self, ".server.hl_api_server")
+            type(self).server = _lazy_module_property("server")
+        except ImportError:
+            pass
 
         self.__version__ = ll_api.sli_func("statusdict /version get")
         # Finalize the nest module with a public API.

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -91,18 +91,16 @@ class NestModule(types.ModuleType):
         _rel_import_star(self, ".lib.hl_api_simulation")
         _rel_import_star(self, ".lib.hl_api_spatial")
         _rel_import_star(self, ".lib.hl_api_types")
-
-        # Lazy loaded modules. They are descriptors, so add them to the type object
-        type(self).raster_plot = _lazy_module_property("raster_plot")
-        type(self).spatial = _lazy_module_property("spatial")
-        type(self).visualization = _lazy_module_property("visualization")
-        type(self).voltage_trace = _lazy_module_property("voltage_trace")
-
         try:
             _rel_import_star(self, ".server.hl_api_server")
-            type(self).server = _lazy_module_property("server")
         except ImportError:
             pass
+
+        # Lazy loaded modules. They are descriptors, so add them to the type object
+        type(self).spatial = _lazy_module_property("spatial")
+        type(self).raster_plot = _lazy_module_property("raster_plot")
+        type(self).visualization = _lazy_module_property("visualization")
+        type(self).voltage_trace = _lazy_module_property("voltage_trace")
 
         self.__version__ = ll_api.sli_func("statusdict /version get")
         # Finalize the nest module with a public API.

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -74,6 +74,11 @@ class NestModule(types.ModuleType):
     from . import spatial_distributions              # noqa
     from . import logic                              # noqa
     from .ll_api import set_communicator
+    
+    try:
+        from . import server                         # noqa
+    except ImportError:
+        pass
 
     def __init__(self, name):
         super().__init__(name)
@@ -91,14 +96,9 @@ class NestModule(types.ModuleType):
         _rel_import_star(self, ".lib.hl_api_simulation")
         _rel_import_star(self, ".lib.hl_api_spatial")
         _rel_import_star(self, ".lib.hl_api_types")
-        try:
-            _rel_import_star(self, ".server")
-        except ImportError:
-            pass
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
         type(self).raster_plot = _lazy_module_property("raster_plot")
-        type(self).server = _lazy_module_property("server")
         type(self).spatial = _lazy_module_property("spatial")
         type(self).visualization = _lazy_module_property("visualization")
         type(self).voltage_trace = _lazy_module_property("voltage_trace")

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -97,8 +97,8 @@ class NestModule(types.ModuleType):
         _rel_import_star(self, ".lib.hl_api_types")
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
-        type(self).raster_plot = _lazy_module_property("raster_plot")
         type(self).spatial = _lazy_module_property("spatial")
+        type(self).raster_plot = _lazy_module_property("raster_plot")
         type(self).visualization = _lazy_module_property("visualization")
         type(self).voltage_trace = _lazy_module_property("voltage_trace")
 
@@ -466,9 +466,6 @@ def _lazy_module_property(module_name, optional=False, optional_hint=""):
         cls = type(self)
         delattr(cls, module_name)
         try:
-            module = importlib.import_module("." + module_name, __name__)
-        except AttributeError as e:
-            # retry importing module.
             module = importlib.import_module("." + module_name, __name__)
         except ImportError as e:
             if optional:

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -74,6 +74,7 @@ class NestModule(types.ModuleType):
     from . import spatial_distributions              # noqa
     from . import logic                              # noqa
     from .ll_api import set_communicator
+
     try:
         from . import server                         # noqa
     except ImportError:

--- a/pynest/nest/server/__init__.py
+++ b/pynest/nest/server/__init__.py
@@ -19,4 +19,4 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-from .hl_api_server import *
+from .hl_api_server import app                        # noqa


### PR DESCRIPTION
Since the commit `44d52d` (Fixed circular NEST server imports), the command `nest-server` is not able to start NEST Server. 

See the error output:

```
***
*** WARNING: NEST Server runs without a RestrictedPython trusted environment.
***
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 979, in _find_and_load_unlocked
  File "/home/spreizer/opt/nest/lib/python3.8/site-packages/nest/__init__.py", line 423, in _setattr_error
    raise err from None
AttributeError: can't set attribute 'server' on module 'nest'
unable to load app 0 (mountpoint='') (callable not found or import error)
*** no app loaded. going in full dynamic mode ***
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI worker 1 (and the only) (pid: 121581, cores: 1)

```

Actually, the command `nest-server` only needs Flask app. -> `uwsgi -m nest.server:app`

Due to the short time left to next release, I re-implemented importing server in `__init__.py` but it only imports `app`.
I hope that it is not considered as a circular importing issue.

However, I am open for alternative solution which resolves this issue.