### PR TITLE
Fix some dimensions in developer documentation adex neurons

### DIFF
--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -247,7 +247,7 @@ private:
     double E_ex;       //!< Excitatory reversal Potential in mV
     double E_in;       //!< Inhibitory reversal Potential in mV
     double E_L;        //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T;    //!< Slope factor in ms
+    double Delta_T;    //!< Slope factor in mV
     double tau_w;      //!< Adaptation time-constant in ms
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -228,7 +228,7 @@ private:
     double g_L;     //!< Leak Conductance in nS
     double C_m;     //!< Membrane Capacitance in pF
     double E_L;     //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T; //!< Slope factor in ms
+    double Delta_T; //!< Slope factor in mV
     double tau_w;   //!< Adaptation time-constant in ms
     double a;       //!< Subthreshold adaptation in nS
     double b;       //!< Spike-triggered adaptation in pA

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -231,7 +231,7 @@ private:
     double g_L;     //!< Leak Conductance in nS
     double C_m;     //!< Membrane Capacitance in pF
     double E_L;     //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T; //!< Slope factor in ms
+    double Delta_T; //!< Slope factor in mV
     double tau_w;   //!< adaptation time-constant in ms
     double a;       //!< Subthreshold adaptation in nS
     double b;       //!< Spike-triggered adaptation in pA

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -248,7 +248,7 @@ private:
     double E_ex;       //!< Excitatory reversal Potential in mV
     double E_in;       //!< Inhibitory reversal Potential in mV
     double E_L;        //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T;    //!< Slope factor in ms
+    double Delta_T;    //!< Slope factor in mV
     double tau_w;      //!< Adaptation time-constant in ms
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -231,7 +231,7 @@ private:
     double g_L;        //!< Leak Conductance in nS
     double C_m;        //!< Membrane Capacitance in pF
     double E_L;        //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T;    //!< Slope factor in ms
+    double Delta_T;    //!< Slope factor in mV
     double tau_w;      //!< Adaptation time-constant in ms
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -227,7 +227,7 @@ private:
     double g_L;     //!< Leak Conductance in nS
     double C_m;     //!< Membrane Capacitance in pF
     double E_L;     //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T; //!< Slope factor in ms
+    double Delta_T; //!< Slope factor in mV
     double tau_w;   //!< Adaptation time-constant in ms
     double a;       //!< Subthreshold adaptation in nS
     double b;       //!< Spike-triggered adaptation in pA

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -256,7 +256,7 @@ private:
     double g_L;             //!< Leak Conductance in nS
     double C_m;             //!< Membrane Capacitance in pF
     double E_L;             //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T;         //!< Slope factor in ms
+    double Delta_T;         //!< Slope factor in mV
     double tau_w;           //!< Adaptation time constant in ms
     double tau_z;           //!< Spike afterpotential current time constant in ms
     double tau_V_th;        //!< Adaptive threshold time constant in ms

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -129,7 +129,7 @@ The following parameters can be set in the status dictionary.
  b       pA      Spike-triggered adaptation
  Delta_T mV      Slope factor
  tau_w   ms      Adaptation time constant
- V_t     mV      Spike initiation threshold
+ V_th    mV      Spike initiation threshold
  V_peak  mV      Spike detection threshold
 ======== ======= ==================================
 
@@ -233,7 +233,7 @@ private:
     double g_L;        //!< Leak Conductance in nS
     double C_m;        //!< Membrane Capacitance in pF
     double E_L;        //!< Leak reversal Potential (aka resting potential) in mV
-    double Delta_T;    //!< Slope factor in ms
+    double Delta_T;    //!< Slope factor in mV
     double tau_w;      //!< Adaptation time-constant in ms
     double a;          //!< Subthreshold adaptation in nS
     double b;          //!< Spike-triggered adaptation in pA


### PR DESCRIPTION
I wanted to try out the adaptive exponential integrate-and-fire neuron models and realized that some of the comments about the dimensions of the variables in the text seem to be incorrect: The slope factor `Delta_T` is mV, not ms, see [the original publication](https://journals.physiology.org/doi/pdf/10.1152/jn.00686.2005?download=true). This PR corrects the dimensions.