### PR TITLE
Add link to NEST Desktop lecture material

### DIFF
--- a/doc/htmldoc/installation/lecturer.rst
+++ b/doc/htmldoc/installation/lecturer.rst
@@ -7,10 +7,11 @@ Lecturer installation instructions
 NEST Desktop
 ~~~~~~~~~~~~
 
-* :doc:`NEST Desktop <desktop:index>` is a graphical user interface designed for illustrating neural network concepts
-  ideal for the classroom setting.
+:doc:`NEST Desktop <desktop:index>` is a graphical user interface designed for illustrating neural network concepts
+ideal for the classroom setting.
+There are several materials for Bachelor and Master's level already prepared.
 
-We recommend you checkout the NEST desktop project and see if it fits your needs!
+* Check out :doc:`the lecture material for NEST Desktop <desktop:lecturer/index>`
 
 
 Docker install


### PR DESCRIPTION
This PR adds a link to in the lecturer installation instructions directly to the lecture material for NEST  Desktop.

