### PR TITLE
Compose paths only at runtime

### DIFF
--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -270,7 +270,11 @@ DynamicLoaderModule::init( SLIInterpreter* i )
     LOG( M_ERROR, "DynamicLoaderModule::init", "Could not initialize libltdl. No dynamic modules will be available." );
   }
 
-  if ( lt_dladdsearchdir( NEST_INSTALL_PREFIX "/" NEST_INSTALL_LIBDIR ) )
+  // Prevent compile-time construction of path to avoid incorrect Conda replacement. See #2237.
+  std::string moduledir = NEST_INSTALL_PREFIX;
+  moduledir += "/";
+  moduledir += NEST_INSTALL_LIBDIR;
+  if ( lt_dladdsearchdir( moduledir  ) )
   {
     LOG( M_ERROR, "DynamicLoaderModule::init", "Could not add dynamic module search directory." );
   }

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -274,7 +274,7 @@ DynamicLoaderModule::init( SLIInterpreter* i )
   std::string moduledir = NEST_INSTALL_PREFIX;
   moduledir += "/";
   moduledir += NEST_INSTALL_LIBDIR;
-  if ( lt_dladdsearchdir( moduledir  ) )
+  if ( lt_dladdsearchdir( moduledir.c_str() ) )
   {
     LOG( M_ERROR, "DynamicLoaderModule::init", "Could not add dynamic module search directory." );
   }

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -184,12 +184,12 @@ SLIStartup::SLIStartup( int argc, char** argv )
   , exitcode_unknownerror_name( "unknownerror" )
   , environment_name( "environment" )
 {
-	// Initialize here instead of in initializer list to defer string concatenation
-	// until runtime to avoid incorrect path replacement by Conda. See #2237.
-	sliprefix = NEST_INSTALL_PREFIX;
-	slilibdir = sliprefix + "/" + NEST_INSTALL_DATADIR;
-	slidocdir = sliprefix + "/" + NEST_INSTALL_DOCDIR;
-	startupfile = slilibdir + "/sli/sli-init.sli";
+  // Initialize here instead of in initializer list to defer string concatenation
+  // until runtime to avoid incorrect path replacement by Conda. See #2237.
+  sliprefix = NEST_INSTALL_PREFIX;
+  slilibdir = sliprefix + "/" + NEST_INSTALL_DATADIR;
+  slidocdir = sliprefix + "/" + NEST_INSTALL_DOCDIR;
+  startupfile = slilibdir + "/sli/sli-init.sli";
 
   // argv[0] is the name of the program that was given to the shell.
   // This name must be given to SLI, otherwise initialization fails.

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -135,11 +135,7 @@ SLIStartup::GetenvFunction::execute( SLIInterpreter* i ) const
 
 
 SLIStartup::SLIStartup( int argc, char** argv )
-  : sliprefix( NEST_INSTALL_PREFIX )
-  , slilibdir( sliprefix + "/" + NEST_INSTALL_DATADIR )
-  , slidocdir( sliprefix + "/" + NEST_INSTALL_DOCDIR )
-  , startupfile( slilibdir + "/sli/sli-init.sli" )
-  , verbosity_( SLIInterpreter::M_INFO ) // default verbosity level
+  : verbosity_( SLIInterpreter::M_INFO ) // default verbosity level
   , debug_( false )
   , argv_name( "argv" )
   , version_name( "version" )
@@ -188,7 +184,12 @@ SLIStartup::SLIStartup( int argc, char** argv )
   , exitcode_unknownerror_name( "unknownerror" )
   , environment_name( "environment" )
 {
-  ArrayDatum args_array;
+	// Initialize here instead of in initializer list to defer string concatenation
+	// until runtime to avoid incorrect path replacement by Conda. See #2237.
+	sliprefix = NEST_INSTALL_PREFIX;
+	slilibdir = sliprefix + "/" + NEST_INSTALL_DATADIR;
+	slidocdir = sliprefix + "/" + NEST_INSTALL_DOCDIR;
+	startupfile = slilibdir + "/sli/sli-init.sli";
 
   // argv[0] is the name of the program that was given to the shell.
   // This name must be given to SLI, otherwise initialization fails.
@@ -196,6 +197,8 @@ SLIStartup::SLIStartup( int argc, char** argv )
   // a script but by using an interactive session in Python, argv[0] is an
   // empty string, see documentation for argv in
   // https://docs.python.org/3/library/sys.html
+  ArrayDatum args_array;
+
   for ( int i = 0; i < argc; ++i )
   {
     StringDatum* sd = new StringDatum( argv[ i ] );

--- a/sli/slistartup.h
+++ b/sli/slistartup.h
@@ -59,10 +59,11 @@
 
 class SLIStartup : public SLIModule
 {
-  const std::string sliprefix;
-  const std::string slilibdir;
-  const std::string slidocdir;
-  const std::string startupfile;
+	// path and file names not const to prevent incorrect replacement by Conda, see #2237.
+  std::string sliprefix;
+  std::string slilibdir;
+  std::string slidocdir;
+  std::string startupfile;
 
   std::string find_startup_file( const std::string& ) const;
   std::string getenv( const std::string& ) const;

--- a/sli/slistartup.h
+++ b/sli/slistartup.h
@@ -59,7 +59,7 @@
 
 class SLIStartup : public SLIModule
 {
-	// path and file names not const to prevent incorrect replacement by Conda, see #2237.
+  // path and file names not const to prevent incorrect replacement by Conda, see #2237.
   std::string sliprefix;
   std::string slilibdir;
   std::string slidocdir;


### PR DESCRIPTION
This PR ensures that paths including `NEST_INSTALL_PREFIX` are built only at runtime to avoid problems arising from Conda's hex-replacement of `PREFIX` paths during installation.

Fixes #2237.