### PR TITLE
Add missing PyNEST examples to docs

### DIFF
--- a/doc/userdoc/examples/index.rst
+++ b/doc/userdoc/examples/index.rst
@@ -11,22 +11,33 @@ PyNEST examples
    ../auto_examples/one_neuron_with_noise
    ../auto_examples/twoneurons
    ../auto_examples/balancedneuron
-   ../auto_examples/recording_demo
-   ../auto_examples/BrodyHopfield
-   ../auto_examples/CampbellSiegert
-   ../auto_examples/hh_psc_alpha
-   ../auto_examples/hh_phaseplane
-   ../auto_examples/gif_population
-   ../auto_examples/gif_pop_psc_exp
+   ../auto_examples/aeif_cond_beta_multisynapse
+   ../auto_examples/gif_cond_exp_multisynapse
    ../auto_examples/brette_gerstner_fig_2c
    ../auto_examples/brette_gerstner_fig_3d
+   ../auto_examples/hh_psc_alpha
+   ../auto_examples/hh_phaseplane
+   ../auto_examples/BrodyHopfield
+   ../auto_examples/gif_population
+   ../auto_examples/gif_pop_psc_exp
    ../auto_examples/mc_neuron
+   ../auto_examples/glif_cond_neuron
+   ../auto_examples/glif_psc_neuron
    ../auto_examples/precise_spiking
+   ../auto_examples/CampbellSiegert
+.. toctree::
+   :maxdepth: 1
+   :caption: Examples for handling networks
+
+   ../auto_examples/vinit_example
+   ../auto_examples/recording_demo
+   ../auto_examples/store_restore_network
 
 .. toctree::
    :maxdepth: 1
    :caption: Synapse examples
 
+   ../auto_examples/synapsecollection
    ../auto_examples/structural_plasticity
    ../auto_examples/gap_junctions_two_neurons
    ../auto_examples/gap_junctions_inhibitory_network
@@ -34,10 +45,16 @@ PyNEST examples
    ../auto_examples/evaluate_quantal_stp_synapse
    ../auto_examples/clopath_synapse_spike_pairing
    ../auto_examples/clopath_synapse_small_network
+   ../auto_examples/urbanczik_synapse_example
    ../auto_examples/tsodyks_depressing
    ../auto_examples/tsodyks_facilitating
-   ../auto_examples/urbanczik_synapse_example
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Compartmental neuron examples
+
+   ../auto_examples/compartmental_model/receptors_and_current
+   ../auto_examples/compartmental_model/two_comps
 
 .. toctree::
    :maxdepth: 1
@@ -55,45 +72,6 @@ PyNEST examples
    ../auto_examples/brunel_siegert_nest
    ../auto_examples/brunel_exp_multisynapse_nest
    ../auto_examples/brunel_alpha_evolution_strategies
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Device usage examples
-
-   ../auto_examples/testiaf
-   ../auto_examples/repeated_stimulation
-   ../auto_examples/multimeter_file
-   ../auto_examples/sensitivity_to_perturbation
-   ../auto_examples/plot_weight_matrices
-   ../auto_examples/if_curve
-   ../auto_examples/pulsepacket
-   ../auto_examples/correlospinmatrix_detector_two_neuron
-   ../auto_examples/sinusoidal_poisson_generator
-   ../auto_examples/sinusoidal_gamma_generator
-   ../auto_examples/cross_check_mip_corrdet
-   ../auto_examples/intrinsic_currents_spiking
-   ../auto_examples/intrinsic_currents_subthreshold
-
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Compartmental neuron examples
-
-   ../auto_examples/compartmental_model/receptors_and_current
-   ../auto_examples/compartmental_model/two_comps
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Connection set algebra examples
-
-   ../auto_examples/csa_example
-   ../auto_examples/csa_spatial_example
-
-.. toctree::
-   :maxdepth: 1
-   :caption: HPC benchmark
-
-   ../auto_examples/hpc_benchmark
 
 .. toctree::
    :maxdepth: 1
@@ -118,3 +96,36 @@ PyNEST examples
    ../auto_examples/spatial/test_3d
    ../auto_examples/spatial/test_3d_exp
    ../auto_examples/spatial/test_3d_gauss
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Device usage examples
+
+   ../auto_examples/testiaf
+   ../auto_examples/repeated_stimulation
+   ../auto_examples/multimeter_file
+   ../auto_examples/sensitivity_to_perturbation
+   ../auto_examples/plot_weight_matrices
+   ../auto_examples/if_curve
+   ../auto_examples/pulsepacket
+   ../auto_examples/correlospinmatrix_detector_two_neuron
+   ../auto_examples/sinusoidal_poisson_generator
+   ../auto_examples/sinusoidal_gamma_generator
+   ../auto_examples/cross_check_mip_corrdet
+   ../auto_examples/intrinsic_currents_spiking
+   ../auto_examples/intrinsic_currents_subthreshold
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Connection set algebra examples
+
+   ../auto_examples/csa_example
+   ../auto_examples/csa_spatial_example
+
+.. toctree::
+   :maxdepth: 1
+   :caption: HPC benchmark
+
+   ../auto_examples/hpc_benchmark
+
+

--- a/pynest/examples/aeif_cond_beta_multisynapse.py
+++ b/pynest/examples/aeif_cond_beta_multisynapse.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-aeif_cond_beta_multisynapse
----------------------------
+Example of an AEIF neuron with multiple synaptic rise and decay time constants
+------------------------------------------------------------------------------
 
 """
 

--- a/pynest/examples/compartmental_model/two_comps.py
+++ b/pynest/examples/compartmental_model/two_comps.py
@@ -20,7 +20,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 r"""Constructing and simulating compartmental models with active and passive dendrites
-----------------------------------------------------------------
+---------------------------------------------------------------------------------------
 This example demonstrates how to initialize compartmental models. It creates
 two models with two compartments, once with active channels in the dendritic
 compartment and once without. It then adds and excitatory receptors with AMPA

--- a/pynest/examples/gif_cond_exp_multisynapse.py
+++ b/pynest/examples/gif_cond_exp_multisynapse.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-gif_cond_exp_multisynapse
--------------------------
+Example network using generalized IAF neuron with postsynaptic conductances
+---------------------------------------------------------------------------
 
 """
 

--- a/pynest/examples/glif_cond_neuron.py
+++ b/pynest/examples/glif_cond_neuron.py
@@ -32,7 +32,6 @@ with externally applied current and spikes impinging
 Voltage traces, injecting current traces, threshold traces, synaptic
 conductance traces and spikes are shown.
 
-KEYWORDS: glif_cond
 """
 
 ##############################################################################

--- a/pynest/examples/glif_psc_neuron.py
+++ b/pynest/examples/glif_psc_neuron.py
@@ -31,7 +31,6 @@ with externally applied current and spikes impinging
 
 Voltage traces, current traces, threshold traces, and spikes are shown.
 
-KEYWORDS: glif_psc
 """
 
 ##############################################################################

--- a/pynest/examples/synapsecollection.py
+++ b/pynest/examples/synapsecollection.py
@@ -60,49 +60,58 @@ def plotMatrix(srcs, tgts, weights, title, pos):
     plt.colorbar(fraction=0.046, pad=0.04)
 
 
-"""
-Start with a simple, one_to_one example.
-We create the neurons, connect them, and get the connections. From this we can
-get the connected sources, targets, and weights. The corresponding matrix will
-be the identity matrix, as we have a one_to_one connection.
-"""
+#################################################################################
+# Start with a simple, one_to_one example.
+# We create the neurons, connect them, and get the connections. From this we can
+# get the connected sources, targets, and weights. The corresponding matrix will
+# be the identity matrix, as we have a one_to_one connection.
+
 nest.ResetKernel()
 
 nrns = nest.Create('iaf_psc_alpha', 10)
 
 nest.Connect(nrns, nrns, 'one_to_one')
 conns = nest.GetConnections(nrns, nrns)  # This returns a SynapseCollection
+
+#################################################################################
 # We can get desired information of the SynapseCollection with simple get() call.
+
 g = conns.get(['source', 'target', 'weight'])
 srcs = g['source']
 tgts = g['target']
 weights = g['weight']
 
+#################################################################################
 # Plot the matrix consisting of the weights between the sources and targets
+
 plt.figure(figsize=(12, 10))
 plotMatrix(srcs, tgts, weights, 'Uniform weight', 121)
 
-"""
-Add some weights to the connections, and plot the updated weight matrix.
-"""
+#################################################################################
+# Add some weights to the connections, and plot the updated weight matrix.
+
+#################################################################################
 # We can set data of the connections with a simple set() call.
+
 w = [{'weight': x * 1.0} for x in range(1, 11)]
 conns.set(w)
 weights = conns.weight
 
 plotMatrix(srcs, tgts, weights, 'Set weight', 122)
 
-"""
-We can also plot an all_to_all connection, with uniformly distributed weights,
-and different number of sources and targets.
-"""
+#################################################################################
+# We can also plot an all_to_all connection, with uniformly distributed weights,
+# and different number of sources and targets.
+
 nest.ResetKernel()
 
 pre = nest.Create('iaf_psc_alpha', 10)
 post = nest.Create('iaf_psc_delta', 5)
 nest.Connect(pre, post, syn_spec={'weight': nest.random.uniform(min=0.5, max=4.5)})
 
+#################################################################################
 # Get a SynapseCollection with all connections
+
 conns = nest.GetConnections()
 srcs = conns.source
 tgts = conns.target
@@ -111,11 +120,11 @@ weights = conns.weight
 plt.figure(figsize=(12, 10))
 plotMatrix(srcs, tgts, weights, 'All to all connection', 111)
 
-"""
-Lastly, we'll do an exmple that is a bit more complex. We connect different
-neurons with different rules, synapse models and weight distributions, and get
-different SynapseCollections by calling GetConnections with different inputs.
-"""
+#################################################################################
+# Lastly, we'll do an exmple that is a bit more complex. We connect different
+# neurons with different rules, synapse models and weight distributions, and get
+# different SynapseCollections by calling GetConnections with different inputs.
+
 nest.ResetKernel()
 
 nrns = nest.Create('iaf_psc_alpha', 15)
@@ -134,7 +143,9 @@ nest.Connect(nrns[10:], nrns[:12],
 nest.Connect(nrns, nrns[12:],
              {'rule': 'fixed_indegree', 'indegree': 3})
 
+#################################################################################
 # First get a SynapseCollection consisting of all the connections
+
 conns = nest.GetConnections()
 srcs = conns.source
 tgts = conns.target
@@ -143,7 +154,9 @@ weights = conns.weight
 plt.figure(figsize=(14, 12))
 plotMatrix(list(srcs), list(tgts), weights, 'All connections', 221)
 
+#################################################################################
 # Get SynapseCollection consisting of a subset of connections
+
 conns = nest.GetConnections(nrns[:10], nrns[:10])
 g = conns.get(['source', 'target', 'weight'])
 srcs = g['source']
@@ -152,7 +165,9 @@ weights = g['weight']
 
 plotMatrix(srcs, tgts, weights, 'Connections of the first ten neurons', 222)
 
+#################################################################################
 # Get SynapseCollection consisting of just the stdp_synapses
+
 conns = nest.GetConnections(synapse_model='stdp_synapse')
 g = conns.get(['source', 'target', 'weight'])
 srcs = g['source']
@@ -161,8 +176,10 @@ weights = g['weight']
 
 plotMatrix(srcs, tgts, weights, 'Connections with stdp_synapse', 223)
 
+#################################################################################
 # Get SynapseCollection consisting of the fixed_total_number connections, but set
 # weight before plotting
+
 conns = nest.GetConnections(nrns[5:10], nrns[:5])
 w = [{'weight': x * 1.0} for x in range(1, 6)]
 conns.set(w)

--- a/pynest/examples/testiaf.py
+++ b/pynest/examples/testiaf.py
@@ -20,8 +20,8 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-IAF neuron example
-------------------
+IAF neuron example with current generator
+-----------------------------------------
 
 A DC current is injected into the neuron using a current generator
 device. The membrane potential as well as the spiking activity are

--- a/pynest/examples/urbanczik_synapse_example.py
+++ b/pynest/examples/urbanczik_synapse_example.py
@@ -29,7 +29,7 @@ Urbanczik and Senn [1]_. In this simple setup, a spike pattern of 200 poisson
 spike trains is repeatedly presented to a neuron that is composed of one
 somatic and one dendritic compartment. At the same time, the somatic
 conductances are activated to produce a time-varying matching potential.
-After the learning, this signal is then reproreproduced by the membrane
+After the learning, this signal is then reproduced by the membrane
 potential of the neuron. This script produces Fig. 1B in [1]_ but uses standard
 units instead of the unitless quantities used in the paper.
 


### PR DESCRIPTION
This PR adds the examples that were missing from the table of contents in the documentation.
It also fixes up some formatting issues and reorganizes the example a bit. A lot more can probably be done to improve how examples are categorized, but the examples should at least be available.

Addresses #2369