### PR TITLE
Ensure consistent return values in "impossible" situations even if assertions are compiled out

### DIFF
--- a/models/bernoulli_synapse.h
+++ b/models/bernoulli_synapse.h
@@ -132,7 +132,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/clopath_synapse.h
+++ b/models/clopath_synapse.h
@@ -166,7 +166,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/cont_delay_synapse.h
+++ b/models/cont_delay_synapse.h
@@ -147,42 +147,42 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( RateEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DataLoggingRequest&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( CurrentEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( ConductanceEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DoubleDataEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DSSpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DSCurrentEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/gamma_sup_generator.h
+++ b/models/gamma_sup_generator.h
@@ -227,7 +227,7 @@ gamma_sup_generator::send_test_event( Node& target, rport receptor_type, syninde
     SpikeEvent e;
     e.set_sender( *this );
     const port p = target.handles_test_event( e, receptor_type );
-    if ( p != invalid_port_ )
+    if ( p != invalid_port )
     {
       // count number of targets
       ++P_.num_targets_;

--- a/models/ht_synapse.h
+++ b/models/ht_synapse.h
@@ -153,7 +153,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/jonke_synapse.h
+++ b/models/jonke_synapse.h
@@ -262,7 +262,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/multimeter.cpp
+++ b/models/multimeter.cpp
@@ -51,7 +51,7 @@ multimeter::send_test_event( Node& target, rport receptor_type, synindex, bool )
   DataLoggingRequest e( P_.interval_, P_.offset_, P_.record_from_ );
   e.set_sender( *this );
   port p = target.handles_test_event( e, receptor_type );
-  if ( p != invalid_port_ and not is_model_prototype() )
+  if ( p != invalid_port and not is_model_prototype() )
   {
     B_.has_targets_ = true;
   }

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -223,7 +223,7 @@ nest::music_cont_out_proxy::send_test_event( Node& target, rport receptor_type, 
   DataLoggingRequest e( P_.interval_, P_.record_from_ );
   e.set_sender( *this );
   port p = target.handles_test_event( e, receptor_type );
-  if ( p != invalid_port_ and not is_model_prototype() )
+  if ( p != invalid_port and not is_model_prototype() )
   {
     B_.has_targets_ = true;
   }

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -275,7 +275,7 @@ nest::noise_generator::send_test_event( Node& target, rport receptor_type, synin
     CurrentEvent e;
     e.set_sender( *this );
     const port p = target.handles_test_event( e, receptor_type );
-    if ( p != invalid_port_ and not is_model_prototype() )
+    if ( p != invalid_port and not is_model_prototype() )
     {
       ++P_.num_targets_;
     }

--- a/models/poisson_generator_ps.h
+++ b/models/poisson_generator_ps.h
@@ -219,7 +219,7 @@ poisson_generator_ps::send_test_event( Node& target, rport receptor_type, synind
     SpikeEvent e;
     e.set_sender( *this );
     const port p = target.handles_test_event( e, receptor_type );
-    if ( p != invalid_port_ and not is_model_prototype() )
+    if ( p != invalid_port and not is_model_prototype() )
     {
       ++P_.num_targets_; // count number of targets
     }

--- a/models/ppd_sup_generator.h
+++ b/models/ppd_sup_generator.h
@@ -251,7 +251,7 @@ ppd_sup_generator::send_test_event( Node& target, rport receptor_type, synindex 
     SpikeEvent e;
     e.set_sender( *this );
     const port p = target.handles_test_event( e, receptor_type );
-    if ( p != invalid_port_ and not is_model_prototype() )
+    if ( p != invalid_port and not is_model_prototype() )
     {
       ++P_.num_targets_; // count number of targets
     }

--- a/models/quantal_stp_synapse.h
+++ b/models/quantal_stp_synapse.h
@@ -156,7 +156,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/sinusoidal_gamma_generator.h
+++ b/models/sinusoidal_gamma_generator.h
@@ -367,7 +367,7 @@ sinusoidal_gamma_generator::send_test_event( Node& target, rport receptor_type, 
       SpikeEvent e;
       e.set_sender( *this );
       const rport r = target.handles_test_event( e, receptor_type );
-      if ( r != invalid_port_ and not is_model_prototype() )
+      if ( r != invalid_port and not is_model_prototype() )
       {
         ++P_.num_trains_;
       }

--- a/models/static_synapse.h
+++ b/models/static_synapse.h
@@ -101,42 +101,42 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( RateEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DataLoggingRequest&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( CurrentEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( ConductanceEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DoubleDataEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DSSpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DSCurrentEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/static_synapse_hom_w.h
+++ b/models/static_synapse_hom_w.h
@@ -87,42 +87,42 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( RateEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DataLoggingRequest&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( CurrentEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( ConductanceEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DoubleDataEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DSSpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
     port
     handles_test_event( DSCurrentEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -258,7 +258,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_nn_pre_centered_synapse.h
+++ b/models/stdp_nn_pre_centered_synapse.h
@@ -180,7 +180,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_nn_restr_synapse.h
+++ b/models/stdp_nn_restr_synapse.h
@@ -175,7 +175,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_nn_symm_synapse.h
+++ b/models/stdp_nn_symm_synapse.h
@@ -177,7 +177,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_pl_synapse_hom.h
+++ b/models/stdp_pl_synapse_hom.h
@@ -179,7 +179,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_synapse.h
+++ b/models/stdp_synapse.h
@@ -167,7 +167,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_synapse_facetshw_hom.h
+++ b/models/stdp_synapse_facetshw_hom.h
@@ -283,7 +283,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_synapse_hom.h
+++ b/models/stdp_synapse_hom.h
@@ -212,7 +212,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/stdp_triplet_synapse.h
+++ b/models/stdp_triplet_synapse.h
@@ -176,7 +176,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/tsodyks2_synapse.h
+++ b/models/tsodyks2_synapse.h
@@ -174,7 +174,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/tsodyks_synapse.h
+++ b/models/tsodyks_synapse.h
@@ -193,7 +193,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/tsodyks_synapse_hom.h
+++ b/models/tsodyks_synapse_hom.h
@@ -226,7 +226,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/urbanczik_synapse.h
+++ b/models/urbanczik_synapse.h
@@ -161,7 +161,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/models/vogels_sprekeler_synapse.h
+++ b/models/vogels_sprekeler_synapse.h
@@ -144,7 +144,7 @@ public:
     port
     handles_test_event( SpikeEvent&, rport )
     {
-      return invalid_port_;
+      return invalid_port;
     }
   };
 

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1724,7 +1724,7 @@ nest::SymmetricBernoulliBuilder::connect_()
         // check whether the target is on this thread
         if ( target->is_proxy() )
         {
-          target_thread = invalid_thread_;
+          target_thread = invalid_thread;
         }
 
         previous_snode_ids.clear();
@@ -1749,7 +1749,7 @@ nest::SymmetricBernoulliBuilder::connect_()
 
           if ( source->is_proxy() )
           {
-            source_thread = invalid_thread_;
+            source_thread = invalid_thread;
           }
 
           // if target is local: connect

--- a/nestkernel/nest_types.h
+++ b/nestkernel/nest_types.h
@@ -158,7 +158,7 @@ typedef int thread;
 /**
  * Value for invalid connection port number.
  */
-const thread invalid_thread_ = -1;
+const thread invalid_thread = -1;
 
 /**
  * Connection port number to distinguish incoming connections,
@@ -170,7 +170,7 @@ const thread invalid_thread_ = -1;
 typedef long rport;
 
 /**
- * Connection port number to distinguis outgoing connections.
+ * Connection port number to distinguish outgoing connections.
  * Connections between Nodes are assigned port numbers.
  * Valid port numbers start at zero (0).
  * The value -1 is used for invalid or unassigned ports.
@@ -180,7 +180,7 @@ typedef long port;
 /**
  * Value for invalid connection port number.
  */
-const rport invalid_port_ = -1;
+const rport invalid_port = -1;
 
 /**
  * Weight of a connection.

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -44,7 +44,7 @@ Node::Node()
   , thread_lid_( invalid_index )
   , model_id_( -1 )
   , thread_( 0 )
-  , vp_( invalid_thread_ )
+  , vp_( invalid_thread )
   , frozen_( false )
   , initialized_( false )
   , node_uses_wfr_( false )
@@ -131,13 +131,14 @@ Node::get_status_dict_()
 void
 Node::set_local_device_id( const index )
 {
-  assert( false && "set_local_device_id() called on a non-device node of type" );
+  assert( false and "set_local_device_id() called on a non-device node of type" );
 }
 
 index
 Node::get_local_device_id() const
 {
-  assert( false && "set_local_device_id() called on a non-device node." );
+  assert( false and "get_local_device_id() called on a non-device node." );
+  return invalid_index;
 }
 
 DictionaryDatum
@@ -335,7 +336,7 @@ port
 Node::handles_test_event( GapJunctionEvent&, rport )
 {
   throw IllegalConnection( "The target node or synapse model does not support gap junction input." );
-  return invalid_port_;
+  return invalid_port;
 }
 
 void
@@ -354,7 +355,7 @@ port
 Node::handles_test_event( InstantaneousRateConnectionEvent&, rport )
 {
   throw IllegalConnection( "The target node or synapse model does not support instantaneous rate input." );
-  return invalid_port_;
+  return invalid_port;
 }
 
 void
@@ -373,7 +374,7 @@ port
 Node::handles_test_event( DiffusionConnectionEvent&, rport )
 {
   throw IllegalConnection( "The target node or synapse model does not support diffusion input." );
-  return invalid_port_;
+  return invalid_port;
 }
 
 void
@@ -392,7 +393,7 @@ port
 Node::handles_test_event( DelayedRateConnectionEvent&, rport )
 {
   throw IllegalConnection( "The target node or synapse model does not support delayed rate input." );
-  return invalid_port_;
+  return invalid_port;
 }
 
 void

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -1005,7 +1005,7 @@ Node::set_model_id( int i )
 inline bool
 Node::is_model_prototype() const
 {
-  return vp_ == invalid_thread_;
+  return vp_ == invalid_thread;
 }
 
 inline void

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -115,6 +115,7 @@ public:
   get_thread() const
   {
     assert( false );
+    return invalid_thread;
   }
 
 private:


### PR DESCRIPTION
This PR addresses all parts of #2295 and fixes some minor issues (typos, inconsistent naming) as well. It replaces #2296.

Fixes #2295.