### PR TITLE
Remove set sender node id from deliver events pr

### DIFF
--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -530,7 +530,7 @@ binary_neuron< TGainfunction >::handle( SpikeEvent& e )
 
 
   const long m = e.get_multiplicity();
-  const long node_id = e.get_sender_node_id();
+  const long node_id = e.retrieve_sender_node_id_from_source_table();
   const Time& t_spike = e.get_stamp();
 
   if ( m == 1 )

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -68,7 +68,7 @@ Event::retrieve_sender_node_id_from_source_table() const
 }
 
 index
-Event::get_receiver_node_id( void ) const
+Event::get_receiver_node_id() const
 {
   return receiver_->get_node_id();
 }

--- a/nestkernel/event.cpp
+++ b/nestkernel/event.cpp
@@ -30,6 +30,7 @@
 #include "event.h"
 
 // Includes from nestkernel:
+#include "kernel_manager.h"
 #include "node.h"
 
 namespace nest
@@ -38,6 +39,7 @@ Event::Event()
   : sender_node_id_( 0 ) // initializing to 0 as this is an unsigned type
                          // node ID 0 is network, can never send an event, so
                          // this is safe
+  , sender_spike_data_()
   , sender_( NULL )
   , receiver_( NULL )
   , p_( -1 )
@@ -50,6 +52,26 @@ Event::Event()
 {
 }
 
+index
+Event::retrieve_sender_node_id_from_source_table() const
+{
+  if ( sender_node_id_ > 0 )
+  {
+    return sender_node_id_;
+  }
+  else
+  {
+    const index node_id = kernel().connection_manager.get_source_node_id(
+      sender_spike_data_.get_tid(), sender_spike_data_.get_syn_id(), sender_spike_data_.get_lcid() );
+    return node_id;
+  }
+}
+
+index
+Event::get_receiver_node_id( void ) const
+{
+  return receiver_->get_node_id();
+}
 
 void
 SpikeEvent::operator()()
@@ -134,10 +156,5 @@ DiffusionConnectionEvent::operator()()
 {
   receiver_->handle( *this );
 }
-}
 
-nest::index
-nest::Event::get_receiver_node_id( void ) const
-{
-  return receiver_->get_node_id();
-}
+} // namespace nest

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -630,6 +630,9 @@ EventDeliveryManager::deliver_events_( const thread tid, const std::vector< Spik
           const index syn_id = spike_data.get_syn_id();
           const index lcid = spike_data.get_lcid();
 
+          // non-local sender -> receiver retrieves ID of sender Node from SourceTable based on tid, syn_id, lcid
+          // only if needed, as this is computationally costly
+          se.set_sender_node_id_info( tid, syn_id, lcid );
           kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
         }
       }
@@ -647,6 +650,9 @@ EventDeliveryManager::deliver_events_( const thread tid, const std::vector< Spik
           {
             const index lcid = it->get_lcid();
 
+            // non-local sender -> receiver retrieves ID of sender Node from SourceTable based on tid, syn_id, lcid
+            // only if needed, as this is computationally costly
+            se.set_sender_node_id_info( tid, syn_id, lcid );
             kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
           }
         }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -629,8 +629,6 @@ EventDeliveryManager::deliver_events_( const thread tid, const std::vector< Spik
         {
           const index syn_id = spike_data.get_syn_id();
           const index lcid = spike_data.get_lcid();
-          const index source_node_id = kernel().connection_manager.get_source_node_id( tid, syn_id, lcid );
-          se.set_sender_node_id( source_node_id );
 
           kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
         }
@@ -648,8 +646,6 @@ EventDeliveryManager::deliver_events_( const thread tid, const std::vector< Spik
           if ( it->get_tid() == tid )
           {
             const index lcid = it->get_lcid();
-            const index source_node_id = kernel().connection_manager.get_source_node_id( tid, syn_id, lcid );
-            se.set_sender_node_id( source_node_id );
 
             kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
           }

--- a/nestkernel/spike_data.h
+++ b/nestkernel/spike_data.h
@@ -63,6 +63,8 @@ public:
   SpikeData( const SpikeData& rhs );
   SpikeData( const thread tid, const synindex syn_id, const index lcid, const unsigned int lag );
 
+  SpikeData& operator=( const SpikeData& rhs );
+
   void set( const thread tid, const synindex syn_id, const index lcid, const unsigned int lag, const double offset );
 
   /**
@@ -154,6 +156,17 @@ inline SpikeData::SpikeData( const thread tid, const synindex syn_id, const inde
   , tid_( tid )
   , syn_id_( syn_id )
 {
+}
+
+inline SpikeData&
+SpikeData::operator=( const SpikeData& rhs )
+{
+  lcid_ = rhs.lcid_;
+  marker_ = SPIKE_DATA_ID_DEFAULT;
+  lag_ = rhs.lag_;
+  tid_ = rhs.tid_;
+  syn_id_ = rhs.syn_id_;
+  return *this;
 }
 
 inline void


### PR DESCRIPTION
Retrieving the node id from `SourceTable` is computationally costly, and most targets don't need the node id (with the exception of `binary_neuron`s).  To support `binary_neuron`s, an alternative solution is suggested here: The location (`tid`, `syn_id`, `lcid`) of the sender node id in `SourceTable` is stored in `Event` instead of the node id retrieved from `SourceTable`, and `Event` now provides a function to perform the look-up of the node id in `SourceTable`.

For local receivers (i.e., recording devices), delivery anyway takes a different, more direct path:
https://github.com/nest/nest-simulator/blob/8ea4121e81199b83028dee8082d19183da78057b/nestkernel/event_delivery_manager_impl.h#L87
The node id is retrieved from the local sender and stored in `Event`, and it can subsequently be retrieved through `Event::get_sender_node_id()`.