### PR TITLE
Replace UWSGI by Gunicorn to start NEST Server instance

### DIFF
--- a/bin/nest-server
+++ b/bin/nest-server
@@ -1,34 +1,27 @@
 #!/bin/bash
 
-BUFFER_SIZE="${NEST_SERVER_BUFFER_SIZE:-4096}"
-DAEMONIZE="${NEST_SERVER_DAEMONIZE:-0}"
+DAEMON="${NEST_SERVER_DAEMON:-0}"
 HOST="${NEST_SERVER_HOST:-127.0.0.1}"
-PLUGIN="${NEST_SERVER_PLUGIN:-}"
 PORT="${NEST_SERVER_PORT:-5000}"
 STDOUT="${NEST_SERVER_STDOUT:-0}"
-USER="${NEST_SERVER_USER:-${USER:-65534}}"
-WSGI="${NEST_SERVER_WSGI:-uwsgi}"
 
 usage() {
   echo "NEST Server"
   echo "-----------"
-  echo "Usage: nest-server log|status|start|stop|restart [-d] [-o] [-h <HOST>] [-p <PORT>] [-P <PLUGIN>] [-u <UID>]"
+  echo "Usage: nest-server log|status|start|stop|restart [-D] [-h <HOST>] [-o] [-p <PORT>]"
   echo ""
   echo "Commands:"
-  echo "  log         display the sever log stored in /tmp/nest-server.log"
-  echo "  status      display the status of NEST Server"
-  echo "  start       start a new instance of the server"
-  echo "  stop        stop a server instance running on <HOST>:<PORT>"
-  echo "  restart     restart (i.e. stop and start) a server on <HOST>:<PORT>"
+  echo "  log         display the server log stored in /tmp/nest-server.log"
+  echo "  status      display the status of all server instances"
+  echo "  start       start a server instance on <HOST>:<PORT>"
+  echo "  stop        stop a server instance on <HOST>:<PORT>"
+  echo "  restart     restart (i.e. stop and start) a server instance on <HOST>:<PORT>"
   echo
   echo "Options:"
-  echo "  -b <BUFFER_SIZE>   set internal buffer size [default: 4096]"
-  echo "  -d                 daemonize the server process"
+  echo "  -D                 daemonize the server process"
   echo "  -h <HOST>          use hostname/IP address <HOST> for the server [default: 127.0.0.1]"
-  echo "  -o                 print all output to both the console and to the log"
+  echo "  -o                 print all output to the console"
   echo "  -p <PORT>          use port <PORT> for opening the socket [default: 5000]"
-  echo "  -P <PLUGIN>        use the specified uWSGI plugin"
-  echo "  -u <UID>           run the server under the user with ID <UID>" >&2; exit 1
 }
 
 log() {
@@ -37,54 +30,30 @@ log() {
 }
 
 pid() {
-  # Get Process ID of instance of NEST Server with host and port.
-  if [ "${WSGI}" = "uwsgi" ]; then
-    pgrep -f "uwsgi --module nest.server.app --http-socket ${HOST}:${PORT}"
-  elif [ "${WSGI}" = "gunicorn" ]; then
-    pgrep -f "gunicorn nest.server.app --bind ${HOST}:${PORT}"
-  fi
+  # Get process ID of instance on defined host and port.
+  pgrep -f "gunicorn nest.server.app --bind ${HOST}:${PORT}"
 }
 
 set-gunicorn_opts() {
   # Set opts for gunicorn.
   GUNICORN_OPTS="--bind ${HOST}:${PORT}"
-  GUNICORN_OPTS="${GUNICORN_OPTS} --user ${USER}"
-  GUNICORN_OPTS="${GUNICORN_OPTS} --limit-request-line ${BUFFER_SIZE}"
-  if [ "${STDOUT}" -eq 0 ]; then
+  if [ "${DAEMON}" -eq 1 ]; then
     GUNICORN_OPTS="${GUNICORN_OPTS} --daemon"
   fi
   GUNICORN_OPTS="${GUNICORN_OPTS} --log-file /tmp/nest-server.log"
 }
 
-set-uwsgi_opts() {
-  # Set opts for uwsgi.
-  UWSGI_OPTS="--http-socket ${HOST}:${PORT}"
-  UWSGI_OPTS="${UWSGI_OPTS} --uid ${USER}"
-  UWSGI_OPTS="${UWSGI_OPTS} --buffer-size ${BUFFER_SIZE}"
-  if [ -n "${PLUGIN}" ]; then
-    UWSGI_OPTS="${UWSGI_OPTS} --plugin \"${PLUGIN}\""
-  fi
-  if [ "${STDOUT}" -eq 0 ]; then
-    UWSGI_OPTS="${UWSGI_OPTS} --daemonize /tmp/nest-server.log"
-  fi
-}
-
 start() {
-  # Start instance of NEST Server.
+  # Start server instance.
   if pid > /dev/null;  then
     echo "NEST Server is already running at http://${HOST}:${PORT}."
   else
-    if [ "${WSGI}" = "uwsgi" ]; then
-      set-uwsgi_opts
-      uwsgi --module nest.server:app ${UWSGI_OPTS}
-    elif [ "${WSGI}" = "gunicorn" ]; then
-      set-gunicorn_opts
-      gunicorn nest.server:app ${GUNICORN_OPTS}
-    fi
+    set-gunicorn_opts
+    gunicorn nest.server:app ${GUNICORN_OPTS}
 
     if [ "${STDOUT}" -eq 0 ]; then
       echo "NEST Server is running at http://${HOST}:${PORT}."
-      if [ "${DAEMONIZE}" -eq 0 ]; then
+      if [ "${DAEMON}" -eq 0 ]; then
         read -p "Press any key to stop... "
         stop
       fi
@@ -94,11 +63,7 @@ start() {
 
 status() {
   # List all processes of NEST Server.
-  if [ "${WSGI}" = "uwsgi" ]; then
-    PS_AUX="$(ps aux | grep "[u]wsgi --module nest.server.app")"
-  elif [ "${WSGI}" = "gunicorn" ]; then
-    PS_AUX="$(ps aux | grep "[g]unicorn nest.server.app")"
-  fi
+  PS_AUX="$(ps aux | grep "[g]unicorn nest.server.app")"
 
   PS_CMD="$(echo ${PS_AUX} | awk '{ for(i=1;i<=NF;i++) {if ( i >= 11 ) printf $i" "}; printf "\n" }')"
   printf "HTTP-SOCKET\t\tUID\n"
@@ -106,7 +71,7 @@ status() {
 }
 
 stop() {
-  # Stop instance of NEST Server.
+  # Stop server instance.
   if pid > /dev/null; then
     kill "$(pid 2>&1 | head -n 1)"
     echo "NEST Server running at http://${HOST}:${PORT} has stopped."
@@ -117,15 +82,12 @@ stop() {
 }
 
 CMD=$1; shift
-while getopts "b:dh:op:P:u:" opt; do
+while getopts "Dh:op:" opt; do
     case $opt in
-        b) BUFFER_SIZE=$OPTARG ;;
-        d) DAEMONIZE=1 ;;
+        D) DAEMON=1 ;;
         h) HOST=$OPTARG ;;
         o) STDOUT=1 ;;
         p) PORT=$OPTARG ;;
-        P) PLUGIN=$OPTARG ;;
-        u) USER=$OPTARG ;;
     esac
 done
 

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -8,7 +8,7 @@ STDOUT="${NEST_SERVER_STDOUT:-0}"
 usage() {
   echo "NEST Server"
   echo "-----------"
-  echo "Usage: nest-server log|status|start|stop|restart [-D] [-h <HOST>] [-o] [-p <PORT>]"
+  echo "Usage: nest-server log|status|start|stop|restart [-d] [-h <HOST>] [-o] [-p <PORT>]"
   echo ""
   echo "Commands:"
   echo "  log         display the server log stored in /tmp/nest-server.log"
@@ -18,9 +18,9 @@ usage() {
   echo "  restart     restart (i.e. stop and start) a server instance on <HOST>:<PORT>"
   echo
   echo "Options:"
-  echo "  -D                 daemonize the server process"
+  echo "  -d                 daemonize the server process"
   echo "  -h <HOST>          use hostname/IP address <HOST> for the server [default: 127.0.0.1]"
-  echo "  -o                 print all output to the console"
+  echo "  -o                 print all outputs to the console"
   echo "  -p <PORT>          use port <PORT> for opening the socket [default: 5000]"
 }
 
@@ -82,9 +82,9 @@ stop() {
 }
 
 CMD=$1; shift
-while getopts "Dh:op:" opt; do
+while getopts "dh:op:" opt; do
     case $opt in
-        D) DAEMON=1 ;;
+        d) DAEMON=1 ;;
         h) HOST=$OPTARG ;;
         o) STDOUT=1 ;;
         p) PORT=$OPTARG ;;

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -77,7 +77,7 @@ start() {
     if [ "${WSGI}" = "uwsgi" ]; then
       set-uwsgi_opts
       uwsgi --module nest.server:app ${UWSGI_OPTS}
-    elif [ "${WSGI}" == "gunicorn" ]; then
+    elif [ "${WSGI}" = "gunicorn" ]; then
       set-gunicorn_opts
       gunicorn nest.server:app ${GUNICORN_OPTS}
     fi

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -7,6 +7,7 @@ PLUGIN="${NEST_SERVER_PLUGIN:-}"
 PORT="${NEST_SERVER_PORT:-5000}"
 STDOUT="${NEST_SERVER_STDOUT:-0}"
 USER="${NEST_SERVER_USER:-${USER:-65534}}"
+WSGI="${NEST_SERVER_WSGI:-uwsgi}"
 
 usage() {
   echo "NEST Server"
@@ -37,12 +38,27 @@ log() {
 
 pid() {
   # Get Process ID of instance of NEST Server with host and port.
-  pgrep -f "uwsgi --module nest.server.app --http-socket ${HOST}:${PORT}"
+  if [ "${WSGI}" = "uwsgi" ]; then
+    pgrep -f "uwsgi --module nest.server.app --http-socket ${HOST}:${PORT}"
+  elif [ "${WSGI}" = "gunicorn" ]; then
+    pgrep -f "gunicorn nest.server.app --bind ${HOST}:${PORT}"
+  fi
+}
+
+set-gunicorn_opts() {
+  # Set opts for gunicorn.
+  GUNICORN_OPTS="--bind ${HOST}:${PORT}"
+  GUNICORN_OPTS="${GUNICORN_OPTS} --user ${USER}"
+  GUNICORN_OPTS="${GUNICORN_OPTS} --limit-request-line ${BUFFER_SIZE}"
+  if [ "${STDOUT}" -eq 0 ]; then
+    GUNICORN_OPTS="${GUNICORN_OPTS} --daemon"
+  fi
+  GUNICORN_OPTS="${GUNICORN_OPTS} --log-file /tmp/nest-server.log"
 }
 
 set-uwsgi_opts() {
   # Set opts for uwsgi.
-  UWSGI_OPTS="--module nest.server:app --http-socket ${HOST}:${PORT}"
+  UWSGI_OPTS="--http-socket ${HOST}:${PORT}"
   UWSGI_OPTS="${UWSGI_OPTS} --uid ${USER}"
   UWSGI_OPTS="${UWSGI_OPTS} --buffer-size ${BUFFER_SIZE}"
   if [ -n "${PLUGIN}" ]; then
@@ -58,11 +74,17 @@ start() {
   if pid > /dev/null;  then
     echo "NEST Server is already running at http://${HOST}:${PORT}."
   else
-    set-uwsgi_opts
-    uwsgi ${UWSGI_OPTS}
-    if [ ${STDOUT} == 0 ]; then
+    if [ "${WSGI}" = "uwsgi" ]; then
+      set-uwsgi_opts
+      uwsgi --module nest.server:app ${UWSGI_OPTS}
+    elif [ "${WSGI}" == "gunicorn" ]; then
+      set-gunicorn_opts
+      gunicorn nest.server:app ${GUNICORN_OPTS}
+    fi
+
+    if [ "${STDOUT}" -eq 0 ]; then
       echo "NEST Server is running at http://${HOST}:${PORT}."
-      if [ ${DAEMONIZE} == 0 ]; then
+      if [ "${DAEMONIZE}" -eq 0 ]; then
         read -p "Press any key to stop... "
         stop
       fi
@@ -72,7 +94,12 @@ start() {
 
 status() {
   # List all processes of NEST Server.
-  PS_AUX="$(ps aux | grep "[u]wsgi --module nest.server.app")"
+  if [ "${WSGI}" = "uwsgi" ]; then
+    PS_AUX="$(ps aux | grep "[u]wsgi --module nest.server.app")"
+  elif [ "${WSGI}" = "gunicorn" ]; then
+    PS_AUX="$(ps aux | grep "[g]unicorn nest.server.app")"
+  fi
+
   PS_CMD="$(echo ${PS_AUX} | awk '{ for(i=1;i<=NF;i++) {if ( i >= 11 ) printf $i" "}; printf "\n" }')"
   printf "HTTP-SOCKET\t\tUID\n"
   echo "${PS_CMD}" | awk '{ for(i=1;i<=NF;i++) {if ( i == 5 || i == 7 ) printf $i"\t\t"}; printf "\n" }'
@@ -81,7 +108,7 @@ status() {
 stop() {
   # Stop instance of NEST Server.
   if pid > /dev/null; then
-    kill "$(pid)"
+    kill "$(pid 2>&1 | head -n 1)"
     echo "NEST Server running at http://${HOST}:${PORT} has stopped."
   else
     echo "NEST Server is not running at http://${HOST}:${PORT}."

--- a/doc/userdoc/nest_server.rst
+++ b/doc/userdoc/nest_server.rst
@@ -118,7 +118,7 @@ Possible commands are `start`, `stop`, `status`, or `log`. The meaning
 of the other arguments is as follows:
 
 -d
-    Run Nest Server in the background (i.e., daemonize it)
+    Run NEST Server in the background (i.e., daemonize it)
 -o
     Print all outputs to the console
 -h <host>

--- a/doc/userdoc/nest_server.rst
+++ b/doc/userdoc/nest_server.rst
@@ -74,7 +74,7 @@ Server and would like to have it listed here, feel free to `drop us a
 line <https://github.com/nest/nest-simulator/issues>`_.
 
 Install and run NEST Server
---------------------------
+---------------------------
 
 NEST Server is included in all source code distributions of NEST and
 consequently, also available in derived packages, our virtual
@@ -83,7 +83,7 @@ machine, and Docker images.
 For native installations, the requirements can be simply installed via
 ``pip``::
 
-  pip3 install RestrictedPython uwsgi flask flask-cors
+  pip3 install Flask Flask-Cors gunicorn RestrictedPython
 
 or by installing the full NEST development environment in case you
 prefer using ``conda``::
@@ -97,7 +97,7 @@ from the NEST Docker image. Please check out the corresponding
 :ref:`installation instructions <docker_vm_install>` for more details.
 
 Run NEST Server
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 All NEST Server operations are managed using the ``nest-server``
 command that can either be run directly::
@@ -112,26 +112,22 @@ container::
 The generic invocation command line for the ``nest-server`` command
 looks as follows::
 
-  nest-server <command> [-d] [-o] [-h <host>] [-p <port>] [-P <plugin>] [-u <user>]
+  nest-server <command> [-d] [-h <host>] [-o] [-p <port>]
 
 Possible commands are `start`, `stop`, `status`, or `log`. The meaning
 of the other arguments is as follows:
 
 -d
-    Run nest-server in the background (i.e., daemonize it)
+    Run Nest Server in the background (i.e., daemonize it)
 -o
-    Print all output to both the console and the logger
+    Print all outputs to the console
 -h <host>
-    Use hostname/IP address <host> for the server [default: 127.0.0.1]
+    Use hostname/IP address <host> for the server instance [default: 127.0.0.1]
 -p <port>
     Use port <port> for opening the socket [default: 5000]
--P <plugin>
-    Use the uWSGI plugin <plugin> when running the server
--u <uid>
-    Run the server under the user with ID <user>
 
 Run with MPI
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 If NEST was compiled with support for :ref:`distributed computing via
 MPI <distributed_computing>`, it will usually execute the exact same
@@ -237,7 +233,7 @@ NEST Server Client.
             print('Number of events:', n_events)
 
 Run scripts
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 The NEST Server Client is able to send complete simulation scripts to
 the NEST Server using the functions ``exec_script`` and ``from_file``.
@@ -342,7 +338,7 @@ To obtain basic information about the running server, run::
 
 NEST Server responds to this by sending data in JSON format::
 
-  {"nest":"master@b08590af6"}
+  {"mpi":false,"nest":"3.2"}
 
 You can retrieve data about the callable functions of NEST by running::
 
@@ -468,7 +464,7 @@ Advanced topics
 ---------------
 
 Run scripts in NEST Server using `curl`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As shown above, you can send custom simulation code to
 ``localhost:5000/exec``. On the command line, this approach might be a
@@ -493,7 +489,7 @@ command:
 
 
 Interact with NEST Server using JavaScript
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As the NEST Server is built on modern web technologies, it may be
 desirable to create a frontend to it in the form of a
@@ -613,7 +609,7 @@ Now, we can send a custom Python script to NEST Server:
     account of Steffen Graber.
 
 Control NEST from Bash
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 For POST requests to the NEST API Server, we recommend to use a Bash function:
 

--- a/environment.yml
+++ b/environment.yml
@@ -76,20 +76,20 @@ dependencies:
   - tqdm
   - yamllint
 
+  # Running NEST Server ----
+  - flask
+  - flask_cors
+  - gunicorn
   - requests
   - werkzeug
 
   # PIP dependencies -- do not delete
   - pip:
-      # For testsuite
-      - junitparser >= 2
-      # For documentation
-      - example
-      - Image
-      - sphinx_autobuild
-      - sphinx_gallery
-      - sphinx-tabs
-      # For NEST Server
-      - Flask
-      - Flask-Cors
-      - gunicorn
+    # For testsuite
+    - junitparser >= 2
+    # For documentation
+    - example
+    - Image
+    - sphinx_autobuild
+    - sphinx_gallery
+    - sphinx-tabs

--- a/environment.yml
+++ b/environment.yml
@@ -11,17 +11,13 @@
 # parallelisation, GSL-dependent models, NumPy and Pandas-dependent
 # features of PyNEST and examples requiring Matplotlib, and to run
 # the NEST testsuite. It also comprises all tools required to build
-# NEST documentation and to run NEST server. The requirements for the
+# NEST documentation and to run NEST Server. The requirements for the
 # documentation and server are marked in separate sections below so
 # you can remove them if you would like a leaner environment.
 #
 # NOTE: Do NOT delete the PIP section at the end of the file. Environment files
 #       allow just a single PIP section. All dependencies not satisfied by
 #       conda-forge are placed there.
-#
-# NOTE: If you are working on Apple Silicon (M1 CPU), you must comment out the
-#       NEST Server section below because conda-forge does not provide uwsgi
-#       for osx-arm64 yet.
 #
 # NOTE: libneurosim, MUSIC and SIONLib are not included in this environment.
 #
@@ -80,20 +76,20 @@ dependencies:
   - tqdm
   - yamllint
 
-  # Running NEST Server ----
-  - flask
-  - flask_cors
   - requests
-  - uwsgi
   - werkzeug
 
   # PIP dependencies -- do not delete
   - pip:
-    # For testsuite
-    - junitparser >= 2
-    # For documentation
-    - example
-    - Image
-    - sphinx_autobuild
-    - sphinx_gallery
-    - sphinx-tabs
+      # For testsuite
+      - junitparser >= 2
+      # For documentation
+      - example
+      - Image
+      - sphinx_autobuild
+      - sphinx_gallery
+      - sphinx-tabs
+      # For NEST Server
+      - Flask
+      - Flask-Cors
+      - gunicorn


### PR DESCRIPTION
This PR uses `gunicorn` execution in nest-server command:

```
nest-server start
```

Resolves #2211.