### PR TITLE
Ensure membrane potential of non-linear neuron models is fully clamped during refractory phase

### DIFF
--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -81,19 +81,24 @@ nest::gif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
   assert( pnode );
   const nest::gif_cond_exp& node = *( reinterpret_cast< nest::gif_cond_exp* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ref_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
 
-  const double I_syn_exc = y[ S::G_EXC ] * ( y[ S::V_M ] - node.P_.E_ex_ );
-  const double I_syn_inh = y[ S::G_INH ] * ( y[ S::V_M ] - node.P_.E_in_ );
-  const double I_L = node.P_.g_L_ * ( y[ S::V_M ] - node.P_.E_L_ );
+  // Clamp membrane potential to V_reset while refractory.
+  const double V = is_refractory ? node.P_.V_reset_ : y[ S::V_M ];
+
+  const double I_syn_exc = y[ S::G_EXC ] * ( V - node.P_.E_ex_ );
+  const double I_syn_inh = y[ S::G_INH ] * ( V - node.P_.E_in_ );
+  const double I_L = node.P_.g_L_ * ( V - node.P_.E_L_ );
   const double stc = node.S_.stc_;
 
   // V dot
-  f[ 0 ] = ( -I_L + node.S_.I_stim_ + node.P_.I_e_ - I_syn_exc - I_syn_inh - stc ) / node.P_.c_m_;
+  f[ 0 ] = is_refractory? 0.0 : ( -I_L + node.S_.I_stim_ + node.P_.I_e_ - I_syn_exc - I_syn_inh - stc ) / node.P_.c_m_;
 
   f[ 1 ] = -y[ S::G_EXC ] / node.P_.tau_synE_;
   f[ 2 ] = -y[ S::G_INH ] / node.P_.tau_synI_;

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -98,7 +98,7 @@ nest::gif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
   const double stc = node.S_.stc_;
 
   // V dot
-  f[ 0 ] = is_refractory? 0.0 : ( -I_L + node.S_.I_stim_ + node.P_.I_e_ - I_syn_exc - I_syn_inh - stc ) / node.P_.c_m_;
+  f[ 0 ] = is_refractory ? 0.0 : ( -I_L + node.S_.I_stim_ + node.P_.I_e_ - I_syn_exc - I_syn_inh - stc ) / node.P_.c_m_;
 
   f[ 1 ] = -y[ S::G_EXC ] / node.P_.tau_synE_;
   f[ 2 ] = -y[ S::G_INH ] / node.P_.tau_synI_;

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -117,8 +117,7 @@ nest::glif_cond_dynamics( double, const double y[], double f[], void* pnode )
   for ( size_t i = 0; i < node.P_.n_receptors_(); ++i )
   {
     const size_t j = i * S::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR;
-    I_syn +=
-      y[ S::G_SYN - S::NUMBER_OF_RECORDABLES_ELEMENTS + j ] * ( V + node.P_.E_L_ - node.P_.E_rev_[ i ] );
+    I_syn += y[ S::G_SYN - S::NUMBER_OF_RECORDABLES_ELEMENTS + j ] * ( V + node.P_.E_L_ - node.P_.E_rev_[ i ] );
   }
 
   const double I_leak = node.P_.G_ * V;

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -102,24 +102,29 @@ nest::glif_cond_dynamics( double, const double y[], double f[], void* pnode )
   assert( pnode );
   const nest::glif_cond& node = *( reinterpret_cast< nest::glif_cond* >( pnode ) );
 
+  const bool is_refractory = node.S_.refractory_steps_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
 
+  // Clamp membrane potential to V_reset while refractory.
+  const double V = is_refractory ? node.P_.V_reset_ : y[ S::V_M ];
+
   double I_syn = 0.0;
   for ( size_t i = 0; i < node.P_.n_receptors_(); ++i )
   {
     const size_t j = i * S::NUMBER_OF_STATES_ELEMENTS_PER_RECEPTOR;
     I_syn +=
-      y[ S::G_SYN - S::NUMBER_OF_RECORDABLES_ELEMENTS + j ] * ( y[ S::V_M ] + node.P_.E_L_ - node.P_.E_rev_[ i ] );
+      y[ S::G_SYN - S::NUMBER_OF_RECORDABLES_ELEMENTS + j ] * ( V + node.P_.E_L_ - node.P_.E_rev_[ i ] );
   }
 
-  const double I_leak = node.P_.G_ * ( y[ S::V_M ] );
+  const double I_leak = node.P_.G_ * ( V );
 
   // dV_m/dt
-  f[ 0 ] = ( -I_leak - I_syn + node.B_.I_ + node.S_.ASCurrents_sum_ ) / node.P_.C_m_;
+  f[ 0 ] = is_refractory ? 0.0 : ( -I_leak - I_syn + node.B_.I_ + node.S_.ASCurrents_sum_ ) / node.P_.C_m_;
 
   // d dg/dt
   for ( size_t i = 0; i < node.P_.n_receptors_(); ++i )

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -121,7 +121,7 @@ nest::glif_cond_dynamics( double, const double y[], double f[], void* pnode )
       y[ S::G_SYN - S::NUMBER_OF_RECORDABLES_ELEMENTS + j ] * ( V + node.P_.E_L_ - node.P_.E_rev_[ i ] );
   }
 
-  const double I_leak = node.P_.G_ * ( V );
+  const double I_leak = node.P_.G_ * V;
 
   // dV_m/dt
   f[ 0 ] = is_refractory ? 0.0 : ( -I_leak - I_syn + node.B_.I_ + node.S_.ASCurrents_sum_ ) / node.P_.C_m_;

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -85,17 +85,24 @@ nest::iaf_cond_alpha_dynamics( double, const double y[], double f[], void* pnode
   assert( pnode );
   const nest::iaf_cond_alpha& node = *( reinterpret_cast< nest::iaf_cond_alpha* >( pnode ) );
 
+  const bool is_refractory = node.S_.r > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
-  const double I_syn_exc = y[ S::G_EXC ] * ( y[ S::V_M ] - node.P_.E_ex );
-  const double I_syn_inh = y[ S::G_INH ] * ( y[ S::V_M ] - node.P_.E_in );
-  const double I_leak = node.P_.g_L * ( y[ S::V_M ] - node.P_.E_L );
+
+  // Clamp membrane potential to V_reset while refractory, otherwise bound
+  // it to V_th.
+  const double V = is_refractory ? node.P_.V_reset : std::min( y[ S::V_M ], node.P_.V_th );
+
+  const double I_syn_exc = y[ S::G_EXC ] * ( V - node.P_.E_ex );
+  const double I_syn_inh = y[ S::G_INH ] * ( V - node.P_.E_in );
+  const double I_leak = node.P_.g_L * ( V - node.P_.E_L );
 
   // dV_m/dt
-  f[ 0 ] = ( -I_leak - I_syn_exc - I_syn_inh + node.B_.I_stim_ + node.P_.I_e ) / node.P_.C_m;
+  f[ 0 ] = is_refractory ? 0.0 : ( -I_leak - I_syn_exc - I_syn_inh + node.B_.I_stim_ + node.P_.I_e ) / node.P_.C_m;
 
   // d dg_exc/dt, dg_exc/dt
   f[ 1 ] = -y[ S::DG_EXC ] / node.P_.tau_synE;

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -146,7 +146,7 @@ nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pn
     case N::DIST:
     {
       V = y[ S::idx( N::DIST, S::V_M ) ];
-      I_conn = node.P_.g_conn[ N::PROX ] * ( V - y[ S::idx( N::PROX - 1, S::V_M ) ] );
+      I_conn = node.P_.g_conn[ N::PROX ] * ( V - y[ S::idx( N::PROX, S::V_M ) ] );
       break;
     }
     }

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -127,11 +127,12 @@ nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pn
     // membrane potential for current compartment and coupling currents
     double V;
     double I_conn;
-    switch ( n ) {
+    switch ( n )
+    {
     case N::SOMA:
     {
       is_refractory = node.S_.r_ > 0;
-      V = is_refractory ? node.P_.V_reset : std::min(  y[ S::idx( n, S::V_M ) ], node.P_.V_th );
+      V = is_refractory ? node.P_.V_reset : std::min( y[ S::idx( n, S::V_M ) ], node.P_.V_th );
       I_conn = node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
       break;
     }

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -132,21 +132,21 @@ nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pn
     case N::SOMA:
     {
       is_refractory = node.S_.r_ > 0;
-      V = is_refractory ? node.P_.V_reset : std::min( y[ S::idx( n, S::V_M ) ], node.P_.V_th );
-      I_conn = node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
+      V = is_refractory ? node.P_.V_reset : std::min( y[ S::idx( N::SOMA, S::V_M ) ], node.P_.V_th );
+      I_conn = node.P_.g_conn[ N::SOMA ] * ( V - y[ S::idx( N::PROX, S::V_M ) ] );
       break;
     }
     case N::PROX:
     {
-      V = y[ S::idx( n, S::V_M ) ];
-      I_conn = node.P_.g_conn[ n - 1 ] * ( V - y[ S::idx( n - 1, S::V_M ) ] )
-        + node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
+      V = y[ S::idx( N::PROX, S::V_M ) ];
+      I_conn = node.P_.g_conn[ N::SOMA ] * ( V - y[ S::idx( N::SOMA, S::V_M ) ] )
+        + node.P_.g_conn[ N::PROX ] * ( V - y[ S::idx( N::DIST, S::V_M ) ] );
       break;
     }
     case N::DIST:
     {
-      V = y[ S::idx( n, S::V_M ) ];
-      I_conn = node.P_.g_conn[ n - 1 ] * ( V - y[ S::idx( n - 1, S::V_M ) ] );
+      V = y[ S::idx( N::DIST, S::V_M ) ];
+      I_conn = node.P_.g_conn[ N::PROX ] * ( V - y[ S::idx( N::PROX - 1, S::V_M ) ] );
       break;
     }
     }

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -128,26 +128,26 @@ nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pn
     double V;
     double I_conn;
     switch ( n ) {
-      case N::SOMA:
-      {
-        is_refractory = node.S_.r_ > 0;
-        V = is_refractory ? node.P_.V_reset : std::min(  y[ S::idx( n, S::V_M ) ], node.P_.V_th );
-        I_conn = node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
-        break;
-      }
-      case N::PROX:
-      {
-        V = y[ S::idx( n, S::V_M ) ];
-        I_conn = node.P_.g_conn[ n - 1 ] * ( V - y[ S::idx( n - 1, S::V_M ) ] )
-          + node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
-        break;
-      }
-      case N::DIST:
-      {
-        V = y[ S::idx( n, S::V_M ) ];
-        I_conn = node.P_.g_conn[ n - 1 ] * ( V - y[ S::idx( n - 1, S::V_M ) ] );
-        break;
-      }
+    case N::SOMA:
+    {
+      is_refractory = node.S_.r_ > 0;
+      V = is_refractory ? node.P_.V_reset : std::min(  y[ S::idx( n, S::V_M ) ], node.P_.V_th );
+      I_conn = node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
+      break;
+    }
+    case N::PROX:
+    {
+      V = y[ S::idx( n, S::V_M ) ];
+      I_conn = node.P_.g_conn[ n - 1 ] * ( V - y[ S::idx( n - 1, S::V_M ) ] )
+        + node.P_.g_conn[ n ] * ( V - y[ S::idx( n + 1, S::V_M ) ] );
+      break;
+    }
+    case N::DIST:
+    {
+      V = y[ S::idx( n, S::V_M ) ];
+      I_conn = node.P_.g_conn[ n - 1 ] * ( V - y[ S::idx( n - 1, S::V_M ) ] );
+      break;
+    }
     }
 
     // excitatory synaptic current

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -86,19 +86,24 @@ nest::iaf_cond_beta_dynamics( double, const double y[], double f[], void* pnode 
   assert( pnode );
   const nest::iaf_cond_beta& node = *( reinterpret_cast< nest::iaf_cond_beta* >( pnode ) );
 
+  const bool is_refractory = node.S_.r > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
-  const double& V = y[ S::V_M ];
+
+  // Clamp membrane potential to V_reset while refractory, otherwise bound
+  // it to V_th.
+  const double V = is_refractory ? node.P_.V_reset : std::min( y[ S::V_M ], node.P_.V_th );
 
   const double I_syn_exc = y[ S::G_EXC ] * ( V - node.P_.E_ex );
   const double I_syn_inh = y[ S::G_INH ] * ( V - node.P_.E_in );
   const double I_leak = node.P_.g_L * ( V - node.P_.E_L );
 
   // dV_m/dt
-  f[ 0 ] = ( -I_leak - I_syn_exc - I_syn_inh + node.B_.I_stim_ + node.P_.I_e ) / node.P_.C_m;
+  f[ 0 ] = is_refractory ? 0.0 : ( -I_leak - I_syn_exc - I_syn_inh + node.B_.I_stim_ + node.P_.I_e ) / node.P_.C_m;
 
   // d dg_exc/dt, dg_exc/dt
   f[ 1 ] = -y[ S::DG_EXC ] / node.P_.tau_decay_ex;

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -77,17 +77,24 @@ nest::iaf_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
   assert( pnode );
   const nest::iaf_cond_exp& node = *( reinterpret_cast< nest::iaf_cond_exp* >( pnode ) );
 
+  const bool is_refractory = node.S_.r_ > 0;
+
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
-  const double I_syn_exc = y[ S::G_EXC ] * ( y[ S::V_M ] - node.P_.E_ex );
-  const double I_syn_inh = y[ S::G_INH ] * ( y[ S::V_M ] - node.P_.E_in );
-  const double I_L = node.P_.g_L * ( y[ S::V_M ] - node.P_.E_L );
+
+  // Clamp membrane potential to V_reset while refractory, otherwise bound
+  // it to V_th.
+  const double V = is_refractory ? node.P_.V_reset_ : std::min( y[ S::V_M ], node.P_.V_th_ );
+
+  const double I_syn_exc = y[ S::G_EXC ] * ( V - node.P_.E_ex );
+  const double I_syn_inh = y[ S::G_INH ] * ( V - node.P_.E_in );
+  const double I_L = node.P_.g_L * ( V - node.P_.E_L );
 
   // V dot
-  f[ 0 ] = ( -I_L + node.B_.I_stim_ + node.P_.I_e - I_syn_exc - I_syn_inh ) / node.P_.C_m;
+  f[ 0 ] = is_refractory ? 0.0 : ( -I_L + node.B_.I_stim_ + node.P_.I_e - I_syn_exc - I_syn_inh ) / node.P_.C_m;
 
   f[ 1 ] = -y[ S::G_EXC ] / node.P_.tau_synE;
   f[ 2 ] = -y[ S::G_INH ] / node.P_.tau_synI;


### PR DESCRIPTION
I have checked the GSL models and updated the ones that does not already check for refactoriness in the dynamics function.
This fixes #1097.

Pay extra attention to `iaf_cond_alpha_mc`, I am not sure I have handled the multicompartments correctly.