### PR TITLE
Automatically adjust model defaults upon changes to resolution

### DIFF
--- a/doc/userdoc/release_notes/v3.3/index.rst
+++ b/doc/userdoc/release_notes/v3.3/index.rst
@@ -1,0 +1,28 @@
+All about NEST 3.3
+==================
+
+This page contains a summary of all breaking and non-breaking changes
+from NEST 3.2 to NEST 3.3. In addition to the `auto-generated release
+notes on GitHub <https://github.com/nest/nest-simulator/releases/>`_,
+this page also contains transition information that helps you to
+update your simulation scripts when you come from an older version of
+NEST.
+
+If you transition from a version earlier than 3.0, please see our
+selection of earlier :doc:`transition guides <release_notes/index>`.
+
+.. contents:: On this page you'll find
+   :local:
+   :depth: 1
+
+Model defaults
+~~~~~~~~~~~~~~
+
+The model parameter ``delta_tau`` in the ``correlation_detector``,
+``correlomatrix_detector``, and ``correlospinmatrix_detector``, as
+well as ``dt`` in the ``noise_generator`` are now automatically
+adjusted and made compatible with a newly set simulation resolution to
+avoid errors when those models are instantiated. Moreover, the default
+value for ``delta_tau`` in the ``correlation_detector`` has been
+changed from 1.0 to 5 times the simulation resolution, in order to be
+consistent with the documentation of the device.

--- a/models/correlation_detector.h
+++ b/models/correlation_detector.h
@@ -49,11 +49,15 @@ Device for evaluating cross correlation between two spike sources
 Description
 +++++++++++
 
-The correlation_detector device is a recording device. It is used to record
-spikes from two pools of spike inputs and calculates the count_histogram of
-inter-spike intervals (raw cross correlation) binned to bins of duration
-:math:`\delta_\tau`. The result can be obtained via GetStatus under the key
+The correlation_detector is a device that receives spikes from two pools of
+spike inputs and calculates the count_histogram of inter-spike intervals
+(raw cross correlation) binned to bins of duration :math:`\delta_\tau`.
+The corresponding parameter ``delta_tau`` defaults to 5 times the simulation
+resolution.
+
+The result can be obtained from the node's status dictionary under the key
 /count_histogram.
+
 In parallel it records a weighted histogram, where the connection weights
 are used to weight every count. In order to minimize numerical errors, the
 `Kahan summation algorithm <http://en.wikipedia.org/wiki/Kahan_summation_algorithm>`_
@@ -100,9 +104,8 @@ the
 delta_tau            ms       Bin width. This has to be an odd multiple of
                               the resolution, to allow the symmetry between
                               positive and negative time-lags.
-tau_max              ms       One-sided width. In the lower triagnular part
-                              events with differences in [0,
-tau_max+delta_tau/2)
+tau_max              ms       One-sided width. In the lower triangular part
+                              events with differences in [0, tau_max+delta_tau/2)
                               are counted. On the diagonal and in the upper
                               triangular part events with differences in
                               (0, tau_max+delta_tau/2].
@@ -317,7 +320,7 @@ correlation_detector::handles_test_event( SpikeEvent&, rport receptor_type )
 }
 
 inline void
-nest::correlation_detector::get_status( DictionaryDatum& d ) const
+correlation_detector::get_status( DictionaryDatum& d ) const
 {
   device_.get_status( d );
   P_.get( d );
@@ -325,7 +328,7 @@ nest::correlation_detector::get_status( DictionaryDatum& d ) const
 }
 
 inline void
-nest::correlation_detector::set_status( const DictionaryDatum& d )
+correlation_detector::set_status( const DictionaryDatum& d )
 {
   Parameters_ ptmp = P_;
   const bool reset_required = ptmp.set( d, *this, this );
@@ -336,16 +339,6 @@ nest::correlation_detector::set_status( const DictionaryDatum& d )
   P_ = ptmp;
   S_ = stmp;
 }
-
-inline void
-nest::correlation_detector::calibrate_time( const TimeConverter& tc )
-{
-  P_.delta_tau_ = tc.from_old_tics( P_.delta_tau_.get_tics() );
-  P_.tau_max_ = tc.from_old_tics( P_.tau_max_.get_tics() );
-  P_.Tstart_ = tc.from_old_tics( P_.Tstart_.get_tics() );
-  P_.Tstop_ = tc.from_old_tics( P_.Tstop_.get_tics() );
-}
-
 
 } // namespace
 

--- a/models/correlomatrix_detector.h
+++ b/models/correlomatrix_detector.h
@@ -49,14 +49,17 @@ Device for measuring the covariance matrix from several inputs
 Description
 +++++++++++
 
-The correlomatrix_detector is a recording device. It is used to
-record spikes from several pools of spike inputs and calculates the
-covariance matrix of inter-spike intervals (raw auto and cross correlation)
-binned to bins of duration delta_tau. The histogram is only recorded for
+The correlomatrix_detector is a device that receives spikes from several pools
+of spike inputs and calculates the covariance matrix of inter-spike intervals
+(raw auto and cross correlation) binned to bins of duration ``delta_tau``, which
+defaults to 5 times the simulation resolution. The histogram is only recorded for
 non-negative time lags. The negative part can be obtained by the symmetry of
 the covariance matrix
  :math:` C(t) = C^T(-t)`.
-The result can be obtained via GetStatus under the key /count_covariance.
+
+The result can be obtained from the node's status dictionary under the key
+/count_covariance.
+
 In parallel it records a weighted histogram, where the connection weight are
 used to weight every count, which is available under the key /covariance.
 Both are matrices of size N_channels x N_channels, with each entry C_ij being
@@ -302,7 +305,7 @@ correlomatrix_detector::handles_test_event( SpikeEvent&, rport receptor_type )
 }
 
 inline void
-nest::correlomatrix_detector::get_status( DictionaryDatum& d ) const
+correlomatrix_detector::get_status( DictionaryDatum& d ) const
 {
   device_.get_status( d );
   P_.get( d );
@@ -310,7 +313,7 @@ nest::correlomatrix_detector::get_status( DictionaryDatum& d ) const
 }
 
 inline void
-nest::correlomatrix_detector::set_status( const DictionaryDatum& d )
+correlomatrix_detector::set_status( const DictionaryDatum& d )
 {
   Parameters_ ptmp = P_;
   const bool reset_required = ptmp.set( d, *this, this );
@@ -323,14 +326,6 @@ nest::correlomatrix_detector::set_status( const DictionaryDatum& d )
   }
 }
 
-inline void
-nest::correlomatrix_detector::calibrate_time( const TimeConverter& tc )
-{
-  P_.delta_tau_ = tc.from_old_tics( P_.delta_tau_.get_tics() );
-  P_.tau_max_ = tc.from_old_tics( P_.tau_max_.get_tics() );
-  P_.Tstart_ = tc.from_old_tics( P_.Tstart_.get_tics() );
-  P_.Tstop_ = tc.from_old_tics( P_.Tstop_.get_tics() );
-}
 
 } // namespace
 

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -28,7 +28,9 @@
 #include <numeric>
 
 // Includes from libnestutil:
+#include "compose.hpp"
 #include "dict_util.h"
+#include "logging.h"
 
 // Includes from nestkernel:
 #include "kernel_manager.h"
@@ -58,13 +60,15 @@ nest::correlospinmatrix_detector::Parameters_::Parameters_( const Parameters_& p
   , Tstop_( p.Tstop_ )
   , N_channels_( p.N_channels_ )
 {
-  // Check for proper properties is not done here but in the
-  // correlospinmatrix_detector() copy c'tor. The check cannot be
-  // placed here, since this c'tor is also used to copy to
-  // temporaries in correlospinmatrix_detector::set_status().
-  // If we checked for errors here, we could never change values
-  // that have become invalid after a resolution change.
-  delta_tau_.calibrate();
+  if ( not delta_tau_.is_step() )
+  {
+    delta_tau_ = Time::get_resolution();
+  }
+  else
+  {
+    delta_tau_.calibrate();
+  }
+
   tau_max_.calibrate();
   Tstart_.calibrate();
   Tstop_.calibrate();
@@ -248,10 +252,6 @@ nest::correlospinmatrix_detector::correlospinmatrix_detector()
   , P_()
   , S_()
 {
-  if ( not P_.delta_tau_.is_step() )
-  {
-    throw InvalidDefaultResolution( get_name(), names::delta_tau, P_.delta_tau_ );
-  }
 }
 
 nest::correlospinmatrix_detector::correlospinmatrix_detector( const correlospinmatrix_detector& n )
@@ -260,10 +260,6 @@ nest::correlospinmatrix_detector::correlospinmatrix_detector( const correlospinm
   , P_( n.P_ )
   , S_()
 {
-  if ( not P_.delta_tau_.is_step() )
-  {
-    throw InvalidTimeInModel( get_name(), names::delta_tau, P_.delta_tau_ );
-  }
 }
 
 
@@ -482,4 +478,26 @@ nest::correlospinmatrix_detector::handle( SpikeEvent& e )
     S_.t_last_in_spike_ = stamp;
 
   } // device active
+}
+
+void
+nest::correlospinmatrix_detector::calibrate_time( const TimeConverter& tc )
+{
+  if ( not P_.delta_tau_.is_step() )
+  {
+    std::string old = String::compose( "(was %1 ms)", P_.delta_tau_.get_ms() );
+    P_.delta_tau_ = Time::get_resolution();
+    std::string msg = String::compose( "Default value for delta_tau is now %1 ms %2", P_.delta_tau_.get_ms(), old );
+    LOG( M_INFO, get_name(), msg );
+  }
+  else
+  {
+    P_.delta_tau_ = tc.from_old_tics( P_.delta_tau_.get_tics() );
+  }
+
+  P_.tau_max_ = tc.from_old_tics( P_.tau_max_.get_tics() );
+  P_.Tstart_ = tc.from_old_tics( P_.Tstart_.get_tics() );
+  P_.Tstop_ = tc.from_old_tics( P_.Tstop_.get_tics() );
+
+  S_.t_last_in_spike_ = tc.from_old_tics( S_.t_last_in_spike_.get_tics() );
 }

--- a/models/correlospinmatrix_detector.h
+++ b/models/correlospinmatrix_detector.h
@@ -49,15 +49,15 @@ Device for measuring the covariance matrix from several inputs
 Description
 +++++++++++
 
-The correlospinmatrix_detector is a recording device. It is used
-to record correlations from binary neurons from several binary sources and
-calculates the raw auto and cross correlation binned to bins of duration
-delta_tau. The result can be obtained via GetStatus under the key
-/count_covariance. The result is a tensor of rank 3 of size
+The correlospinmatrix_detector is a device that receives input from several
+binary neuron sources and calculates the raw auto and cross correlation binned
+to bins of duration delta_tau, which defaults to the simulation resolution.
+
+The result can be obtained from the node's status dictionary under the key
+/count_covariance in the format of a tensor of rank 3 of size
 N_channels x N_channels, with each entry :math:`C_{ij}` being a vector of size
 :math:`2*\tau_{max}/\delta_{\tau} + 1` containing the histogram for the
-different
-time lags.
+different time lags.
 
 The bins are centered around the time difference they represent, and are
 left-closed and right-open in the lower triangular part of the matrix. On the
@@ -300,7 +300,7 @@ correlospinmatrix_detector::handles_test_event( SpikeEvent&, rport receptor_type
 }
 
 inline void
-nest::correlospinmatrix_detector::get_status( DictionaryDatum& d ) const
+correlospinmatrix_detector::get_status( DictionaryDatum& d ) const
 {
   device_.get_status( d );
   P_.get( d );
@@ -308,7 +308,7 @@ nest::correlospinmatrix_detector::get_status( DictionaryDatum& d ) const
 }
 
 inline void
-nest::correlospinmatrix_detector::set_status( const DictionaryDatum& d )
+correlospinmatrix_detector::set_status( const DictionaryDatum& d )
 {
   Parameters_ ptmp = P_;
   const bool reset_required = ptmp.set( d, *this, this );
@@ -323,20 +323,9 @@ nest::correlospinmatrix_detector::set_status( const DictionaryDatum& d )
 
 
 inline SignalType
-nest::correlospinmatrix_detector::receives_signal() const
+correlospinmatrix_detector::receives_signal() const
 {
   return BINARY;
-}
-
-inline void
-nest::correlospinmatrix_detector::calibrate_time( const TimeConverter& tc )
-{
-  P_.delta_tau_ = tc.from_old_tics( P_.delta_tau_.get_tics() );
-  P_.tau_max_ = tc.from_old_tics( P_.tau_max_.get_tics() );
-  P_.Tstart_ = tc.from_old_tics( P_.Tstart_.get_tics() );
-  P_.Tstop_ = tc.from_old_tics( P_.Tstop_.get_tics() );
-
-  S_.t_last_in_spike_ = tc.from_old_tics( S_.t_last_in_spike_.get_tics() );
 }
 
 } // namespace

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -23,6 +23,7 @@
 #include "noise_generator.h"
 
 // Includes from libnestutil:
+#include "compose.hpp"
 #include "dict_util.h"
 #include "logging.h"
 #include "numerics.h"
@@ -60,7 +61,7 @@ nest::noise_generator::Parameters_::Parameters_()
   , std_mod_( 0.0 ) // pA / sqrt(s)
   , freq_( 0.0 )    // Hz
   , phi_deg_( 0.0 ) // degree
-  , dt_( Time::ms( 1.0 ) )
+  , dt_( 10 * Time::get_resolution() )
   , num_targets_( 0 )
 {
 }
@@ -74,9 +75,14 @@ nest::noise_generator::Parameters_::Parameters_( const Parameters_& p )
   , dt_( p.dt_ )
   , num_targets_( 0 ) // we do not copy connections
 {
-  // do not check validity of dt_ here, otherwise we cannot copy
-  // to temporary in set(); see node copy c'tor
-  dt_.calibrate();
+  if ( not dt_.is_step() )
+  {
+    dt_ = 10 * Time::get_resolution();
+  }
+  else
+  {
+    dt_.calibrate();
+  }
 }
 
 nest::noise_generator::Parameters_& nest::noise_generator::Parameters_::operator=( const Parameters_& p )
@@ -183,10 +189,6 @@ nest::noise_generator::noise_generator()
   , B_( *this )
 {
   recordablesMap_.create();
-  if ( not P_.dt_.is_step() )
-  {
-    throw InvalidDefaultResolution( get_name(), names::dt, P_.dt_ );
-  }
 }
 
 nest::noise_generator::noise_generator( const noise_generator& n )
@@ -195,10 +197,6 @@ nest::noise_generator::noise_generator( const noise_generator& n )
   , S_( n.S_ )
   , B_( n.B_, *this )
 {
-  if ( not P_.dt_.is_step() )
-  {
-    throw InvalidTimeInModel( get_name(), names::dt, P_.dt_ );
-  }
 }
 
 
@@ -390,4 +388,20 @@ nest::noise_generator::set_data_from_stimulation_backend( std::vector< double >&
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
   P_.num_targets_ = ptmp.num_targets_;
+}
+
+void
+nest::noise_generator::calibrate_time( const TimeConverter& tc )
+{
+  if ( not P_.dt_.is_step() )
+  {
+    std::string old = String::compose( "(was %1 ms)", P_.dt_.get_ms() );
+    P_.dt_ = 10 * Time::get_resolution();
+    std::string msg = String::compose( "Default value for dt is now %1 ms %2", P_.dt_.get_ms(), old );
+    LOG( M_INFO, get_name(), msg );
+  }
+  else
+  {
+    P_.dt_ = tc.from_old_tics( P_.dt_.get_tics() );
+  }
 }

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -51,10 +51,12 @@ Description
 
 This device can be used to inject a Gaussian "white" noise current into a node.
 
-The current is not really white, but a piecewise constant current with Gaussian
-distributed amplitude. The current changes at intervals of dt. dt must be a
-multiple of the simulation step size, the default is 1.0 ms,
-corresponding to a 1 kHz cut-off.
+The current is not really white, but a piecewise constant current with
+Gaussian distributed amplitude. The current changes at intervals of
+dt. dt must be a multiple of the simulation step size, the default is
+10 times the simulation resolution (equating to 1.0 ms, corresponding
+to a 1 kHz cut-off).
+
 Additionally a second sinusodial modulated term can be added to the standard
 deviation of the noise.
 
@@ -346,12 +348,6 @@ inline SignalType
 noise_generator::sends_signal() const
 {
   return ALL;
-}
-
-inline void
-noise_generator::calibrate_time( const TimeConverter& tc )
-{
-  P_.dt_ = tc.from_old_tics( P_.dt_.get_tics() );
 }
 
 inline bool

--- a/testsuite/pytests/test_changing_tic_base.py
+++ b/testsuite/pytests/test_changing_tic_base.py
@@ -36,52 +36,6 @@ class TestChangingTicBase(unittest.TestCase):
     def setUp(self):
         nest.ResetKernel()
 
-    def test_models(self):
-        """Time objects in models correctly updated"""
-        # Generate a dictionary of reference values for each model.
-        reference = {}
-        for model in nest.Models():
-            if model in self.ignored_models:
-                continue
-            try:
-                reference[model] = nest.GetDefaults(model)
-            except nest.kernel.NESTError:
-                # If we can't get the defaults, we ignore the model.
-                pass
-
-        # Change the tic-base.
-        nest.set(resolution=0.5, tics_per_ms=1500.0)
-
-        # At this point, Time objects in models should have been updated to
-        # account for the new tic-base. Values in model defaults should therefore
-        # be equal (within a tolerance) to the reference values.
-
-        failing_models = []
-        for model in reference.keys():
-            model_reference = reference[model]
-            model_defaults = nest.GetDefaults(model)
-            # Remove entries where the item contains more than one value, as this causes issues when comparing.
-            array_keys = [key for key, value in model_defaults.items()
-                          if isinstance(value, (list, tuple, dict, np.ndarray))]
-            for key in array_keys:
-                del model_defaults[key]
-                del model_reference[key]
-
-            keydiff = []
-            for key, value in model_defaults.items():
-                # value may not be a number, so we test for equality first.
-                # If it's not equal to the reference value, we assume it is a number.
-                if value != model_reference[key] and abs(value - model_reference[key]) > self.eps:
-                    print(value - model_reference[key])
-                    keydiff.append([key, model_reference[key], value])
-            # If any keys have values different from the reference, the model fails.
-            if len(keydiff) > 0:
-                print(model, keydiff)
-                failing_models.append(model)
-
-        # No models should fail for the test to pass.
-        self.assertEqual([], failing_models)
-
     def _assert_ticbase_change_raises_and_reset(self, after_call):
         """Assert that changing tic-base raises a NESTError, and reset the kernel"""
         with self.assertRaises(nest.kernel.NESTError, msg=f'after calling "{after_call}"'):


### PR DESCRIPTION
Previous to this PR, the four models `correlation_detector`, `correlomatrix_detector`, `correlospinmatrix_detector` and `noise_generator` contained parameters as `nest::Time` objects that were not properly updated when the resolution was re-set, which could lead to problems upon instantiation of these models when a non-default resolution was set. This PR adds automatic conversions to the corresponding variables to avoid such problems.

The general old behavior was like this:
* a parameter was initialized to the resolution or a fixed value in ms in the default constructor
* the copy constructor of `Parameters` copied the values from the original node instance
* node constructors threw an exception if the value was incompatible with the current resolution.
 
The new behavior is like this:
* a parameter is initialized to the resolution or a fixed value in ms in the default constructor
* the copy constructor of `Parameters` and `calibrate_time()` update the value to a reasonable value based on the newly set resolution *if* the stored value becomes incompatible 
* the node constructors don't throw exceptions anymore upon incompatible values as those are impossible now.

The parameter `delta_tau_` in the `correlation_detector` was changed to `5 * Time::get_resolution()` from the previous value of `Time(1.0)` in the default constructor to fulfill the condition "odd multiple of the resolution" that is mentioned in the documentation.

The changes are explained in a user-understandable fashion in the release notes for NEST 3.3.