### PR TITLE
Fix path to connection diagram for HPC benchmark example

### DIFF
--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -37,7 +37,7 @@ This is the standard network investigated in [1]_, [2]_, [3]_.
 A note on connectivity
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. image:: ../../../examples/hpc_benchmark_connectivity.svg
+.. image:: ../examples/hpc_benchmark_connectivity.svg
    :width: 50 %
    :alt: HPC Benchmark network architecture
    :align: right


### PR DESCRIPTION
The used path works only in the local preview of the HTML files. 
The path inside the generated `.rst` file must point to the image in the directory `userdoc/examples`, only then it will be moved to the correct path by make html.