### PR TITLE
More detailed explanation of why C++ ADL requires nest::apply()

### DIFF
--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -1996,7 +1996,9 @@ NestModule::Apply_P_DFunction::execute( SLIInterpreter* i ) const
   auto positions = getValue< DictionaryDatum >( i->OStack.pick( 0 ) );
   auto param = getValue< ParameterDatum >( i->OStack.pick( 1 ) );
 
-  auto result = nest::apply( param, positions ); // Using nest namespace explicitly to avoid confusion with std in C++17
+  // Argument-dependent lookup requires explicit namespace qualification to avoid confusion with std::apply() in C++17 and later
+  // See https://github.com/llvm/llvm-project/issues/53084#issuecomment-1007969489
+  auto result = nest::apply( param, positions );
 
   i->OStack.pop( 2 );
   i->OStack.push( result );
@@ -2011,7 +2013,9 @@ NestModule::Apply_P_gFunction::execute( SLIInterpreter* i ) const
   NodeCollectionDatum nc = getValue< NodeCollectionDatum >( i->OStack.pick( 0 ) );
   ParameterDatum param = getValue< ParameterDatum >( i->OStack.pick( 1 ) );
 
-  auto result = nest::apply( param, nc ); // Using nest namespace explicitly to avoid confusion with std in C++17
+  // Argument-dependent lookup requires explicit namespace qualification to avoid confusion with std::apply() in C++17 and later
+  // See https://github.com/llvm/llvm-project/issues/53084#issuecomment-1007969489
+  auto result = nest::apply( param, nc );
 
   i->OStack.pop( 2 );
   i->OStack.push( result );


### PR DESCRIPTION
Extended the comment based on information given in https://github.com/llvm/llvm-project/issues/53084.