### PR TITLE
Include NEST GPU into the docs

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -196,8 +196,9 @@ intersphinx_mapping = {
     'pynn': ('http://neuralensemble.org/docs/PyNN/', None),
     'elephant': ('https://elephant.readthedocs.io/en/latest/', None),
     'desktop': ('https://nest-desktop.readthedocs.io/en/latest/', None),
+    'gpu': ('https://nest-gpu.readthedocs.io/en/latest/', None),
     'neuromorph': ('https://electronicvisions.github.io/hbp-sp9-guidebook/', None),
-    'arbor': ('https://arbor.readthedocs.io/en/latest/', None),
+    'arbor': ('https://docs.arbor-sim.org/en/latest/objects.inv', None),
     'tvb': ('http://docs.thevirtualbrain.org/', None),
     'extmod': ('https://nest-extension-module.readthedocs.io/en/latest/', None),
 }

--- a/doc/htmldoc/related_projects.rst
+++ b/doc/htmldoc/related_projects.rst
@@ -41,6 +41,13 @@ The app enables the rapid construction, parametrization, and instrumentation of 
 
 * :doc:`Get started with NEST desktop <desktop:user/index>`
 
+NEST GPU
+--------
+
+NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons. Iti can be used in Python, in C++ and in C.
+
+* :doc:`Get started with NEST GPU <gpu:index>`
+
 PyNN
 ----
 

--- a/doc/htmldoc/related_projects.rst
+++ b/doc/htmldoc/related_projects.rst
@@ -44,7 +44,7 @@ The app enables the rapid construction, parametrization, and instrumentation of 
 NEST GPU
 --------
 
-NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons. Iti can be used in Python, in C++ and in C.
+NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons. It can be used in Python, in C++ and in C.
 
 * :doc:`Get started with NEST GPU <gpu:index>`
 


### PR DESCRIPTION
This PR adds the NEST GPU repo as an intersphinx link, and also adds a link in the related projects page.