### PR TITLE
Correct doc for with-python CMake option and remove Python 2 check.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 ################################################################################
 
 # use Python to build PyNEST
-set( with-python ON CACHE STRING "Build PyNEST [default=ON]. To set a specific Python, give the install path." )
+set( with-python ON CACHE STRING "Build PyNEST [default=ON]." )
 option( cythonize-pynest "Use Cython to cythonize pynestkernel.pyx [default=ON]. If OFF, PyNEST has to be build from a pre-cythonized pynestkernel.pyx." ON )
 
 # select parallelization scheme

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -358,9 +358,8 @@ endfunction()
 function( NEST_PROCESS_WITH_PYTHON )
   # Find Python
   set( HAVE_PYTHON OFF PARENT_SCOPE )
-  if ( ${with-python} STREQUAL "2" )
-    message( FATAL_ERROR "Python 2 is not supported anymore, please use Python 3 by setting CMake option -Dwith-python=ON." )
-  elseif ( ${with-python} STREQUAL "ON" )
+  
+  if ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter and ABI
     find_package( Python 3.8 QUIET COMPONENTS Interpreter Development.Module )

--- a/doc/userdoc/installation/cmake_options.rst
+++ b/doc/userdoc/installation/cmake_options.rst
@@ -35,8 +35,7 @@ Use Python to build PyNEST
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +-----------------------------------------------+----------------------------------------------------------------+
-| ``-Dwith-python=[OFF|ON|<path/to/Python>]``   | Build PyNEST [default=ON]. To set a specific Python, give the  |
-|                                               | install path.                                                  |
+| ``-Dwith-python=[OFF|ON]``                    | Build PyNEST [default=ON].                                     |
 +-----------------------------------------------+----------------------------------------------------------------+
 | ``-Dcythonize-pynest=[OFF|ON]``               | Use Cython to cythonize pynestkernel.pyx [default=ON]. If OFF, |
 |                                               | PyNEST has to be build from a pre-cythonized pynestkernel.pyx. |


### PR DESCRIPTION
- For some time, only ON and OFF have been valid values for `-Dwith-python`. This PR fixes the documentation on this point.
- The PR also removes a check for `-Dwith-python=2` which is not longer relevant.