### PR TITLE
Fix GHA clang format issue

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get install libltdl-dev libreadline6-dev libncurses5-dev libgsl0-dev python3-all-dev jq pycodestyle libpcre3 libpcre3-dev python2-dev libboost-all-dev
           sudo apt-get install openmpi-bin libopenmpi-dev libgsl0-dev tcl8.6 tcl8.6-dev tk8.6-dev
           sudo apt-get install libboost-filesystem-dev libboost-regex-dev libboost-wave-dev libboost-python-dev libboost-program-options-dev libboost-test-dev
-          sudo apt-get install vera++
+          sudo apt-get install vera++ clang-format-9
           sudo ldconfig
           g++ --version
 

--- a/build_support/static_code_analysis.sh
+++ b/build_support/static_code_analysis.sh
@@ -79,18 +79,34 @@ print_msg() {
 print_msg "MSGBLD0105: " "Following tools are in use:"
 print_msg "MSGBLD0105: " "---------------------------"
 if $PERFORM_VERA; then
+  if ! command -v $VERA; then
+    print_msg "MSGBLD0105:" "Could not find $VERA!"
+    exit 1
+  fi
   VERA_VERS=`$VERA --version`
   print_msg "MSGBLD0105: " "VERA++       : $VERA_VERS"
 fi
 if $PERFORM_CPPCHECK; then
+  if ! command -v $CPPCHECK; then
+    print_msg "MSGBLD0105:" "Could not find $CPPCHECK!"
+    exit 1
+  fi
   CPPCHECK_VERS=`$CPPCHECK --version | sed 's/^Cppcheck //'`
   print_msg "MSGBLD0105: " "CPPCHECK     : $CPPCHECK_VERS"
 fi
 if $PERFORM_CLANG_FORMAT; then
+  if ! command -v $CLANG_FORMAT; then
+    print_msg "MSGBLD0105:" "Could not find $CLANG_FORMAT!"
+    exit 1
+  fi
   CLANG_FORMAT_VERS=`$CLANG_FORMAT --version`
   print_msg "MSGBLD0105: " "CLANG-FORMAT : $CLANG_FORMAT_VERS"
 fi
 if $PERFORM_PEP8; then
+  if ! command -v $PEP8; then
+    print_msg "MSGBLD0105:" "Could not find $PEP8!"
+    exit 1
+  fi
   PYCODESTYLE_VERS=`$PEP8 --version`
   print_msg "MSGBLD0105: " "PEP8         : $PYCODESTYLE_VERS"
   print_msg "MSGBLD0105: " "PEP8 ignores : $PYCODESTYLE_IGNORES"


### PR DESCRIPTION
Fixes an issue with the static code checks where clang-format failed because version 9 was not installed (it is required since #2279). That led to every formatting check of C++ files failing with the following message:
```
./build_support/static_code_analysis.sh: line 90: clang-format-9: command not found
```
This PR adds clang-format-9 to system dependencies, which fixes the problem. Additionally, the static code analysis script aborts if any of the requested tools are not found.