### PR TITLE
Fix sign in equation documentation of spatial connection kernels

### DIFF
--- a/doc/userdoc/guides/spatially_structured_networks.rst
+++ b/doc/userdoc/guides/spatially_structured_networks.rst
@@ -918,7 +918,7 @@ parameters drawing values from random distributions.
   |                                              | | x,               |                                                      |
   |                                              | | y,               |    p(x) = e^{-\frac{\frac{(x-\text{mean_x})^2}       |
   |                                              | | mean_x,          |    {\text{std_x}^2}+\frac{                           |
-  | ``nest.spatial_distributions.gaussian2D()``  | | mean_y,          |    (y-\text{mean_y})^2}{\text{std_y}^2}+2            |
+  | ``nest.spatial_distributions.gaussian2D()``  | | mean_y,          |    (y-\text{mean_y})^2}{\text{std_y}^2}-2            |
   |                                              | | std_x,           |    \rho\frac{(x-\text{mean_x})(y-\text{mean_y})}     |
   |                                              | | std_y,           |    {\text{std_x}\text{std_y}}}                       |
   |                                              | | rho              |    {2(1-\rho^2)}}                                    |


### PR DESCRIPTION
Just a minimal documentation fix.