### PR TITLE
Return invalid_thread_ for proxynode

### DIFF
--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -115,6 +115,7 @@ public:
   get_thread() const
   {
     assert( false );
+    return invalid_thread_;
   }
 
 private:


### PR DESCRIPTION
Not returning in a non-void function causes undefined-behavior.

Fixes #2295