### PR TITLE
Remove warning for conda-forge install

### DIFF
--- a/doc/userdoc/installation/index.rst
+++ b/doc/userdoc/installation/index.rst
@@ -127,6 +127,11 @@ and :ref:`cmake_options`.
 
    .. tab:: Conda (Linux/macOS)
 
+       .. note::
+
+         For NEST 3.x, the conda-forge package is available from NEST 3.3.
+
+         For NEST 2.x, the conda-forge package is available from NEST 2.16.0.
 
        1. To keep your conda setup tidy, we recommend that you install NEST into
           a separate `conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_

--- a/doc/userdoc/installation/index.rst
+++ b/doc/userdoc/installation/index.rst
@@ -127,10 +127,6 @@ and :ref:`cmake_options`.
 
    .. tab:: Conda (Linux/macOS)
 
-       .. warning::
-
-           The Conda package is only available for NEST 2.X.
-           If you want to use NEST 3.X, please see other installation options.
 
        1. To keep your conda setup tidy, we recommend that you install NEST into
           a separate `conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_


### PR DESCRIPTION
This PR removes the warning regarding conda-forge package for NEST not working in 3.x since there is a fix. It also adds which versions are available.



