### PR TITLE
Fix version warning

### DIFF
--- a/doc/userdoc/conf.py
+++ b/doc/userdoc/conf.py
@@ -177,18 +177,6 @@ html_theme_options = {'logo_only': True,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = [str(doc_build_dir / 'static')]
 
-if os.environ.get("READTHEDOCS") == "True":
-    # The short X.Y version.
-    version = os.environ.get("READTHEDOCS_VERSION")
-    print(f"NEST Version: {version}")
-    if version == "latest":
-        rst_prolog = ".. warning:: \n   This version of the documentation is NOT an official release. \
-                     You are looking at 'latest', which is in active and ongoing development. \
-                     You can change versions on the bottom left of the screen."
-        rst_epilog = ""
-else:
-    version = "latest"
-
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
On Read the docs the version specified as "latest" is in some places ambiguously pointing to "latest release" and "latest on main branch". This leads to some confusion when referring to "latest". Removing this from the code and relying only on the "show version warning" option on readthedocs, we can enable and disable this warning from the outside, without having a potentially wrong warning in a release that is not removable.