### PR TITLE
Only set relevant runpaths in libraries and executables

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -191,29 +191,42 @@ function( NEST_PROCESS_STATIC_LIBRARIES )
     # ``${CMAKE_INSTALL_PREFIX}/bin`` for the nest and sli executables, ``${CMAKE_INSTALL_PREFIX}/lib/nest`` for all
     # dynamic libraries except PyNEST (libnestkernel.so, etc.), and  something like
     # ``${CMAKE_INSTALL_PREFIX}/lib/python3.x/site-packages/nest`` for ``pynestkernel.so``. The RPATH is relative to
-    # this origin, so the binary ``bin/nest`` can find the files in the relative location ``../lib/nest``, and
-    # similarly for PyNEST and the other libraries. For simplicity, we set all the possibilities on all generated
-    # objects.
+    # this origin. For the libraries, the relative path is the same dir ("./"), for the exucutables and python
+    # module the relative path is calculated below.
+    # For simplicity, we set all the possibilities on all generated objects.
 
     # PyNEST can only act as an entry point; it does not need to be included in the other objects' RPATH itself.
+
+    cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+               BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
+               OUTPUT_VARIABLE executable_libdir_relative_path)
+
+    if ( HAVE_PYTHON )
+      cmake_path(ABSOLUTE_PATH PYEXECDIR
+                 BASE_DIRECTORY ${CMAKE_INSTALL_PREFIX}
+                 OUTPUT_VARIABLE pyexecdir_full)
+      cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+                 BASE_DIRECTORY "${pyexecdir_full}/nest"
+                 OUTPUT_VARIABLE python_libdir_relative_path)
+    endif ()
 
     if ( APPLE )
       set( CMAKE_INSTALL_RPATH
           # for binaries
-          "@loader_path/../${CMAKE_INSTALL_LIBDIR}/nest"
+          "@executable_path/${executable_libdir_relative_path}/nest"
           # for libraries (except pynestkernel)
-          "@loader_path/../../${CMAKE_INSTALL_LIBDIR}/nest"
+          "@loader_path"
           # for pynestkernel: origin at <prefix>/lib/python3.x/site-packages/nest
-          "@loader_path/../../../nest"
+          "@loader_path/${python_libdir_relative_path}/nest"
           PARENT_SCOPE )
     else ()
       set( CMAKE_INSTALL_RPATH
           # for binaries
-          "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/nest"
+          "\$ORIGIN/${executable_libdir_relative_path}/nest"
           # for libraries (except pynestkernel)
-          "\$ORIGIN/../../${CMAKE_INSTALL_LIBDIR}/nest"
+          "\$ORIGIN"
           # for pynestkernel: origin at <prefix>/lib/python3.x/site-packages/nest
-          "\$ORIGIN/../../../nest"
+          "\$ORIGIN/${python_libdir_relative_path}/nest"
           PARENT_SCOPE )
     endif ()
 

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -193,13 +193,13 @@ function( NEST_PROCESS_STATIC_LIBRARIES )
     # ``${CMAKE_INSTALL_PREFIX}/lib/python3.x/site-packages/nest`` for ``pynestkernel.so``. The RPATH is relative to
     # this origin. For the libraries, the relative path is the same dir ("./"), for the exucutables and python
     # module the relative path is calculated below.
-    # For simplicity, we set all the possibilities on all generated objects.
 
     # PyNEST can only act as an entry point; it does not need to be included in the other objects' RPATH itself.
 
     cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
                BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
                OUTPUT_VARIABLE executable_libdir_relative_path)
+    set( executable_libdir_relative_path ${executable_libdir_relative_path} PARENT_SCOPE )
 
     if ( HAVE_PYTHON )
       cmake_path(ABSOLUTE_PATH PYEXECDIR
@@ -208,26 +208,7 @@ function( NEST_PROCESS_STATIC_LIBRARIES )
       cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
                  BASE_DIRECTORY "${pyexecdir_full}/nest"
                  OUTPUT_VARIABLE python_libdir_relative_path)
-    endif ()
-
-    if ( APPLE )
-      set( CMAKE_INSTALL_RPATH
-          # for binaries
-          "@executable_path/${executable_libdir_relative_path}/nest"
-          # for libraries (except pynestkernel)
-          "@loader_path"
-          # for pynestkernel: origin at <prefix>/lib/python3.x/site-packages/nest
-          "@loader_path/${python_libdir_relative_path}/nest"
-          PARENT_SCOPE )
-    else ()
-      set( CMAKE_INSTALL_RPATH
-          # for binaries
-          "\$ORIGIN/${executable_libdir_relative_path}/nest"
-          # for libraries (except pynestkernel)
-          "\$ORIGIN"
-          # for pynestkernel: origin at <prefix>/lib/python3.x/site-packages/nest
-          "\$ORIGIN/${python_libdir_relative_path}/nest"
-          PARENT_SCOPE )
+      set( python_libdir_relative_path ${python_libdir_relative_path} PARENT_SCOPE )
     endif ()
 
     # add the automatically determined parts of the RPATH

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -150,6 +150,18 @@ set_target_properties( models
     )
 target_link_libraries( models nestutil sli_lib nestkernel )
 
+if ( NOT APPLE )
+    set_target_properties( models
+        PROPERTIES
+        INSTALL_RPATH "\$ORIGIN"
+        )
+else ()
+    set_target_properties( models
+        PROPERTIES
+        INSTALL_RPATH "@loader_path"
+        )
+endif ()
+
 target_include_directories( models PRIVATE
     ${PROJECT_SOURCE_DIR}/thirdparty
     ${PROJECT_SOURCE_DIR}/libnestutil

--- a/nest/CMakeLists.txt
+++ b/nest/CMakeLists.txt
@@ -27,6 +27,12 @@ if ( NOT APPLE )
     set_target_properties( nest
         PROPERTIES
         LINK_FLAGS "-Wl,--no-as-needed"
+        INSTALL_RPATH "\$ORIGIN/${executable_libdir_relative_path}/nest"
+        )
+else ()
+    set_target_properties( nest
+        PROPERTIES
+        INSTALL_RPATH "@executable_path/${executable_libdir_relative_path}/nest"
         )
 endif ()
 
@@ -36,12 +42,14 @@ if ( NOT APPLE )
     set_target_properties( nest_lib
         PROPERTIES
         OUTPUT_NAME nest
+        INSTALL_RPATH "\$ORIGIN"
         LINK_FLAGS "-Wl,--no-as-needed"
         )
 else ()
     set_target_properties( nest_lib
         PROPERTIES
         OUTPUT_NAME nest
+        INSTALL_RPATH "@loader_path"
 
         # delay lookup of symbols from libpython when building with MPI4Py
         LINK_FLAGS "-Wl,-undefined -Wl,dynamic_lookup"

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -161,6 +161,18 @@ install( TARGETS nestkernel
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
+if ( NOT APPLE )
+    set_target_properties( nestkernel
+        PROPERTIES
+        INSTALL_RPATH "\$ORIGIN"
+        )
+else ()
+    set_target_properties( nestkernel
+        PROPERTIES
+        INSTALL_RPATH "@loader_path"
+        )
+endif ()
+
 FILTER_HEADERS("${nestkernel_sources}" install_headers )
 install( FILES ${install_headers}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nest)

--- a/pynest/CMakeLists.txt
+++ b/pynest/CMakeLists.txt
@@ -58,6 +58,18 @@ if ( HAVE_PYTHON )
       ${SLI_MODULES} ${EXTERNAL_MODULE_LIBRARIES}
       )
 
+  if ( NOT APPLE )
+      set_target_properties( pynestkernel
+          PROPERTIES
+          INSTALL_RPATH "\$ORIGIN/${python_libdir_relative_path}/nest"
+          )
+  else ()
+      set_target_properties( pynestkernel
+          PROPERTIES
+          INSTALL_RPATH "@loader_path/${python_libdir_relative_path}/nest"
+          )
+  endif ()
+
   target_include_directories( pynestkernel PRIVATE
       ${PROJECT_BINARY_DIR}/libnestutil
       ${PROJECT_SOURCE_DIR}/libnestutil

--- a/sli/CMakeLists.txt
+++ b/sli/CMakeLists.txt
@@ -143,6 +143,26 @@ install( TARGETS sli_readline sli_lib sli
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
+if ( APPLE )
+    set_target_properties( sli
+        PROPERTIES
+        INSTALL_RPATH "@executable_path/${executable_libdir_relative_path}/nest"
+        )
+    set_target_properties( sli_lib sli_readline
+        PROPERTIES
+        INSTALL_RPATH "@loader_path"
+        )
+else ()
+    set_target_properties( sli
+        PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/${executable_libdir_relative_path}/nest"
+        )
+    set_target_properties( sli_lib sli_readline
+        PROPERTIES
+        INSTALL_RPATH "\$ORIGIN"
+        )
+endif ()
+
 FILTER_HEADERS("${sli_sources}" install_headers )
 install( FILES ${install_headers} gnureadline.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nest)

--- a/testsuite/cpptests/CMakeLists.txt
+++ b/testsuite/cpptests/CMakeLists.txt
@@ -25,6 +25,18 @@ if ( HAVE_BOOST )
 
   target_link_libraries( run_all_cpptests ${BOOST_LIBRARIES} nestkernel models )
 
+  if ( NOT APPLE )
+    set_target_properties( run_all_cpptests
+        PROPERTIES
+        INSTALL_RPATH "\$ORIGIN/${executable_libdir_relative_path}/nest"
+        )
+  else ()
+    set_target_properties( run_all_cpptests
+        PROPERTIES
+        INSTALL_RPATH "@executable_path/${executable_libdir_relative_path}/nest"
+        )
+  endif ()
+
   target_include_directories( run_all_cpptests PRIVATE
     ${PROJECT_SOURCE_DIR}/libnestutil
     ${PROJECT_BINARY_DIR}/libnestutil


### PR DESCRIPTION
Libraries and executables install into different directories, and thus the relative directories to the library dir differ.

Only set the RUNPATH which actually applies, avoiding extraneous and invalid entries.