### PR TITLE
Remove remaining uses of `float` datatype from C++ code.

### DIFF
--- a/libnestutil/block_vector.h
+++ b/libnestutil/block_vector.h
@@ -324,7 +324,7 @@ inline BlockVector< value_type_ >::BlockVector( size_t n )
   : blockmap_( std::vector< std::vector< value_type_ > >( 1, std::vector< value_type_ >( max_block_size ) ) )
   , finish_( begin() )
 {
-  size_t num_blocks_needed = std::ceil( ( float ) n / max_block_size );
+  size_t num_blocks_needed = std::ceil( static_cast< double >( n ) / max_block_size );
   for ( size_t i = 0; i < num_blocks_needed - 1; ++i )
   {
     blockmap_.emplace_back( max_block_size );

--- a/nestkernel/recording_backend_ascii.cpp
+++ b/nestkernel/recording_backend_ascii.cpp
@@ -156,8 +156,8 @@ nest::RecordingBackendASCII::write( const RecordingDevice& device,
 const std::string
 nest::RecordingBackendASCII::compute_vp_node_id_string_( const RecordingDevice& device ) const
 {
-  const float num_vps = kernel().vp_manager.get_num_virtual_processes();
-  const float num_nodes = kernel().node_manager.size();
+  const double num_vps = kernel().vp_manager.get_num_virtual_processes();
+  const double num_nodes = kernel().node_manager.size();
   const int vp_digits = static_cast< int >( std::floor( std::log10( num_vps ) ) + 1 );
   const int node_id_digits = static_cast< int >( std::floor( std::log10( num_nodes ) ) + 1 );
 

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -1121,7 +1121,7 @@ nest::SimulationManager::print_progress_()
     rt_factor = t_real_acc / t_sim_acc;
   }
 
-  int percentage = ( 100 - int( float( to_do_ ) / to_do_total_ * 100 ) );
+  int percentage = ( 100 - static_cast< int >( static_cast< double >( to_do_ ) / to_do_total_ * 100 ) );
 
   std::cout << "\r[ " << std::setw( 3 ) << std::right << percentage << "% ] "
             << "Model time: " << std::fixed << std::setprecision( 1 ) << clock_.get_ms() << " ms, "

--- a/nestkernel/vp_manager_impl.h
+++ b/nestkernel/vp_manager_impl.h
@@ -79,7 +79,7 @@ inline index
 VPManager::node_id_to_lid( const index node_id ) const
 {
   // starts at lid 0 for node_ids >= 1 (expected value for neurons, excl. node ID 0)
-  return ceil( static_cast< double >( node_id ) / get_num_virtual_processes() ) - 1;
+  return std::ceil( static_cast< double >( node_id ) / get_num_virtual_processes() ) - 1;
 }
 
 inline index
@@ -92,7 +92,7 @@ VPManager::lid_to_node_id( const index lid ) const
 inline thread
 VPManager::get_num_assigned_ranks_per_thread() const
 {
-  return ceil( float( kernel().mpi_manager.get_num_processes() ) / n_threads_ );
+  return std::ceil( static_cast< double >( kernel().mpi_manager.get_num_processes() ) / n_threads_ );
 }
 
 inline thread

--- a/sli/token.h
+++ b/sli/token.h
@@ -214,7 +214,6 @@ public:
   operator size_t() const;
   operator long() const;
   operator double() const;
-  operator float() const;
   operator bool() const;
   operator std::string() const;
   //  operator vector<double> const;

--- a/sli/tokenarray.cc
+++ b/sli/tokenarray.cc
@@ -73,18 +73,6 @@ TokenArray::TokenArray( const std::vector< double >& a )
   }
 }
 
-TokenArray::TokenArray( const std::vector< float >& a )
-  : data( new TokenArrayObj( a.size(), Token(), 0 ) )
-{
-  assert( data != NULL );
-  for ( size_t i = 0; i < a.size(); ++i )
-  {
-    Token ddt( new DoubleDatum( a[ i ] ) );
-    ( *data )[ i ].move( ddt );
-  }
-}
-
-
 void
 TokenArray::toVector( std::vector< long >& a ) const
 {

--- a/sli/tokenarray.h
+++ b/sli/tokenarray.h
@@ -128,7 +128,6 @@ public:
   TokenArray( const std::vector< size_t >& );
   TokenArray( const std::vector< long >& );
   TokenArray( const std::vector< double >& );
-  TokenArray( const std::vector< float >& );
 
   virtual ~TokenArray()
   {


### PR DESCRIPTION
This PR removes the last remaining uses of the `float` data type from NEST C++ code. Some uses may have crept in as a side-effect of too much Python programming ;).