### PR TITLE
Add link to release notes for 3.3

### DIFF
--- a/doc/userdoc/release_notes/index.rst
+++ b/doc/userdoc/release_notes/index.rst
@@ -11,3 +11,4 @@ transition your simulation code to the new versions.
 * :ref:`NEST 3.0 (June 10, 2021 ) <release_3.0>`
 * :ref:`NEST 3.1 (September 15, 2021 ) <release_3.1>`
 * :ref:`NEST 3.2 (January 21, 2022 ) <release_3.2>`
+* :ref:`NEST 3.3 (March 22, 2022 ) <release_3.3>`


### PR DESCRIPTION
Added missing link to the release notes page for v3.3.