### PR TITLE
Conda packages for Apple's M1 are available now

### DIFF
--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -46,8 +46,3 @@ Conda forge install
 
    - We currently provide NEST with thread-based parallelization on conda. This should suffice for most
      uses on personal computers.
-   - Until dedicated conda builds for Apple's M1 chip (arm64) become available, you should expect relatively
-     poor performance on computers with the M1 chip. You need to :ref:`build NEST yourself <mac_install>` on
-     M1 systems for good performance.
-
-


### PR DESCRIPTION
osx-arm64 packages are now available for NEST v3.3. The warning in the documentation is obsolete and can be deleted.