### PR TITLE
fix typo in docstring

### DIFF
--- a/pynest/nest/lib/hl_api_models.py
+++ b/pynest/nest/lib/hl_api_models.py
@@ -95,7 +95,7 @@ def Models(mtype="all", sel=None):
 
 @check_stack
 def ConnectionRules():
-    """Return a typle of all available connection rules, sorted by name.
+    """Return a tuple of all available connection rules, sorted by name.
 
     Returns
     -------


### PR DESCRIPTION
fix typo ('typle' -> 'tuple') in `hl_api_models.py` docstring