### PR TITLE
Mark MPI as required if explicitly requested during CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set( with-python ON CACHE STRING "Build PyNEST [default=ON]." )
 option( cythonize-pynest "Use Cython to cythonize pynestkernel.pyx [default=ON]. If OFF, PyNEST has to be build from a pre-cythonized pynestkernel.pyx." ON )
 
 # select parallelization scheme
-set( with-mpi OFF CACHE STRING "Build with MPI parallelization [default=OFF]. Optionally give directory with MPI installation." )
+set( with-mpi OFF CACHE STRING "Build with MPI parallelization [default=OFF]." )
 set( with-openmp ON CACHE BOOL "Build with OpenMP multi-threading [default=ON]. Optionally set OMP compiler flags." )
 
 # external libraries

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -358,7 +358,7 @@ endfunction()
 function( NEST_PROCESS_WITH_PYTHON )
   # Find Python
   set( HAVE_PYTHON OFF PARENT_SCOPE )
-  
+
   if ( ${with-python} STREQUAL "ON" )
 
     # Localize the Python interpreter and ABI
@@ -462,7 +462,7 @@ function( NEST_PROCESS_WITH_MPI )
   # Find MPI
   set( HAVE_MPI OFF PARENT_SCOPE )
   if ( with-mpi )
-    find_package( MPI )
+    find_package( MPI REQUIRED )
     if ( MPI_CXX_FOUND )
       set( HAVE_MPI ON PARENT_SCOPE )
 

--- a/doc/htmldoc/installation/cmake_options.rst
+++ b/doc/htmldoc/installation/cmake_options.rst
@@ -47,8 +47,8 @@ Select parallelization scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +---------------------------------------------+----------------------------------------------------------------+
-| ``-Dwith-mpi=[OFF|ON|</path/to/mpi>]``      | Build with MPI parallelization [default=OFF]. Optionally give  |
-|                                             | directory with MPI installation.                               |
+| ``-Dwith-mpi=[OFF|ON]``                     | Build with MPI parallelization [default=OFF].                  |
+|                                             |                                                                |
 +---------------------------------------------+----------------------------------------------------------------+
 | ``-Dwith-openmp=[OFF|ON|<OpenMP-Flag>]``    | Build with OpenMP multi-threading [default=ON]. Optionally set |
 |                                             | OMP compiler flags.                                            |


### PR DESCRIPTION
During CMake configuration, if MPI is explicitly requested (with `-Dwith-mpi=ON`), MPI is set as `REQUIRED` which makes CMake error if MPI is not found. Previously CMake would continue, and NEST would be installed without MPI support (this may be loosely related to #2381).

Furthermore, if `with-mpi` is passed a path, it is not used to find MPI as indicated by the documentation. There are no good ways to select an MPI installation based on the path alone, and this is a corner-case anyway, so the related text in the documentation is instead removed.