### PR TITLE
Handle single node in PlotLayer

### DIFF
--- a/pynest/nest/lib/hl_api_spatial.py
+++ b/pynest/nest/lib/hl_api_spatial.py
@@ -946,7 +946,12 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         xctr, yctr = layer.spatial['center']
 
         # extract position information, transpose to list of x and y pos
-        xpos, ypos = zip(*GetPosition(layer))
+        try:
+            # try zipping coordinates
+            xpos, ypos = zip(*GetPosition(layer))
+        except TypeError:
+            # handle case of single node
+            xpos, ypos = GetPosition(layer)
 
         if fig is None:
             fig = plt.figure()
@@ -962,7 +967,12 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         from mpl_toolkits.mplot3d import Axes3D
 
         # extract position information, transpose to list of x,y,z pos
-        pos = zip(*GetPosition(layer))
+        try:
+            # try zipping coordinates
+            pos = zip(*GetPosition(layer))
+        except TypeError:
+            # handle case of single node
+            pos = GetPosition(layer)
 
         if fig is None:
             fig = plt.figure()

--- a/pynest/nest/lib/hl_api_spatial.py
+++ b/pynest/nest/lib/hl_api_spatial.py
@@ -946,12 +946,11 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         xctr, yctr = layer.spatial['center']
 
         # extract position information, transpose to list of x and y pos
-        try:
-            # try zipping coordinates
-            xpos, ypos = zip(*GetPosition(layer))
-        except TypeError:
+        if len(layer) == 1:
             # handle case of single node
             xpos, ypos = GetPosition(layer)
+        else:
+            xpos, ypos = zip(*GetPosition(layer))
 
         if fig is None:
             fig = plt.figure()
@@ -967,12 +966,11 @@ def PlotLayer(layer, fig=None, nodecolor='b', nodesize=20):
         from mpl_toolkits.mplot3d import Axes3D
 
         # extract position information, transpose to list of x,y,z pos
-        try:
-            # try zipping coordinates
-            pos = zip(*GetPosition(layer))
-        except TypeError:
+        if len(layer) == 1:
             # handle case of single node
             pos = GetPosition(layer)
+        else:
+            pos = zip(*GetPosition(layer))
 
         if fig is None:
             fig = plt.figure()


### PR DESCRIPTION
Currently, the following code plotting a single node with spatial metadata with internal plotting routines, fails with a Python level ```TypeError```:
```
import nest
import matplotlib.pyplot as plt

num_neurons = 1
extent = 2

neuron = nest.Create(
    'iaf_psc_exp',
    num_neurons,
    positions=nest.spatial.free(
        pos=nest.random.uniform(min=-extent / 2, max=extent / 2),
        num_dimensions=2,
        edge_wrap=True)
)
nest.PlotLayer(neuron)
```
This PR tries to fix this problem.