### PR TITLE
remove non-functional `$?` in do_tests.sh

### DIFF
--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -111,8 +111,7 @@ if test "${PYTHON}"; then
       PYTEST_VERSION="$(echo "${PYTEST_VERSION}" | cut -d' ' -f2)"
 fi
 
-python3 -c "import junitparser" >/dev/null 2>&1
-if test $? != 0; then
+if ! python3 -c "import junitparser" >/dev/null 2>&1; then
     echo "Error: Required Python package 'junitparser' not found."
     exit 1
 fi
@@ -517,6 +516,9 @@ if command -v run_all_cpptests >/dev/null 2>&1; then
 else
   echo "  Not running C++ tests because NEST was compiled without Boost."
 fi
+
+# the following steps rely on `$?`, so breaking on error is not an option and we turn it off
+set +e
 
 # We use plain python3 here to collect results. This also works if
 # PyNEST was not enabled and ${PYTHON} is consequently not set.


### PR DESCRIPTION
The test suite failing without error message when `junitparser` is not installed uncovered some structural bugs. When `set -e` is in effect, the shell variable `$?` is not useful, since any failling statement will abort execution.
This PR removes non-functional `$?` in `do_tests.sh`, and removes the flag for the final MacOS error handling.