### PR TITLE
Temporary fix for noqa problems.

### DIFF
--- a/build_support/parse_build_log.py
+++ b/build_support/parse_build_log.py
@@ -1032,7 +1032,7 @@ if __name__ == '__main__':
                                         "MSGBLD0180", "MSGBLD0175")
 
     summary_pep8 = msg_summary_pep8(log_filename, "MSGBLD0190",
-                                    "MSGBLD0200", "MSGBLD0195")
+                                    "MSGBLD0200", "MSGBLD0195", "MSGBLD185")
 
     # Summarize the per file build error messages and warnings.
     status_make, number_of_errors, summary_errors, number_of_warnings, expected_warnings, \

--- a/build_support/static_code_analysis.sh
+++ b/build_support/static_code_analysis.sh
@@ -247,6 +247,14 @@ for f in $FILE_NAMES; do
       fi
       ;;
 
+    *clopath_synapse_spike_pairing.py )
+       # Skip checking files which cannot be handled correctly by pycodestyle
+       # See https://github.com/nest/nest-simulator/issues/2175
+       # This should be removed as soon as we have moved to flake8.
+       print_msg "MSGBLD0185: " "Skipping ...........: $f  (not handled correctly by pycodestyle)"
+       continue
+       ;;
+
     *.py )
       # PYCODESTYLE
       if $PERFORM_PEP8; then


### PR DESCRIPTION
This PR provides a temporary fix for the PEP8/noqa problem described in #2175, which currently leads to CI failure for many PRs. It brute-force ignores the problematic file.

This should be reversed as soon as a proper fix is in place (flake8 instead of pycodestyle).