### PR TITLE
Rename `calibrate` method to `pre_run_hook`

### DIFF
--- a/doc/userdoc/guides/using_nest_with_music.rst
+++ b/doc/userdoc/guides/using_nest_with_music.rst
@@ -245,7 +245,7 @@ which yields the following output:
 
 ::
 
-	Nov 23 11:18:23 music_message_in_proxy::calibrate() [Info]:
+	Nov 23 11:18:23 music_message_in_proxy::pre_run_hook() [Info]:
 		Mapping MUSIC input port 'msgdata' with width=0 and acceptable latency=0
 		ms.
 
@@ -350,7 +350,7 @@ which yields the following output:
 
 ::
 
-	Nov 23 11:33:26 music_cont_in_proxy::calibrate() [Info]:
+	Nov 23 11:33:26 music_cont_in_proxy::pre_run_hook() [Info]:
 		Mapping MUSIC input port 'contdata' with width=10.
 
 	Nov 23 11:33:26 NodeManager::prepare_nodes [Info]:

--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -175,11 +175,11 @@ nest::ac_generator::init_buffers_()
 }
 
 void
-nest::ac_generator::calibrate()
+nest::ac_generator::pre_run_hook()
 {
   B_.logger_.init();
 
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   const double h = Time::get_resolution().get_ms();
   const double t = kernel().simulation_manager.get_time().get_ms();

--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -137,7 +137,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -421,7 +421,7 @@ nest::aeif_cond_alpha::init_buffers_()
 }
 
 void
-nest::aeif_cond_alpha::calibrate()
+nest::aeif_cond_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -218,7 +218,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -424,17 +424,17 @@ aeif_cond_alpha_multisynapse::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  // Stepping function and evolution function are allocated in calibrate()
+  // Stepping function and evolution function are allocated in pre_run_hook()
 
   B_.sys_.function = aeif_cond_alpha_multisynapse_dynamics;
   B_.sys_.jacobian = NULL;
   B_.sys_.params = reinterpret_cast< void* >( this );
-  // B_.sys_.dimension is assigned in calibrate()
+  // B_.sys_.dimension is assigned in pre_run_hook()
   B_.I_stim_ = 0.0;
 }
 
 void
-aeif_cond_alpha_multisynapse::calibrate()
+aeif_cond_alpha_multisynapse::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -206,7 +206,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // The next three classes need to be friends to access the State_ class/member

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -432,17 +432,17 @@ aeif_cond_beta_multisynapse::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  // Stepping function and evolution function are allocated in calibrate()
+  // Stepping function and evolution function are allocated in pre_run_hook()
 
   B_.sys_.function = aeif_cond_beta_multisynapse_dynamics;
   B_.sys_.jacobian = NULL;
   B_.sys_.params = reinterpret_cast< void* >( this );
-  // B_.sys_.dimension is assigned in calibrate()
+  // B_.sys_.dimension is assigned in pre_run_hook()
   B_.I_stim_ = 0.0;
 }
 
 void
-aeif_cond_beta_multisynapse::calibrate()
+aeif_cond_beta_multisynapse::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -209,7 +209,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // The next three classes need to be friends to access the State_ class/member

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -416,7 +416,7 @@ nest::aeif_cond_exp::init_buffers_()
 }
 
 void
-nest::aeif_cond_exp::calibrate()
+nest::aeif_cond_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -219,7 +219,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( const Time&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -411,7 +411,7 @@ nest::aeif_psc_alpha::init_buffers_()
 }
 
 void
-nest::aeif_psc_alpha::calibrate()
+nest::aeif_psc_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -204,7 +204,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -387,7 +387,7 @@ nest::aeif_psc_delta::init_buffers_()
 }
 
 void
-nest::aeif_psc_delta::calibrate()
+nest::aeif_psc_delta::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -199,7 +199,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( const Time&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -455,7 +455,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
 }
 
 void
-nest::aeif_psc_delta_clopath::calibrate()
+nest::aeif_psc_delta_clopath::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -229,7 +229,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( const Time&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -406,7 +406,7 @@ nest::aeif_psc_exp::init_buffers_()
 }
 
 void
-nest::aeif_psc_exp::calibrate()
+nest::aeif_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -206,7 +206,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( const Time&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -260,7 +260,7 @@ nest::amat2_psc_exp::init_buffers_()
 }
 
 void
-nest::amat2_psc_exp::calibrate()
+nest::amat2_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -190,7 +190,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // The next two classes need to be friends to access private members

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -115,7 +115,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   // gain function functor
   // must have an double operator(double) defined
@@ -433,7 +433,7 @@ binary_neuron< TGainfunction >::init_buffers_()
 
 template < class TGainfunction >
 void
-binary_neuron< TGainfunction >::calibrate()
+binary_neuron< TGainfunction >::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/cm_compartmentcurrents.h
+++ b/models/cm_compartmentcurrents.h
@@ -62,8 +62,8 @@ public:
   explicit Na( const DictionaryDatum& channel_params );
   ~Na() {};
 
-  // calibrate initialization
-  void calibrate() {};
+  // pre_run_hook initialization
+  void pre_run_hook() {};
   void append_recordables( std::map< Name, double* >* recordables, const long compartment_idx );
 
   // numerical integration step
@@ -98,8 +98,8 @@ public:
   explicit K( const DictionaryDatum& channel_params );
   ~K() {};
 
-  // calibrate initialization
-  void calibrate() {};
+  // pre_run_hook initialization
+  void pre_run_hook() {};
   void append_recordables( std::map< Name, double* >* recordables, const long compartment_idx );
 
   // numerical integration step
@@ -143,7 +143,7 @@ public:
 
   // calibrateialization of the state variables
   void
-  calibrate()
+  pre_run_hook()
   {
     const double dt = Time::get_resolution().get_ms();
     // construct propagators
@@ -200,7 +200,7 @@ public:
 
   // calibrate state variables
   void
-  calibrate()
+  pre_run_hook()
   {
     const double dt = Time::get_resolution().get_ms();
     // construct propagators
@@ -257,7 +257,7 @@ public:
 
   // calibrate state variables
   void
-  calibrate()
+  pre_run_hook()
   {
     const double dt = Time::get_resolution().get_ms();
     // construct propagators
@@ -329,7 +329,7 @@ public:
 
   // calibrate state variables
   void
-  calibrate()
+  pre_run_hook()
   {
     const double dt = Time::get_resolution().get_ms();
     prop_r_AMPA_ = std::exp( -dt / tau_r_AMPA_ );
@@ -383,31 +383,31 @@ public:
   ~CompartmentCurrents() {};
 
   void
-  calibrate()
+  pre_run_hook()
   {
     // calibrate ion channels
-    Na_chan_.calibrate();
-    K_chan_.calibrate();
+    Na_chan_.pre_run_hook();
+    K_chan_.pre_run_hook();
 
     // calibrate AMPA synapses
     for ( auto syn_it = AMPA_syns_.begin(); syn_it != AMPA_syns_.end(); ++syn_it )
     {
-      syn_it->calibrate();
+      syn_it->pre_run_hook();
     }
     // calibrate GABA synapses
     for ( auto syn_it = GABA_syns_.begin(); syn_it != GABA_syns_.end(); ++syn_it )
     {
-      syn_it->calibrate();
+      syn_it->pre_run_hook();
     }
     // calibrate NMDA synapses
     for ( auto syn_it = NMDA_syns_.begin(); syn_it != NMDA_syns_.end(); ++syn_it )
     {
-      syn_it->calibrate();
+      syn_it->pre_run_hook();
     }
     // calibrateialization of AMPA_NMDA synapses
     for ( auto syn_it = AMPA_NMDA_syns_.begin(); syn_it != AMPA_NMDA_syns_.end(); ++syn_it )
     {
-      syn_it->calibrate();
+      syn_it->pre_run_hook();
     }
   }
 

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -27,7 +27,7 @@ namespace nest
 
 /*
  * For some reason this code block is needed. However, I have found no
- * difference in calling init_recordable_pointers() from the calibrate function,
+ * difference in calling init_recordable_pointers() from the pre_run_hook function,
  * except that an unused-variable warning is generated in the code-checks
  */
 template <>
@@ -270,7 +270,7 @@ nest::cm_default::init_recordables_pointers_()
 }
 
 void
-nest::cm_default::calibrate()
+nest::cm_default::pre_run_hook()
 {
   logger_.init();
 
@@ -281,7 +281,7 @@ nest::cm_default::calibrate()
   // initialize the recordables pointers
   init_recordables_pointers_();
 
-  c_tree_.calibrate();
+  c_tree_.pre_run_hook();
 }
 
 /**

--- a/models/cm_default.h
+++ b/models/cm_default.h
@@ -253,7 +253,7 @@ private:
   void add_receptor_( DictionaryDatum& dd );
 
   void init_recordables_pointers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -82,9 +82,9 @@ nest::Compartment::Compartment( const long compartment_index,
 }
 
 void
-nest::Compartment::calibrate()
+nest::Compartment::pre_run_hook()
 {
-  compartment_currents.calibrate();
+  compartment_currents.pre_run_hook();
 
   const double dt = Time::get_resolution().get_ms();
   ca__div__dt = ca / dt;
@@ -364,7 +364,7 @@ nest::CompTree::get_recordables()
  * Initialize state variables
  */
 void
-nest::CompTree::calibrate()
+nest::CompTree::pre_run_hook()
 {
   if ( root_.comp_index < 0 )
   {
@@ -375,7 +375,7 @@ nest::CompTree::calibrate()
   // initialize the compartments
   for ( auto compartment_it = compartments_.begin(); compartment_it != compartments_.end(); ++compartment_it )
   {
-    ( *compartment_it )->calibrate();
+    ( *compartment_it )->pre_run_hook();
   }
 }
 

--- a/models/cm_tree.h
+++ b/models/cm_tree.h
@@ -94,7 +94,7 @@ public:
   ~Compartment(){};
 
   // initialization
-  void calibrate();
+  void pre_run_hook();
   std::map< Name, double* > get_recordables();
 
   // matrix construction
@@ -174,7 +174,7 @@ public:
   void add_compartment( const long parent_index );
   void add_compartment( const long parent_index, const DictionaryDatum& compartment_params );
   void add_compartment( Compartment* compartment, const long parent_index );
-  void calibrate();
+  void pre_run_hook();
   void init_pointers();
   void set_syn_buffers( std::vector< RingBuffer >& syn_buffers );
   std::map< Name, double* > get_recordables();

--- a/models/correlation_detector.cpp
+++ b/models/correlation_detector.cpp
@@ -240,9 +240,9 @@ nest::correlation_detector::init_buffers_()
 }
 
 void
-nest::correlation_detector::calibrate()
+nest::correlation_detector::pre_run_hook()
 {
-  device_.calibrate();
+  device_.pre_run_hook();
 }
 
 

--- a/models/correlation_detector.h
+++ b/models/correlation_detector.h
@@ -200,7 +200,7 @@ public:
 private:
   void init_state_();
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -271,9 +271,9 @@ nest::correlomatrix_detector::init_buffers_()
 }
 
 void
-nest::correlomatrix_detector::calibrate()
+nest::correlomatrix_detector::pre_run_hook()
 {
-  device_.calibrate();
+  device_.pre_run_hook();
 }
 
 

--- a/models/correlomatrix_detector.h
+++ b/models/correlomatrix_detector.h
@@ -190,7 +190,7 @@ public:
 private:
   void init_state_();
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -281,9 +281,9 @@ nest::correlospinmatrix_detector::init_buffers_()
 }
 
 void
-nest::correlospinmatrix_detector::calibrate()
+nest::correlospinmatrix_detector::pre_run_hook()
 {
-  device_.calibrate();
+  device_.pre_run_hook();
 }
 
 

--- a/models/correlospinmatrix_detector.h
+++ b/models/correlospinmatrix_detector.h
@@ -174,7 +174,7 @@ public:
 private:
   void init_state_();
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/dc_generator.cpp
+++ b/models/dc_generator.cpp
@@ -147,11 +147,11 @@ nest::dc_generator::init_buffers_()
 }
 
 void
-nest::dc_generator::calibrate()
+nest::dc_generator::pre_run_hook()
 {
   B_.logger_.init();
 
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 }
 
 

--- a/models/dc_generator.h
+++ b/models/dc_generator.h
@@ -113,7 +113,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/gamma_sup_generator.cpp
+++ b/models/gamma_sup_generator.cpp
@@ -205,9 +205,9 @@ nest::gamma_sup_generator::init_buffers_()
 }
 
 void
-nest::gamma_sup_generator::calibrate()
+nest::gamma_sup_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   double h = Time::get_resolution().get_ms();
 

--- a/models/gamma_sup_generator.h
+++ b/models/gamma_sup_generator.h
@@ -112,7 +112,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   /**
    * Update state.

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -439,7 +439,7 @@ nest::gif_cond_exp::init_buffers_()
 }
 
 void
-nest::gif_cond_exp::calibrate()
+nest::gif_cond_exp::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -247,7 +247,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -446,7 +446,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
 }
 
 void
-nest::gif_cond_exp_multisynapse::calibrate()
+nest::gif_cond_exp_multisynapse::pre_run_hook()
 {
   B_.sys_.dimension = S_.y_.size();
 

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -244,7 +244,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -272,7 +272,7 @@ nest::gif_pop_psc_exp::init_buffers_()
 
 
 void
-nest::gif_pop_psc_exp::calibrate()
+nest::gif_pop_psc_exp::pre_run_hook()
 {
   if ( P_.tau_sfa_.size() == 0 )
   {

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -187,7 +187,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -279,7 +279,7 @@ nest::gif_psc_exp::init_buffers_()
 }
 
 void
-nest::gif_psc_exp::calibrate()
+nest::gif_psc_exp::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -229,7 +229,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -293,7 +293,7 @@ nest::gif_psc_exp_multisynapse::init_buffers_()
 }
 
 void
-nest::gif_psc_exp_multisynapse::calibrate()
+nest::gif_psc_exp_multisynapse::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -234,7 +234,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -544,7 +544,7 @@ nest::glif_cond::init_buffers_()
 }
 
 void
-nest::glif_cond::calibrate()
+nest::glif_cond::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -224,7 +224,7 @@ private:
   void init_buffers_();
 
   //! Initialize auxiliary quantities, leave parameters and state untouched.
-  void calibrate();
+  void pre_run_hook();
 
   //! Take neuron through given time interval
   void update( nest::Time const&, const long, const long );

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -393,7 +393,7 @@ nest::glif_psc::init_buffers_()
 }
 
 void
-nest::glif_psc::calibrate()
+nest::glif_psc::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -219,7 +219,7 @@ private:
   void init_buffers_();
 
   //! Initialize auxiliary quantities, leave parameters and state untouched.
-  void calibrate();
+  void pre_run_hook();
 
   //! Take neuron through given time interval
   void update( nest::Time const&, const long, const long );

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -450,7 +450,7 @@ nest::hh_cond_beta_gap_traub::get_normalisation_factor( double tau_rise, double 
 }
 
 void
-nest::hh_cond_beta_gap_traub::calibrate()
+nest::hh_cond_beta_gap_traub::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -214,7 +214,7 @@ public:
 private:
   void init_buffers_();
   double get_normalisation_factor( double, double );
-  void calibrate();
+  void pre_run_hook();
 
   /** This is the actual update function. The additional boolean parameter
    * determines if the function is called by update (false) or wfr_update (true)
@@ -495,7 +495,7 @@ hh_cond_beta_gap_traub::set_status( const DictionaryDatum& d )
   P_ = ptmp;
   S_ = stmp;
 
-  calibrate();
+  pre_run_hook();
 }
 
 } // namespace

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -374,7 +374,7 @@ nest::hh_cond_exp_traub::init_buffers_()
 }
 
 void
-nest::hh_cond_exp_traub::calibrate()
+nest::hh_cond_exp_traub::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -177,7 +177,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 
@@ -399,7 +399,7 @@ hh_cond_exp_traub::set_status( const DictionaryDatum& d )
   P_ = ptmp;
   S_ = stmp;
 
-  calibrate();
+  pre_run_hook();
 }
 
 } // namespace

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -370,7 +370,7 @@ nest::hh_psc_alpha::init_buffers_()
 }
 
 void
-nest::hh_psc_alpha::calibrate()
+nest::hh_psc_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -173,7 +173,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -398,7 +398,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
 }
 
 void
-nest::hh_psc_alpha_clopath::calibrate()
+nest::hh_psc_alpha_clopath::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -211,7 +211,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -434,7 +434,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
 }
 
 void
-nest::hh_psc_alpha_gap::calibrate()
+nest::hh_psc_alpha_gap::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -191,7 +191,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   /** This is the actual update function. The additional boolean parameter
    * determines if the function is called by update (false) or wfr_update (true)

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -705,7 +705,7 @@ nest::ht_neuron::get_synapse_constant( double tau_1, double tau_2, double g_peak
 }
 
 void
-nest::ht_neuron::calibrate()
+nest::ht_neuron::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -227,7 +227,7 @@ private:
   };
 
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -194,7 +194,7 @@ nest::iaf_chs_2007::init_buffers_()
 }
 
 void
-nest::iaf_chs_2007::calibrate()
+nest::iaf_chs_2007::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_chs_2007.h
+++ b/models/iaf_chs_2007.h
@@ -138,7 +138,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( const Time&, const long, const long );
 

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -341,7 +341,7 @@ nest::iaf_chxk_2008::init_buffers_()
 }
 
 void
-nest::iaf_chxk_2008::calibrate()
+nest::iaf_chxk_2008::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -179,7 +179,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -347,7 +347,7 @@ nest::iaf_cond_alpha::init_buffers_()
 }
 
 void
-nest::iaf_cond_alpha::calibrate()
+nest::iaf_cond_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -163,7 +163,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -530,7 +530,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
 }
 
 void
-nest::iaf_cond_alpha_mc::calibrate()
+nest::iaf_cond_alpha_mc::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -203,7 +203,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // Enumerations and constants specifying structure and properties ----

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -362,7 +362,7 @@ nest::iaf_cond_beta::get_normalisation_factor( double tau_rise, double tau_decay
 }
 
 void
-nest::iaf_cond_beta::calibrate()
+nest::iaf_cond_beta::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -183,7 +183,7 @@ public:
 private:
   void init_buffers_();
   double get_normalisation_factor( double, double );
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -325,7 +325,7 @@ nest::iaf_cond_exp::init_buffers_()
 }
 
 void
-nest::iaf_cond_exp::calibrate()
+nest::iaf_cond_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -153,7 +153,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -360,7 +360,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::calibrate()
+nest::iaf_cond_exp_sfa_rr::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -176,7 +176,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // END Boilerplate function declarations ----------------------------

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -245,7 +245,7 @@ iaf_psc_alpha::init_buffers_()
 }
 
 void
-iaf_psc_alpha::calibrate()
+iaf_psc_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -181,7 +181,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -263,7 +263,7 @@ nest::iaf_psc_alpha_canon::init_buffers_()
 }
 
 void
-nest::iaf_psc_alpha_canon::calibrate()
+nest::iaf_psc_alpha_canon::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/iaf_psc_alpha_canon.h
+++ b/models/iaf_psc_alpha_canon.h
@@ -212,7 +212,7 @@ private:
    */
   //@{
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   /**
    * Time Evolution Operator.

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -286,7 +286,7 @@ iaf_psc_alpha_multisynapse::init_buffers_()
 }
 
 void
-iaf_psc_alpha_multisynapse::calibrate()
+iaf_psc_alpha_multisynapse::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_psc_alpha_multisynapse.h
+++ b/models/iaf_psc_alpha_multisynapse.h
@@ -113,7 +113,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -257,7 +257,7 @@ nest::iaf_psc_alpha_ps::init_buffers_()
 }
 
 void
-nest::iaf_psc_alpha_ps::calibrate()
+nest::iaf_psc_alpha_ps::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -210,7 +210,7 @@ private:
    */
   //@{
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   bool get_next_event_( const long T, double& ev_offset, double& ev_weight, bool& end_of_refract );
 

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -230,7 +230,7 @@ nest::iaf_psc_delta::init_buffers_()
 }
 
 void
-nest::iaf_psc_delta::calibrate()
+nest::iaf_psc_delta::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -171,7 +171,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/iaf_psc_delta_ps.cpp
+++ b/models/iaf_psc_delta_ps.cpp
@@ -238,7 +238,7 @@ nest::iaf_psc_delta_ps::init_buffers_()
 }
 
 void
-iaf_psc_delta_ps::calibrate()
+iaf_psc_delta_ps::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -207,7 +207,7 @@ private:
   //@{
   void init_buffers_();
 
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   /**

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -241,7 +241,7 @@ nest::iaf_psc_exp::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp::calibrate()
+nest::iaf_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -204,7 +204,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( const Time&, const long, const long );
 

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -230,7 +230,7 @@ nest::iaf_psc_exp_htum::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_htum::calibrate()
+nest::iaf_psc_exp_htum::pre_run_hook()
 {
   B_.logger_.init();
 

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -178,7 +178,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -273,7 +273,7 @@ iaf_psc_exp_multisynapse::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_multisynapse::calibrate()
+nest::iaf_psc_exp_multisynapse::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -117,7 +117,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -247,7 +247,7 @@ nest::iaf_psc_exp_ps::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_ps::calibrate()
+nest::iaf_psc_exp_ps::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -204,7 +204,7 @@ private:
    */
   //@{
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   /**
    * Time Evolution Operator.

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -272,7 +272,7 @@ nest::iaf_psc_exp_ps_lossless::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::calibrate()
+nest::iaf_psc_exp_ps_lossless::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -200,7 +200,7 @@ private:
    */
   //@{
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   /**
    * Time Evolution Operator.

--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -227,9 +227,9 @@ nest::inhomogeneous_poisson_generator::init_buffers_()
 }
 
 void
-nest::inhomogeneous_poisson_generator::calibrate()
+nest::inhomogeneous_poisson_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
   V_.h_ = Time::get_resolution().get_ms();
 }
 

--- a/models/inhomogeneous_poisson_generator.h
+++ b/models/inhomogeneous_poisson_generator.h
@@ -123,7 +123,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
   void event_hook( DSSpikeEvent& ) override;

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -179,7 +179,7 @@ nest::izhikevich::init_buffers_()
 }
 
 void
-nest::izhikevich::calibrate()
+nest::izhikevich::pre_run_hook()
 {
   B_.logger_.init();
 }

--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -157,7 +157,7 @@ private:
   friend class UniversalDataLogger< izhikevich >;
 
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -239,7 +239,7 @@ nest::mat2_psc_exp::init_buffers_()
 }
 
 void
-nest::mat2_psc_exp::calibrate()
+nest::mat2_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -171,7 +171,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // The next two classes need to be friends to access private members

--- a/models/mip_generator.cpp
+++ b/models/mip_generator.cpp
@@ -102,9 +102,9 @@ nest::mip_generator::init_buffers_()
 }
 
 void
-nest::mip_generator::calibrate()
+nest::mip_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   // rate_ is in Hz, dt in ms, so we have to convert from s to ms
   poisson_distribution::param_type param( Time::get_resolution().get_ms() * P_.rate_ * 1e-3 );

--- a/models/mip_generator.h
+++ b/models/mip_generator.h
@@ -128,7 +128,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/multimeter.cpp
+++ b/models/multimeter.cpp
@@ -170,7 +170,7 @@ nest::multimeter::Parameters_::set( const DictionaryDatum& d, const Buffers_& b,
 }
 
 void
-multimeter::calibrate()
+multimeter::pre_run_hook()
 {
   RecordingDevice::calibrate( P_.record_from_, RecordingBackend::NO_LONG_VALUE_NAMES );
 }

--- a/models/multimeter.cpp
+++ b/models/multimeter.cpp
@@ -172,7 +172,7 @@ nest::multimeter::Parameters_::set( const DictionaryDatum& d, const Buffers_& b,
 void
 multimeter::pre_run_hook()
 {
-  RecordingDevice::calibrate( P_.record_from_, RecordingBackend::NO_LONG_VALUE_NAMES );
+  RecordingDevice::pre_run_hook( P_.record_from_, RecordingBackend::NO_LONG_VALUE_NAMES );
 }
 
 void

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -174,7 +174,7 @@ public:
   void calibrate_time( const TimeConverter& tc );
 
 protected:
-  void calibrate();
+  void pre_run_hook();
 
   /**
    * Collect and output membrane potential information.

--- a/models/music_cont_in_proxy.cpp
+++ b/models/music_cont_in_proxy.cpp
@@ -119,7 +119,7 @@ nest::music_cont_in_proxy::init_buffers_()
 }
 
 void
-nest::music_cont_in_proxy::calibrate()
+nest::music_cont_in_proxy::pre_run_hook()
 {
   // only publish the port once
   if ( not S_.published_ )
@@ -151,7 +151,7 @@ nest::music_cont_in_proxy::calibrate()
     S_.published_ = true;
 
     std::string msg = String::compose( "Mapping MUSIC input port '%1' with width=%2.", P_.port_name_, S_.port_width_ );
-    LOG( M_INFO, "music_cont_in_proxy::calibrate()", msg.c_str() );
+    LOG( M_INFO, "music_cont_in_proxy::pre_run_hook()", msg.c_str() );
   }
 }
 

--- a/models/music_cont_in_proxy.h
+++ b/models/music_cont_in_proxy.h
@@ -113,7 +113,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void
   update( Time const&, const long, const long )

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -232,7 +232,7 @@ nest::music_cont_out_proxy::send_test_event( Node& target, rport receptor_type, 
 }
 
 void
-nest::music_cont_out_proxy::calibrate()
+nest::music_cont_out_proxy::pre_run_hook()
 {
   // only publish the output port once,
   if ( S_.published_ == false )
@@ -299,7 +299,7 @@ nest::music_cont_out_proxy::calibrate()
 
     std::string msg =
       String::compose( "Mapping MUSIC continuous output port '%1' with width=%2.", P_.port_name_, S_.port_width_ );
-    LOG( M_INFO, "music_cont_out_proxy::calibrate()", msg.c_str() );
+    LOG( M_INFO, "music_cont_out_proxy::pre_run_hook()", msg.c_str() );
   }
 }
 

--- a/models/music_cont_out_proxy.h
+++ b/models/music_cont_out_proxy.h
@@ -152,7 +152,7 @@ public:
 
 protected:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void finalize();
 
   /**

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -121,7 +121,7 @@ nest::music_event_in_proxy::init_buffers_()
 }
 
 void
-nest::music_event_in_proxy::calibrate()
+nest::music_event_in_proxy::pre_run_hook()
 {
   // register my port and my channel at the scheduler
   if ( not S_.registered_ )

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -121,7 +121,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void
   update( Time const&, const long, const long )

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -125,7 +125,7 @@ nest::music_event_out_proxy::init_buffers_()
 }
 
 void
-nest::music_event_out_proxy::calibrate()
+nest::music_event_out_proxy::pre_run_hook()
 {
   // only publish the output port once,
   if ( not S_.published_ )

--- a/models/music_event_out_proxy.h
+++ b/models/music_event_out_proxy.h
@@ -127,7 +127,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void
   update( Time const&, const long, const long )

--- a/models/music_message_in_proxy.cpp
+++ b/models/music_message_in_proxy.cpp
@@ -119,7 +119,7 @@ nest::music_message_in_proxy::init_buffers_()
 }
 
 void
-nest::music_message_in_proxy::calibrate()
+nest::music_message_in_proxy::pre_run_hook()
 {
   // only publish the port once,
   if ( not S_.published_ )
@@ -156,7 +156,7 @@ nest::music_message_in_proxy::calibrate()
       P_.port_name_,
       S_.port_width_,
       P_.acceptable_latency_ );
-    LOG( M_INFO, "music_message_in_proxy::calibrate()", msg.c_str() );
+    LOG( M_INFO, "music_message_in_proxy::pre_run_hook()", msg.c_str() );
   }
 }
 

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -157,7 +157,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void
   update( Time const&, const long, const long )

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -120,7 +120,7 @@ nest::music_rate_in_proxy::init_buffers_()
 }
 
 void
-nest::music_rate_in_proxy::calibrate()
+nest::music_rate_in_proxy::pre_run_hook()
 {
   // only publish the port once
   if ( not S_.registered_ )

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -139,7 +139,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -134,7 +134,7 @@ nest::music_rate_out_proxy::init_buffers_()
 }
 
 void
-nest::music_rate_out_proxy::calibrate()
+nest::music_rate_out_proxy::pre_run_hook()
 {
   // only publish the output port once,
   if ( not S_.published_ )

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -125,7 +125,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void
   update( Time const&, const long, const long )

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -223,11 +223,11 @@ nest::noise_generator::init_buffers_()
 }
 
 void
-nest::noise_generator::calibrate()
+nest::noise_generator::pre_run_hook()
 {
   B_.logger_.init();
 
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
   if ( P_.num_targets_ != B_.amps_.size() )
   {
     LOG( M_INFO, "noise_generator::calibrate()", "The number of targets has changed, drawing new amplitudes." );

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -230,7 +230,7 @@ nest::noise_generator::pre_run_hook()
   StimulationDevice::pre_run_hook();
   if ( P_.num_targets_ != B_.amps_.size() )
   {
-    LOG( M_INFO, "noise_generator::calibrate()", "The number of targets has changed, drawing new amplitudes." );
+    LOG( M_INFO, "noise_generator::pre_run_hook()", "The number of targets has changed, drawing new amplitudes." );
     init_buffers_();
   }
 

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -200,7 +200,7 @@ private:
    * Recalculates parameters and forces reinitialization
    * of amplitudes if number of targets has changed.
    */
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
   void event_hook( DSCurrentEvent& ) override;

--- a/models/parrot_neuron.h
+++ b/models/parrot_neuron.h
@@ -104,7 +104,7 @@ public:
 private:
   void init_buffers_();
   void
-  calibrate()
+  pre_run_hook()
   {
   } // no variables
 

--- a/models/parrot_neuron_ps.h
+++ b/models/parrot_neuron_ps.h
@@ -108,7 +108,7 @@ private:
   void init_buffers_();
 
   void
-  calibrate()
+  pre_run_hook()
   {
   } // no variables
 

--- a/models/poisson_generator.cpp
+++ b/models/poisson_generator.cpp
@@ -100,9 +100,9 @@ nest::poisson_generator::init_buffers_()
 }
 
 void
-nest::poisson_generator::calibrate()
+nest::poisson_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   // rate_ is in Hz, dt in ms, so we have to convert from s to ms
   poisson_distribution::param_type param( Time::get_resolution().get_ms() * P_.rate_ * 1e-3 );

--- a/models/poisson_generator.h
+++ b/models/poisson_generator.h
@@ -106,7 +106,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
   void event_hook( DSSpikeEvent& ) override;

--- a/models/poisson_generator_ps.cpp
+++ b/models/poisson_generator_ps.cpp
@@ -123,9 +123,9 @@ nest::poisson_generator_ps::init_buffers_()
 }
 
 void
-nest::poisson_generator_ps::calibrate()
+nest::poisson_generator_ps::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
   if ( P_.rate_ > 0 )
   {
     V_.inv_rate_ms_ = 1000.0 / P_.rate_ - P_.dead_time_;

--- a/models/poisson_generator_ps.h
+++ b/models/poisson_generator_ps.h
@@ -114,7 +114,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   /**
    * Update state.

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -554,7 +554,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::calibrate()
+nest::pp_cond_exp_mc_urbanczik::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -277,7 +277,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   // Enumerations and constants specifying structure and properties ----

--- a/models/pp_pop_psc_delta.cpp
+++ b/models/pp_pop_psc_delta.cpp
@@ -230,7 +230,7 @@ nest::pp_pop_psc_delta::init_buffers_()
 
 
 void
-nest::pp_pop_psc_delta::calibrate()
+nest::pp_pop_psc_delta::pre_run_hook()
 {
 
   if ( P_.tau_eta_.size() == 0 )

--- a/models/pp_pop_psc_delta.h
+++ b/models/pp_pop_psc_delta.h
@@ -188,7 +188,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -290,7 +290,7 @@ nest::pp_psc_delta::init_buffers_()
 }
 
 void
-nest::pp_psc_delta::calibrate()
+nest::pp_psc_delta::pre_run_hook()
 {
 
   B_.logger_.init();

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -224,7 +224,7 @@ public:
 private:
   void init_state_();
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( Time const&, const long, const long );
 

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -198,9 +198,9 @@ nest::ppd_sup_generator::init_buffers_()
 }
 
 void
-nest::ppd_sup_generator::calibrate()
+nest::ppd_sup_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   double h = Time::get_resolution().get_ms();
 

--- a/models/ppd_sup_generator.h
+++ b/models/ppd_sup_generator.h
@@ -128,7 +128,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   /**
    * Update state.

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -129,9 +129,9 @@ nest::pulsepacket_generator::init_buffers_()
 }
 
 void
-nest::pulsepacket_generator::calibrate()
+nest::pulsepacket_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
   assert( V_.start_center_idx_ <= V_.stop_center_idx_ );
 
   if ( P_.sdev_ > 0.0 )

--- a/models/pulsepacket_generator.h
+++ b/models/pulsepacket_generator.h
@@ -117,7 +117,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/rate_neuron_ipn.h
+++ b/models/rate_neuron_ipn.h
@@ -144,7 +144,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   TNonlinearities nonlinearities_;
 

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -237,7 +237,7 @@ nest::rate_neuron_ipn< TNonlinearities >::init_buffers_()
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::calibrate()
+nest::rate_neuron_ipn< TNonlinearities >::pre_run_hook()
 {
   B_.logger_.init(); // ensures initialization in case mm connected after Simulate
 

--- a/models/rate_neuron_opn.h
+++ b/models/rate_neuron_opn.h
@@ -147,7 +147,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   TNonlinearities nonlinearities_;
 

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -221,7 +221,7 @@ nest::rate_neuron_opn< TNonlinearities >::init_buffers_()
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::calibrate()
+nest::rate_neuron_opn< TNonlinearities >::pre_run_hook()
 {
   B_.logger_.init(); // ensures initialization in case mm connected after Simulate
 

--- a/models/rate_transformer_node.h
+++ b/models/rate_transformer_node.h
@@ -140,7 +140,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   TNonlinearities nonlinearities_;
 

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -165,7 +165,7 @@ nest::rate_transformer_node< TNonlinearities >::init_buffers_()
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::calibrate()
+nest::rate_transformer_node< TNonlinearities >::pre_run_hook()
 {
   B_.logger_.init(); // ensures initialization in case mm connected after Simulate
 }

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -292,7 +292,7 @@ nest::siegert_neuron::init_buffers_()
 }
 
 void
-nest::siegert_neuron::calibrate()
+nest::siegert_neuron::pre_run_hook()
 {
   B_.logger_.init(); // ensures initialization in case mm connected after Simulate
 

--- a/models/siegert_neuron.h
+++ b/models/siegert_neuron.h
@@ -169,7 +169,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   /** This is the actual update function. The additional boolean parameter
    * determines if the function is called by update (false) or wfr_update (true)

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -270,11 +270,11 @@ nest::sinusoidal_gamma_generator::deltaLambda_( const Parameters_& p, double t_a
 // ----------------------------------------------------
 
 void
-nest::sinusoidal_gamma_generator::calibrate()
+nest::sinusoidal_gamma_generator::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   V_.h_ = Time::get_resolution().get_ms();
   V_.rng_ = get_vp_specific_rng( get_thread() );

--- a/models/sinusoidal_gamma_generator.h
+++ b/models/sinusoidal_gamma_generator.h
@@ -223,7 +223,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
   void event_hook( DSSpikeEvent& ) override;
 
   void update( Time const&, const long, const long ) override;

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -210,12 +210,12 @@ nest::sinusoidal_poisson_generator::init_buffers_()
 }
 
 void
-nest::sinusoidal_poisson_generator::calibrate()
+nest::sinusoidal_poisson_generator::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 
   // time resolution
   V_.h_ = Time::get_resolution().get_ms();

--- a/models/sinusoidal_poisson_generator.h
+++ b/models/sinusoidal_poisson_generator.h
@@ -176,7 +176,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
   void event_hook( DSSpikeEvent& ) override;
 
   void update( Time const&, const long, const long ) override;

--- a/models/spike_dilutor.cpp
+++ b/models/spike_dilutor.cpp
@@ -99,9 +99,9 @@ nest::spike_dilutor::init_buffers_()
 }
 
 void
-nest::spike_dilutor::calibrate()
+nest::spike_dilutor::pre_run_hook()
 {
-  device_.calibrate();
+  device_.pre_run_hook();
 }
 
 /* ----------------------------------------------------------------

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -106,7 +106,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/spike_generator.cpp
+++ b/models/spike_generator.cpp
@@ -307,9 +307,9 @@ nest::spike_generator::init_buffers_()
 }
 
 void
-nest::spike_generator::calibrate()
+nest::spike_generator::pre_run_hook()
 {
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 }
 
 

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -249,7 +249,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/spike_recorder.cpp
+++ b/models/spike_recorder.cpp
@@ -52,7 +52,7 @@ nest::spike_recorder::spike_recorder( const spike_recorder& n )
 }
 
 void
-nest::spike_recorder::calibrate()
+nest::spike_recorder::pre_run_hook()
 {
   RecordingDevice::calibrate( RecordingBackend::NO_DOUBLE_VALUE_NAMES, RecordingBackend::NO_LONG_VALUE_NAMES );
 }

--- a/models/spike_recorder.cpp
+++ b/models/spike_recorder.cpp
@@ -54,7 +54,7 @@ nest::spike_recorder::spike_recorder( const spike_recorder& n )
 void
 nest::spike_recorder::pre_run_hook()
 {
-  RecordingDevice::calibrate( RecordingBackend::NO_DOUBLE_VALUE_NAMES, RecordingBackend::NO_LONG_VALUE_NAMES );
+  RecordingDevice::pre_run_hook( RecordingBackend::NO_DOUBLE_VALUE_NAMES, RecordingBackend::NO_LONG_VALUE_NAMES );
 }
 
 void

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -123,7 +123,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 };
 

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -62,7 +62,7 @@ nest::spin_detector::init_buffers_()
 void
 nest::spin_detector::pre_run_hook()
 {
-  RecordingDevice::calibrate( RecordingBackend::NO_DOUBLE_VALUE_NAMES, { nest::names::state } );
+  RecordingDevice::pre_run_hook( RecordingBackend::NO_DOUBLE_VALUE_NAMES, { nest::names::state } );
 }
 
 void

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -60,7 +60,7 @@ nest::spin_detector::init_buffers_()
 }
 
 void
-nest::spin_detector::calibrate()
+nest::spin_detector::pre_run_hook()
 {
   RecordingDevice::calibrate( RecordingBackend::NO_DOUBLE_VALUE_NAMES, { nest::names::state } );
 }

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -139,7 +139,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   /**
    * Update detector by recording spikes.

--- a/models/step_current_generator.cpp
+++ b/models/step_current_generator.cpp
@@ -258,10 +258,10 @@ nest::step_current_generator::init_buffers_()
 }
 
 void
-nest::step_current_generator::calibrate()
+nest::step_current_generator::pre_run_hook()
 {
   B_.logger_.init();
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 }
 
 

--- a/models/step_current_generator.h
+++ b/models/step_current_generator.h
@@ -127,7 +127,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, long, long ) override;
 

--- a/models/step_rate_generator.cpp
+++ b/models/step_rate_generator.cpp
@@ -258,11 +258,11 @@ nest::step_rate_generator::init_buffers_()
 }
 
 void
-nest::step_rate_generator::calibrate()
+nest::step_rate_generator::pre_run_hook()
 {
   B_.logger_.init();
 
-  StimulationDevice::calibrate();
+  StimulationDevice::pre_run_hook();
 }
 
 

--- a/models/step_rate_generator.h
+++ b/models/step_rate_generator.h
@@ -133,7 +133,7 @@ public:
 private:
   void init_state_() override;
   void init_buffers_() override;
-  void calibrate() override;
+  void pre_run_hook() override;
 
   void update( Time const&, const long, const long ) override;
 

--- a/models/volume_transmitter.cpp
+++ b/models/volume_transmitter.cpp
@@ -92,7 +92,7 @@ nest::volume_transmitter::init_buffers_()
 }
 
 void
-nest::volume_transmitter::calibrate()
+nest::volume_transmitter::pre_run_hook()
 {
   // +1 as pseudo dopa spike at t_trig is inserted after trigger_update_weight
   B_.spikecounter_.reserve( kernel().connection_manager.get_min_delay() * P_.deliver_interval_ + 1 );

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -155,7 +155,7 @@ public:
 
 private:
   void init_buffers_();
-  void calibrate();
+  void pre_run_hook();
 
   void update( const Time&, const long, const long );
 

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -136,7 +136,7 @@ nest::weight_recorder::Parameters_::set( const DictionaryDatum& d )
 void
 nest::weight_recorder::pre_run_hook()
 {
-  RecordingDevice::calibrate(
+  RecordingDevice::pre_run_hook(
     { nest::names::weights }, { nest::names::targets, nest::names::receptors, nest::names::ports } );
 }
 

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -134,7 +134,7 @@ nest::weight_recorder::Parameters_::set( const DictionaryDatum& d )
 }
 
 void
-nest::weight_recorder::calibrate()
+nest::weight_recorder::pre_run_hook()
 {
   RecordingDevice::calibrate(
     { nest::names::weights }, { nest::names::targets, nest::names::receptors, nest::names::ports } );

--- a/models/weight_recorder.h
+++ b/models/weight_recorder.h
@@ -126,7 +126,7 @@ public:
   void set_status( const DictionaryDatum& );
 
 private:
-  void calibrate();
+  void pre_run_hook();
   void update( Time const&, const long, const long );
 
   struct Parameters_

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -71,7 +71,7 @@ class ConnectorModel;
 class ConnTestDummyNodeBase : public Node
 {
   void
-  calibrate()
+  pre_run_hook()
   {
   }
   void

--- a/nestkernel/device.cpp
+++ b/nestkernel/device.cpp
@@ -141,7 +141,7 @@ nest::Device::Device( const Device& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::Device::calibrate()
+nest::Device::pre_run_hook()
 {
   // We do not need to recalibrate time objects, since they are
   // recalibrated on instance construction and resolution cannot

--- a/nestkernel/device.h
+++ b/nestkernel/device.h
@@ -80,7 +80,7 @@ public:
   }
 
   /** Set internal variables before calls to SimulationManager::run() */
-  virtual void calibrate();
+  virtual void pre_run_hook();
 
   virtual void get_status( DictionaryDatum& ) const;
   virtual void set_status( const DictionaryDatum& );

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -254,7 +254,7 @@ public:
    * for spike handling or updating the node.
    *
    */
-  virtual void calibrate() = 0;
+  virtual void pre_run_hook() = 0;
 
   /**
    * Re-calculate time-based properties of the node.

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -607,7 +607,7 @@ NodeManager::prepare_node_( Node* n )
   // Frozen nodes are initialized and calibrated, so that they
   // have ring buffers and can accept incoming spikes.
   n->init();
-  n->calibrate();
+  n->pre_run_hook();
 }
 
 void

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -127,7 +127,7 @@ private:
   {
   }
   void
-  calibrate()
+  pre_run_hook()
   {
   }
   void

--- a/nestkernel/recording_backend_ascii.h
+++ b/nestkernel/recording_backend_ascii.h
@@ -142,7 +142,7 @@ namespace nest
  * RecordingBackendASCII maintains a data structure mapping one file
  * stream to every recording device instance on every thread. Files
  * are opened and inserted into the map during the enroll() call
- * (issued by the recorder's calibrate() function) and closed in
+ * (issued by the recorder's pre_run_hook() function) and closed in
  * cleanup(), which is called on all registered recording backends by
  * IOManager::cleanup().
  */

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -49,7 +49,7 @@ nest::RecordingDevice::set_initialized_()
 }
 
 void
-nest::RecordingDevice::calibrate( const std::vector< Name >& double_value_names,
+nest::RecordingDevice::pre_run_hook( const std::vector< Name >& double_value_names,
   const std::vector< Name >& long_value_names )
 {
   Device::pre_run_hook();

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -52,7 +52,7 @@ void
 nest::RecordingDevice::calibrate( const std::vector< Name >& double_value_names,
   const std::vector< Name >& long_value_names )
 {
-  Device::calibrate();
+  Device::pre_run_hook();
   kernel().io_manager.set_recording_value_names( P_.record_to_, *this, double_value_names, long_value_names );
 }
 

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -134,7 +134,7 @@ public:
 
   using Device::pre_run_hook;
   using Node::pre_run_hook;
-  void calibrate( const std::vector< Name >&, const std::vector< Name >& );
+  void pre_run_hook( const std::vector< Name >&, const std::vector< Name >& );
 
   bool is_active( Time const& T ) const override;
 

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -132,8 +132,8 @@ public:
   RecordingDevice();
   RecordingDevice( const RecordingDevice& );
 
-  using Device::calibrate;
-  using Node::calibrate;
+  using Device::pre_run_hook;
+  using Node::pre_run_hook;
   void calibrate( const std::vector< Name >&, const std::vector< Name >& );
 
   bool is_active( Time const& T ) const override;

--- a/nestkernel/stimulation_device.cpp
+++ b/nestkernel/stimulation_device.cpp
@@ -70,9 +70,9 @@ nest::StimulationDevice::enforce_single_syn_type( synindex syn_id )
 }
 
 void
-nest::StimulationDevice::calibrate()
+nest::StimulationDevice::pre_run_hook()
 {
-  Device::calibrate();
+  Device::pre_run_hook();
 }
 
 void

--- a/nestkernel/stimulation_device.h
+++ b/nestkernel/stimulation_device.h
@@ -163,12 +163,12 @@ public:
   bool has_proxies() const override;
   Name get_element_type() const override;
 
-  using Device::calibrate;
+  using Device::pre_run_hook;
   using Device::init_buffers;
   using Device::init_state;
-  using Node::calibrate;
+  using Node::pre_run_hook;
 
-  void calibrate() override;
+  void pre_run_hook() override;
 
   //! Throws IllegalConnection if synapse id differs from initial synapse id
   void enforce_single_syn_type( synindex );


### PR DESCRIPTION
Fixes #2060 

The `calibrate()` method recomputes the internal variables and is called for every call of simulation. It is now renamed to`pre_run_hook()` which is more descriptive.