### PR TITLE
Fix spatial attribute positions of sliced NodeCollection

### DIFF
--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -394,4 +394,31 @@ node_collection_array_index( const Datum* datum, const bool* array, unsigned lon
   return new NodeCollectionDatum( NodeCollection::create( node_ids ) );
 }
 
+void
+slice_positions_if_sliced_nc( DictionaryDatum& dict, const NodeCollectionDatum& nc )
+{
+  // If metadata contains node positions and the NodeCollection is sliced, get only positions of the sliced nodes.
+  if ( dict->known( names::positions ) )
+  {
+    const auto positions = getValue< TokenArray >( dict, names::positions );
+    if ( nc->size() != positions.size() )
+    {
+      TokenArray sliced_points;
+      // Iterate only local nodes
+      NodeCollection::const_iterator nc_begin = nc->has_proxies() ? nc->MPI_local_begin() : nc->begin();
+      NodeCollection::const_iterator nc_end = nc->end();
+      for ( auto node = nc_begin; node < nc_end; ++node )
+      {
+        // Because the local ID also includes non-local nodes, it must be adapted to represent
+        // the index for the local node position.
+        const auto index =
+          static_cast< size_t >( std::floor( ( *node ).lid / kernel().mpi_manager.get_num_processes() ) );
+        sliced_points.push_back( positions[ index ] );
+      }
+      def2< TokenArray, ArrayDatum >( dict, names::positions, sliced_points );
+    }
+  }
+}
+
+
 } // namespace nest

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -200,6 +200,8 @@ std::vector< double > apply( const ParameterDatum& param, const DictionaryDatum&
 
 Datum* node_collection_array_index( const Datum* datum, const long* array, unsigned long n );
 Datum* node_collection_array_index( const Datum* datum, const bool* array, unsigned long n );
+
+void slice_positions_if_sliced_nc( DictionaryDatum& dict, const NodeCollectionDatum& nc );
 }
 
 

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -201,6 +201,14 @@ std::vector< double > apply( const ParameterDatum& param, const DictionaryDatum&
 Datum* node_collection_array_index( const Datum* datum, const long* array, unsigned long n );
 Datum* node_collection_array_index( const Datum* datum, const bool* array, unsigned long n );
 
+/**
+ * @brief Get only positions of the sliced nodes if metadata contains node positions and the NodeCollection is sliced.
+ *
+ * Puts an array of positions sliced the same way as a sliced NodeCollection into dict.
+ * Positions have to be sliced on introspection because metadata of a sliced NodeCollection
+ * for internal consistency and efficiency points to the metadata of the original
+ * NodeCollection.
+ */
 void slice_positions_if_sliced_nc( DictionaryDatum& dict, const NodeCollectionDatum& nc );
 }
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -586,6 +586,7 @@ NestModule::GetMetadata_gFunction::execute( SLIInterpreter* i ) const
   if ( meta.get() )
   {
     meta->get_status( dict );
+    slice_positions_if_sliced_nc( dict, nc );
 
     ( *dict )[ names::network_size ] = nc->size();
   }

--- a/testsuite/pytests/test_spatial/test_basics.py
+++ b/testsuite/pytests/test_spatial/test_basics.py
@@ -425,9 +425,8 @@ class BasicsTestCase(unittest.TestCase):
         """Correct positions from spatial attribute of sliced NodeCollection"""
         nest.ResetKernel()
         positions = nest.spatial.free(nest.random.uniform(min=-1, max=1), num_dimensions=2)
-        nodes = nest.Create('iaf_psc_alpha', positions=positions)
+        nodes = nest.Create('iaf_psc_alpha', 10, positions=positions)
         all_positions = sum([list(nodes[i].spatial['positions']) for i in range(len(nodes))], start=[])
-        all_positions.sort()
         self.assertEqual(tuple(all_positions), nodes.spatial['positions'])
 
 

--- a/testsuite/pytests/test_spatial/test_basics.py
+++ b/testsuite/pytests/test_spatial/test_basics.py
@@ -421,6 +421,15 @@ class BasicsTestCase(unittest.TestCase):
             self.assertAlmostEqual(positions[indx][0], p[0][indx][0])
             self.assertAlmostEqual(positions[indx][1], p[0][indx][1])
 
+    def testSlicedPositions(self):
+        """Correct positions from spatial attribute of sliced NodeCollection"""
+        nest.ResetKernel()
+        positions = nest.spatial.free(nest.random.uniform(min=-1, max=1), num_dimensions=2)
+        nodes = nest.Create('iaf_psc_alpha', positions=positions)
+        all_positions = sum([list(nodes[i].spatial['positions']) for i in range(len(nodes))], start=[])
+        all_positions.sort()
+        self.assertEqual(tuple(all_positions), nodes.spatial['positions'])
+
 
 def suite():
     suite = unittest.makeSuite(BasicsTestCase, 'test')

--- a/testsuite/pytests/test_spatial/test_basics.py
+++ b/testsuite/pytests/test_spatial/test_basics.py
@@ -428,6 +428,7 @@ class BasicsTestCase(unittest.TestCase):
         nodes = nest.Create('iaf_psc_alpha', 10, positions=positions)
         all_positions = sum([list(nodes[i].spatial['positions']) for i in range(len(nodes))], start=[])
         self.assertEqual(tuple(all_positions), nodes.spatial['positions'])
+        self.assertEqual(tuple(nodes[::2].spatial['positions']), nodes.spatial['positions'][::2])
 
 
 def suite():

--- a/testsuite/pytests/test_spatial_positions.py
+++ b/testsuite/pytests/test_spatial_positions.py
@@ -63,3 +63,13 @@ def testGridPositions(reset):
     # which corresponds to the node ID.
     expected_weight = conns.target
     assert(conns.weight == expected_weight)
+
+
+def testSlicedPositions(reset):
+    """Correct positions from spatial attribute of sliced NodeCollection"""
+    positions = nest.spatial.free(nest.random.uniform(min=-1, max=1), num_dimensions=2)
+    # Positions are only stored for local nodes.
+    nodes = nest.GetLocalNodeCollection(nest.Create('iaf_psc_alpha', positions=positions))
+    all_positions = sum([list(nodes[i].spatial['positions']) for i in range(len(nodes))], start=[])
+    all_positions.sort()
+    assert tuple(all_positions) == nodes.spatial['positions']

--- a/testsuite/pytests/test_spatial_positions.py
+++ b/testsuite/pytests/test_spatial_positions.py
@@ -63,13 +63,3 @@ def testGridPositions(reset):
     # which corresponds to the node ID.
     expected_weight = conns.target
     assert(conns.weight == expected_weight)
-
-
-def testSlicedPositions(reset):
-    """Correct positions from spatial attribute of sliced NodeCollection"""
-    positions = nest.spatial.free(nest.random.uniform(min=-1, max=1), num_dimensions=2)
-    # Positions are only stored for local nodes.
-    nodes = nest.GetLocalNodeCollection(nest.Create('iaf_psc_alpha', positions=positions))
-    all_positions = sum([list(nodes[i].spatial['positions']) for i in range(len(nodes))], start=[])
-    all_positions.sort()
-    assert tuple(all_positions) == nodes.spatial['positions']


### PR DESCRIPTION
For internal consistency and efficiency, metadata of nodes in a sliced NodeCollection points to the metadata of the original NodeCollection. When getting the positions in the spatial parameter of a sliced NodeCollection, using `nodes.spatial['positions']`, positions for all nodes in the original NodeCollection is therefore returned. This PR adds a filter on the returned positions to only get positions of nodes in the sliced NodeCollection, which fixes #2414.