### PR TITLE
Remove pathlib from requirements.txt as this is a Python-builtin now

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,7 +13,7 @@ nbsphinx
 numpy
 numpydoc
 path.py
-pathlib
+pathlib2
 pytest
 recommonmark
 scipy

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,7 +13,6 @@ nbsphinx
 numpy
 numpydoc
 path.py
-pathlib2
 pytest
 recommonmark
 scipy


### PR DESCRIPTION
This PR replaces the no longer maintained and outdated version of the pathlib module with a new module in requirements.txt.

The problem was noticed in the automatic build of the NEST docker containers and is fixed with the exchange of the packages.