### PR TITLE
Re-add version number for clang-format

### DIFF
--- a/build_support/ci_build.sh
+++ b/build_support/ci_build.sh
@@ -94,7 +94,7 @@ if [ "$xNEST_BUILD_TYPE" = "STATIC_CODE_ANALYSIS" ]; then
     # The names of the static code analysis tools executables.
     VERA=vera++
     CPPCHECK=cppcheck
-    CLANG_FORMAT=clang-format
+    CLANG_FORMAT=clang-format-9
     PEP8=pycodestyle
     PYCODESTYLE_IGNORES="E121,E123,E126,E226,E24,E704,W503,W504"
 


### PR DESCRIPTION
This avoids problems when multiple versions are around and fixes #2276.