### PR TITLE
Explicitly use nest namespace to avoid compiler confusion

### DIFF
--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -1996,7 +1996,7 @@ NestModule::Apply_P_DFunction::execute( SLIInterpreter* i ) const
   auto positions = getValue< DictionaryDatum >( i->OStack.pick( 0 ) );
   auto param = getValue< ParameterDatum >( i->OStack.pick( 1 ) );
 
-  auto result = apply( param, positions );
+  auto result = nest::apply( param, positions ); // Using nest namespace explicitly to avoid confusion with std in C++17
 
   i->OStack.pop( 2 );
   i->OStack.push( result );
@@ -2011,7 +2011,7 @@ NestModule::Apply_P_gFunction::execute( SLIInterpreter* i ) const
   NodeCollectionDatum nc = getValue< NodeCollectionDatum >( i->OStack.pick( 0 ) );
   ParameterDatum param = getValue< ParameterDatum >( i->OStack.pick( 1 ) );
 
-  auto result = apply( param, nc );
+  auto result = nest::apply( param, nc ); // Using nest namespace explicitly to avoid confusion with std in C++17
 
   i->OStack.pop( 2 );
   i->OStack.push( result );

--- a/testsuite/pytests/test_nodeParametrization.py
+++ b/testsuite/pytests/test_nodeParametrization.py
@@ -512,13 +512,13 @@ class TestNodeParametrization(unittest.TestCase):
         """Test cosine of a parameter"""
         for value in np.linspace(-5.0, 5.0, 15):
             p = nest.CreateParameter('constant', {'value': value})
-            self.assertEqual(nest.math.cos(p).GetValue(), np.cos(value))
+            self.assertAlmostEqual(nest.math.cos(p).GetValue(), np.cos(value))
 
     def test_sin_parameter(self):
         """Test sine of a parameter"""
         for value in np.linspace(-5.0, 5.0, 15):
             p = nest.CreateParameter('constant', {'value': value})
-            self.assertEqual(nest.math.sin(p).GetValue(), np.sin(value))
+            self.assertAlmostEqual(nest.math.sin(p).GetValue(), np.sin(value))
 
     def test_power_parameter(self):
         """Test parameter raised to the power of an exponent"""


### PR DESCRIPTION
When compiling with `-std=c++17`, the compiler confuses the `apply()` in nest.h with `std::apply()` from `<tuple>`. This happens with both GCC and Clang. However, there doesn't seem to be any place where we say that the `std` namespace should be used in that context. The calls are therefore changed to explicitly use the `nest` namespace, which fixes the problem and therefore fixes #2252.

<details>
<summary>As a side-note, it's possible to reproduce the behaviour without NEST, with this reproducer.</summary>

```C++
#include <tuple>
#include <vector>

namespace foo
{

void
bar()
{
}

std::vector< double >
apply( const std::vector< double >&, const std::vector< double >& )
{
  return {};
}

void
run()
{
  std::vector< double > vec;

  bar();                  // OK
  apply( vec, vec );      // Tries to use std::apply() from <tuple>, which causes an error with the arguments
  foo::apply( vec, vec ); // OK
}
} // end of namespace foo

int
main()
{
  foo::run();
}

```
</details>