### PR TITLE
Create classes for the different propagators

### DIFF
--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -82,12 +82,12 @@ PropagatorExp::evaluate( double h ) const
 }
 
 PropagatorAlpha::PropagatorAlpha()
-  : PropagatorExp( 0., 0.,  0. )
+  : PropagatorExp( 0., 0., 0. )
 {
 }
 
 PropagatorAlpha::PropagatorAlpha( double tau_syn, double tau, double c )
-  : PropagatorExp( tau_syn, tau,  c )
+  : PropagatorExp( tau_syn, tau, c )
 {
 }
 

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -57,7 +57,7 @@ PropagatorExp::evaluate( double h ) const
 
   double P32 = gamma_ * exp_h_tau_syn * expm1_h_tau;
 
-  if ( tau_m_ == tau_syn_ or std::abs( tau_m_ - tau_syn_ ) < 0.1 )
+  if ( std::abs( tau_m_ - tau_syn_ ) < 0.1 )
   {
     const double exp_h_tau = std::exp( -h / tau_m_ );
 

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -86,8 +86,8 @@ PropagatorAlpha::PropagatorAlpha()
 {
 }
 
-PropagatorAlpha::PropagatorAlpha( double tau_syn, double tau, double c )
-  : PropagatorExp( tau_syn, tau, c )
+PropagatorAlpha::PropagatorAlpha( double tau_syn, double tau_m, double c_m )
+  : PropagatorExp( tau_syn, tau_m, c_m )
 {
 }
 

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -59,13 +59,13 @@ void propagator::update_constants( double tau_syn, double tau, double c )
   c_ = c;
 }
 
-propogate
+propagators
 propagator::propagate( double h ) const
 {
   const double exp_h_tau_syn = std::exp( -h / tau_syn_ );
   const double expm1_h_tau = numerics::expm1( -h / tau_ + h / tau_syn_ );
 
-  propogate P;
+  propagators P;
 
   P.P31 = gamma_ * ( beta_ * exp_h_tau_syn * expm1_h_tau - h * exp_h_tau_syn);
   P.P32 = gamma_ * exp_h_tau_syn * expm1_h_tau;

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -82,6 +82,7 @@ PropagatorAlpha::evaluate( double h ) const
   std::tie( P32, exp_h_tau_syn, expm1_h_tau, exp_h_tau ) = evaluate_P32_( h );
 
   double P31 = gamma_ * exp_h_tau_syn * ( beta_ * expm1_h_tau - h );
+
   if ( std::abs( tau_m_ - tau_syn_ ) < 0.1 )
   {
     const double P31_singular = h * h / 2 / c_m_ * exp_h_tau;

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -28,29 +28,58 @@
 // Includes from libnestutil:
 #include "numerics.h"
 
-double
-propagator_31( double tau_syn, double tau, double C, double h )
+propagator::propagator( )
+  : alpha_( 0 )
+  , beta_ ( 0 )
+  , gamma_ ( 0 )
+  , gamma_sq_ ( 0 )
 {
-  const double P31_linear = 1 / ( 3. * C * tau * tau ) * h * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
-  const double P31 = 1 / C
-    * ( std::exp( -h / tau_syn ) * numerics::expm1( -h / tau + h / tau_syn ) / ( tau / tau_syn - 1 ) * tau
-      - h * std::exp( -h / tau_syn ) )
-    / ( -1 - -tau / tau_syn ) * tau;
-  const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
-  const double dev_P31 = std::abs( P31 - P31_singular );
+}
 
-  if ( tau == tau_syn or ( std::abs( tau - tau_syn ) < 0.1 and dev_P31 > 2 * std::abs( P31_linear ) ) )
-  {
-    return P31_singular;
-  }
-  else
-  {
-    return P31;
-  }
+void propagator::calculate_constants( double tau_syn, double tau, double c )
+{
+  alpha_ = 1 / ( 3. * c * tau * tau ) * ( tau_syn - tau );
+  beta_ = tau_syn  * tau / (tau - tau_syn);
+  gamma_ = 1 / c * beta_;
+  gamma_sq_ = 1 / c / ( ( 1 / tau_syn - 1 / tau ) * ( 1 / tau_syn - 1 / tau ) );
 }
 
 double
-propagator_32( double tau_syn, double tau, double C, double h )
+propagator::propagator_31( double tau_syn, double tau, double C, double h ) const
+{
+  const double exp_h_tau_syn = std::exp( -h / tau_syn );
+  const double expm1_h_tau = numerics::expm1( -h / tau + h / tau_syn );
+
+
+  //const double P31_linear = 1 / ( 3. * C * tau * tau ) * h * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
+
+  //const double P31 = 1 / C
+  //  * ( std::exp( -h / tau_syn ) * numerics::expm1( -h / tau + h / tau_syn ) / ( tau / tau_syn - 1 ) * tau
+  //    - h * std::exp( -h / tau_syn ) )
+  //  / ( -1 - -tau / tau_syn ) * tau;
+
+  const double P31 = gamma_ * ( beta_ * exp_h_tau_syn * expm1_h_tau - h * exp_h_tau_syn);
+
+  //const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
+  //const double dev_P31 = std::abs( P31 - P31_singular );
+
+  if ( tau == tau_syn or std::abs( tau - tau_syn ) < 0.1 )
+  {
+    const double P31_linear = alpha_ * h * h * h * std::exp( -h / tau );
+    const double P31_singular = h * h / 2 / C * std::exp( -h / tau );
+    const double dev_P31 = std::abs( P31 - P31_singular );
+
+    if ( dev_P31 > 2 * std::abs( P31_linear ) )
+    {
+      return P31_singular;
+    }
+  }
+
+  return P31;
+}
+
+double
+propagator::propagator_32( double tau_syn, double tau, double C, double h ) const
 {
   const double P32_linear = 1 / ( 2. * C * tau * tau ) * h * h * ( tau_syn - tau ) * std::exp( -h / tau );
   const double P32_singular = h / C * std::exp( -h / tau );
@@ -67,4 +96,16 @@ propagator_32( double tau_syn, double tau, double C, double h )
   {
     return P32;
   }
+}
+
+double
+propagator_31( double tau_syn, double tau, double C, double h )
+{
+  return 1.;
+}
+
+double
+propagator_32( double tau_syn, double tau, double C, double h )
+{
+  return 1.;
 }

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -31,7 +31,7 @@
 
 PropagatorExp::PropagatorExp()
   : tau_syn_( 0.0 )
-  , tau_( 0.0 )
+  , tau_m_( 0.0 )
   , c_m_( 0.0 )
   , alpha_( 0.0 )
   , beta_( 0.0 )
@@ -39,12 +39,12 @@ PropagatorExp::PropagatorExp()
 {
 }
 
-PropagatorExp::PropagatorExp( double tau_syn, double tau, double c_m )
+PropagatorExp::PropagatorExp( double tau_syn, double tau_m, double c_m )
   : tau_syn_( tau_syn )
-  , tau_( tau )
+  , tau_m_( tau_m )
   , c_m_( c_m )
-  , alpha_( 1 / ( c_m * tau * tau ) * ( tau_syn - tau ) )
-  , beta_( tau_syn * tau / ( tau - tau_syn ) )
+  , alpha_( 1 / ( c_m * tau_m * tau_m ) * ( tau_syn - tau_m ) )
+  , beta_( tau_syn * tau_m / ( tau_m - tau_syn ) )
   , gamma_( beta_ / c_m )
 {
 }
@@ -53,16 +53,16 @@ double
 PropagatorExp::evaluate( double h ) const
 {
   const double exp_h_tau_syn = std::exp( -h / tau_syn_ );
-  const double expm1_h_tau = numerics::expm1( -h / tau_ + h / tau_syn_ );
+  const double expm1_h_tau = numerics::expm1( -h / tau_m_ + h / tau_syn_ );
 
   double P32 = gamma_ * exp_h_tau_syn * expm1_h_tau;
 
-  if ( tau_ == tau_syn_ or std::abs( tau_ - tau_syn_ ) < 0.1 )
+  if ( tau_m_ == tau_syn_ or std::abs( tau_m_ - tau_syn_ ) < 0.1 )
   {
-    const double exp_h_tau = std::exp( -h / tau_ );
+    const double exp_h_tau = std::exp( -h / tau_m_ );
 
     const double P32_singular = h / c_m_ * exp_h_tau;
-    if ( tau_ == tau_syn_ )
+    if ( tau_m_ == tau_syn_ )
     {
       P32 = P32_singular;
     }
@@ -95,18 +95,18 @@ std::tuple< double, double >
 PropagatorAlpha::evaluate( double h ) const
 {
   const double exp_h_tau_syn = std::exp( -h / tau_syn_ );
-  const double expm1_h_tau = numerics::expm1( -h / tau_ + h / tau_syn_ );
+  const double expm1_h_tau = numerics::expm1( -h / tau_m_ + h / tau_syn_ );
 
   double P31 = gamma_ * exp_h_tau_syn * ( beta_ * expm1_h_tau - h );
   double P32 = gamma_ * exp_h_tau_syn * expm1_h_tau;
 
-  if ( std::abs( tau_ - tau_syn_ ) < 0.1 )
+  if ( std::abs( tau_m_ - tau_syn_ ) < 0.1 )
   {
-    const double exp_h_tau = std::exp( -h / tau_ );
+    const double exp_h_tau = std::exp( -h / tau_m_ );
 
     const double P31_singular = h * h / 2 / c_m_ * exp_h_tau;
 
-    if ( tau_ == tau_syn_ )
+    if ( tau_m_ == tau_syn_ )
     {
       P31 = P31_singular;
     }
@@ -122,7 +122,7 @@ PropagatorAlpha::evaluate( double h ) const
     }
 
     const double P32_singular = h / c_m_ * exp_h_tau;
-    if ( tau_ == tau_syn_ )
+    if ( tau_m_ == tau_syn_ )
     {
       P32 = P32_singular;
     }

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -44,15 +44,15 @@ propagator::propagator( double tau_syn, double tau, double c )
   , c_ ( c )
 {
   alpha_ = 1 / ( c * tau * tau ) * ( tau_syn - tau );
-  beta_ = tau_syn  * tau / (tau - tau_syn);
-  gamma_ = 1 / c * beta_;
+  beta_ = tau_syn  * tau / ( tau - tau_syn );
+  gamma_ = beta_ / c;
 }
 
 void propagator::update_constants( double tau_syn, double tau, double c )
 {
   alpha_ = 1 / ( c * tau * tau ) * ( tau_syn - tau );
-  beta_ = tau_syn  * tau / (tau - tau_syn);
-  gamma_ = 1 / c * beta_;
+  beta_ = tau_syn  * tau / ( tau - tau_syn );
+  gamma_ = beta_ / c;
 
   tau_syn_ = tau_syn;
   tau_ = tau;

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -67,7 +67,7 @@ propagator::propagate( double h ) const
 
   propagators P;
 
-  P.P31 = gamma_ * ( beta_ * exp_h_tau_syn * expm1_h_tau - h * exp_h_tau_syn);
+  P.P31 = gamma_ * ( beta_ * exp_h_tau_syn * expm1_h_tau - h * exp_h_tau_syn );
   P.P32 = gamma_ * exp_h_tau_syn * expm1_h_tau;
 
   if ( tau_ == tau_syn_ or std::abs( tau_ - tau_syn_ ) < 0.1 )
@@ -80,7 +80,7 @@ propagator::propagate( double h ) const
 
     if ( dev_P31 > 2 * std::abs( P31_linear ) )
     {
-      P.P31 =  P31_singular;
+      P.P31 = P31_singular;
     }
 
     const double P32_linear = alpha_ * h * h * exp_h_tau / 2.;

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -29,29 +29,28 @@
 #include "numerics.h"
 
 propagator::propagator()
-  : alpha_( 0 )
-  , beta_ ( 0 )
-  , gamma_ ( 0 )
-  , tau_syn_ ( 0 )
-  , tau_ ( 0 )
-  , c_ ( 0 )
+  : alpha_( 0.0 )
+  , beta_( 0.0 )
+  , gamma_( 0.0 )
+  , tau_syn_( 0.0 )
+  , tau_( 0.0 )
+  , c_( 0.0 )
 {
 }
 
 propagator::propagator( double tau_syn, double tau, double c )
-  : tau_syn_ ( tau_syn )
-  , tau_ ( tau )
-  , c_ ( c )
+  : tau_syn_( tau_syn )
+  , tau_( tau )
+  , c_( c )
 {
-  alpha_ = 1 / ( c * tau * tau ) * ( tau_syn - tau );
-  beta_ = tau_syn  * tau / ( tau - tau_syn );
-  gamma_ = beta_ / c;
+  update_constants( tau_syn, tau, c );
 }
 
-void propagator::update_constants( double tau_syn, double tau, double c )
+void
+propagator::update_constants( double tau_syn, double tau, double c )
 {
   alpha_ = 1 / ( c * tau * tau ) * ( tau_syn - tau );
-  beta_ = tau_syn  * tau / ( tau - tau_syn );
+  beta_ = tau_syn * tau / ( tau - tau_syn );
   gamma_ = beta_ / c;
 
   tau_syn_ = tau_syn;

--- a/libnestutil/propagator_stability.cpp
+++ b/libnestutil/propagator_stability.cpp
@@ -100,7 +100,7 @@ PropagatorAlpha::evaluate( double h ) const
   double P31 = gamma_ * exp_h_tau_syn * ( beta_ * expm1_h_tau - h );
   double P32 = gamma_ * exp_h_tau_syn * expm1_h_tau;
 
-  if ( tau_ == tau_syn_ or std::abs( tau_ - tau_syn_ ) < 0.1 )
+  if ( std::abs( tau_ - tau_syn_ ) < 0.1 )
   {
     const double exp_h_tau = std::exp( -h / tau_ );
 

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -32,6 +32,14 @@ struct propagators
   double P32;
 };
 
+/**
+ * Propagator class for handling similar tau_m and tau_syn_* time constants.
+ *
+ * Constants are calculated in the constructor or `update_constants`, while
+ * propagator_31 and propagator_32 are calculated in `propagate( h )`.
+ *
+ * For details, please see doc/userdoc/model_details/IAF_neurons_singularity.ipynb.
+ */
 class propagator
 {
 public:
@@ -39,8 +47,23 @@ public:
   propagator();
   propagator( double tau_syn, double tau, double c );
 
+  /**
+   * Update constants used in `propagate`.
+   *
+   * @param tau_syn Time constant of synaptic current in ms
+   * @param tau Membrane time constant in ms
+   * @param Membrane capacitance in pF
+   */
   void update_constants( double tau_syn, double tau, double c );
-  propogate propagate( double h ) const;
+
+  /**
+   * Calculate propagators 31 and 32.
+   *
+   * @param h time step
+   *
+   * @returns propagators struct containing 31 and 32
+   */
+  propagators propagate( double h ) const;
 
 private:
   double alpha_;   //!< 1/(c*tau*tau) * (tau_syn - tau)

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -42,7 +42,6 @@
 class PropagatorExp
 {
 public:
-
   /**
    * Empty constructor needed for initialization of buffers.
    */
@@ -77,7 +76,6 @@ protected:
 class PropagatorAlpha : public PropagatorExp
 {
 public:
-
   /**
    * Empty constructor needed for initialization of buffers.
    */
@@ -98,7 +96,6 @@ public:
    * @returns tuple containing propagators 31 and 32
    */
   std::tuple< double, double > evaluate( double h ) const;
-
 };
 
 #endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -69,9 +69,9 @@ protected:
   double tau_;     //!< Membrane time constant in ms
   double c_m_;     //!< Membrane capacitance in pF
 
-  double alpha_;   //!< 1/(c*tau*tau) * (tau_syn - tau)
-  double beta_;    //!< tau_syn  * tau/(tau - tau_syn)
-  double gamma_;   //!< beta_/c
+  double alpha_; //!< 1/(c*tau*tau) * (tau_syn - tau)
+  double beta_;  //!< tau_syn * tau/(tau - tau_syn)
+  double gamma_; //!< beta_/c
 };
 
 class PropagatorAlpha : public PropagatorExp

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -26,24 +26,30 @@
 // Propagators to handle similar tau_m and tau_syn_* time constants.
 // For details, please see doc/userdoc/model_details/IAF_neurons_singularity.ipynb.
 
+struct propogate
+{
+  double P31;
+  double P32;
+};
+
 class propagator
 {
 public:
 
   propagator();
+  propagator( double tau_syn, double tau, double c );
 
-  void calculate_constants( double tau_syn, double tau, double c );
-  double propagator_31( double tau_syn, double tau, double C, double h ) const;
-  double propagator_32( double tau_syn, double tau, double C, double h ) const;
+  void update_constants( double tau_syn, double tau, double c );
+  propogate propagate( double h ) const;
 
 private:
   double alpha_;
   double beta_;
   double gamma_;    //!< 1/c * 1/(1/tau_syn - 1/tau)
-  double gamma_sq_; //!< 1/c * 1/(1/tau_syn - 1/tau)^2
-};
 
-double propagator_31( double tau_syn, double tau, double C, double h );
-double propagator_32( double tau_syn, double tau, double C, double h );
+  double tau_syn_;
+  double tau_;
+  double c_;
+};
 
 #endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -52,7 +52,7 @@ public:
    * @param tau Membrane time constant in ms
    * @param Membrane capacitance in pF
    */
-  PropagatorExp( double tau_syn, double tau, double c_m );
+  PropagatorExp( double tau_syn, double tau_m, double c_m );
 
   /**
    * Calculate propagator 32.
@@ -86,7 +86,7 @@ public:
    * @param tau Membrane time constant in ms
    * @param Membrane capacitance in pF
    */
-  PropagatorAlpha( double tau_syn, double tau, double c_m );
+  PropagatorAlpha( double tau_syn, double tau_m, double c_m );
 
   /**
    * Calculate propagators 31 and 32.

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -49,8 +49,8 @@ public:
 
   /**
    * @param tau_syn Time constant of synaptic current in ms
-   * @param tau Membrane time constant in ms
-   * @param Membrane capacitance in pF
+   * @param tau_m Membrane time constant in ms
+   * @param c_m Membrane capacitance in pF
    */
   PropagatorExp( double tau_syn, double tau_m, double c_m );
 
@@ -65,7 +65,7 @@ public:
 
 protected:
   double tau_syn_; //!< Time constant of synaptic current in ms
-  double tau_;     //!< Membrane time constant in ms
+  double tau_m_;   //!< Membrane time constant in ms
   double c_m_;     //!< Membrane capacitance in pF
 
   double alpha_; //!< 1/(c*tau*tau) * (tau_syn - tau)

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -23,14 +23,8 @@
 #ifndef PROPAGATOR_STABILITY_H
 #define PROPAGATOR_STABILITY_H
 
-/**
- * Propagator variables
- */
-struct propagators
-{
-  double P31;
-  double P32;
-};
+// C++ includes:
+#include <tuple>
 
 /**
  * Propagator class for handling similar tau_m and tau_syn_* time constants.
@@ -40,21 +34,17 @@ struct propagators
  *
  * For details, please see doc/userdoc/model_details/IAF_neurons_singularity.ipynb.
  */
-class propagator
+class PropagatorExp
 {
 public:
 
-  propagator();
-  propagator( double tau_syn, double tau, double c );
-
+  PropagatorExp();
   /**
-   * Update constants used in `propagate`.
-   *
    * @param tau_syn Time constant of synaptic current in ms
    * @param tau Membrane time constant in ms
    * @param Membrane capacitance in pF
    */
-  void update_constants( double tau_syn, double tau, double c );
+  PropagatorExp( double tau_syn, double tau, double c_m );
 
   /**
    * Calculate propagators 31 and 32.
@@ -63,16 +53,39 @@ public:
    *
    * @returns propagators struct containing 31 and 32
    */
-  propagators propagate( double h ) const;
+  double evaluate( double h ) const;
 
-private:
+protected:
+  double tau_syn_; //!< Time constant of synaptic current in ms
+  double tau_;     //!< Membrane time constant in ms
+  double c_m_;       //!< Membrane capacitance in pF
+
   double alpha_;   //!< 1/(c*tau*tau) * (tau_syn - tau)
   double beta_;    //!< tau_syn  * tau/(tau - tau_syn)
   double gamma_;   //!< beta_/c
+};
 
-  double tau_syn_; //!< Time constant of synaptic current in ms
-  double tau_;     //!< Membrane time constant in ms
-  double c_;       //!< Membrane capacitance in pF
+class PropagatorAlpha : public PropagatorExp
+{
+public:
+
+  PropagatorAlpha();
+  /**
+   * @param tau_syn Time constant of synaptic current in ms
+   * @param tau Membrane time constant in ms
+   * @param Membrane capacitance in pF
+   */
+  PropagatorAlpha( double tau_syn, double tau, double c_m );
+
+  /**
+   * Calculate propagators 31 and 32.
+   *
+   * @param h time step
+   *
+   * @returns propagators struct containing 31 and 32
+   */
+  std::tuple< double, double > evaluate( double h ) const;
+
 };
 
 #endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -25,6 +25,24 @@
 
 // Propagators to handle similar tau_m and tau_syn_* time constants.
 // For details, please see doc/userdoc/model_details/IAF_neurons_singularity.ipynb.
+
+class propagator
+{
+public:
+
+  propagator();
+
+  void calculate_constants( double tau_syn, double tau, double c );
+  double propagator_31( double tau_syn, double tau, double C, double h ) const;
+  double propagator_32( double tau_syn, double tau, double C, double h ) const;
+
+private:
+  double alpha_;
+  double beta_;
+  double gamma_;    //!< 1/c * 1/(1/tau_syn - 1/tau)
+  double gamma_sq_; //!< 1/c * 1/(1/tau_syn - 1/tau)^2
+};
+
 double propagator_31( double tau_syn, double tau, double C, double h );
 double propagator_32( double tau_syn, double tau, double C, double h );
 

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -43,13 +43,13 @@ public:
   propogate propagate( double h ) const;
 
 private:
-  double alpha_;
-  double beta_;
-  double gamma_;    //!< 1/c * 1/(1/tau_syn - 1/tau)
+  double alpha_;   //!< 1/(c*tau*tau) * (tau_syn - tau)
+  double beta_;    //!< tau_syn  * tau/(tau - tau_syn)
+  double gamma_;   //!< beta_/c
 
-  double tau_syn_;
-  double tau_;
-  double c_;
+  double tau_syn_; //!< Time constant of synaptic current in ms
+  double tau_;     //!< Membrane time constant in ms
+  double c_;       //!< Membrane capacitance in pF
 };
 
 #endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -55,7 +55,6 @@ public:
   Propagator( double tau_syn, double tau_m, double c_m );
 
 protected:
-
   /**
    * Calculate propagator 32 and return value along with exponentials.
    *
@@ -66,7 +65,7 @@ protected:
    * @returns tuple with propagator 32, exp( -h / tau_syn_ ), expm1( -h / tau_m_ + h / tau_syn_ )
    * and exp( -h / tau_m_ ), all as doubles
    */
-  std::tuple < double, double, double, double > evaluate_P32_( double h ) const;
+  std::tuple< double, double, double, double > evaluate_P32_( double h ) const;
 
   double tau_syn_; //!< Time constant of synaptic current in ms
   double tau_m_;   //!< Membrane time constant in ms
@@ -141,7 +140,7 @@ public:
   std::tuple< double, double > evaluate( double h ) const;
 };
 
-inline std::tuple < double, double, double, double >
+inline std::tuple< double, double, double, double >
 Propagator::evaluate_P32_( double h ) const
 {
   const double exp_h_tau_syn = std::exp( -h / tau_syn_ );
@@ -171,7 +170,7 @@ Propagator::evaluate_P32_( double h ) const
     }
   }
 
-  return std::make_tuple(P32, exp_h_tau_syn, expm1_h_tau, exp_h_tau);
+  return std::make_tuple( P32, exp_h_tau_syn, expm1_h_tau, exp_h_tau );
 }
 
 #endif

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -23,10 +23,10 @@
 #ifndef PROPAGATOR_STABILITY_H
 #define PROPAGATOR_STABILITY_H
 
-// Propagators to handle similar tau_m and tau_syn_* time constants.
-// For details, please see doc/userdoc/model_details/IAF_neurons_singularity.ipynb.
-
-struct propogate
+/**
+ * Propagator variables
+ */
+struct propagators
 {
   double P31;
   double P32;

--- a/libnestutil/propagator_stability.h
+++ b/libnestutil/propagator_stability.h
@@ -27,10 +27,15 @@
 #include <tuple>
 
 /**
- * Propagator class for handling similar tau_m and tau_syn_* time constants.
+ * Propagator classes for handling similar tau_m and tau_syn_* time constants.
  *
- * Constants are calculated in the constructor or `update_constants`, while
- * propagator_31 and propagator_32 are calculated in `propagate( h )`.
+ * Constants are calculated in the constructor, while
+ * propagator_31 and propagator_32 are calculated in `evaluate( h )`.
+ *
+ * Models with exponential postsynaptic currents should use PropagatorExp.
+ * Here `evaluate( h )` returns P32 as a double. Models with postsynaptic
+ * currents modeled as an alpha current on the other hand, should use PropagatorAlpha.
+ * P31 and P32 are then returned as a tuple, where P31 is the first variable.
  *
  * For details, please see doc/userdoc/model_details/IAF_neurons_singularity.ipynb.
  */
@@ -38,7 +43,11 @@ class PropagatorExp
 {
 public:
 
+  /**
+   * Empty constructor needed for initialization of buffers.
+   */
   PropagatorExp();
+
   /**
    * @param tau_syn Time constant of synaptic current in ms
    * @param tau Membrane time constant in ms
@@ -47,18 +56,18 @@ public:
   PropagatorExp( double tau_syn, double tau, double c_m );
 
   /**
-   * Calculate propagators 31 and 32.
+   * Calculate propagator 32.
    *
    * @param h time step
    *
-   * @returns propagators struct containing 31 and 32
+   * @returns propagator 32 as a double
    */
   double evaluate( double h ) const;
 
 protected:
   double tau_syn_; //!< Time constant of synaptic current in ms
   double tau_;     //!< Membrane time constant in ms
-  double c_m_;       //!< Membrane capacitance in pF
+  double c_m_;     //!< Membrane capacitance in pF
 
   double alpha_;   //!< 1/(c*tau*tau) * (tau_syn - tau)
   double beta_;    //!< tau_syn  * tau/(tau - tau_syn)
@@ -69,7 +78,11 @@ class PropagatorAlpha : public PropagatorExp
 {
 public:
 
+  /**
+   * Empty constructor needed for initialization of buffers.
+   */
   PropagatorAlpha();
+
   /**
    * @param tau_syn Time constant of synaptic current in ms
    * @param tau Membrane time constant in ms
@@ -82,7 +95,7 @@ public:
    *
    * @param h time step
    *
-   * @returns propagators struct containing 31 and 32
+   * @returns tuple containing propagators 31 and 32
    */
   std::tuple< double, double > evaluate( double h ) const;
 

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -292,10 +292,8 @@ nest::gif_psc_exp::calibrate()
   const double tau_m = P_.c_m_ / P_.g_L_;
 
   // these are determined according to a numeric stability criterion
-  PropagatorExp prop_ex( P_.tau_ex_, tau_m, P_.c_m_ );
-  PropagatorExp prop_in( P_.tau_in_, tau_m, P_.c_m_ );
-  V_.P21ex_ = prop_ex.evaluate( h );
-  V_.P21in_ = prop_in.evaluate( h );
+  V_.P21ex_ = PropagatorExp( P_.tau_ex_, tau_m, P_.c_m_ ).evaluate( h );
+  V_.P21in_ = PropagatorExp( P_.tau_in_, tau_m, P_.c_m_ ).evaluate( h );
 
   V_.P33_ = std::exp( -h / tau_m );
   V_.P30_ = -1 / P_.c_m_ * numerics::expm1( -h / tau_m ) * tau_m;

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -293,10 +293,10 @@ nest::gif_psc_exp::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, tau_m, P_.c_m_ );
-  propagators propagators_ex = prop_ex.propagate( h );
+  const propagators propagators_ex = prop_ex.propagate( h );
   V_.P21ex_ = propagators_ex.P32;
   propagator prop_in( P_.tau_in_, tau_m, P_.c_m_ );
-  propagators propagators_in = prop_in.propagate( h );
+  const propagators propagators_in = prop_in.propagate( h );
   V_.P21in_ = propagators_in.P32;
 
   V_.P33_ = std::exp( -h / tau_m );

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -293,11 +293,11 @@ nest::gif_psc_exp::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, tau_m, P_.c_m_ );
-  propogate prop_ex_struct = prop_ex.propagate( h );
-  V_.P21ex_ = prop_ex_struct.P32;
+  propagators propagators_ex = prop_ex.propagate( h );
+  V_.P21ex_ = propagators_ex.P32;
   propagator prop_in( P_.tau_in_, tau_m, P_.c_m_ );
-  propogate prop_in_struct = prop_in.propagate( h );
-  V_.P21in_ = prop_in_struct.P32;
+  propagators propagators_in = prop_in.propagate( h );
+  V_.P21in_ = propagators_in.P32;
 
   V_.P33_ = std::exp( -h / tau_m );
   V_.P30_ = -1 / P_.c_m_ * numerics::expm1( -h / tau_m ) * tau_m;

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -292,8 +292,12 @@ nest::gif_psc_exp::calibrate()
   const double tau_m = P_.c_m_ / P_.g_L_;
 
   // these are determined according to a numeric stability criterion
-  V_.P21ex_ = propagator_32( P_.tau_ex_, tau_m, P_.c_m_, h );
-  V_.P21in_ = propagator_32( P_.tau_in_, tau_m, P_.c_m_, h );
+  propagator prop_ex( P_.tau_ex_, tau_m, P_.c_m_ );
+  propogate prop_ex_struct = prop_ex.propagate( h );
+  V_.P21ex_ = prop_ex_struct.P32;
+  propagator prop_in( P_.tau_in_, tau_m, P_.c_m_ );
+  propogate prop_in_struct = prop_in.propagate( h );
+  V_.P21in_ = prop_in_struct.P32;
 
   V_.P33_ = std::exp( -h / tau_m );
   V_.P30_ = -1 / P_.c_m_ * numerics::expm1( -h / tau_m ) * tau_m;

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -292,12 +292,10 @@ nest::gif_psc_exp::calibrate()
   const double tau_m = P_.c_m_ / P_.g_L_;
 
   // these are determined according to a numeric stability criterion
-  propagator prop_ex( P_.tau_ex_, tau_m, P_.c_m_ );
-  const propagators propagators_ex = prop_ex.propagate( h );
-  V_.P21ex_ = propagators_ex.P32;
-  propagator prop_in( P_.tau_in_, tau_m, P_.c_m_ );
-  const propagators propagators_in = prop_in.propagate( h );
-  V_.P21in_ = propagators_in.P32;
+  PropagatorExp prop_ex( P_.tau_ex_, tau_m, P_.c_m_ );
+  PropagatorExp prop_in( P_.tau_in_, tau_m, P_.c_m_ );
+  V_.P21ex_ = prop_ex.evaluate( h );
+  V_.P21in_ = prop_in.evaluate( h );
 
   V_.P33_ = std::exp( -h / tau_m );
   V_.P30_ = -1 / P_.c_m_ * numerics::expm1( -h / tau_m ) * tau_m;

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -335,9 +335,8 @@ nest::gif_psc_exp_multisynapse::calibrate()
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
 
-    propagator prop( P_.tau_syn_[ i ], tau_m, P_.c_m_ );
-    const propagators pgts = prop.propagate( h );
-    V_.P21_syn_[ i ] = pgts.P32;
+    PropagatorExp prop( P_.tau_syn_[ i ], tau_m, P_.c_m_ );
+    V_.P21_syn_[ i ] = prop.evaluate( h );
 
     B_.spikes_[ i ].resize();
   }

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -334,7 +334,10 @@ nest::gif_psc_exp_multisynapse::calibrate()
   for ( size_t i = 0; i < P_.n_receptors_(); i++ )
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
-    V_.P21_syn_[ i ] = propagator_32( P_.tau_syn_[ i ], tau_m, P_.c_m_, h );
+
+    propagator prop( P_.tau_syn_[ i ], tau_m, P_.c_m_ );
+    propogate prop_struct = prop.propagate( h );
+    V_.P21_syn_[ i ] = prop_struct.P32;
 
     B_.spikes_[ i ].resize();
   }

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -336,8 +336,8 @@ nest::gif_psc_exp_multisynapse::calibrate()
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
 
     propagator prop( P_.tau_syn_[ i ], tau_m, P_.c_m_ );
-    propagators propagators = prop.propagate( h );
-    V_.P21_syn_[ i ] = propagators.P32;
+    const propagators pgts = prop.propagate( h );
+    V_.P21_syn_[ i ] = pgts.P32;
 
     B_.spikes_[ i ].resize();
   }

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -336,8 +336,8 @@ nest::gif_psc_exp_multisynapse::calibrate()
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
 
     propagator prop( P_.tau_syn_[ i ], tau_m, P_.c_m_ );
-    propogate prop_struct = prop.propagate( h );
-    V_.P21_syn_[ i ] = prop_struct.P32;
+    propagators propagators = prop.propagate( h );
+    V_.P21_syn_[ i ] = propagators.P32;
 
     B_.spikes_[ i ].resize();
   }

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -335,8 +335,7 @@ nest::gif_psc_exp_multisynapse::calibrate()
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
 
-    PropagatorExp prop( P_.tau_syn_[ i ], tau_m, P_.c_m_ );
-    V_.P21_syn_[ i ] = prop.evaluate( h );
+    V_.P21_syn_[ i ] = PropagatorExp( P_.tau_syn_[ i ], tau_m, P_.c_m_ ).evaluate( h );
 
     B_.spikes_[ i ].resize();
   }

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -453,10 +453,8 @@ nest::glif_psc::calibrate()
 
     // these are determined according to a numeric stability criterion
     // input time parameter shall be in ms, capacity in pF
-    propagator prop( P_.tau_syn_[ i ], Tau_, P_.C_m_ );
-    const propagators pgts = prop.propagate( h );
-    V_.P31_[ i ] = pgts.P31;
-    V_.P32_[ i ] = pgts.P32;
+    PropagatorAlpha prop( P_.tau_syn_[ i ], Tau_, P_.C_m_ );
+    std::tie( V_.P31_[ i ], V_.P32_[ i ] ) = prop.evaluate( h );
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -453,8 +453,7 @@ nest::glif_psc::calibrate()
 
     // these are determined according to a numeric stability criterion
     // input time parameter shall be in ms, capacity in pF
-    PropagatorAlpha prop( P_.tau_syn_[ i ], Tau_, P_.C_m_ );
-    std::tie( V_.P31_[ i ], V_.P32_[ i ] ) = prop.evaluate( h );
+    std::tie( V_.P31_[ i ], V_.P32_[ i ] ) = PropagatorAlpha( P_.tau_syn_[ i ], Tau_, P_.C_m_ ).evaluate( h );
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -454,9 +454,9 @@ nest::glif_psc::calibrate()
     // these are determined according to a numeric stability criterion
     // input time parameter shall be in ms, capacity in pF
     propagator prop( P_.tau_syn_[ i ], Tau_, P_.C_m_ );
-    propogate prop_struct = prop.propagate( h );
-    V_.P31_[ i ] = prop_struct.P31;
-    V_.P32_[ i ] = prop_struct.P32;
+    propagators propagators = prop.propagate( h );
+    V_.P31_[ i ] = propagators.P31;
+    V_.P32_[ i ] = propagators.P32;
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -453,8 +453,10 @@ nest::glif_psc::calibrate()
 
     // these are determined according to a numeric stability criterion
     // input time parameter shall be in ms, capacity in pF
-    V_.P31_[ i ] = propagator_31( P_.tau_syn_[ i ], Tau_, P_.C_m_, h );
-    V_.P32_[ i ] = propagator_32( P_.tau_syn_[ i ], Tau_, P_.C_m_, h );
+    propagator prop( P_.tau_syn_[ i ], Tau_, P_.C_m_ );
+    propogate prop_struct = prop.propagate( h );
+    V_.P31_[ i ] = prop_struct.P31;
+    V_.P32_[ i ] = prop_struct.P32;
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -454,9 +454,9 @@ nest::glif_psc::calibrate()
     // these are determined according to a numeric stability criterion
     // input time parameter shall be in ms, capacity in pF
     propagator prop( P_.tau_syn_[ i ], Tau_, P_.C_m_ );
-    propagators propagators = prop.propagate( h );
-    V_.P31_[ i ] = propagators.P31;
-    V_.P32_[ i ] = propagators.P32;
+    const propagators pgts = prop.propagate( h );
+    V_.P31_[ i ] = pgts.P31;
+    V_.P32_[ i ] = pgts.P32;
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -266,15 +266,11 @@ iaf_psc_alpha::calibrate()
   V_.P21_in_ = h * V_.P11_in_;
 
   // these are determined according to a numeric stability criterion
-  propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  const propagators propagators_ex = prop_ex.propagate( h );
-  V_.P31_ex_ = propagators_ex.P31;
-  V_.P32_ex_ = propagators_ex.P32;
+  PropagatorAlpha prop_ex( P_.tau_ex_,  P_.Tau_, P_.C_ );
+  std::tie( V_.P31_ex_, V_.P32_ex_ ) = prop_ex.evaluate( h );
 
-  propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  const propagators propagators_in = prop_in.propagate( h );
-  V_.P31_in_ = propagators_in.P31;
-  V_.P32_in_ = propagators_in.P32;
+  PropagatorAlpha prop_in( P_.tau_in_,  P_.Tau_, P_.C_ );
+  std::tie( V_.P31_in_, V_.P32_in_ ) = prop_ex.evaluate( h );
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
   V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -266,11 +266,8 @@ iaf_psc_alpha::calibrate()
   V_.P21_in_ = h * V_.P11_in_;
 
   // these are determined according to a numeric stability criterion
-  PropagatorAlpha prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  std::tie( V_.P31_ex_, V_.P32_ex_ ) = prop_ex.evaluate( h );
-
-  PropagatorAlpha prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  std::tie( V_.P31_in_, V_.P32_in_ ) = prop_ex.evaluate( h );
+  std::tie( V_.P31_ex_, V_.P32_ex_ ) = PropagatorAlpha( P_.tau_ex_, P_.Tau_, P_.C_ ).evaluate( h );
+  std::tie( V_.P31_in_, V_.P32_in_ ) = PropagatorAlpha( P_.tau_in_, P_.Tau_, P_.C_ ).evaluate( h );
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
   V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -266,10 +266,10 @@ iaf_psc_alpha::calibrate()
   V_.P21_in_ = h * V_.P11_in_;
 
   // these are determined according to a numeric stability criterion
-  PropagatorAlpha prop_ex( P_.tau_ex_,  P_.Tau_, P_.C_ );
+  PropagatorAlpha prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
   std::tie( V_.P31_ex_, V_.P32_ex_ ) = prop_ex.evaluate( h );
 
-  PropagatorAlpha prop_in( P_.tau_in_,  P_.Tau_, P_.C_ );
+  PropagatorAlpha prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
   std::tie( V_.P31_in_, V_.P32_in_ ) = prop_ex.evaluate( h );
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -266,10 +266,15 @@ iaf_psc_alpha::calibrate()
   V_.P21_in_ = h * V_.P11_in_;
 
   // these are determined according to a numeric stability criterion
-  V_.P31_ex_ = propagator_31( P_.tau_ex_, P_.Tau_, P_.C_, h );
-  V_.P32_ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
-  V_.P31_in_ = propagator_31( P_.tau_in_, P_.Tau_, P_.C_, h );
-  V_.P32_in_ = propagator_32( P_.tau_in_, P_.Tau_, P_.C_, h );
+  propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
+  propogate prop_ex_struct = prop_ex.propagate( h );
+  V_.P31_ex_ = prop_ex_struct.P31;
+  V_.P32_ex_ = prop_ex_struct.P32;
+
+  propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
+  propogate prop_in_struct = prop_in.propagate( h );
+  V_.P31_in_ = prop_in_struct.P31;
+  V_.P32_in_ = prop_in_struct.P32;
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
   V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -267,12 +267,12 @@ iaf_psc_alpha::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  propagators propagators_ex = prop_ex.propagate( h );
+  const propagators propagators_ex = prop_ex.propagate( h );
   V_.P31_ex_ = propagators_ex.P31;
   V_.P32_ex_ = propagators_ex.P32;
 
   propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  propagators propagators_in = prop_in.propagate( h );
+  const propagators propagators_in = prop_in.propagate( h );
   V_.P31_in_ = propagators_in.P31;
   V_.P32_in_ = propagators_in.P32;
 

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -267,14 +267,14 @@ iaf_psc_alpha::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  propogate prop_ex_struct = prop_ex.propagate( h );
-  V_.P31_ex_ = prop_ex_struct.P31;
-  V_.P32_ex_ = prop_ex_struct.P32;
+  propagators propagators_ex = prop_ex.propagate( h );
+  V_.P31_ex_ = propagators_ex.P31;
+  V_.P32_ex_ = propagators_ex.P32;
 
   propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  propogate prop_in_struct = prop_in.propagate( h );
-  V_.P31_in_ = prop_in_struct.P31;
-  V_.P32_in_ = prop_in_struct.P32;
+  propagators propagators_in = prop_in.propagate( h );
+  V_.P31_in_ = propagators_in.P31;
+  V_.P32_in_ = propagators_in.P32;
 
   V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
   V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -280,9 +280,9 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
   propagator prop( P_.tau_syn_, P_.tau_m_, P_.c_m_ );
-  propagators propagators = prop.propagate( V_.h_ms_ );
-  V_.P31_ = propagators.P31;
-  V_.P32_ = propagators.P32;
+  const propagators pgts = prop.propagate( V_.h_ms_ );
+  V_.P31_ = pgts.P31;
+  V_.P32_ = pgts.P32;
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -279,8 +279,10 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.expm1_tau_syn_ = numerics::expm1( -V_.h_ms_ / P_.tau_syn_ );
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  V_.P31_ = propagator_31( P_.tau_syn_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P32_ = propagator_32( P_.tau_syn_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  propagator prop( P_.tau_syn_, P_.tau_m_, P_.c_m_ );
+  propogate prop_struct = prop.propagate( V_.h_ms_ );
+  V_.P31_ = prop_struct.P31;
+  V_.P32_ = prop_struct.P32;
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -279,10 +279,8 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.expm1_tau_syn_ = numerics::expm1( -V_.h_ms_ / P_.tau_syn_ );
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  propagator prop( P_.tau_syn_, P_.tau_m_, P_.c_m_ );
-  const propagators pgts = prop.propagate( V_.h_ms_ );
-  V_.P31_ = pgts.P31;
-  V_.P32_ = pgts.P32;
+  PropagatorAlpha prop( P_.tau_syn_,  P_.tau_m_, P_.c_m_ );
+  std::tie( V_.P31_, V_.P32_ ) = prop.evaluate(  V_.h_ms_ );
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -280,9 +280,9 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
   propagator prop( P_.tau_syn_, P_.tau_m_, P_.c_m_ );
-  propogate prop_struct = prop.propagate( V_.h_ms_ );
-  V_.P31_ = prop_struct.P31;
-  V_.P32_ = prop_struct.P32;
+  propagators propagators = prop.propagate( V_.h_ms_ );
+  V_.P31_ = propagators.P31;
+  V_.P32_ = propagators.P32;
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -279,8 +279,8 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.expm1_tau_syn_ = numerics::expm1( -V_.h_ms_ / P_.tau_syn_ );
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  PropagatorAlpha prop( P_.tau_syn_,  P_.tau_m_, P_.c_m_ );
-  std::tie( V_.P31_, V_.P32_ ) = prop.evaluate(  V_.h_ms_ );
+  PropagatorAlpha prop( P_.tau_syn_, P_.tau_m_, P_.c_m_ );
+  std::tie( V_.P31_, V_.P32_ ) = prop.evaluate( V_.h_ms_ );
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -279,8 +279,7 @@ nest::iaf_psc_alpha_canon::calibrate()
   V_.expm1_tau_syn_ = numerics::expm1( -V_.h_ms_ / P_.tau_syn_ );
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  PropagatorAlpha prop( P_.tau_syn_, P_.tau_m_, P_.c_m_ );
-  std::tie( V_.P31_, V_.P32_ ) = prop.evaluate( V_.h_ms_ );
+  std::tie( V_.P31_, V_.P32_ ) = PropagatorAlpha( P_.tau_syn_, P_.tau_m_, P_.c_m_ ).evaluate( V_.h_ms_ );
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -315,10 +315,8 @@ iaf_psc_alpha_multisynapse::calibrate()
     V_.P21_syn_[ i ] = h * V_.P11_syn_[ i ];
 
     // these are determined according to a numeric stability criterion
-    propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
-    const propagators pgts = prop.propagate( h );
-    V_.P31_syn_[ i ] = pgts.P31;
-    V_.P32_syn_[ i ] = pgts.P32;
+    PropagatorAlpha prop( P_.tau_syn_[ i ],  P_.Tau_, P_.C_ );
+    std::tie( V_.P31_syn_[ i ], V_.P32_syn_[ i ] ) = prop.evaluate(  h );
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -315,8 +315,8 @@ iaf_psc_alpha_multisynapse::calibrate()
     V_.P21_syn_[ i ] = h * V_.P11_syn_[ i ];
 
     // these are determined according to a numeric stability criterion
-    PropagatorAlpha prop( P_.tau_syn_[ i ],  P_.Tau_, P_.C_ );
-    std::tie( V_.P31_syn_[ i ], V_.P32_syn_[ i ] ) = prop.evaluate(  h );
+    PropagatorAlpha prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
+    std::tie( V_.P31_syn_[ i ], V_.P32_syn_[ i ] ) = prop.evaluate( h );
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -316,9 +316,9 @@ iaf_psc_alpha_multisynapse::calibrate()
 
     // these are determined according to a numeric stability criterion
     propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
-    propogate prop_struct = prop.propagate( h );
-    V_.P31_syn_[ i ] = prop_struct.P31;
-    V_.P32_syn_[ i ] = prop_struct.P32;
+    propagators propagators = prop.propagate( h );
+    V_.P31_syn_[ i ] = propagators.P31;
+    V_.P32_syn_[ i ] = propagators.P32;
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -316,9 +316,9 @@ iaf_psc_alpha_multisynapse::calibrate()
 
     // these are determined according to a numeric stability criterion
     propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
-    propagators propagators = prop.propagate( h );
-    V_.P31_syn_[ i ] = propagators.P31;
-    V_.P32_syn_[ i ] = propagators.P32;
+    const propagators pgts = prop.propagate( h );
+    V_.P31_syn_[ i ] = pgts.P31;
+    V_.P32_syn_[ i ] = pgts.P32;
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -315,8 +315,7 @@ iaf_psc_alpha_multisynapse::calibrate()
     V_.P21_syn_[ i ] = h * V_.P11_syn_[ i ];
 
     // these are determined according to a numeric stability criterion
-    PropagatorAlpha prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
-    std::tie( V_.P31_syn_[ i ], V_.P32_syn_[ i ] ) = prop.evaluate( h );
+    std::tie( V_.P31_syn_[ i ], V_.P32_syn_[ i ] ) = PropagatorAlpha( P_.tau_syn_[ i ], P_.Tau_, P_.C_ ).evaluate( h );
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -315,8 +315,10 @@ iaf_psc_alpha_multisynapse::calibrate()
     V_.P21_syn_[ i ] = h * V_.P11_syn_[ i ];
 
     // these are determined according to a numeric stability criterion
-    V_.P31_syn_[ i ] = propagator_31( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
-    V_.P32_syn_[ i ] = propagator_32( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
+    propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
+    propogate prop_struct = prop.propagate( h );
+    V_.P31_syn_[ i ] = prop_struct.P31;
+    V_.P32_syn_[ i ] = prop_struct.P32;
 
     V_.PSCInitialValues_[ i ] = 1.0 * numerics::e / P_.tau_syn_[ i ];
     B_.spikes_[ i ].resize();

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -521,15 +521,15 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
     S_.V_m_ = ( S_.V_m_ < P_.U_min_ ? P_.U_min_ : S_.V_m_ );
   }
 
-  const double ps_e_TauSyn_ex = numerics::expm1( -dt / P_.tau_syn_ex_ );
-  const double ps_e_TauSyn_in = numerics::expm1( -dt / P_.tau_syn_in_ );
+  const double ps_e_TauSyn_ex = std::exp( -dt / P_.tau_syn_ex_ );
+  const double ps_e_TauSyn_in = std::exp( -dt / P_.tau_syn_in_ );
 
   // now the synaptic components
-  S_.I_ex_ = ps_e_TauSyn_ex * dt * S_.dI_ex_ + ps_e_TauSyn_ex * S_.I_ex_ + dt * S_.dI_ex_ + S_.I_ex_;
-  S_.dI_ex_ = ps_e_TauSyn_ex * S_.dI_ex_ + S_.dI_ex_;
+  S_.I_ex_ = ps_e_TauSyn_ex * dt * S_.dI_ex_ + ps_e_TauSyn_ex * S_.I_ex_;
+  S_.dI_ex_ = ps_e_TauSyn_ex * S_.dI_ex_;
 
-  S_.I_in_ = ps_e_TauSyn_in * dt * S_.dI_in_ + ps_e_TauSyn_in * S_.I_in_ + dt * S_.dI_in_ + S_.I_in_;
-  S_.dI_in_ = ps_e_TauSyn_in * S_.dI_in_ + S_.dI_in_;
+  S_.I_in_ = ps_e_TauSyn_in * dt * S_.dI_in_ + ps_e_TauSyn_in * S_.I_in_;
+  S_.dI_in_ = ps_e_TauSyn_in * S_.dI_in_;
 }
 
 void

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -274,14 +274,14 @@ nest::iaf_psc_alpha_ps::calibrate()
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
   P_.prop_ex_.update_constants( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_ );
-  propogate propogate_ex = P_.prop_ex_.propagate( V_.h_ms_ );
-  V_.P31_ex_ = propogate_ex.P31;
-  V_.P32_ex_ = propogate_ex.P32;
+  propagators propagators_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  V_.P31_ex_ = propagators_ex.P31;
+  V_.P32_ex_ = propagators_ex.P32;
 
   P_.prop_in_.update_constants( P_.tau_syn_in_, P_.tau_m_, P_.c_m_ );
-  propogate propogate_in = P_.prop_in_.propagate( V_.h_ms_ );
-  V_.P31_in_ = propogate_in.P31;
-  V_.P32_in_ = propogate_in.P32;
+  propagators propagators_in = P_.prop_in_.propagate( V_.h_ms_ );
+  V_.P31_in_ = propagators_in.P31;
+  V_.P32_in_ = propagators_in.P32;
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole
@@ -507,12 +507,12 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
 
     const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-    propogate propogate_ex = P_.prop_ex_.propagate( dt );
-    propogate propogate_in = P_.prop_in_.propagate( dt );
-    const double ps_P31_ex = propogate_ex.P31;
-    const double ps_P32_ex = propogate_ex.P32;
-    const double ps_P31_in = propogate_in.P31;
-    const double ps_P32_in = propogate_in.P32;
+    propagators propagators_ex = P_.prop_ex_.propagate( dt );
+    propagators propagators_in = P_.prop_in_.propagate( dt );
+    const double ps_P31_ex = propagators_ex.P31;
+    const double ps_P32_ex = propagators_ex.P32;
+    const double ps_P31_in = propagators_in.P31;
+    const double ps_P32_in = propagators_in.P32;
 
     S_.V_m_ = ps_P30 * ( P_.I_e_ + S_.y_input_ ) + ps_P31_ex * S_.dI_ex_ + ps_P32_ex * S_.I_ex_ + ps_P31_in * S_.dI_in_
       + ps_P32_in * S_.I_in_ + S_.V_m_ * expm1_tau_m + S_.V_m_;
@@ -585,12 +585,12 @@ nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 
   const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-  propogate propogate_ex = P_.prop_ex_.propagate( t_step );
-  propogate propogate_in = P_.prop_in_.propagate( t_step );
-  const double ps_P31_ex = propogate_ex.P31;
-  const double ps_P32_ex = propogate_ex.P32;
-  const double ps_P31_in = propogate_in.P31;
-  const double ps_P32_in = propogate_in.P32;
+  propagators propagators_ex = P_.prop_ex_.propagate( t_step );
+  propagators propagators_in = P_.prop_in_.propagate( t_step );
+  const double ps_P31_ex = propagators_ex.P31;
+  const double ps_P32_ex = propagators_ex.P32;
+  const double ps_P31_in = propagators_in.P31;
+  const double ps_P32_in = propagators_in.P32;
 
   const double V_m_root = ps_P30 * ( P_.I_e_ + V_.y_input_before_ ) + ps_P31_ex * V_.dI_ex_before_
     + ps_P32_ex * V_.I_ex_before_ + ps_P31_in * V_.dI_in_before_ + ps_P32_in * V_.I_in_before_

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -273,13 +273,13 @@ nest::iaf_psc_alpha_ps::calibrate()
 
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  P_.prop_ex_.update_constants( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  prop_ex_.update_constants( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_ );
+  propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
   V_.P31_ex_ = propagators_ex.P31;
   V_.P32_ex_ = propagators_ex.P32;
 
-  P_.prop_in_.update_constants( P_.tau_syn_in_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_in = P_.prop_in_.propagate( V_.h_ms_ );
+  prop_in_.update_constants( P_.tau_syn_in_, P_.tau_m_, P_.c_m_ );
+  propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
   V_.P31_in_ = propagators_in.P31;
   V_.P32_in_ = propagators_in.P32;
 
@@ -507,8 +507,8 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
 
     const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-    propagators propagators_ex = P_.prop_ex_.propagate( dt );
-    propagators propagators_in = P_.prop_in_.propagate( dt );
+    propagators propagators_ex = prop_ex_.propagate( dt );
+    propagators propagators_in = prop_in_.propagate( dt );
     const double ps_P31_ex = propagators_ex.P31;
     const double ps_P32_ex = propagators_ex.P32;
     const double ps_P31_in = propagators_in.P31;
@@ -585,8 +585,8 @@ nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 
   const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-  propagators propagators_ex = P_.prop_ex_.propagate( t_step );
-  propagators propagators_in = P_.prop_in_.propagate( t_step );
+  propagators propagators_ex = prop_ex_.propagate( t_step );
+  propagators propagators_in = prop_in_.propagate( t_step );
   const double ps_P31_ex = propagators_ex.P31;
   const double ps_P32_ex = propagators_ex.P32;
   const double ps_P31_in = propagators_in.P31;

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -274,12 +274,12 @@ nest::iaf_psc_alpha_ps::calibrate()
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
   prop_ex_.update_constants( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
+  const propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
   V_.P31_ex_ = propagators_ex.P31;
   V_.P32_ex_ = propagators_ex.P32;
 
   prop_in_.update_constants( P_.tau_syn_in_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
+  const propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
   V_.P31_in_ = propagators_in.P31;
   V_.P32_in_ = propagators_in.P32;
 
@@ -507,8 +507,8 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
 
     const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-    propagators propagators_ex = prop_ex_.propagate( dt );
-    propagators propagators_in = prop_in_.propagate( dt );
+    const propagators propagators_ex = prop_ex_.propagate( dt );
+    const propagators propagators_in = prop_in_.propagate( dt );
     const double ps_P31_ex = propagators_ex.P31;
     const double ps_P32_ex = propagators_ex.P32;
     const double ps_P31_in = propagators_in.P31;
@@ -585,8 +585,8 @@ nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 
   const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-  propagators propagators_ex = prop_ex_.propagate( t_step );
-  propagators propagators_in = prop_in_.propagate( t_step );
+  const propagators propagators_ex = prop_ex_.propagate( t_step );
+  const propagators propagators_in = prop_in_.propagate( t_step );
   const double ps_P31_ex = propagators_ex.P31;
   const double ps_P32_ex = propagators_ex.P32;
   const double ps_P31_in = propagators_in.P31;

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -273,12 +273,15 @@ nest::iaf_psc_alpha_ps::calibrate()
 
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  P_.prop_.calculate_constants(P_.tau_syn_ex_, P_.tau_m_, P_.c_m_);
-  V_.P31_ex_ = P_.prop_.propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P32_ex_ = P_.prop_.propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  P_.prop_ex_.update_constants( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_ );
+  propogate propogate_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  V_.P31_ex_ = propogate_ex.P31;
+  V_.P32_ex_ = propogate_ex.P32;
 
-  V_.P31_in_ = P_.prop_.propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P32_in_ = P_.prop_.propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  P_.prop_in_.update_constants( P_.tau_syn_in_, P_.tau_m_, P_.c_m_ );
+  propogate propogate_in = P_.prop_in_.propagate( V_.h_ms_ );
+  V_.P31_in_ = propogate_in.P31;
+  V_.P32_in_ = propogate_in.P32;
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole
@@ -504,10 +507,12 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
 
     const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-    const double ps_P31_ex = P_.prop_.propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, dt );
-    const double ps_P32_ex = P_.prop_.propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, dt );
-    const double ps_P31_in = P_.prop_.propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, dt );
-    const double ps_P32_in = P_.prop_.propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, dt );
+    propogate propogate_ex = P_.prop_ex_.propagate( dt );
+    propogate propogate_in = P_.prop_in_.propagate( dt );
+    const double ps_P31_ex = propogate_ex.P31;
+    const double ps_P32_ex = propogate_ex.P32;
+    const double ps_P31_in = propogate_in.P31;
+    const double ps_P32_in = propogate_in.P32;
 
     S_.V_m_ = ps_P30 * ( P_.I_e_ + S_.y_input_ ) + ps_P31_ex * S_.dI_ex_ + ps_P32_ex * S_.I_ex_ + ps_P31_in * S_.dI_in_
       + ps_P32_in * S_.I_in_ + S_.V_m_ * expm1_tau_m + S_.V_m_;
@@ -516,15 +521,15 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
     S_.V_m_ = ( S_.V_m_ < P_.U_min_ ? P_.U_min_ : S_.V_m_ );
   }
 
-  const double ps_e_TauSyn_ex = std::exp( -dt / P_.tau_syn_ex_ );
-  const double ps_e_TauSyn_in = std::exp( -dt / P_.tau_syn_in_ );
+  const double ps_e_TauSyn_ex = numerics::expm1( -dt / P_.tau_syn_ex_ );
+  const double ps_e_TauSyn_in = numerics::expm1( -dt / P_.tau_syn_in_ );
 
   // now the synaptic components
-  S_.I_ex_ = ps_e_TauSyn_ex * dt * S_.dI_ex_ + ps_e_TauSyn_ex * S_.I_ex_;
-  S_.dI_ex_ = ps_e_TauSyn_ex * S_.dI_ex_;
+  S_.I_ex_ = ps_e_TauSyn_ex * dt * S_.dI_ex_ + ps_e_TauSyn_ex * S_.I_ex_ + dt * S_.dI_ex_ + S_.I_ex_;
+  S_.dI_ex_ = ps_e_TauSyn_ex * S_.dI_ex_ + S_.dI_ex_;
 
-  S_.I_in_ = ps_e_TauSyn_in * dt * S_.dI_in_ + ps_e_TauSyn_in * S_.I_in_;
-  S_.dI_in_ = ps_e_TauSyn_in * S_.dI_in_;
+  S_.I_in_ = ps_e_TauSyn_in * dt * S_.dI_in_ + ps_e_TauSyn_in * S_.I_in_ + dt * S_.dI_in_ + S_.I_in_;
+  S_.dI_in_ = ps_e_TauSyn_in * S_.dI_in_ + S_.dI_in_;
 }
 
 void
@@ -580,10 +585,12 @@ nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 
   const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-  const double ps_P31_ex = P_.prop_.propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, t_step );
-  const double ps_P32_ex = P_.prop_.propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, t_step );
-  const double ps_P31_in = P_.prop_.propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, t_step );
-  const double ps_P32_in = P_.prop_.propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, t_step );
+  propogate propogate_ex = P_.prop_ex_.propagate( t_step );
+  propogate propogate_in = P_.prop_in_.propagate( t_step );
+  const double ps_P31_ex = propogate_ex.P31;
+  const double ps_P32_ex = propogate_ex.P32;
+  const double ps_P31_in = propogate_in.P31;
+  const double ps_P32_in = propogate_in.P32;
 
   const double V_m_root = ps_P30 * ( P_.I_e_ + V_.y_input_before_ ) + ps_P31_ex * V_.dI_ex_before_
     + ps_P32_ex * V_.I_ex_before_ + ps_P31_in * V_.dI_in_before_ + ps_P32_in * V_.I_in_before_

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -273,11 +273,12 @@ nest::iaf_psc_alpha_ps::calibrate()
 
   V_.P30_ = -P_.tau_m_ / P_.c_m_ * V_.expm1_tau_m_;
   // these are determined according to a numeric stability criterion
-  V_.P31_ex_ = propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P32_ex_ = propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  P_.prop_.calculate_constants(P_.tau_syn_ex_, P_.tau_m_, P_.c_m_);
+  V_.P31_ex_ = P_.prop_.propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  V_.P32_ex_ = P_.prop_.propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
 
-  V_.P31_in_ = propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P32_in_ = propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  V_.P31_in_ = P_.prop_.propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  V_.P32_in_ = P_.prop_.propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
 
   // t_ref_ is the refractory period in ms
   // refractory_steps_ is the duration of the refractory period in whole
@@ -503,10 +504,10 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
 
     const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-    const double ps_P31_ex = propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, dt );
-    const double ps_P32_ex = propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, dt );
-    const double ps_P31_in = propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, dt );
-    const double ps_P32_in = propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, dt );
+    const double ps_P31_ex = P_.prop_.propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, dt );
+    const double ps_P32_ex = P_.prop_.propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, dt );
+    const double ps_P31_in = P_.prop_.propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, dt );
+    const double ps_P32_in = P_.prop_.propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, dt );
 
     S_.V_m_ = ps_P30 * ( P_.I_e_ + S_.y_input_ ) + ps_P31_ex * S_.dI_ex_ + ps_P32_ex * S_.I_ex_ + ps_P31_in * S_.dI_in_
       + ps_P32_in * S_.I_in_ + S_.V_m_ * expm1_tau_m + S_.V_m_;
@@ -579,12 +580,12 @@ nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 
   const double ps_P30 = -P_.tau_m_ / P_.c_m_ * expm1_tau_m;
 
-  const double ps_P31_ex = propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, t_step );
-  const double ps_P32_ex = propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, t_step );
-  const double ps_P31_in = propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, t_step );
-  const double ps_P32_in = propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, t_step );
+  const double ps_P31_ex = P_.prop_.propagator_31( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, t_step );
+  const double ps_P32_ex = P_.prop_.propagator_32( P_.tau_syn_ex_, P_.tau_m_, P_.c_m_, t_step );
+  const double ps_P31_in = P_.prop_.propagator_31( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, t_step );
+  const double ps_P32_in = P_.prop_.propagator_32( P_.tau_syn_in_, P_.tau_m_, P_.c_m_, t_step );
 
-  double V_m_root = ps_P30 * ( P_.I_e_ + V_.y_input_before_ ) + ps_P31_ex * V_.dI_ex_before_
+  const double V_m_root = ps_P30 * ( P_.I_e_ + V_.y_input_before_ ) + ps_P31_ex * V_.dI_ex_before_
     + ps_P32_ex * V_.I_ex_before_ + ps_P31_in * V_.dI_in_before_ + ps_P32_in * V_.I_in_before_
     + V_.V_m_before_ * expm1_tau_m + V_.V_m_before_;
 

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -269,8 +269,8 @@ private:
   void emit_instant_spike_( Time const& origin, const long lag, const double spike_offset );
 
   /** Propagator object for updating synaptic components */
-  propagator prop_ex_;
-  propagator prop_in_;
+  PropagatorAlpha propagator_ex_;
+  PropagatorAlpha propagator_in_;
 
   // The next two classes need to be friends to access the State_ class/member
   friend class RecordablesMap< iaf_psc_alpha_ps >;

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -313,7 +313,8 @@ private:
      */
     double U_reset_;
 
-    propagator prop_;
+    propagator prop_ex_;
+    propagator prop_in_;
 
     Parameters_(); //!< Sets default parameter values
 

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -268,6 +268,10 @@ private:
    */
   void emit_instant_spike_( Time const& origin, const long lag, const double spike_offset );
 
+  /** Propagator object for updating synaptic components */
+  propagator prop_ex_;
+  propagator prop_in_;
+
   // The next two classes need to be friends to access the State_ class/member
   friend class RecordablesMap< iaf_psc_alpha_ps >;
   friend class UniversalDataLogger< iaf_psc_alpha_ps >;
@@ -312,9 +316,6 @@ private:
               value. Relative to resting potential.
      */
     double U_reset_;
-
-    propagator prop_ex_;
-    propagator prop_in_;
 
     Parameters_(); //!< Sets default parameter values
 

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -29,6 +29,9 @@
 // Generated includes:
 #include "config.h"
 
+// Includes from libnestutil:
+#include "propagator_stability.h"
+
 // Includes from nestkernel:
 #include "archiving_node.h"
 #include "connection.h"
@@ -309,6 +312,8 @@ private:
               value. Relative to resting potential.
      */
     double U_reset_;
+
+    propagator prop_;
 
     Parameters_(); //!< Sets default parameter values
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -255,10 +255,8 @@ nest::iaf_psc_exp::calibrate()
   V_.P22_ = std::exp( -h / P_.Tau_ );
 
   // these are determined according to a numeric stability criterion
-  PropagatorExp prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  PropagatorExp prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  V_.P21ex_ = prop_ex.evaluate( h );
-  V_.P21in_ = prop_in.evaluate( h );
+  V_.P21ex_ = PropagatorExp( P_.tau_ex_, P_.Tau_, P_.C_ ).evaluate( h );
+  V_.P21in_ = PropagatorExp( P_.tau_in_, P_.Tau_, P_.C_ ).evaluate( h );
 
   V_.P20_ = P_.Tau_ / P_.C_ * ( 1.0 - V_.P22_ );
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -255,12 +255,10 @@ nest::iaf_psc_exp::calibrate()
   V_.P22_ = std::exp( -h / P_.Tau_ );
 
   // these are determined according to a numeric stability criterion
-  propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  const propagators propagators_ex = prop_ex.propagate( h );
-  V_.P21ex_ = propagators_ex.P32;
-  propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  const propagators propagators_in = prop_in.propagate( h );
-  V_.P21in_ = propagators_in.P32;
+  PropagatorExp prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
+  PropagatorExp prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
+  V_.P21ex_ = prop_ex.evaluate( h );
+  V_.P21in_ = prop_in.evaluate( h );
 
   V_.P20_ = P_.Tau_ / P_.C_ * ( 1.0 - V_.P22_ );
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -255,8 +255,12 @@ nest::iaf_psc_exp::calibrate()
   V_.P22_ = std::exp( -h / P_.Tau_ );
 
   // these are determined according to a numeric stability criterion
-  V_.P21ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
-  V_.P21in_ = propagator_32( P_.tau_in_, P_.Tau_, P_.C_, h );
+  propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
+  propogate prop_ex_struct = prop_ex.propagate( h );
+  V_.P21ex_ = prop_ex_struct.P32;
+  propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
+  propogate prop_in_struct = prop_in.propagate( h );
+  V_.P21in_ = prop_in_struct.P32;
 
   V_.P20_ = P_.Tau_ / P_.C_ * ( 1.0 - V_.P22_ );
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -256,10 +256,10 @@ nest::iaf_psc_exp::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  propagators propagators_ex = prop_ex.propagate( h );
+  const propagators propagators_ex = prop_ex.propagate( h );
   V_.P21ex_ = propagators_ex.P32;
   propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  propagators propagators_in = prop_in.propagate( h );
+  const propagators propagators_in = prop_in.propagate( h );
   V_.P21in_ = propagators_in.P32;
 
   V_.P20_ = P_.Tau_ / P_.C_ * ( 1.0 - V_.P22_ );

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -256,11 +256,11 @@ nest::iaf_psc_exp::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  propogate prop_ex_struct = prop_ex.propagate( h );
-  V_.P21ex_ = prop_ex_struct.P32;
+  propagators propagators_ex = prop_ex.propagate( h );
+  V_.P21ex_ = propagators_ex.P32;
   propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  propogate prop_in_struct = prop_in.propagate( h );
-  V_.P21in_ = prop_in_struct.P32;
+  propagators propagators_in = prop_in.propagate( h );
+  V_.P21in_ = propagators_in.P32;
 
   V_.P20_ = P_.Tau_ / P_.C_ * ( 1.0 - V_.P22_ );
 

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -253,10 +253,10 @@ nest::iaf_psc_exp_htum::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  propagators propagators_ex = prop_ex.propagate( h );
+  const propagators propagators_ex = prop_ex.propagate( h );
   V_.P21ex_ = propagators_ex.P32;
   propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  propagators propagators_in = prop_in.propagate( h );
+  const propagators propagators_in = prop_in.propagate( h );
   V_.P21in_ = propagators_in.P32;
 
   // P21ex_ = h/C_;

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -253,11 +253,11 @@ nest::iaf_psc_exp_htum::calibrate()
 
   // these are determined according to a numeric stability criterion
   propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  propogate prop_ex_struct = prop_ex.propagate( h );
-  V_.P21ex_ = prop_ex_struct.P32;
+  propagators propagators_ex = prop_ex.propagate( h );
+  V_.P21ex_ = propagators_ex.P32;
   propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  propogate prop_in_struct = prop_in.propagate( h );
-  V_.P21in_ = prop_in_struct.P32;
+  propagators propagators_in = prop_in.propagate( h );
+  V_.P21in_ = propagators_in.P32;
 
   // P21ex_ = h/C_;
   // P21in_ = h/C_;

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -252,8 +252,12 @@ nest::iaf_psc_exp_htum::calibrate()
   // P22_ = 1.0-h/Tau_;
 
   // these are determined according to a numeric stability criterion
-  V_.P21ex_ = propagator_32( P_.tau_ex_, P_.Tau_, P_.C_, h );
-  V_.P21in_ = propagator_32( P_.tau_in_, P_.Tau_, P_.C_, h );
+  propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
+  propogate prop_ex_struct = prop_ex.propagate( h );
+  V_.P21ex_ = prop_ex_struct.P32;
+  propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
+  propogate prop_in_struct = prop_in.propagate( h );
+  V_.P21in_ = prop_in_struct.P32;
 
   // P21ex_ = h/C_;
   // P21in_ = h/C_;

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -252,10 +252,8 @@ nest::iaf_psc_exp_htum::calibrate()
   // P22_ = 1.0-h/Tau_;
 
   // these are determined according to a numeric stability criterion
-  PropagatorExp prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  PropagatorExp prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  V_.P21ex_ = prop_ex.evaluate( h );
-  V_.P21in_ = prop_in.evaluate( h );
+  V_.P21ex_ = PropagatorExp( P_.tau_ex_, P_.Tau_, P_.C_ ).evaluate( h );
+  V_.P21in_ = PropagatorExp( P_.tau_in_, P_.Tau_, P_.C_ ).evaluate( h );
 
   // P21ex_ = h/C_;
   // P21in_ = h/C_;

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -252,12 +252,10 @@ nest::iaf_psc_exp_htum::calibrate()
   // P22_ = 1.0-h/Tau_;
 
   // these are determined according to a numeric stability criterion
-  propagator prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
-  const propagators propagators_ex = prop_ex.propagate( h );
-  V_.P21ex_ = propagators_ex.P32;
-  propagator prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
-  const propagators propagators_in = prop_in.propagate( h );
-  V_.P21in_ = propagators_in.P32;
+  PropagatorExp prop_ex( P_.tau_ex_, P_.Tau_, P_.C_ );
+  PropagatorExp prop_in( P_.tau_in_, P_.Tau_, P_.C_ );
+  V_.P21ex_ = prop_ex.evaluate( h );
+  V_.P21in_ = prop_in.evaluate( h );
 
   // P21ex_ = h/C_;
   // P21in_ = h/C_;

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -294,8 +294,7 @@ nest::iaf_psc_exp_multisynapse::calibrate()
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     // these are determined according to a numeric stability criterion
-    PropagatorExp prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
-    V_.P21_syn_[ i ] = prop.evaluate( h );
+    V_.P21_syn_[ i ] = PropagatorExp( P_.tau_syn_[ i ], P_.Tau_, P_.C_ ).evaluate( h );
 
     B_.spikes_[ i ].resize();
   }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -295,8 +295,8 @@ nest::iaf_psc_exp_multisynapse::calibrate()
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     // these are determined according to a numeric stability criterion
     propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_);
-    propogate prop_struct = prop.propagate( h );
-    V_.P21_syn_[ i ] = prop_struct.P32;
+    propagators propagators = prop.propagate( h );
+    V_.P21_syn_[ i ] = propagators.P32;
 
     B_.spikes_[ i ].resize();
   }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -294,7 +294,9 @@ nest::iaf_psc_exp_multisynapse::calibrate()
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     // these are determined according to a numeric stability criterion
-    V_.P21_syn_[ i ] = propagator_32( P_.tau_syn_[ i ], P_.Tau_, P_.C_, h );
+    propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_);
+    propogate prop_struct = prop.propagate( h );
+    V_.P21_syn_[ i ] = prop_struct.P32;
 
     B_.spikes_[ i ].resize();
   }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -294,9 +294,8 @@ nest::iaf_psc_exp_multisynapse::calibrate()
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     // these are determined according to a numeric stability criterion
-    propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
-    const propagators pgts = prop.propagate( h );
-    V_.P21_syn_[ i ] = pgts.P32;
+    PropagatorExp prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
+    V_.P21_syn_[ i ] = prop.evaluate( h );
 
     B_.spikes_[ i ].resize();
   }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -295,8 +295,8 @@ nest::iaf_psc_exp_multisynapse::calibrate()
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     // these are determined according to a numeric stability criterion
     propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_);
-    propagators propagators = prop.propagate( h );
-    V_.P21_syn_[ i ] = propagators.P32;
+    const propagators pgts = prop.propagate( h );
+    V_.P21_syn_[ i ] = pgts.P32;
 
     B_.spikes_[ i ].resize();
   }

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -294,7 +294,7 @@ nest::iaf_psc_exp_multisynapse::calibrate()
   {
     V_.P11_syn_[ i ] = std::exp( -h / P_.tau_syn_[ i ] );
     // these are determined according to a numeric stability criterion
-    propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_);
+    propagator prop( P_.tau_syn_[ i ], P_.Tau_, P_.C_ );
     const propagators pgts = prop.propagate( h );
     V_.P21_syn_[ i ] = pgts.P32;
 

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -260,12 +260,10 @@ nest::iaf_psc_exp_ps::calibrate()
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
 
   // these are determined according to a numeric stability criterion
-  prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  const propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
-  V_.P21_ex_ = propagators_ex.P32;
-  prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  const propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
-  V_.P21_in_ = propagators_in.P32;
+  propagator_ex_ = PropagatorExp( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
+  propagator_in_ = PropagatorExp( P_.tau_in_, P_.tau_m_, P_.c_m_ );
+  V_.P21_ex_ = propagator_ex_.evaluate( V_.h_ms_ );
+  V_.P21_in_ = propagator_in_.evaluate( V_.h_ms_ );
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   // since t_ref_ >= sim step size, this can only fail in error
@@ -482,10 +480,8 @@ nest::iaf_psc_exp_ps::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    const propagators propagators_ex = prop_ex_.propagate( dt );
-    const propagators propagators_in = prop_in_.propagate( dt );
-    const double P21_ex = propagators_ex.P32;
-    const double P21_in = propagators_in.P32;
+    const double P21_ex = propagator_ex_.evaluate( dt );
+    const double P21_in = propagator_in_.evaluate( dt );
 
     S_.y2_ =
       P20 * ( P_.I_e_ + S_.y0_ ) + P21_ex * S_.y1_ex_ + P21_in * S_.y1_in_ + S_.y2_ * std::exp( -dt / P_.tau_m_ );
@@ -550,10 +546,8 @@ nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  const propagators propagators_ex = prop_ex_.propagate( t_step );
-  const propagators propagators_in = prop_in_.propagate( t_step );
-  const double P21_ex = propagators_ex.P32;
-  const double P21_in = propagators_in.P32;
+  const double P21_ex = propagator_ex_.evaluate( t_step );
+  const double P21_in = propagator_in_.evaluate( t_step );
 
   double y2_root = P20 * ( P_.I_e_ + V_.y0_before_ ) + P21_ex * V_.y1_ex_before_ + P21_in * V_.y1_in_before_
     + V_.y2_before_ * std::exp( -t_step / P_.tau_m_ );

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -261,10 +261,10 @@ nest::iaf_psc_exp_ps::calibrate()
 
   // these are determined according to a numeric stability criterion
   prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
+  const propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
   V_.P21_ex_ = propagators_ex.P32;
   prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
+  const propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
   V_.P21_in_ = propagators_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
@@ -482,8 +482,8 @@ nest::iaf_psc_exp_ps::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    propagators propagators_ex = prop_ex_.propagate( dt );
-    propagators propagators_in = prop_in_.propagate( dt );
+    const propagators propagators_ex = prop_ex_.propagate( dt );
+    const propagators propagators_in = prop_in_.propagate( dt );
     const double P21_ex = propagators_ex.P32;
     const double P21_in = propagators_in.P32;
 
@@ -550,8 +550,8 @@ nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  propagators propagators_ex = prop_ex_.propagate( t_step );
-  propagators propagators_in = prop_in_.propagate( t_step );
+  const propagators propagators_ex = prop_ex_.propagate( t_step );
+  const propagators propagators_in = prop_in_.propagate( t_step );
   const double P21_ex = propagators_ex.P32;
   const double P21_in = propagators_in.P32;
 

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -261,11 +261,11 @@ nest::iaf_psc_exp_ps::calibrate()
 
   // these are determined according to a numeric stability criterion
   P_.prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  propogate propogate_ex = P_.prop_ex_.propagate( V_.h_ms_ );
-  V_.P21_ex_ = propogate_ex.P32;
+  propagators propagators_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  V_.P21_ex_ = propagators_ex.P32;
   P_.prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  propogate propogate_in = P_.prop_in_.propagate( V_.h_ms_ );
-  V_.P21_in_ = propogate_in.P32;
+  propagators propagators_in = P_.prop_in_.propagate( V_.h_ms_ );
+  V_.P21_in_ = propagators_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   // since t_ref_ >= sim step size, this can only fail in error
@@ -482,10 +482,10 @@ nest::iaf_psc_exp_ps::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    propogate propogate_ex = P_.prop_ex_.propagate( dt );
-    propogate propogate_in = P_.prop_in_.propagate( dt );
-    const double P21_ex = propogate_ex.P32;
-    const double P21_in = propogate_in.P32;
+    propagators propagators_ex = P_.prop_ex_.propagate( dt );
+    propagators propagators_in = P_.prop_in_.propagate( dt );
+    const double P21_ex = propagators_ex.P32;
+    const double P21_in = propagators_in.P32;
 
     S_.y2_ =
       P20 * ( P_.I_e_ + S_.y0_ ) + P21_ex * S_.y1_ex_ + P21_in * S_.y1_in_ + S_.y2_ * std::exp( -dt / P_.tau_m_ );
@@ -550,10 +550,10 @@ nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  propogate propogate_ex = P_.prop_ex_.propagate( t_step );
-  propogate propogate_in = P_.prop_in_.propagate( t_step );
-  const double P21_ex = propogate_ex.P32;
-  const double P21_in = propogate_in.P32;
+  propagators propagators_ex = P_.prop_ex_.propagate( t_step );
+  propagators propagators_in = P_.prop_in_.propagate( t_step );
+  const double P21_ex = propagators_ex.P32;
+  const double P21_in = propagators_in.P32;
 
   double y2_root = P20 * ( P_.I_e_ + V_.y0_before_ ) + P21_ex * V_.y1_ex_before_ + P21_in * V_.y1_in_before_
     + V_.y2_before_ * std::exp( -t_step / P_.tau_m_ );

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -260,11 +260,11 @@ nest::iaf_psc_exp_ps::calibrate()
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
 
   // these are determined according to a numeric stability criterion
-  P_.prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
+  propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
   V_.P21_ex_ = propagators_ex.P32;
-  P_.prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_in = P_.prop_in_.propagate( V_.h_ms_ );
+  prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
+  propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
   V_.P21_in_ = propagators_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
@@ -482,8 +482,8 @@ nest::iaf_psc_exp_ps::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    propagators propagators_ex = P_.prop_ex_.propagate( dt );
-    propagators propagators_in = P_.prop_in_.propagate( dt );
+    propagators propagators_ex = prop_ex_.propagate( dt );
+    propagators propagators_in = prop_in_.propagate( dt );
     const double P21_ex = propagators_ex.P32;
     const double P21_in = propagators_in.P32;
 
@@ -550,8 +550,8 @@ nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  propagators propagators_ex = P_.prop_ex_.propagate( t_step );
-  propagators propagators_in = P_.prop_in_.propagate( t_step );
+  propagators propagators_ex = prop_ex_.propagate( t_step );
+  propagators propagators_in = prop_in_.propagate( t_step );
   const double P21_ex = propagators_ex.P32;
   const double P21_in = propagators_in.P32;
 

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -260,8 +260,12 @@ nest::iaf_psc_exp_ps::calibrate()
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
 
   // these are determined according to a numeric stability criterion
-  V_.P21_ex_ = propagator_32( P_.tau_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P21_in_ = propagator_32( P_.tau_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+  P_.prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
+  propogate propogate_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  V_.P21_ex_ = propogate_ex.P32;
+  P_.prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
+  propogate propogate_in = P_.prop_in_.propagate( V_.h_ms_ );
+  V_.P21_in_ = propogate_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   // since t_ref_ >= sim step size, this can only fail in error
@@ -478,8 +482,10 @@ nest::iaf_psc_exp_ps::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    const double P21_ex = propagator_32( P_.tau_ex_, P_.tau_m_, P_.c_m_, dt );
-    const double P21_in = propagator_32( P_.tau_in_, P_.tau_m_, P_.c_m_, dt );
+    propogate propogate_ex = P_.prop_ex_.propagate( dt );
+    propogate propogate_in = P_.prop_in_.propagate( dt );
+    const double P21_ex = propogate_ex.P32;
+    const double P21_in = propogate_in.P32;
 
     S_.y2_ =
       P20 * ( P_.I_e_ + S_.y0_ ) + P21_ex * S_.y1_ex_ + P21_in * S_.y1_in_ + S_.y2_ * std::exp( -dt / P_.tau_m_ );
@@ -544,8 +550,10 @@ nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  const double P21_ex = propagator_32( P_.tau_ex_, P_.tau_m_, P_.c_m_, t_step );
-  const double P21_in = propagator_32( P_.tau_in_, P_.tau_m_, P_.c_m_, t_step );
+  propogate propogate_ex = P_.prop_ex_.propagate( t_step );
+  propogate propogate_in = P_.prop_in_.propagate( t_step );
+  const double P21_ex = propogate_ex.P32;
+  const double P21_in = propogate_in.P32;
 
   double y2_root = P20 * ( P_.I_e_ + V_.y0_before_ ) + P21_ex * V_.y1_ex_before_ + P21_in * V_.y1_in_before_
     + V_.y2_before_ * std::exp( -t_step / P_.tau_m_ );

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -263,6 +263,10 @@ private:
    */
   void emit_instant_spike_( const Time& origin, const long lag, const double spike_offset );
 
+  /** Propagator object for updating synaptic components */
+  propagator prop_ex_;
+  propagator prop_in_;
+
   // ----------------------------------------------------------------
 
   /**
@@ -303,9 +307,6 @@ private:
         At threshold crossing, the membrane potential is reset to this value.
         Relative to resting potential. */
     double U_reset_;
-
-    propagator prop_ex_;
-    propagator prop_in_;
 
     Parameters_(); //!< Sets default parameter values
 

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -29,6 +29,9 @@
 // Generated includes:
 #include "config.h"
 
+// Includes from libnestutil:
+#include "propagator_stability.h"
+
 // Includes from nestkernel:
 #include "archiving_node.h"
 #include "connection.h"
@@ -300,6 +303,9 @@ private:
         At threshold crossing, the membrane potential is reset to this value.
         Relative to resting potential. */
     double U_reset_;
+
+    propagator prop_ex_;
+    propagator prop_in_;
 
     Parameters_(); //!< Sets default parameter values
 

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -264,8 +264,8 @@ private:
   void emit_instant_spike_( const Time& origin, const long lag, const double spike_offset );
 
   /** Propagator object for updating synaptic components */
-  propagator prop_ex_;
-  propagator prop_in_;
+  PropagatorExp propagator_ex_;
+  PropagatorExp propagator_in_;
 
   // ----------------------------------------------------------------
 

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -286,11 +286,11 @@ nest::iaf_psc_exp_ps_lossless::calibrate()
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
 
   P_.prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  propogate propogate_ex = P_.prop_ex_.propagate( V_.h_ms_ );
-  V_.P21_ex_ = propogate_ex.P32;
+  propagators propagators_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  V_.P21_ex_ = propagators_ex.P32;
   P_.prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  propogate propogate_in = P_.prop_in_.propagate( V_.h_ms_ );
-  V_.P21_in_ = propogate_in.P32;
+  propagators propagators_in = P_.prop_in_.propagate( V_.h_ms_ );
+  V_.P21_in_ = propagators_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   assert( V_.refractory_steps_ >= 0 ); // since t_ref_ >= 0, this can only fail in error
@@ -526,10 +526,10 @@ nest::iaf_psc_exp_ps_lossless::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    propogate propogate_ex = P_.prop_ex_.propagate( dt );
-    propogate propogate_in = P_.prop_in_.propagate( dt );
-    const double P21_ex = propogate_ex.P32;
-    const double P21_in = propogate_in.P32;
+    propagators propagators_ex = P_.prop_ex_.propagate( dt );
+    propagators propagators_in = P_.prop_in_.propagate( dt );
+    const double P21_ex = propagators_ex.P32;
+    const double P21_in = propagators_in.P32;
 
     S_.y2_ =
       P20 * ( P_.I_e_ + S_.y0_ ) + P21_ex * S_.I_syn_ex_ + P21_in * S_.I_syn_in_ + S_.y2_ * std::exp( -dt / P_.tau_m_ );
@@ -593,10 +593,10 @@ nest::iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  propogate propogate_ex = P_.prop_ex_.propagate( t_step );
-  propogate propogate_in = P_.prop_in_.propagate( t_step );
-  const double P21_ex = propogate_ex.P32;
-  const double P21_in = propogate_in.P32;
+  propagators propagators_ex = P_.prop_ex_.propagate( t_step );
+  propagators propagators_in = P_.prop_in_.propagate( t_step );
+  const double P21_ex = propagators_ex.P32;
+  const double P21_in = propagators_in.P32;
 
   double y2_root = P20 * ( P_.I_e_ + V_.y0_before_ ) + P21_ex * V_.I_syn_ex_before_ + P21_in * V_.I_syn_in_before_
     + V_.y2_before_ * std::exp( -t_step / P_.tau_m_ );

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -284,8 +284,13 @@ nest::iaf_psc_exp_ps_lossless::calibrate()
   V_.exp_tau_in_ = std::exp( -V_.h_ms_ / P_.tau_in_ );
 
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
-  V_.P21_ex_ = propagator_32( P_.tau_ex_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
-  V_.P21_in_ = propagator_32( P_.tau_in_, P_.tau_m_, P_.c_m_, V_.h_ms_ );
+
+  P_.prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
+  propogate propogate_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  V_.P21_ex_ = propogate_ex.P32;
+  P_.prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
+  propogate propogate_in = P_.prop_in_.propagate( V_.h_ms_ );
+  V_.P21_in_ = propogate_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   assert( V_.refractory_steps_ >= 0 ); // since t_ref_ >= 0, this can only fail in error
@@ -521,8 +526,10 @@ nest::iaf_psc_exp_ps_lossless::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    const double P21_ex = propagator_32( P_.tau_ex_, P_.tau_m_, P_.c_m_, dt );
-    const double P21_in = propagator_32( P_.tau_in_, P_.tau_m_, P_.c_m_, dt );
+    propogate propogate_ex = P_.prop_ex_.propagate( dt );
+    propogate propogate_in = P_.prop_in_.propagate( dt );
+    const double P21_ex = propogate_ex.P32;
+    const double P21_in = propogate_in.P32;
 
     S_.y2_ =
       P20 * ( P_.I_e_ + S_.y0_ ) + P21_ex * S_.I_syn_ex_ + P21_in * S_.I_syn_in_ + S_.y2_ * std::exp( -dt / P_.tau_m_ );
@@ -586,8 +593,10 @@ nest::iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  const double P21_ex = propagator_32( P_.tau_ex_, P_.tau_m_, P_.c_m_, t_step );
-  const double P21_in = propagator_32( P_.tau_in_, P_.tau_m_, P_.c_m_, t_step );
+  propogate propogate_ex = P_.prop_ex_.propagate( t_step );
+  propogate propogate_in = P_.prop_in_.propagate( t_step );
+  const double P21_ex = propogate_ex.P32;
+  const double P21_in = propogate_in.P32;
 
   double y2_root = P20 * ( P_.I_e_ + V_.y0_before_ ) + P21_ex * V_.I_syn_ex_before_ + P21_in * V_.I_syn_in_before_
     + V_.y2_before_ * std::exp( -t_step / P_.tau_m_ );

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -286,10 +286,10 @@ nest::iaf_psc_exp_ps_lossless::calibrate()
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
 
   prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
+  const propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
   V_.P21_ex_ = propagators_ex.P32;
   prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
+  const propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
   V_.P21_in_ = propagators_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
@@ -526,8 +526,8 @@ nest::iaf_psc_exp_ps_lossless::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    propagators propagators_ex = prop_ex_.propagate( dt );
-    propagators propagators_in = prop_in_.propagate( dt );
+    const propagators propagators_ex = prop_ex_.propagate( dt );
+    const propagators propagators_in = prop_in_.propagate( dt );
     const double P21_ex = propagators_ex.P32;
     const double P21_in = propagators_in.P32;
 
@@ -593,8 +593,8 @@ nest::iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  propagators propagators_ex = prop_ex_.propagate( t_step );
-  propagators propagators_in = prop_in_.propagate( t_step );
+  const propagators propagators_ex = prop_ex_.propagate( t_step );
+  const propagators propagators_in = prop_in_.propagate( t_step );
   const double P21_ex = propagators_ex.P32;
   const double P21_in = propagators_in.P32;
 

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -285,11 +285,11 @@ nest::iaf_psc_exp_ps_lossless::calibrate()
 
   V_.P20_ = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -V_.h_ms_ / P_.tau_m_ );
 
-  P_.prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_ex = P_.prop_ex_.propagate( V_.h_ms_ );
+  prop_ex_.update_constants( P_.tau_ex_, P_.tau_m_, P_.c_m_ );
+  propagators propagators_ex = prop_ex_.propagate( V_.h_ms_ );
   V_.P21_ex_ = propagators_ex.P32;
-  P_.prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
-  propagators propagators_in = P_.prop_in_.propagate( V_.h_ms_ );
+  prop_in_.update_constants( P_.tau_in_, P_.tau_m_, P_.c_m_ );
+  propagators propagators_in = prop_in_.propagate( V_.h_ms_ );
   V_.P21_in_ = propagators_in.P32;
 
   V_.refractory_steps_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
@@ -526,8 +526,8 @@ nest::iaf_psc_exp_ps_lossless::propagate_( const double dt )
   {
     const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -dt / P_.tau_m_ );
 
-    propagators propagators_ex = P_.prop_ex_.propagate( dt );
-    propagators propagators_in = P_.prop_in_.propagate( dt );
+    propagators propagators_ex = prop_ex_.propagate( dt );
+    propagators propagators_in = prop_in_.propagate( dt );
     const double P21_ex = propagators_ex.P32;
     const double P21_in = propagators_in.P32;
 
@@ -593,8 +593,8 @@ nest::iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
-  propagators propagators_ex = P_.prop_ex_.propagate( t_step );
-  propagators propagators_in = P_.prop_in_.propagate( t_step );
+  propagators propagators_ex = prop_ex_.propagate( t_step );
+  propagators propagators_in = prop_in_.propagate( t_step );
   const double P21_ex = propagators_ex.P32;
   const double P21_in = propagators_in.P32;
 

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -275,8 +275,8 @@ private:
   double is_spike_( const double );
 
   /** Propagator object for updating synaptic components */
-  propagator prop_ex_;
-  propagator prop_in_;
+  PropagatorExp propagator_ex_;
+  PropagatorExp propagator_in_;
 
   // ----------------------------------------------------------------
 

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -274,6 +274,10 @@ private:
    */
   double is_spike_( const double );
 
+  /** Propagator object for updating synaptic components */
+  propagator prop_ex_;
+  propagator prop_in_;
+
   // ----------------------------------------------------------------
 
   /**
@@ -314,9 +318,6 @@ private:
         At threshold crossing, the membrane potential is reset to this value.
         Relative to resting potential. */
     double U_reset_;
-
-    propagator prop_ex_;
-    propagator prop_in_;
 
     Parameters_(); //!< Sets default parameter values
 

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -29,6 +29,9 @@
 // Generated includes:
 #include "config.h"
 
+// Includes from libnestutil:
+#include "propagator_stability.h"
+
 // Includes from nestkernel:
 #include "archiving_node.h"
 #include "connection.h"
@@ -311,6 +314,9 @@ private:
         At threshold crossing, the membrane potential is reset to this value.
         Relative to resting potential. */
     double U_reset_;
+
+    propagator prop_ex_;
+    propagator prop_in_;
 
     Parameters_(); //!< Sets default parameter values
 


### PR DESCRIPTION
This PR follows up the discussion in #2294 and #2017. I have created two propagator classes, `PropagateExp` and `PropagateAlpha` for calculating propagators for models with exponential and alpha postsynaptic currents. Both classes have an `evaluate` function where the exp version just calculates `P31`, and the alpha version calculates `P31` and `P32` simultaneously. This way, the exponentials are calculated fewer times than what we do currently. I have not been able to get the simulation time for `iaf_psc_alpha_ps` to precisely match `iaf_psc_alpha_canon`, but the times are closer than with master, see results below.

With this new version, getting P31 and P32 is handled slightly differently than before:
Old version
```
V_.P31_ = propagator_31( P_.tau_syn_, tau_m, P_.c_m_, h );
V_.P32_ = propagator_32( P_.tau_syn_, tau_m, P_.c_m_, h );
```
New version exp model
```
V_.P21_ = PropagatorExp( P_.tau_syn_, tau_m, P_.c_m_ ).evaluate( h );
```
New version alpha model
```
std::tie( V_.P31_, V_.P32_ ) = PropagatorAlpha( P_.tau_syn_, tau_m_, P_.c_m_ ).evaluate( h );
```

Here are some timing results. All measured on my computer.
| model  | Simulation time for `brunel_ps.sli` | Time `ArtificialSyncrony.sli`
| ------------- | ------------- | ------------- |
| `iaf_psc_alpha_ps` with `propagator` class  | 132.82 sec  | 7 min 23 sec |
| master version of `iaf_psc_alpha_ps`  | 222.86 sec  | 9 min 18 sec |
| master version of `iaf_psc_alpha_canon`  | 95.03 sec | 6 min 33 sec |

`iaf_psc_alpha_canon` does not use `propagate_31` and `propagate_32` in it's [`propogate_` function](https://github.com/nest/nest-simulator/blob/master/models/iaf_psc_alpha_canon.cpp#L473). Using canon's version in the ps model decrease the time further, see comment [here](https://github.com/nest/nest-simulator/pull/2294#issuecomment-1065174892).

@heplesser 