### PR TITLE
Fix quirks with import machinery in Python 3.8

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -416,19 +416,20 @@ def _setattr_error(self, attr, val):
     `__dict__` manipulation. It is added onto the module at the end of `__init__`,
     "freezing" the module.
     """
-    # Allow import machinery to set imported modules on `nest`
     if isinstance(val, types.ModuleType):
-        return super(type(self), self).__setattr__(attr, val)
-    err = AttributeError(f"can't set attribute '{attr}' on module 'nest'")
-    try:
-        cls_attr = getattr(type(self), attr)
-    except AttributeError:
-        raise err from None
+        # Allow import machinery to set imported modules on `nest`
+        self.__dict__[attr] = val
     else:
-        if hasattr(cls_attr, "__set__"):
-            cls_attr.__set__(self, val)
+        err = AttributeError(f"can't set attribute '{attr}' on module 'nest'")
+        try:
+            cls_attr = getattr(type(self), attr)
+        except AttributeError:
+            raise err from None
         else:
-            raise err
+            if hasattr(cls_attr, "__set__"):
+                cls_attr.__set__(self, val)
+            else:
+                raise err
 
 
 def _rel_import_star(module, import_module_name):

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -429,7 +429,7 @@ def _setattr_error(self, attr, val):
             if hasattr(cls_attr, "__set__"):
                 cls_attr.__set__(self, val)
             else:
-                raise err
+                raise err from None
 
 
 def _rel_import_star(module, import_module_name):

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -93,8 +93,9 @@ class NestModule(types.ModuleType):
         _rel_import_star(self, ".lib.hl_api_types")
 
         # Lazy loaded modules. They are descriptors, so add them to the type object
-        type(self).spatial = _lazy_module_property("spatial")
         type(self).raster_plot = _lazy_module_property("raster_plot")
+        type(self).server = _lazy_module_property("server")
+        type(self).spatial = _lazy_module_property("spatial")
         type(self).visualization = _lazy_module_property("visualization")
         type(self).voltage_trace = _lazy_module_property("voltage_trace")
 
@@ -415,7 +416,9 @@ def _setattr_error(self, attr, val):
     `__dict__` manipulation. It is added onto the module at the end of `__init__`,
     "freezing" the module.
     """
-
+    # Allow import machinery to set imported modules on `nest`
+    if isinstance(val, types.ModuleType):
+        return super(type(self), self).__setattr__(attr, val)
     err = AttributeError(f"can't set attribute '{attr}' on module 'nest'")
     try:
         cls_attr = getattr(type(self), attr)

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -420,7 +420,7 @@ def _setattr_error(self, attr, val):
         # Allow import machinery to set imported modules on `nest`
         self.__dict__[attr] = val
     else:
-        err = AttributeError(f"can't set attribute '{attr}' on module 'nest'")
+        err = AttributeError(f"Cannot set attribute '{attr}' on module 'nest'")
         try:
             cls_attr = getattr(type(self), attr)
         except AttributeError:


### PR DESCRIPTION
Apparently `importlib.import_module` sets an attribute on the parent module in python 3.8 (no longer does this in 3.9 it seems, or it was a bug that was fixed?), this didn't play nice with #2220.  On top of that, the error of `_setattr_error` during the `importlib.import_module` was silenced but would lead to an `AttributeError` for `nest.<lazy_module>` even though by all means the attribute was declared, likely because `_lazy_module_property` uses `delattr` right before `import_module` which would then error out, dissapearing the attribute.

I also added `nest.server` as a lazy loaded module.

closes #2241, closes #2242, closes #2239