### PR TITLE
Fix problems with Conda path substitutions in binaries.

### DIFF
--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -284,7 +284,7 @@ private:
     //! Shift spike times at present to next step
     bool shift_now_spikes_;
 
-    Parameters_();                               //!< Sets default parameter values
+    Parameters_(); //!< Sets default parameter values
     Parameters_( const Parameters_& ) = default;
     Parameters_& operator=( const Parameters_& ) = default;
 

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -131,6 +131,10 @@ if ( HAVE_MPI )
 endif ()
 
 
+# Prevent problems with Conda path substitution (see #2348) 
+set_source_files_properties( dynamicloader.cpp PROPERTIES COMPILE_OPTIONS "-O0" )
+
+
 add_library( nestkernel ${nestkernel_sources} )
 target_link_libraries( nestkernel
     nestutil sli_lib

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -275,7 +275,7 @@ DynamicLoaderModule::init( SLIInterpreter* i )
   // a c_str; converting that to string again will limit at the first 0-byte in the cstr.
   // We then need to convert back to c_str since lt_dladdsearchdir needs that.
   // see #2237 and https://github.com/conda/conda-build/issues/1674#issuecomment-280378336
-  const std::string module_dir = std::string( std::string( NEST_INSTALL_PREFIX ).c_str() ) + "/" + NEST_INSTALL_LIBDIR;
+  const std::string module_dir = std::string( NEST_INSTALL_PREFIX ).c_str() + std::string( "/" NEST_INSTALL_LIBDIR );
   if ( lt_dladdsearchdir( module_dir.c_str() ) )
   {
     LOG( M_ERROR, "DynamicLoaderModule::init", "Could not add dynamic module search directory." );

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -271,9 +271,7 @@ DynamicLoaderModule::init( SLIInterpreter* i )
   }
 
   // To avoid problems due to string substitution in NEST binaries during
-  // Conda installation, we need to convert the literal to string to be able to see it as
-  // a c_str; converting that to string again will limit at the first 0-byte in the cstr.
-  // We then need to convert back to c_str since lt_dladdsearchdir needs that.
+  // Conda installation, we need to convert the literal to string, cstr and back,
   // see #2237 and https://github.com/conda/conda-build/issues/1674#issuecomment-280378336
   const std::string module_dir = std::string( NEST_INSTALL_PREFIX ).c_str() + std::string( "/" NEST_INSTALL_LIBDIR );
   if ( lt_dladdsearchdir( module_dir.c_str() ) )

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -270,7 +270,13 @@ DynamicLoaderModule::init( SLIInterpreter* i )
     LOG( M_ERROR, "DynamicLoaderModule::init", "Could not initialize libltdl. No dynamic modules will be available." );
   }
 
-  if ( lt_dladdsearchdir( NEST_INSTALL_PREFIX "/" NEST_INSTALL_LIBDIR ) )
+  // To avoid problems due to string substitution in NEST binaries during
+  // Conda installation, we need to convert the literal to string to be able to see it as
+  // a c_str; converting that to string again will limit at the first 0-byte in the cstr.
+  // We then need to convert back to c_str since lt_dladdsearchdir needs that.
+  // see #2237 and https://github.com/conda/conda-build/issues/1674#issuecomment-280378336
+  const std::string module_dir = std::string( std::string( NEST_INSTALL_PREFIX ).c_str() ) + "/" + NEST_INSTALL_LIBDIR;
+  if ( lt_dladdsearchdir( module_dir.c_str() ) )
   {
     LOG( M_ERROR, "DynamicLoaderModule::init", "Could not add dynamic module search directory." );
   }

--- a/sli/CMakeLists.txt
+++ b/sli/CMakeLists.txt
@@ -82,6 +82,10 @@ set( sli_sources
     utils.cc utils.h
     )
 
+
+# Prevent problems with Conda path substitution (see #2348) 
+set_source_files_properties( slistartup.cc PROPERTIES COMPILE_OPTIONS "-O0" )
+
 add_library( sli_lib ${sli_sources} )
 target_link_libraries( sli_lib nestutil OpenMP::OpenMP_CXX )
 

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -135,7 +135,10 @@ SLIStartup::GetenvFunction::execute( SLIInterpreter* i ) const
 
 
 SLIStartup::SLIStartup( int argc, char** argv )
-  : sliprefix( NEST_INSTALL_PREFIX )
+  // To avoid problems due to string substitution in NEST binaries during
+  // Conda installation, we need to convert the literal to string, cstr and back,
+  // see #2237 and https://github.com/conda/conda-build/issues/1674#issuecomment-280378336
+  : sliprefix( std::string( NEST_INSTALL_PREFIX ).c_str() )
   , slilibdir( sliprefix + "/" + NEST_INSTALL_DATADIR )
   , slidocdir( sliprefix + "/" + NEST_INSTALL_DOCDIR )
   , startupfile( slilibdir + "/sli/sli-init.sli" )

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -133,19 +133,6 @@ SLIStartup::GetenvFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 }
 
-void
-disp( const std::string& s, const std::string& nm )
-{
-  std::cout << nm << "                #" << s << "#" << std::endl;
-  std::cout << nm << ".c_str()        #" << s.c_str() << "#" << std::endl;
-  for ( size_t j = 0; j < s.size(); ++j )
-    std::cout << std::setw( 4 ) << s[ j ];
-  std::cout << std::endl;
-  for ( size_t j = 0; j < s.size(); ++j )
-    std::cout << std::setw( 4 ) << int( s[ j ] );
-  std::cout << std::endl << std::endl;
-}
-
 SLIStartup::SLIStartup( int argc, char** argv )
   // To avoid problems due to string substitution in NEST binaries during
   // Conda installation, we need to convert the literal to string, cstr and back,
@@ -203,10 +190,6 @@ SLIStartup::SLIStartup( int argc, char** argv )
   , exitcode_unknownerror_name( "unknownerror" )
   , environment_name( "environment" )
 {
-  disp( sliprefix, std::string( "sliprefix" ) );
-  disp( slilibdir, std::string( "slilibdir" ) );
-  disp( startupfile, std::string( "startupfile" ) );
-
   ArrayDatum args_array;
 
   // argv[0] is the name of the program that was given to the shell.

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -133,6 +133,18 @@ SLIStartup::GetenvFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 }
 
+void
+disp( const std::string& s, const std::string& nm )
+{
+  std::cout << nm << "                #" << s << "#" << std::endl;
+  std::cout << nm << ".c_str()        #" << s.c_str() << "#" << std::endl;
+  for ( size_t j = 0; j < s.size(); ++j )
+    std::cout << std::setw( 4 ) << s[ j ];
+  std::cout << std::endl;
+  for ( size_t j = 0; j < s.size(); ++j )
+    std::cout << std::setw( 4 ) << int( s[ j ] );
+  std::cout << std::endl << std::endl;
+}
 
 SLIStartup::SLIStartup( int argc, char** argv )
   // To avoid problems due to string substitution in NEST binaries during
@@ -191,6 +203,10 @@ SLIStartup::SLIStartup( int argc, char** argv )
   , exitcode_unknownerror_name( "unknownerror" )
   , environment_name( "environment" )
 {
+  disp( sliprefix, std::string( "sliprefix" ) );
+  disp( slilibdir, std::string( "slilibdir" ) );
+  disp( startupfile, std::string( "startupfile" ) );
+
   ArrayDatum args_array;
 
   // argv[0] is the name of the program that was given to the shell.


### PR DESCRIPTION
This PR replaces #2341 with a direct solution to the problems cause by binary path substitution during conda installation. It is based on https://github.com/conda/conda-build/issues/1674#issuecomment-280378336.

I have not tested it with the Conda build process yet.