### PR TITLE
Use MAKE variable to pass correct info to child.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ install( FILES LICENSE README.md
     )
 
 add_custom_target( install-nodoc
-  COMMAND make NEST_INSTALL_NODOC=true install
+  COMMAND $(MAKE) NEST_INSTALL_NODOC=true install
 )
 
 nest_print_config_summary()


### PR DESCRIPTION
Spawning a make subprocess should be done through use of the `$(MAKE)` variable so that the child process receives all the information it needs. closes #2395. I didn't check the whole list of `make` targets, but more could be affected.