### PR TITLE
Fix clang 13 pedantic warnings

### DIFF
--- a/build_support/parse_build_log.py
+++ b/build_support/parse_build_log.py
@@ -370,10 +370,10 @@ def makebuild_summary(log_filename, msg_make_section_start,
 
     nest_warning_re = re.compile(f'.*({build_dir}.*: warning:.*)')
     known_warnings = [
-        f'{build_dir}/sli/scanner.cc:643:13: warning: this statement may fall through [-Wimplicit-fallthrough=]',
-        f'{build_dir}/sli/scanner.cc:675:19: warning: this statement may fall through [-Wimplicit-fallthrough=]',
-        f'{build_dir}/sli/scanner.cc:717:13: warning: this statement may fall through [-Wimplicit-fallthrough=]',
-        f'{build_dir}/sli/scanner.cc:745:24: warning: this statement may fall through [-Wimplicit-fallthrough=]',
+        f'{build_dir}/sli/scanner.cc:638:13: warning: this statement may fall through [-Wimplicit-fallthrough=]',
+        f'{build_dir}/sli/scanner.cc:668:19: warning: this statement may fall through [-Wimplicit-fallthrough=]',
+        f'{build_dir}/sli/scanner.cc:710:13: warning: this statement may fall through [-Wimplicit-fallthrough=]',
+        f'{build_dir}/sli/scanner.cc:738:24: warning: this statement may fall through [-Wimplicit-fallthrough=]',
         (f'{build_dir}/thirdparty/Random123/conventional/Engine.hpp:140:15: warning: implicitly-declared'
          ' ‘r123::Engine<r123::Threefry4x64_R<20> >& r123::Engine<r123::Threefry4x64_R<20> >::operator='
          '(const r123::Engine<r123::Threefry4x64_R<20> >&)’ is deprecated [-Wdeprecated-copy]'),

--- a/models/bernoulli_synapse.h
+++ b/models/bernoulli_synapse.h
@@ -112,6 +112,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   bernoulli_synapse( const bernoulli_synapse& rhs ) = default;
+  bernoulli_synapse& operator=( const bernoulli_synapse& rhs ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/clopath_synapse.h
+++ b/models/clopath_synapse.h
@@ -128,6 +128,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   clopath_synapse( const clopath_synapse& ) = default;
+  clopath_synapse& operator=( const clopath_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/jonke_synapse.h
+++ b/models/jonke_synapse.h
@@ -217,6 +217,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   jonke_synapse( const jonke_synapse& ) = default;
+  jonke_synapse& operator=( const jonke_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/quantal_stp_synapse.h
+++ b/models/quantal_stp_synapse.h
@@ -118,6 +118,7 @@ public:
    * Copy constructor to propagate common properties.
    */
   quantal_stp_synapse( const quantal_stp_synapse& ) = default;
+  quantal_stp_synapse& operator=( const quantal_stp_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -123,6 +123,7 @@ private:
 
     Parameters_(); //!< Sets default parameter values
     Parameters_( const Parameters_& ) = default;
+    Parameters_& operator=( const Parameters_& ) = default;
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
     void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -285,7 +285,8 @@ private:
     bool shift_now_spikes_;
 
     Parameters_();                               //!< Sets default parameter values
-    Parameters_( const Parameters_& ) = default; //!< Recalibrate all times
+    Parameters_( const Parameters_& ) = default;
+    Parameters_& operator=( const Parameters_& ) = default;
 
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 

--- a/models/static_synapse.h
+++ b/models/static_synapse.h
@@ -81,6 +81,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   static_synapse( const static_synapse& rhs ) = default;
+  static_synapse& operator=( const static_synapse& rhs ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -208,6 +208,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_dopamine_synapse( const stdp_dopamine_synapse& ) = default;
+  stdp_dopamine_synapse& operator=( const stdp_dopamine_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_nn_pre_centered_synapse.h
+++ b/models/stdp_nn_pre_centered_synapse.h
@@ -142,6 +142,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_nn_pre_centered_synapse( const stdp_nn_pre_centered_synapse& ) = default;
+  stdp_nn_pre_centered_synapse& operator=( const stdp_nn_pre_centered_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_nn_restr_synapse.h
+++ b/models/stdp_nn_restr_synapse.h
@@ -137,6 +137,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_nn_restr_synapse( const stdp_nn_restr_synapse& ) = default;
+  stdp_nn_restr_synapse& operator=( const stdp_nn_restr_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_nn_symm_synapse.h
+++ b/models/stdp_nn_symm_synapse.h
@@ -139,6 +139,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_nn_symm_synapse( const stdp_nn_symm_synapse& ) = default;
+  stdp_nn_symm_synapse& operator=( const stdp_nn_symm_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_pl_synapse_hom.h
+++ b/models/stdp_pl_synapse_hom.h
@@ -143,6 +143,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_pl_synapse_hom( const stdp_pl_synapse_hom& ) = default;
+  stdp_pl_synapse_hom& operator=( const stdp_pl_synapse_hom& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_synapse.h
+++ b/models/stdp_synapse.h
@@ -129,6 +129,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_synapse( const stdp_synapse& ) = default;
+  stdp_synapse& operator=( const stdp_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_synapse_facetshw_hom.h
+++ b/models/stdp_synapse_facetshw_hom.h
@@ -246,6 +246,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_facetshw_synapse_hom( const stdp_facetshw_synapse_hom& ) = default;
+  stdp_facetshw_synapse_hom& operator=( const stdp_facetshw_synapse_hom& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/stdp_synapse_hom.h
+++ b/models/stdp_synapse_hom.h
@@ -168,6 +168,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_synapse_hom( const stdp_synapse_hom& ) = default;
+  stdp_synapse_hom& operator=( const stdp_synapse_hom& ) = default;
 
 
   // Explicitly declare all methods inherited from the dependent base

--- a/models/stdp_triplet_synapse.h
+++ b/models/stdp_triplet_synapse.h
@@ -132,6 +132,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   stdp_triplet_synapse( const stdp_triplet_synapse& ) = default;
+  stdp_triplet_synapse& operator=( const stdp_triplet_synapse& ) = default;
 
   /**
    * Default Destructor.

--- a/models/tsodyks2_synapse.h
+++ b/models/tsodyks2_synapse.h
@@ -129,6 +129,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   tsodyks2_synapse( const tsodyks2_synapse& ) = default;
+  tsodyks2_synapse& operator=( const tsodyks2_synapse& ) = default;
 
   /**
    * Default Destructor.

--- a/models/tsodyks_synapse.h
+++ b/models/tsodyks_synapse.h
@@ -149,6 +149,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   tsodyks_synapse( const tsodyks_synapse& ) = default;
+  tsodyks_synapse& operator=( const tsodyks_synapse& ) = default;
 
   /**
    * Default Destructor.

--- a/models/tsodyks_synapse_hom.h
+++ b/models/tsodyks_synapse_hom.h
@@ -183,6 +183,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   tsodyks_synapse_hom( const tsodyks_synapse_hom& ) = default;
+  tsodyks_synapse_hom& operator=( const tsodyks_synapse_hom& ) = default;
 
   /**
    * Default Destructor.

--- a/models/urbanczik_synapse.h
+++ b/models/urbanczik_synapse.h
@@ -123,6 +123,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   urbanczik_synapse( const urbanczik_synapse& ) = default;
+  urbanczik_synapse& operator=( const urbanczik_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase. This avoids explicit name prefixes in all places these

--- a/models/vogels_sprekeler_synapse.h
+++ b/models/vogels_sprekeler_synapse.h
@@ -103,6 +103,7 @@ public:
    * Needs to be defined properly in order for GenericConnector to work.
    */
   vogels_sprekeler_synapse( const vogels_sprekeler_synapse& ) = default;
+  vogels_sprekeler_synapse& operator=( const vogels_sprekeler_synapse& ) = default;
 
   // Explicitly declare all methods inherited from the dependent base
   // ConnectionBase.

--- a/models/weight_recorder.h
+++ b/models/weight_recorder.h
@@ -136,6 +136,7 @@ private:
 
     Parameters_();
     Parameters_( const Parameters_& ) = default;
+    Parameters_& operator=( const Parameters_& ) = default;
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum& );
   };

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -127,6 +127,7 @@ public:
   }
 
   Connection( const Connection< targetidentifierT >& rhs ) = default;
+  Connection& operator=( const Connection< targetidentifierT >& rhs ) = default;
 
   /**
    * Get all properties of this connection and put them into a dictionary.

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -433,6 +433,13 @@ public:
   NodeCollectionPrimitive( const NodeCollectionPrimitive& ) = default;
 
   /**
+   * Primitive assignment operator.
+   *
+   * @param rhs Primitive to assign
+   */
+  NodeCollectionPrimitive& operator=( const NodeCollectionPrimitive& ) = default;
+
+  /**
    * Create empty NodeCollection.
    *
    * @note This is only for use by SPBuilder.

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -165,6 +165,7 @@ private:
 
     Parameters_();
     Parameters_( const Parameters_& ) = default;
+    Parameters_& operator=( const Parameters_& ) = default;
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum& );
   } P_;

--- a/nestkernel/source_table_position.h
+++ b/nestkernel/source_table_position.h
@@ -45,6 +45,7 @@ struct SourceTablePosition
   SourceTablePosition();
   SourceTablePosition( const long tid, const long syn_id, const long lcid );
   SourceTablePosition( const SourceTablePosition& rhs ) = default;
+  SourceTablePosition& operator=( const SourceTablePosition& rhs ) = default;
 
   /**
    * Decreases indices until a valid entry is found.

--- a/nestkernel/stimulation_device.h
+++ b/nestkernel/stimulation_device.h
@@ -203,6 +203,7 @@ protected:
 
     Parameters_();
     Parameters_( const Parameters_& ) = default;
+    Parameters_& operator=( const Parameters_& ) = default;
     void get( DictionaryDatum& ) const;
     void set( const DictionaryDatum& );
   } P_;

--- a/nestkernel/syn_id_delay.h
+++ b/nestkernel/syn_id_delay.h
@@ -46,6 +46,7 @@ struct SynIdDelay
   }
 
   SynIdDelay( const SynIdDelay& s ) = default;
+  SynIdDelay& operator=( const SynIdDelay& s ) = default;
 
   /**
    * Return the delay of the connection in ms

--- a/nestkernel/target_identifier.h
+++ b/nestkernel/target_identifier.h
@@ -56,6 +56,7 @@ public:
 
 
   TargetIdentifierPtrRport( const TargetIdentifierPtrRport& t ) = default;
+  TargetIdentifierPtrRport& operator=( const TargetIdentifierPtrRport& t ) = default;
 
 
   void
@@ -119,6 +120,7 @@ public:
 
 
   TargetIdentifierIndex( const TargetIdentifierIndex& t ) = default;
+  TargetIdentifierIndex& operator=( const TargetIdentifierIndex& t ) = default;
 
 
   void

--- a/sli/booldatum.h
+++ b/sli/booldatum.h
@@ -58,7 +58,8 @@ public:
   {
   }
 
-  BoolDatum( const BoolDatum& val ) = default;
+  BoolDatum( const BoolDatum& ) = default;
+  BoolDatum& operator=( const BoolDatum& ) = default;
 
   BoolDatum( bool val )
     : GenericDatum< bool, &SLIInterpreter::Booltype >( val )

--- a/sli/name.h
+++ b/sli/name.h
@@ -74,6 +74,7 @@ public:
   }
 
   Name( const Name& n ) = default;
+  Name& operator=( const Name& n ) = default;
 
   /**
    * Return string represented by Name.

--- a/sli/scanner.cc
+++ b/sli/scanner.cc
@@ -539,12 +539,9 @@ Scanner::operator()( Token& t )
   unsigned char sgc = '\0';
 
   long lng = 0L;
-  double d = 0.0;
   int sg = 1;
   int e = 0;
   int parenth = 0; // to handle PS parenthesis in strings
-  double p = 1.;
-
 
   t.clear();
 
@@ -624,13 +621,11 @@ Scanner::operator()( Token& t )
       break;
 
     case intexpst:
-      d = ( double ) lng;
       ds.push_back( 'e' );
       state = expntlst;
       break;
 
     case decpointst:
-      d = ( double ) lng;
       ds.push_back( '.' );
       break;
 
@@ -643,8 +638,6 @@ Scanner::operator()( Token& t )
       state = fracdgtst;
     /* no break */
     case fracdgtst:
-      p /= base;
-      d += sg * p * digval( c );
       ds.push_back( c );
       break;
 


### PR DESCRIPTION
This PR fixes warnings emitted by Clang 13 when run with `-pedantic -Wextra -Woverloaded-virtual -Wno-unknown-pragmas -Wall`. Almost all of the warnings point out that defining a copy constructor without an assignment operator is deprecated (see also https://stackoverflow.com/questions/51863588/warning-definition-of-implicit-copy-constructor-is-deprecated).

Note that building pynestkernel will issue lot's of warnings. This is Cython problem and reported there (https://github.com/cython/cython/pull/4687).

@poojanbabu This may also be relevant for NESTML code generation, therefore I assign you as reviewer.