### PR TITLE
Add GIF / GLIF acronyms to model title in docs

### DIFF
--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -53,7 +53,7 @@ extern "C" int gif_cond_exp_dynamics( double, const double*, double*, void* );
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron model
+Conductance-based generalized integrate-and-fire neuron (GIF) model
 
 Description
 +++++++++++

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -53,7 +53,7 @@ extern "C" int gif_cond_exp_dynamics( double, const double*, double*, void* );
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron (GIF) model - Gerstner Group
+Conductance-based generalized integrate-and-fire neuron (GIF) model (from the Gerstner lab)
 
 Description
 +++++++++++

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -53,7 +53,7 @@ extern "C" int gif_cond_exp_dynamics( double, const double*, double*, void* );
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron (GIF) model
+Conductance-based generalized integrate-and-fire neuron (GIF) model - Gerstner Group
 
 Description
 +++++++++++

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -51,7 +51,7 @@ extern "C" int gif_cond_exp_multisynapse_dynamics( double, const double*, double
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron with multiple synaptic time constants
+Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants
 
 Description
 +++++++++++

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -51,7 +51,7 @@ extern "C" int gif_cond_exp_multisynapse_dynamics( double, const double*, double
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants
+Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants - Gerstner Group
 
 Description
 +++++++++++

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -51,7 +51,7 @@ extern "C" int gif_cond_exp_multisynapse_dynamics( double, const double*, double
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants (from the Gerstner 
+Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants (from the Gerstner
 lab)
 
 Description

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -51,7 +51,8 @@ extern "C" int gif_cond_exp_multisynapse_dynamics( double, const double*, double
 Short description
 +++++++++++++++++
 
-Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants - Gerstner Group
+Conductance-based generalized integrate-and-fire neuron (GIF) with multiple synaptic time constants (from the Gerstner 
+lab)
 
 Description
 +++++++++++

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -44,7 +44,7 @@ Short description
 +++++++++++++++++
 
 Population of generalized integrate-and-fire neurons (GIF) with exponential
-postsynaptic currents and adaptation - Gerstner Group
+postsynaptic currents and adaptation (from the Gerstner lab)
 
 
 Description

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -44,7 +44,7 @@ Short description
 +++++++++++++++++
 
 Population of generalized integrate-and-fire neurons (GIF) with exponential
-postsynaptic currents and adaptation
+postsynaptic currents and adaptation - Gerstner Group
 
 
 Description

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -43,7 +43,7 @@ class Network;
 Short description
 +++++++++++++++++
 
-Population of generalized integrate-and-fire neurons with exponential
+Population of generalized integrate-and-fire neurons (GIF) with exponential
 postsynaptic currents and adaptation
 
 

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -40,7 +40,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron model
+Current-based generalized integrate-and-fire neuron (GIF) model
 
 Description
 +++++++++++

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -40,7 +40,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron (GIF) model - Gerstner Group
+Current-based generalized integrate-and-fire neuron (GIF) model (from the Gerstner lab)
 
 Description
 +++++++++++

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -40,7 +40,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron (GIF) model
+Current-based generalized integrate-and-fire neuron (GIF) model - Gerstner Group
 
 Description
 +++++++++++

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -40,7 +40,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron model with multiple synaptic time constants
+Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants
 
 Description
 +++++++++++

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -40,7 +40,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants (from the Gerstner 
+Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants (from the Gerstner
 lab)
 
 Description

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -40,7 +40,8 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants - Gerstner Group
+Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants (from the Gerstner 
+lab)
 
 Description
 +++++++++++

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -40,7 +40,7 @@ namespace nest
 Short description
 +++++++++++++++++
 
-Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants
+Current-based generalized integrate-and-fire neuron (GIF) model with multiple synaptic time constants - Gerstner Group
 
 Description
 +++++++++++

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -47,7 +47,7 @@
 Short description
 +++++++++++++++++
 
-Conductance-based generalized leaky integrate and fire (GLIF) model - Allen Institute
+Conductance-based generalized leaky integrate and fire (GLIF) model (from the Allen Institute)
 
 Description
 +++++++++++

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -47,7 +47,7 @@
 Short description
 +++++++++++++++++
 
-Conductance-based generalized leaky integrate and fire (GLIF) model
+Conductance-based generalized leaky integrate and fire (GLIF) model - Allen Institute
 
 Description
 +++++++++++

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -37,7 +37,7 @@
 Short description
 +++++++++++++++++
 
-Current-based generalized leaky integrate-and-fire (GLIF) models
+Current-based generalized leaky integrate-and-fire (GLIF) models - Allen Institute
 
 Description
 +++++++++++

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -37,7 +37,7 @@
 Short description
 +++++++++++++++++
 
-Current-based generalized leaky integrate-and-fire models
+Current-based generalized leaky integrate-and-fire (GLIF) models
 
 Description
 +++++++++++

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -37,7 +37,7 @@
 Short description
 +++++++++++++++++
 
-Current-based generalized leaky integrate-and-fire (GLIF) models - Allen Institute
+Current-based generalized leaky integrate-and-fire (GLIF) models (from the Allen Institute)
 
 Description
 +++++++++++


### PR DESCRIPTION
To help alleviate confusion between the two types of models, I've added the acronyms to the titles in the model userdocs section.

Not sure if further differentiation would be helpful (e.g., do we need to add a tag for leaky models?). @heplesser @diesmann perhaps have ideas. 