### PR TITLE
Fix Jupyter notebook links

### DIFF
--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -101,7 +101,7 @@ and
  \tau_w \frac{dw}{dt} = a(V-E_L) - w
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [1]_.
 

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -91,7 +91,7 @@ spike-adaptation current `w` is
 When the neuron fires a spike, the adaptation current :math:`w <- w + b`.
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 Parameters
 ++++++++++

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -108,7 +108,7 @@ and the differential equation for the spike-adaptation current `w` is:
 When the neuron fires a spike, the adaptation current `w <- w + b`.
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 Parameters
 ++++++++++

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -103,7 +103,7 @@ Note that the spike detection threshold V_peak is automatically set to
 setting V_peak too high.
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [1]_.
 

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -88,7 +88,7 @@ and
  \tau_w \cdot dw/dt= a(V-E_L) -W
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [1]_.
 

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -88,7 +88,7 @@ and
  \tau_w \cdot dw/dt= a(V-E_L) -W
 
 For implementation details see the
-:doc:`aeif_models_implementation <../neurons/neurons/model_details/aeif_models_implementation>` notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [1]_.
 

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -96,7 +96,7 @@ spikes. This is implemented such that ``V_m`` will be incremented/decremented by
 the value of `J` after a spike.
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [1]_.
 

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -89,7 +89,7 @@ important to mimic a spike which is otherwise not described by the aeif neuron
 model.
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [2]_.
 

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -93,7 +93,7 @@ Note that the spike detection threshold ``V_peak`` is automatically set to
 setting ``V_peak`` too high.
 
 For implementation details see the
-`aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.
+:doc:`aeif_models_implementation <../neurons/model_details/aeif_models_implementation>` notebook.
 
 See also [1]_.
 

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -129,7 +129,7 @@ The shape of postsynaptic current is exponential.
   ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 Parameters
 ++++++++++

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -134,7 +134,7 @@ The shape of postsynaptic current is exponential.
    time constant, to avoid numerical instabilities.
 
    For implementation details see the
-   `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+   :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 Parameters
 ++++++++++

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -103,7 +103,7 @@ condition of :math:`(E_L + voltage_reset_fraction * ( V_th - E_L ) + voltage_res
   ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 Parameters
 ++++++++++

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -86,7 +86,7 @@ neuron model described in [1]_. The most important properties are:
 
 For implementation details see:
 
-- `HillTononi_model <../model_details/HillTononiModels.ipynb>`_
+- :doc:`HillTononi_model <../neurons/model_details/HillTononiModels>`
 
 For examples, see:
 

--- a/models/ht_synapse.h
+++ b/models/ht_synapse.h
@@ -52,7 +52,7 @@ Synaptic dynamics are given by
 :math:`w(t) = w_{max} \cdot P(t)`   is the resulting synaptic weight
 
 For implementation details see:
-`HillTononi_model <../model_details/HillTononiModels.ipynb>`_
+:doc:`HillTononi_model <../neurons/model_details/HillTononiModels>`_
 
 .. warning::
 

--- a/models/ht_synapse.h
+++ b/models/ht_synapse.h
@@ -52,7 +52,7 @@ Synaptic dynamics are given by
 :math:`w(t) = w_{max} \cdot P(t)`   is the resulting synaptic weight
 
 For implementation details see:
-:doc:`HillTononi_model <../neurons/model_details/HillTononiModels>`_
+:doc:`HillTononi_model <../neurons/model_details/HillTononiModels>`
 
 .. warning::
 

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -95,7 +95,7 @@ relevant measures analytically.
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
    For implementation details see the
-   `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+   :doc:`IAF_neurons_singularity <../neurons/neurons/model_details/IAF_neurons_singularity>` notebook.
 
 See also [3]_.
 

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -95,7 +95,7 @@ relevant measures analytically.
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
    For implementation details see the
-   :doc:`IAF_neurons_singularity <../neurons/neurons/model_details/IAF_neurons_singularity>` notebook.
+   :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 See also [3]_.
 

--- a/models/iaf_psc_alpha_canon.h
+++ b/models/iaf_psc_alpha_canon.h
@@ -96,7 +96,7 @@ dynamics are integrated using exact integration between events [2]_.
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
    For implementation details see the
-   `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+   :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 This model transmits precise spike times to target nodes (on-grid spike
 time and offset). If this node is connected to a ``spike_recorder``, the

--- a/models/iaf_psc_alpha_multisynapse.h
+++ b/models/iaf_psc_alpha_multisynapse.h
@@ -64,7 +64,7 @@ a different time constant. The port number has to match the respective
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
    For implementation details see the
-   `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+   :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 Sends
 +++++

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -93,7 +93,7 @@ can only change at on-grid times.
   `tau_syn_in`, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 For details about exact subthreshold integration, please see
 :doc:`../guides/exact-integration`.

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -80,7 +80,7 @@ model with escape noise [4]_.
   ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 ``iaf_psc_exp`` can handle current input in two ways:
 

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -93,7 +93,7 @@ neuron like dynamics interacting by point events is described in
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
     For implementation details see the
-    `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+    :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 
 See also [4]_.

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -64,7 +64,7 @@ a different time constant. The port number has to match the respective
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
    For implementation details see the
-   `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+   :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 For conversion between postsynaptic potentials (PSPs) and PSCs,
 please refer to the ``postsynaptic_potential_to_current`` function in

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -89,7 +89,7 @@ can only change at on-grid times.
   `tau_syn_in`, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity>` notebook.
 
 For details about exact subthreshold integration, please see
 :doc:`../guides/exact-integration`.

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -74,7 +74,7 @@ meets the threshold.
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  :doc:`IAF_neurons_singularity <../neurons/neurons/model_details/IAF_neurons_singularity` notebook.
+  :doc:`IAF_neurons_singularity <../neurons/model_details/IAF_neurons_singularity` notebook.
 
 This model transmits precise spike times to target nodes (on-grid spike
 time and offset). If this node is connected to a spike_recorder, the

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -74,7 +74,7 @@ meets the threshold.
    ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  :doc:`IAF_neurons_singularity <../neurons/neurons/model_details/IAF_neurons_singularity` notebook.
 
 This model transmits precise spike times to target nodes (on-grid spike
 time and offset). If this node is connected to a spike_recorder, the

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -76,7 +76,7 @@ If the modulation is added the current is given by
                               \text{ for } t_0 + j dt \leq t < t_0 + (j-1) dt
 
 For a detailed discussion of the properties of the noise generator, please see
-:doc:`noise_generator <../neurons/model_details/noise_generator>`_
+:doc:`noise_generator <../neurons/model_details/noise_generator>`
 notebook included in the NEST source code.
 
 All targets receive different currents, but the currents for all

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -76,7 +76,7 @@ If the modulation is added the current is given by
                               \text{ for } t_0 + j dt \leq t < t_0 + (j-1) dt
 
 For a detailed discussion of the properties of the noise generator, please see
-`noise_generator <../model_details/noise_generator.ipynb>`_
+:doc:`noise_generator <../neurons/model_details/noise_generator>`_
 notebook included in the NEST source code.
 
 All targets receive different currents, but the currents for all

--- a/models/siegert_neuron.h
+++ b/models/siegert_neuron.h
@@ -68,8 +68,8 @@ delay, and uses the secondary_event concept introduced with the
 gap-junction framework.
 
 For details on the numerical solution of the Siegert integral, you can
-check out the `Siegert_neuron_integration
-<../model_details/siegert_neuron_integration.ipynb>`_
+check out the
+:doc:`Siegert_neuron_integration <../neurons/model_details/siegert_neuron_integration>`
 notebook in the NEST source code.
 
 See also [1]_, [4]_.


### PR DESCRIPTION
Resolves  #2404 

This PR fixed the Jupyter notebook links and makes it so they generate properly on Read the docs
