### PR TITLE
Expose `prepared` flag via kernel status dictionary

### DIFF
--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -350,6 +350,7 @@ const Name post_trace( "post_trace" );
 const Name pre_synaptic_element( "pre_synaptic_element" );
 const Name precise_times( "precise_times" );
 const Name precision( "precision" );
+const Name prepared( "prepared" );
 const Name print_time( "print_time" );
 const Name proximal_curr( "proximal_curr" );
 const Name proximal_exc( "proximal_exc" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -376,6 +376,7 @@ extern const Name post_trace;
 extern const Name pre_synaptic_element;
 extern const Name precise_times;
 extern const Name precision;
+extern const Name prepared;
 extern const Name print_time;
 extern const Name proximal_curr;
 extern const Name proximal_exc;

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -409,6 +409,8 @@ nest::SimulationManager::get_status( DictionaryDatum& d )
   def< long >( d, names::to_do, to_do_ );
   def< bool >( d, names::print_time, print_time_ );
 
+  def< bool >( d, names::prepared, prepared_ );
+
   def< bool >( d, names::use_wfr, use_wfr_ );
   def< double >( d, names::wfr_comm_interval, wfr_comm_interval_ );
   def< double >( d, names::wfr_tol, wfr_tol_ );


### PR DESCRIPTION
In a discussion with developers of the NEST-Desktop and Neurorobotics Platform (NRP), we found that both tools require to know if `prepare()` was already called or not. This is internally tracked, but was not available in the kernel status dictionary. This PR just exposes the bool flag to the API layers.