### PR TITLE
Disallow specifying lists of synapse models

### DIFF
--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -75,7 +75,7 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
     if (not isinstance(syn_spec, CollocatedSynapses) and
         "synapse_model" in syn_spec and
             not isinstance(syn_spec["synapse_model"], str)):
-        raise kernel.NESTError("'synapse_model' must be a string")
+        raise kernel.NESTError("'synapse_model' must be a string or a CollocatedSynapses object")
 
     elif isinstance(syn_spec, dict):
         for key, value in syn_spec.items():

--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -71,6 +71,10 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
 
     if isinstance(syn_spec, str):
         return {"synapse_model": syn_spec}
+
+    if "synapse_model" in syn_spec and not isinstance(syn_spec["synapse_model"], str):
+        raise kernel.NESTError("'synapse_model' must be a string")
+
     elif isinstance(syn_spec, dict):
         for key, value in syn_spec.items():
             # if value is a list, it is converted to a numpy array

--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -71,13 +71,9 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
 
     if isinstance(syn_spec, str):
         return {"synapse_model": syn_spec}
-
-    if (not isinstance(syn_spec, CollocatedSynapses) and
-        "synapse_model" in syn_spec and
-            not isinstance(syn_spec["synapse_model"], str)):
-        raise kernel.NESTError("'synapse_model' must be a string or a CollocatedSynapses object")
-
     elif isinstance(syn_spec, dict):
+        if "synapse_model" in syn_spec and not isinstance(syn_spec["synapse_model"], str):
+            raise kernel.NESTError("'synapse_model' must be a string")
         for key, value in syn_spec.items():
             # if value is a list, it is converted to a numpy array
             if isinstance(value, (list, tuple)):
@@ -147,7 +143,7 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
     elif isinstance(syn_spec, CollocatedSynapses):
         return syn_spec
 
-    raise TypeError("syn_spec must be a string or dict")
+    raise TypeError("syn_spec must be a string, dict or CollocatedSynapses object")
 
 
 def _process_spatial_projections(conn_spec, syn_spec):

--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -72,7 +72,9 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
     if isinstance(syn_spec, str):
         return {"synapse_model": syn_spec}
 
-    if "synapse_model" in syn_spec and not isinstance(syn_spec["synapse_model"], str):
+    if (not isinstance(syn_spec, CollocatedSynapses) and
+        "synapse_model" in syn_spec and
+            not isinstance(syn_spec["synapse_model"], str)):
         raise kernel.NESTError("'synapse_model' must be a string")
 
     elif isinstance(syn_spec, dict):

--- a/pynest/nest/lib/hl_api_connection_helpers.py
+++ b/pynest/nest/lib/hl_api_connection_helpers.py
@@ -64,14 +64,16 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
         # for use_connect_arrays, return "static_synapse" by default
         if use_connect_arrays:
             return {"synapse_model": "static_synapse"}
-
         return syn_spec
 
-    rule = conn_spec['rule']
+    if isinstance(syn_spec, CollocatedSynapses):
+        return syn_spec
 
     if isinstance(syn_spec, str):
         return {"synapse_model": syn_spec}
-    elif isinstance(syn_spec, dict):
+
+    rule = conn_spec['rule']
+    if isinstance(syn_spec, dict):
         if "synapse_model" in syn_spec and not isinstance(syn_spec["synapse_model"], str):
             raise kernel.NESTError("'synapse_model' must be a string")
         for key, value in syn_spec.items():
@@ -140,9 +142,8 @@ def _process_syn_spec(syn_spec, conn_spec, prelength, postlength, use_connect_ar
             syn_spec["synapse_model"] = "static_synapse"
 
         return syn_spec
-    elif isinstance(syn_spec, CollocatedSynapses):
-        return syn_spec
 
+    # If we get here, syn_spec is of illegal type.
     raise TypeError("syn_spec must be a string, dict or CollocatedSynapses object")
 
 

--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -450,7 +450,7 @@ cdef inline Datum* python_object_to_datum(obj) except NULL:
             elif numpy.issubdtype(obj.dtype, numpy.floating):
                 ret = python_buffer_to_datum[object, double](obj)
             else:
-                raise NESTError.PyNESTError("only vectors of integers or floats are supported")
+                raise NESTErrors.PyNESTError("only vectors of integers or floats are supported")
 
         if ret is NULL:
             try:


### PR DESCRIPTION
Limits `synapse_model` to be a string, and fixes a typo in pynestkernel.pyx which lead to confusing error messages. Fixes #2301.