### PR TITLE
Add documentation on discretization of uniformly distributed delays

### DIFF
--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -194,7 +194,7 @@ Connection delays in NEST are rounded to the nearest multiple of the simulation 
 even if delays are drawn from a continuous distribution. This will work as expected if the
 distribution has infinite support, for example, the normal distribution. For the uniform distribution,
 though, this rounding will usually lead to lower probabilities for the delays at the edges of
-the distribution. Consider the following case
+the distribution. Consider the following case:
 
 ::
 

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -200,8 +200,7 @@ the distribution. Consider the following case
 
     nest.resolution = 0.1
     n = nest.Create('iaf_psc_alpha', 100)
-    nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1,
-                                                              max=2)})
+    nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1, max=2)})
     
 This will create 10000 connections in total with delay values 1.0, 1.1, ..., 2.0. But while
 the interior delay values 1.1, ..., 1.9 will occur approximately 1000 times each, the corner

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -192,7 +192,7 @@ Rounding effects when randomizing delays
 
 Connection delays in NEST are rounded to the nearest multiple of the simulation resolution,
 even if delays are drawn from a continuous distribution. This will work as expected if the
-distribution has infinite support, e.g., the normal distribution. For the uniform distribution,
+distribution has infinite support, for example, the normal distribution. For the uniform distribution,
 though, this rounding will usually lead to lower probabilities for the delays at the edges of
 the distribution. Consider the following case
 

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -210,7 +210,7 @@ any number from :math:`[1.05, 1.15)` will be rounded to 1.1, but only numbers in
 :math:`[1.0, 1.05)` will be rounded to 1.0.
 
 To achieve equal probabilities of the first and last values, you can either extend the interval
-of the uniform distribution by half the resolution
+of the uniform distribution by half the resolution:
 
 ::
 

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -204,7 +204,7 @@ the distribution. Consider the following case:
     
 This will create 10000 connections in total with delay values 1.0, 1.1, ..., 2.0. But while
 the interior delay values 1.1, ..., 1.9 will occur approximately 1000 times each, the first and last
-cases 1.0 and 2.0 will occur only approximately 500 times each. This happens because NEST
+cases, 1.0 and 2.0, will occur only approximately 500 times each. This happens because NEST
 first draws the delay uniformly from :math:`[1, 2)` and then rounds to a fixed delay. Thus,
 any number from :math:`[1.05, 1.15)` will be rounded to 1.1, but only numbers in
 :math:`[1.0, 1.05)` will be rounded to 1.0.

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -136,7 +136,7 @@ The NEST random module
 The ``nest.random`` module provides a range of random distributions that
 can be used to specify parameters for neurons, synapses, and connection
 rules. See :ref:`below for examples <random_examples>` on how to use them in
-practice.
+practice and :ref:`some details on randomizing delays <random_delays>`.
 
 .. automodule:: nest.random.hl_api_random
     :members:
@@ -184,6 +184,49 @@ Likewise, synapse parameters can be specified using the random distributions.
 
    nest.Connect(n, n, syn_spec={'weight': nest.random.normal(mean=0., std=1.),
                                 'delay': nest.random.uniform(min=0.5, max=1.5)})
+
+.. _random_delays:
+
+Rounding effects when randomizing delays
+........................................
+
+Connection delays in NEST are rounded to the nearest multiple of the simulation resolution,
+even if delays are drawn from a continuous distribution. This will work as expected if the
+distribution has infinite support, e.g., the normal distribution. For the uniform distribution,
+though, this rounding will usually lead to lower probabilites for the delays at the edges of
+the distribution. Consider the following case
+
+::
+
+	nest.resolution = 0.1
+    n = nest.Create('iaf_psc_alpha', 100)
+    nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1,
+                                                              max=2)})
+    
+This will create 10000 connections in total with delay values 1.0, 1.1, ..., 2.0. But while
+the interior delay values 1.1, ..., 1.9 will occur approximately 1000 times each, the corner
+cases 1.0 and 2.0 will occur only approximately 500 times each. This happens because NEST
+first draws the delay uniformly from :math:`[1, 2)` and then rounds to a fixed delay. Thus,
+any number from :math:`[1.05, 1.15)` will be rounded to 1.1, but only numbers in
+:math:`[1.0, 1.05)` will be rounded to 1.0.
+
+To achieve equal probabilities of the corner values, you can either extend the interval
+of the uniform distribution by half the resolution
+
+::
+
+    nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1-0.5*nest.resolution,
+                                                              max=2+0.5*nest.resolution)})
+
+or use the uniform integer distribution. Since it always draws numbers beginning with zero,
+this is slightly more cumbersome:
+
+::
+
+    nest.Connect(n, n, syn_spec={'delay': 1 + 0.1 * nest.random.uniform_int(11)})
+    
+An in-depth analysis of delay rounding is available in a
+:ref:`master thesis <https://hdl.handle.net/11250/3012689>`_.
 
 Randomize spatial positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -214,8 +214,8 @@ of the uniform distribution by half the resolution
 
 ::
 
-    nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1-0.5*nest.resolution,
-                                                              max=2+0.5*nest.resolution)})
+    nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1 - 0.5 * nest.resolution,
+                                                              max=2 + 0.5 * nest.resolution)})
 
 or use the uniform integer distribution. Since it always draws numbers beginning with zero,
 this is slightly more cumbersome:

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -193,7 +193,7 @@ Rounding effects when randomizing delays
 Connection delays in NEST are rounded to the nearest multiple of the simulation resolution,
 even if delays are drawn from a continuous distribution. This will work as expected if the
 distribution has infinite support, e.g., the normal distribution. For the uniform distribution,
-though, this rounding will usually lead to lower probabilites for the delays at the edges of
+though, this rounding will usually lead to lower probabilities for the delays at the edges of
 the distribution. Consider the following case
 
 ::

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -209,7 +209,7 @@ first draws the delay uniformly from :math:`[1, 2)` and then rounds to a fixed d
 any number from :math:`[1.05, 1.15)` will be rounded to 1.1, but only numbers in
 :math:`[1.0, 1.05)` will be rounded to 1.0.
 
-To achieve equal probabilities of the corner values, you can either extend the interval
+To achieve equal probabilities of the first and last values, you can either extend the interval
 of the uniform distribution by half the resolution
 
 ::

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -198,7 +198,7 @@ the distribution. Consider the following case
 
 ::
 
-	nest.resolution = 0.1
+    nest.resolution = 0.1
     n = nest.Create('iaf_psc_alpha', 100)
     nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1,
                                                               max=2)})
@@ -226,7 +226,7 @@ this is slightly more cumbersome:
     nest.Connect(n, n, syn_spec={'delay': 1 + 0.1 * nest.random.uniform_int(11)})
     
 An in-depth analysis of delay rounding is available in a
-:ref:`master thesis <https://hdl.handle.net/11250/3012689>`_.
+`master thesis <https://hdl.handle.net/11250/3012689>`_.
 
 Randomize spatial positions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -203,7 +203,7 @@ the distribution. Consider the following case:
     nest.Connect(n, n, syn_spec={'delay': nest.random.uniform(min=1, max=2)})
     
 This will create 10000 connections in total with delay values 1.0, 1.1, ..., 2.0. But while
-the interior delay values 1.1, ..., 1.9 will occur approximately 1000 times each, the corner
+the interior delay values 1.1, ..., 1.9 will occur approximately 1000 times each, the first and last
 cases 1.0 and 2.0 will occur only approximately 500 times each. This happens because NEST
 first draws the delay uniformly from :math:`[1, 2)` and then rounds to a fixed delay. Thus,
 any number from :math:`[1.05, 1.15)` will be rounded to 1.1, but only numbers in

--- a/pynest/nest/random/hl_api_random.py
+++ b/pynest/nest/random/hl_api_random.py
@@ -36,6 +36,11 @@ def uniform(min=0.0, max=1.0):
 
     Samples are distributed uniformly in [min, max) (includes min, but excludes max).
 
+    Note
+    ----
+    See :ref:`this documentation <random_delays>` for details on the effect
+    of time discretization on delays drawn from a uniform distribution.
+
     Parameters
     ----------
     min : float, optional
@@ -47,11 +52,6 @@ def uniform(min=0.0, max=1.0):
     -------
     Parameter:
         Object yielding values drawn from the distribution.
-        
-    .. note: 
-    
-       See :ref:`this documentation <random_delays>` for details on the effect
-       of time discretization on delays drawn from a uniform distribution.
     """
     return CreateParameter('uniform', {'min': min, 'max': max})
 

--- a/pynest/nest/random/hl_api_random.py
+++ b/pynest/nest/random/hl_api_random.py
@@ -47,6 +47,11 @@ def uniform(min=0.0, max=1.0):
     -------
     Parameter:
         Object yielding values drawn from the distribution.
+        
+    .. note: 
+    
+       See :ref:`this documentation <random_delays>` for details on the effect
+       of time discretization on delays drawn from a uniform distribution.
     """
     return CreateParameter('uniform', {'min': min, 'max': max})
 


### PR DESCRIPTION
Explain in more detail how delays are discretized when drawn from a uniform distribution.

This fixes #833.