### PR TITLE
Fix broken links in release notes

### DIFF
--- a/doc/userdoc/release_notes/v3.0/refguide_nest2_nest3.rst
+++ b/doc/userdoc/release_notes/v3.0/refguide_nest2_nest3.rst
@@ -13,10 +13,6 @@ Reference guide: NEST 2.x vs NEST 3.0
 
 * **Please note that NEST 3.0 no longer supports Python 2**
 
-.. contents:: On this page you'll find
-   :local:
-   :depth: 1
-
 .. seealso::
 
   To see more of the key changes in 3.0, check out our :ref:`list here <toc_3.0_features>`.

--- a/doc/userdoc/release_notes/v3.1/index.rst
+++ b/doc/userdoc/release_notes/v3.1/index.rst
@@ -14,10 +14,6 @@ If you transition from a version earlier than 3.0, please see our
 extensive :ref:`transition guide from NEST 2.x to 3.0
 <refguide_2_3>`.
 
-.. contents:: On this page you'll find
-   :local:
-   :depth: 1
-
 
 Access to kernel properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userdoc/release_notes/v3.2/index.rst
+++ b/doc/userdoc/release_notes/v3.2/index.rst
@@ -1,3 +1,5 @@
+.. _release_3.2:
+
 All about NEST 3.2
 ==================
 
@@ -9,14 +11,9 @@ update your simulation scripts when you come from an older version of
 NEST.
 
 If you transition from a version earlier than 3.1, please see our
-selection of earlier :doc:`transition guides <release_notes/index>`.
-
-.. contents:: On this page you'll find
-   :local:
-   :depth: 1
+selection of earlier :ref:`transition guides <release_notes>`.
 
 ConnPlotter
 ~~~~~~~~~~~
-All files related to ConnPlotter have been removed from NEST 3.2 and 
-moved to a separate repository `connplotter <https://github.com/nest
-/connplotter> _`.
+All files related to ConnPlotter have been removed from NEST 3.2 and
+moved to a separate repository `connplotter <https://github.com/nest/connplotter>`_.

--- a/doc/userdoc/release_notes/v3.3/index.rst
+++ b/doc/userdoc/release_notes/v3.3/index.rst
@@ -1,3 +1,5 @@
+.. _release_3.3:
+
 All about NEST 3.3
 ==================
 
@@ -10,10 +12,6 @@ NEST.
 
 If you transition from a version earlier than 3.0, please see our
 selection of earlier :doc:`transition guides <release_notes/index>`.
-
-.. contents:: On this page you'll find
-   :local:
-   :depth: 1
 
 Model defaults
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR fixes broken internal references and links in the release notes pages, and removes the local toc.