### PR TITLE
Fix static code check in CI

### DIFF
--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -224,7 +224,7 @@ ModelManager::register_node_model_( Model* model )
   builtin_node_models_.push_back( model );
 
   Model* cloned_model = model->clone( name );
-  cloned_model->set_model_id(id);
+  cloned_model->set_model_id( id );
 
   node_models_.push_back( cloned_model );
 


### PR DESCRIPTION
It seems that there are some problems with our CI, as there was a green checkmark on #2335 even though there was code syntax in there that violates the C++ clang-format check.

This PR fixes the syntax according to our clang-format coding standards.

The current CI pipeline is still broken (finding changed files fails); is there already an issue for that? I believe that there might be a PR coming in soon that anyway completely overhauls the CI pipeline. @terhorstd 