### PR TITLE
Return empty dictionary if `get()` is called on empty SynapseCollection

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -795,9 +795,12 @@ class SynapseCollection:
         if pandas_output and not HAVE_PANDAS:
             raise ImportError('Pandas could not be imported')
 
-        # Return empty tuple if we have no connections or if we have done a nest.ResetKernel()
+        # Return empty dictionary if we have no connections or if we have done a nest.ResetKernel()
         num_conns = GetKernelStatus('num_connections')  # Has to be called first because it involves MPI communication.
-        if self.__len__() == 0 or num_conns == 0:
+        if keys == None and ( self.__len__() == 0 or num_conns == 0 ):
+            return {}
+        elif self.__len__() == 0 or num_conns == 0:
+            # Return empty tuple if get is called with an argument
             return ()
 
         if keys is None:

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -797,11 +797,9 @@ class SynapseCollection:
 
         # Return empty dictionary if we have no connections or if we have done a nest.ResetKernel()
         num_conns = GetKernelStatus('num_connections')  # Has to be called first because it involves MPI communication.
-        if keys == None and ( self.__len__() == 0 or num_conns == 0 ):
-            return {}
-        elif self.__len__() == 0 or num_conns == 0:
+        if self.__len__() == 0 or num_conns == 0:
             # Return empty tuple if get is called with an argument
-            return ()
+            return {} if keys is None else ()
 
         if keys is None:
             cmd = 'GetStatus'

--- a/testsuite/pytests/test_synapsecollection.py
+++ b/testsuite/pytests/test_synapsecollection.py
@@ -363,7 +363,7 @@ class TestSynapseCollection(unittest.TestCase):
         """
         conns = nest.GetConnections()
         self.assertEqual(len(conns), 0)
-        self.assertEqual(conns.get(), ())
+        self.assertEqual(conns.get(), {})
 
         nrns = nest.Create('iaf_psc_alpha', 2)
         nest.Connect(nrns, nrns, 'one_to_one')
@@ -371,7 +371,7 @@ class TestSynapseCollection(unittest.TestCase):
         self.assertEqual(len(conns), 2)
 
         nest.ResetKernel()
-        self.assertEqual(conns.get(), ())
+        self.assertEqual(conns.get(), {})
         conns.set(weight=10.)
         self.assertEqual(conns.get('weight'), ())
 

--- a/testsuite/pytests/test_synapsecollection.py
+++ b/testsuite/pytests/test_synapsecollection.py
@@ -364,6 +364,7 @@ class TestSynapseCollection(unittest.TestCase):
         conns = nest.GetConnections()
         self.assertEqual(len(conns), 0)
         self.assertEqual(conns.get(), {})
+        self.assertEqual(conns.get('weight'), ())
 
         nrns = nest.Create('iaf_psc_alpha', 2)
         nest.Connect(nrns, nrns, 'one_to_one')


### PR DESCRIPTION
This fixes #2318.