### PR TITLE
Reduce memory consumption in node creation with many threads

### DIFF
--- a/models/iaf_psc_alpha_canon.h
+++ b/models/iaf_psc_alpha_canon.h
@@ -170,7 +170,7 @@ public:
   iaf_psc_alpha_canon();
 
   /** Copy constructor.
-      GenericModel::allocate_() uses the copy constructor to clone
+      GenericModel::create_() uses the copy constructor to clone
       actual model instances from the prototype instance.
 
       @note The copy constructor MUST NOT be used to create nodes based

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -157,7 +157,7 @@ public:
   iaf_psc_alpha_ps();
 
   /** Copy constructor.
-      GenericModel::allocate_() uses the copy constructor to clone
+      GenericModel::create_() uses the copy constructor to clone
       actual model instances from the prototype instance.
 
       @note The copy constructor MUST NOT be used to create nodes based

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -164,7 +164,7 @@ public:
   iaf_psc_delta_ps();
 
   /** Copy constructor.
-      GenericModel::allocate_() uses the copy constructor to clone
+      GenericModel::create_() uses the copy constructor to clone
       actual model instances from the prototype instance.
 
       @note The copy constructor MUST NOT be used to create nodes based

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -151,7 +151,7 @@ public:
   iaf_psc_exp_ps();
 
   /** Copy constructor.
-      GenericModel::allocate_() uses the copy constructor to clone
+      GenericModel::create_() uses the copy constructor to clone
       actual model instances from the prototype instance.
 
       @note The copy constructor MUST NOT be used to create nodes based

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -147,7 +147,7 @@ public:
   iaf_psc_exp_ps_lossless();
 
   /** Copy constructor.
-      GenericModel::allocate_() uses the copy constructor to clone
+      GenericModel::create_() uses the copy constructor to clone
       actual model instances from the prototype instance.
 
       @note The copy constructor MUST NOT be used to create nodes based

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -103,12 +103,7 @@ private:
   /**
    * Call placement new on the supplied memory position.
    */
-  Node* allocate_( void* );
-
-  /**
-   * Initialize the pool allocator with the node specific properties.
-   */
-  void init_memory_( sli::pool& );
+  Node* allocate_();
 
   /**
    * Prototype node from which all instances are constructed.
@@ -156,17 +151,10 @@ GenericModel< ElementT >::clone( const std::string& newname ) const
 
 template < typename ElementT >
 Node*
-GenericModel< ElementT >::allocate_( void* adr )
+GenericModel< ElementT >::allocate_()
 {
-  Node* n = new ( adr ) ElementT( proto_ );
+  Node* n = new ElementT( proto_ );
   return n;
-}
-
-template < typename ElementT >
-void
-GenericModel< ElementT >::init_memory_( sli::pool& mem )
-{
-  mem.init( sizeof( ElementT ), 1000, 1 );
 }
 
 template < typename ElementT >

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -103,7 +103,7 @@ private:
   /**
    * Call placement new on the supplied memory position.
    */
-  Node* allocate_();
+  Node* create_();
 
   /**
    * Prototype node from which all instances are constructed.
@@ -151,7 +151,7 @@ GenericModel< ElementT >::clone( const std::string& newname ) const
 
 template < typename ElementT >
 Node*
-GenericModel< ElementT >::allocate_()
+GenericModel< ElementT >::create_()
 {
   Node* n = new ElementT( proto_ );
   return n;

--- a/nestkernel/model.cpp
+++ b/nestkernel/model.cpp
@@ -56,33 +56,20 @@ Model::set_threads_( thread t )
 {
   for ( size_t i = 0; i < memory_.size(); ++i )
   {
-    if ( memory_[ i ].get_instantiations() > 0 )
+    if ( memory_[ i ].size() > 0 )
     {
       throw KernelException();
     }
   }
 
-  std::vector< sli::pool > tmp( t );
-  memory_.swap( tmp );
-
-  for ( size_t i = 0; i < memory_.size(); ++i )
-  {
-    init_memory_( memory_[ i ] );
-  }
-}
-
-void
-Model::reserve_additional( thread t, size_t s )
-{
-  assert( ( size_t ) t < memory_.size() );
-  memory_[ t ].reserve_additional( s );
+  memory_.resize( t );
+  memory_.shrink_to_fit();
 }
 
 void
 Model::clear()
 {
-  std::vector< sli::pool > mem;
-  memory_.swap( mem );
+  memory_.clear();
   set_threads_( 1 );
 }
 
@@ -92,7 +79,7 @@ Model::mem_available()
   size_t result = 0;
   for ( size_t t = 0; t < memory_.size(); ++t )
   {
-    result += memory_[ t ].available();
+    result += memory_[ t ].capacity() - memory_[ t ].size();
   }
 
   return result;
@@ -104,7 +91,7 @@ Model::mem_capacity()
   size_t result = 0;
   for ( size_t t = 0; t < memory_.size(); ++t )
   {
-    result += memory_[ t ].get_total();
+    result += memory_[ t ].capacity();
   }
 
   return result;
@@ -131,7 +118,7 @@ Model::get_status( void )
   std::vector< long > tmp( memory_.size() );
   for ( size_t t = 0; t < tmp.size(); ++t )
   {
-    tmp[ t ] = memory_[ t ].get_instantiations();
+    tmp[ t ] = memory_[ t ].size();
   }
 
   ( *d )[ names::instantiations ] = Token( tmp );
@@ -139,14 +126,14 @@ Model::get_status( void )
 
   for ( size_t t = 0; t < tmp.size(); ++t )
   {
-    tmp[ t ] = memory_[ t ].get_total();
+    tmp[ t ] = memory_[ t ].capacity();
   }
 
   ( *d )[ names::capacity ] = Token( tmp );
 
   for ( size_t t = 0; t < tmp.size(); ++t )
   {
-    tmp[ t ] = memory_[ t ].available();
+    tmp[ t ] = memory_[ t ].capacity() - memory_[ t ].size();
   }
 
   ( *d )[ names::available ] = Token( tmp );

--- a/nestkernel/model.cpp
+++ b/nestkernel/model.cpp
@@ -67,6 +67,13 @@ Model::set_threads_( thread t )
 }
 
 void
+Model::reserve_additional( thread t, size_t n )
+{
+  assert( ( size_t ) t < memory_.size() );
+  memory_[ t ].reserve( n );
+}
+
+void
 Model::clear()
 {
   memory_.clear();

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -89,24 +89,11 @@ public:
    */
   Node* allocate( thread t );
 
-  void free( thread t, Node* );
-
   /**
    * Deletes all nodes which belong to this model.
    */
 
   void clear();
-
-  /**
-   * Reserve memory for at least n additional Nodes.
-   * A number of memory managers work more efficiently if they have
-   * an idea about the number of Nodes to be allocated.
-   * This function prepares the memory manager for the subsequent
-   * allocation of n additional Nodes.
-   * @param t Thread for which the Nodes are reserved.
-   * @param n Number of Nodes to be allocated.
-   */
-  void reserve_additional( thread t, size_t n );
 
   /**
    * Return name of the Model.
@@ -223,14 +210,9 @@ private:
   void set_threads_( thread t );
 
   /**
-   * Initialize the pool allocator with the Node specific values.
-   */
-  virtual void init_memory_( sli::pool& ) = 0;
-
-  /**
    * Allocate a new object at the specified memory position.
    */
-  virtual Node* allocate_( void* ) = 0;
+  virtual Node* allocate_() = 0;
 
   /**
    * Name of the Model.
@@ -250,7 +232,7 @@ private:
   /**
    * Memory for all nodes sorted by threads.
    */
-  std::vector< sli::pool > memory_;
+  std::vector< std::vector< Node* > > memory_;
 };
 
 
@@ -258,14 +240,9 @@ inline Node*
 Model::allocate( thread t )
 {
   assert( ( size_t ) t < memory_.size() );
-  return allocate_( memory_[ t ].alloc() );
-}
-
-inline void
-Model::free( thread t, Node* n )
-{
-  assert( ( size_t ) t < memory_.size() );
-  memory_[ t ].free( n );
+  Node* n = allocate_();
+  memory_[ t ].push_back( n );
+  return n;
 }
 
 inline std::string

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -96,6 +96,11 @@ public:
   void clear();
 
   /**
+   * Reserve space for n Nodes.
+   */
+  void reserve_additional( thread t, size_t n );
+
+  /**
    * Return name of the Model.
    * This function returns the name of the Model as C++ string. The
    * name is defined by the constructor. The result is identical to the value

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -83,11 +83,11 @@ public:
 
   /**
    * Allocate new Node and return its pointer.
-   * allocate() is not const, because it
+   * create() is not const, because it
    * is allowed to modify the Model object for
    * 'administrative' purposes.
    */
-  Node* allocate( thread t );
+  Node* create( thread t );
 
   /**
    * Deletes all nodes which belong to this model.
@@ -210,9 +210,9 @@ private:
   void set_threads_( thread t );
 
   /**
-   * Allocate a new object at the specified memory position.
+   * Create a new object.
    */
-  virtual Node* allocate_() = 0;
+  virtual Node* create_() = 0;
 
   /**
    * Name of the Model.
@@ -237,10 +237,10 @@ private:
 
 
 inline Node*
-Model::allocate( thread t )
+Model::create( thread t )
 {
   assert( ( size_t ) t < memory_.size() );
-  Node* n = allocate_();
+  Node* n = create_();
   memory_[ t ].push_back( n );
   return n;
 }

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -96,7 +96,7 @@ public:
   void clear();
 
   /**
-   * Reserve space for n Nodes.
+   * Reserve space for n additional Nodes.
    */
   void reserve_additional( thread t, size_t n );
 

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -601,7 +601,7 @@ ModelManager::register_connection_model_( ConnectorModel* cf )
 Node*
 ModelManager::create_proxynode_( thread t, int model_id )
 {
-  Node* proxy = proxynode_model_->allocate( t );
+  Node* proxy = proxynode_model_->create( t );
   proxy->set_model_id( model_id );
   return proxy;
 }

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -187,7 +187,6 @@ public:
 
   /**
    * Print out the memory information for each node model.
-   * @see sli::pool
    */
   void memory_info() const;
 

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -204,7 +204,7 @@ NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, N
 
       while ( node_id <= max_node_id )
       {
-        Node* node = model.allocate( t );
+        Node* node = model.create( t );
         node->set_node_id_( node_id );
         node->set_nc_( nc_ptr );
         node->set_model_id( model.get_model_id() );
@@ -239,7 +239,7 @@ NodeManager::add_devices_( Model& model, index min_node_id, index max_node_id, N
         // keep track of number of thread local devices
         ++num_thread_local_devices_[ t ];
 
-        Node* node = model.allocate( t );
+        Node* node = model.create( t );
         node->set_node_id_( node_id );
         node->set_nc_( nc_ptr );
         node->set_model_id( model.get_model_id() );
@@ -276,7 +276,7 @@ NodeManager::add_music_nodes_( Model& model, index min_node_id, index max_node_i
           // keep track of number of thread local devices
           ++num_thread_local_devices_[ t ];
 
-          Node* node = model.allocate( 0 );
+          Node* node = model.create( 0 );
           node->set_node_id_( node_id );
           node->set_nc_( nc_ptr );
           node->set_model_id( model.get_model_id() );

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -186,11 +186,7 @@ NodeManager::add_node( index model_id, long n )
 void
 NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, NodeCollectionPTR nc_ptr )
 {
-  // upper limit for number of neurons per thread; in practice, either
-  // max_new_per_thread-1 or max_new_per_thread nodes will be created
   const size_t num_vps = kernel().vp_manager.get_num_virtual_processes();
-  const size_t max_new_per_thread =
-    static_cast< size_t >( std::ceil( static_cast< double >( max_node_id - min_node_id + 1 ) / num_vps ) );
 
 #pragma omp parallel
   {
@@ -198,8 +194,6 @@ NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, N
 
     try
     {
-      model.reserve_additional( t, max_new_per_thread );
-
       // Need to find smallest node ID with:
       //   - node ID local to this vp
       //   - node_id >= min_node_id
@@ -235,15 +229,11 @@ NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, N
 void
 NodeManager::add_devices_( Model& model, index min_node_id, index max_node_id, NodeCollectionPTR nc_ptr )
 {
-  const size_t n_per_thread = max_node_id - min_node_id + 1;
-
 #pragma omp parallel
   {
     const index t = kernel().vp_manager.get_thread_id();
     try
     {
-      model.reserve_additional( t, n_per_thread );
-
       for ( index node_id = min_node_id; node_id <= max_node_id; ++node_id )
       {
         // keep track of number of thread local devices

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -187,6 +187,10 @@ void
 NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, NodeCollectionPTR nc_ptr )
 {
   const size_t num_vps = kernel().vp_manager.get_num_virtual_processes();
+  // Upper limit for number of neurons per thread; in practice, either
+  // max_new_per_thread-1 or max_new_per_thread nodes will be created.
+  const size_t max_new_per_thread =
+    static_cast< size_t >( std::ceil( static_cast< double >( max_node_id - min_node_id + 1 ) / num_vps ) );
 
 #pragma omp parallel
   {
@@ -194,6 +198,7 @@ NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, N
 
     try
     {
+      model.reserve_additional( t, max_new_per_thread );
       // Need to find smallest node ID with:
       //   - node ID local to this vp
       //   - node_id >= min_node_id
@@ -229,11 +234,15 @@ NodeManager::add_neurons_( Model& model, index min_node_id, index max_node_id, N
 void
 NodeManager::add_devices_( Model& model, index min_node_id, index max_node_id, NodeCollectionPTR nc_ptr )
 {
+  const size_t n_per_thread = max_node_id - min_node_id + 1;
+
 #pragma omp parallel
   {
     const index t = kernel().vp_manager.get_thread_id();
     try
     {
+      model.reserve_additional( t, n_per_thread );
+
       for ( index node_id = min_node_id; node_id <= max_node_id; ++node_id )
       {
         // keep track of number of thread local devices


### PR DESCRIPTION
Creating nodes of different models while using many threads uses an excessive amount of memory. For example, creating 10 populations of 5000 nodes each and different models for each population:

| Threads | Memory [MB] |
|---------:|-----------:|
| 1       |         135 |
| 256     |        2255 |

This is because node creation relies on memory management with `sli::pool`:
https://github.com/nest/nest-simulator/blob/d2e49741374331b23d2b2ed7e218da9a5c993fe1/nestkernel/model.h#L253

By replacing the `sli::pool` with an `std::vector`, the memory consumption is kept at a more manageable level:
| Threads | Memory [MB] |
|---------:|-----------:|
| 1       |         129 |
| 256     |        306 |