### PR TITLE
Remove padding of extent if not specified when creating free positions

### DIFF
--- a/doc/htmldoc/release_notes/v3.4/index.rst
+++ b/doc/htmldoc/release_notes/v3.4/index.rst
@@ -13,6 +13,10 @@ NEST.
 If you transition from a version earlier than 3.3, please see our
 selection of earlier :ref:`transition guides <release_notes>`.
 
+* Calculation of extent when specifying node positions with ``spatial.free``
+  is changed (see `#2459 <https://github.com/nest/nest-simulator/pull/2459>`_).
+  Furthermore, if creating a single node, extent has to be explicitly specified.
+
 Deprecation information
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/nestkernel/free_layer.h
+++ b/nestkernel/free_layer.h
@@ -236,18 +236,14 @@ FreeLayer< D >::set_status( const DictionaryDatum& d )
 
     const auto positional_extent = max_point - this->lower_left_;
     const auto center = ( max_point + this->lower_left_ ) / 2;
-    Position< D > rounded_center;
     for ( int d = 0; d < D; ++d )
     {
-      // Round to the first decimal.
-      rounded_center[ d ] = ( std::round( 10.0 * center[ d ] ) ) / 10;
-
       // Set extent to be extent of the points, rounded up in each dimension.
       this->extent_[ d ] = std::ceil( positional_extent[ d ] );
     }
 
     // Adjust lower_left relative to the rounded center with the rounded up extent.
-    this->lower_left_ = rounded_center - this->extent_ / 2;
+    this->lower_left_ = center - this->extent_ / 2;
   }
 }
 

--- a/nestkernel/free_layer.h
+++ b/nestkernel/free_layer.h
@@ -115,13 +115,11 @@ FreeLayer< D >::set_status( const DictionaryDatum& d )
   Layer< D >::set_status( d );
 
   Position< D > max_point; // for each dimension, the largest value of the positions, aka upper right
-  Position< D > epsilon;   // small value which may be added to layer size ensuring that single-point layers have a size
 
   for ( int d = 0; d < D; ++d )
   {
     this->lower_left_[ d ] = std::numeric_limits< double >::infinity();
     max_point[ d ] = -std::numeric_limits< double >::infinity();
-    epsilon[ d ] = 0.1;
   }
 
   num_local_nodes_ = std::accumulate( this->node_collection_->begin(),
@@ -234,9 +232,25 @@ FreeLayer< D >::set_status( const DictionaryDatum& d )
   }
   else
   {
-    this->extent_ = max_point - this->lower_left_;
-    this->extent_ += epsilon * 2;
-    this->lower_left_ -= epsilon;
+    if ( this->node_collection_->size() <= 1 )
+    {
+      throw KernelException( "If only one node is created, 'extent' must be specified." );
+    }
+
+    const auto positional_extent = max_point - this->lower_left_;
+    const auto center = ( max_point + this->lower_left_ ) / 2;
+    Position< D > rounded_center;
+    for ( int d = 0; d < D; ++d )
+    {
+      // Round to the first decimal.
+      rounded_center[ d ] = ( std::round( 10.0 * center[ d ] ) ) / 10;
+
+      // Set extent to be extent of the points, rounded up in each dimension.
+      this->extent_[ d ] = std::ceil( positional_extent[ d ] );
+    }
+
+    // Adjust lower_left relative to the rounded center with the rounded up extent.
+    this->lower_left_ = rounded_center - this->extent_ / 2;
   }
 }
 

--- a/nestkernel/free_layer.h
+++ b/nestkernel/free_layer.h
@@ -122,8 +122,11 @@ FreeLayer< D >::set_status( const DictionaryDatum& d )
     max_point[ d ] = -std::numeric_limits< double >::infinity();
   }
 
-  num_local_nodes_ =
-    std::accumulate( this->node_collection_->begin(), this->node_collection_->end(), 0, []( size_t a, NodeIDTriple b ) {
+  num_local_nodes_ = std::accumulate( this->node_collection_->begin(),
+    this->node_collection_->end(),
+    0,
+    []( size_t a, NodeIDTriple b )
+    {
       const auto node = kernel().node_manager.get_mpi_local_node_or_device_head( b.node_id );
       return node->is_proxy() ? a : a + 1;
     } );

--- a/nestkernel/free_layer.h
+++ b/nestkernel/free_layer.h
@@ -122,11 +122,8 @@ FreeLayer< D >::set_status( const DictionaryDatum& d )
     max_point[ d ] = -std::numeric_limits< double >::infinity();
   }
 
-  num_local_nodes_ = std::accumulate( this->node_collection_->begin(),
-    this->node_collection_->end(),
-    0,
-    []( size_t a, NodeIDTriple b )
-    {
+  num_local_nodes_ =
+    std::accumulate( this->node_collection_->begin(), this->node_collection_->end(), 0, []( size_t a, NodeIDTriple b ) {
       const auto node = kernel().node_manager.get_mpi_local_node_or_device_head( b.node_id );
       return node->is_proxy() ? a : a + 1;
     } );

--- a/testsuite/mpitests/ticket-955.sli
+++ b/testsuite/mpitests/ticket-955.sli
@@ -39,6 +39,7 @@ Author: Hans Ekkehard Plesser, 2015-02-03 based on a reproducer by Janne Morén
 {
   <<
     /positions [[0.0 0.0]]
+    /extent [1.0 1.0]
     /elements /iaf_psc_alpha
   >>
   CreateLayer
@@ -46,6 +47,7 @@ Author: Hans Ekkehard Plesser, 2015-02-03 based on a reproducer by Janne Morén
 
   <<   % test 3d layer
     /positions [[0.0 0.0 0.0]]
+    /extent [1.0 1.0 1.0]
     /elements /iaf_psc_alpha
   >>
   CreateLayer
@@ -60,4 +62,3 @@ Author: Hans Ekkehard Plesser, 2015-02-03 based on a reproducer by Janne Morén
 
 }
 distributed_pass_or_die
-

--- a/testsuite/mpitests/topo_mpi_test_free_layer_to_sd_target_driven.sli
+++ b/testsuite/mpitests/topo_mpi_test_free_layer_to_sd_target_driven.sli
@@ -52,6 +52,7 @@ skip_if_not_threaded
   /layer_spec_b
   <<
     /positions [[0.0 0.0]]
+    /extent [1.0 1.0]
     /edge_wrap false
     /elements /spike_recorder
   >> def
@@ -74,4 +75,3 @@ skip_if_not_threaded
 {
   << /connection_type /pairwise_bernoulli_on_source >> test_connection
 } distributed_process_invariant_collect_assert_or_die
-

--- a/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_pairwise_bernoulli_on_source.sli
+++ b/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_pairwise_bernoulli_on_source.sli
@@ -45,6 +45,7 @@ skip_if_not_threaded
   /layer_spec_a
   <<
     /positions [[0.0 0.0]]
+    /extent [1.0 1.0]
     /edge_wrap false
     /elements /poisson_generator
   >> def
@@ -75,4 +76,3 @@ skip_if_not_threaded
 {
   << /connection_type /pairwise_bernoulli_on_source /number_of_connections 10 >> test_connection
 } distributed_process_invariant_collect_assert_or_die
-

--- a/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_pairwise_bernoulli_on_target.sli
+++ b/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_pairwise_bernoulli_on_target.sli
@@ -45,6 +45,7 @@ skip_if_not_threaded
   /layer_spec_a
   <<
     /positions [[0.0 0.0]]
+    /extent [1.0 1.0]
     /edge_wrap false
     /elements /poisson_generator
   >> def
@@ -75,4 +76,3 @@ skip_if_not_threaded
 {
   << /connection_type /pairwise_bernoulli_on_target /number_of_connections 10 >> test_connection
 } distributed_process_invariant_collect_assert_or_die
-

--- a/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_source_driven.sli
+++ b/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_source_driven.sli
@@ -45,6 +45,7 @@ skip_if_not_threaded
   /layer_spec_a
   <<
     /positions [[0.0 0.0]]
+    /extent [1.0 1.0]
     /edge_wrap false
     /elements /poisson_generator
   >> def
@@ -75,4 +76,3 @@ skip_if_not_threaded
 {
   << /connection_type /pairwise_bernoulli_on_target >> test_connection
 } distributed_process_invariant_collect_assert_or_die
-

--- a/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_target_driven.sli
+++ b/testsuite/mpitests/topo_mpi_test_free_pg_to_layer_target_driven.sli
@@ -45,6 +45,7 @@ skip_if_not_threaded
   /layer_spec_a
   <<
     /positions [[0.0 0.0]]
+    /extent [1.0 1.0]
     /edge_wrap false
     /elements /poisson_generator
   >> def
@@ -75,4 +76,3 @@ skip_if_not_threaded
 {
   << /connection_type /pairwise_bernoulli_on_source >> test_connection
 } distributed_process_invariant_collect_assert_or_die
-

--- a/testsuite/pytests/test_spatial/test_connect_sliced.py
+++ b/testsuite/pytests/test_spatial/test_connect_sliced.py
@@ -131,7 +131,10 @@ class ConnectSlicedSpatialTestCase(unittest.TestCase):
         extent_pos = nest.spatial.free(nest.random.uniform(-0.5, 0.5), extent=[5., 2.5])
         for pos in [self.free_pos, self.grid_pos, wrapped_pos, extent_pos]:
             nest.ResetKernel()
-            nodes = nest.Create('iaf_psc_alpha', positions=pos)
+            # Don't specify number of nodes if using grid_pos
+            nodes = (nest.Create('iaf_psc_alpha', positions=pos)
+                     if pos == self.grid_pos else
+                     nest.Create('iaf_psc_alpha', 10, positions=pos))
             for nodes_sliced in nodes:
                 for attr in ['edge_wrap', 'extent']:
                     spatial_attr = nodes.spatial[attr]

--- a/testsuite/pytests/test_spatial/test_connect_sliced.py
+++ b/testsuite/pytests/test_spatial/test_connect_sliced.py
@@ -131,10 +131,11 @@ class ConnectSlicedSpatialTestCase(unittest.TestCase):
         extent_pos = nest.spatial.free(nest.random.uniform(-0.5, 0.5), extent=[5., 2.5])
         for pos in [self.free_pos, self.grid_pos, wrapped_pos, extent_pos]:
             nest.ResetKernel()
-            # Don't specify number of nodes if using grid_pos
-            nodes = (nest.Create('iaf_psc_alpha', positions=pos)
-                     if pos == self.grid_pos else
-                     nest.Create('iaf_psc_alpha', 10, positions=pos))
+            if pos == self.grid_pos:
+                # Don't specify number of nodes if using grid_pos
+                nodes = nest.Create('iaf_psc_alpha', positions=pos)
+            else:
+                nodes = nest.Create('iaf_psc_alpha', 10, positions=pos)
             for nodes_sliced in nodes:
                 for attr in ['edge_wrap', 'extent']:
                     spatial_attr = nodes.spatial[attr]

--- a/testsuite/pytests/test_spatial/test_layerNodeCollection.py
+++ b/testsuite/pytests/test_spatial/test_layerNodeCollection.py
@@ -58,7 +58,9 @@ class TestLayerNodeCollection(unittest.TestCase):
         """Correct extent and center when connecting with mask"""
         nest.SetKernelStatus({'rng_seed': 1234})
         # Allowing up to 5 percent relative difference from expected number of connections,
-        # because of randomness.
+        # because of randomness. With 100 different seeds the standard deviation is 0.007,
+        # with a maximum relative difference of 1.8 percent. Without the fix from #2459 the
+        # relative difference would be 20-30 percent.
         rel_limit = 0.05
         num_nodes = 100
         r = 0.5

--- a/testsuite/pytests/test_spatial/test_layerNodeCollection.py
+++ b/testsuite/pytests/test_spatial/test_layerNodeCollection.py
@@ -76,7 +76,8 @@ class TestLayerNodeCollection(unittest.TestCase):
 
                 nodes = nest.Create('iaf_psc_alpha', num_nodes, positions=free_positions)
                 spatial = nodes.spatial  # Extract spatial information
-                self.assertAlmostEqual(spatial["extent"], tuple([2 * r for _ in range(num_dimensions)]))
+                for value in spatial["extent"]:
+                    self.assertAlmostEqual(value, 2 * r)
 
                 mask_radius = r
                 if num_dimensions == 2:

--- a/testsuite/pytests/test_spatial/test_layerNodeCollection.py
+++ b/testsuite/pytests/test_spatial/test_layerNodeCollection.py
@@ -25,6 +25,7 @@ General tests for layer NodeCollections.
 
 import unittest
 import nest
+import numpy as np
 
 
 class TestLayerNodeCollection(unittest.TestCase):
@@ -52,6 +53,59 @@ class TestLayerNodeCollection(unittest.TestCase):
 
         with self.assertRaises(nest.kernel.NESTError):
             c = layer1 + layer2
+
+    def test_extent_center_mask(self):
+        """Correct extent and center when connecting with mask"""
+        nest.SetKernelStatus({'rng_seed': 1234})
+        # Allowing up to 5 percent relative difference from expected number of connections,
+        # because of randomness.
+        rel_limit = 0.05
+        num_nodes = 100
+        r = 0.5
+        # Iterate over values of lower left and upper right.
+        for ll, ur in ((-3, -1),
+                       (-2, 0),
+                       (-1, 1),
+                       (0, 2),
+                       (1, 3)):
+            nest.ResetKernel()
+            param = nest.random.uniform(ll * r, ur * r)
+            free_positions = nest.spatial.free(param, num_dimensions=2, edge_wrap=True)
+
+            nodes = nest.Create('iaf_psc_alpha', num_nodes, positions=free_positions)
+            spatial = nodes.spatial  # Extract spatial information
+            center_coord = r * (ur + ll) / 2.0  # Expected center coordinate
+            self.assertEqual(spatial["center"], (center_coord, center_coord))
+            self.assertEqual(spatial["extent"], (2 * r, 2 * r))
+
+            mask_radius = r
+            mask = {'circular': {'radius': mask_radius}}
+            area = np.pi * mask_radius**2
+            density = num_nodes / (2 * r)**2
+            expected_conns_per_node = density * area
+            expected_total_conns = expected_conns_per_node * num_nodes
+            print(f'Expecting {expected_total_conns:.0f} connections')
+            nest.Connect(nodes, nodes, {'rule': 'pairwise_bernoulli', 'p': 1.0, 'mask': mask})
+            print(f'Num. connections: {nest.GetKernelStatus("num_connections")}')
+            rel_diff = abs(nest.GetKernelStatus("num_connections") - expected_total_conns) / expected_total_conns
+            self.assertLess(rel_diff, rel_limit)
+
+    def test_extent_center_single(self):
+        """Correct extent and center with single node"""
+        r = 0.5
+        param = nest.random.uniform(-r, r)
+        free_positions = nest.spatial.free(param, num_dimensions=2, edge_wrap=True)
+
+        with self.assertRaises(nest.kernel.NESTError):
+            nest.Create('iaf_psc_alpha', positions=free_positions)
+
+        extent = [2 * r, 2 * r]
+        free_positions_extent = nest.spatial.free(param, edge_wrap=True, extent=extent)
+        nodes = nest.Create('iaf_psc_alpha', positions=free_positions_extent)
+
+        spatial = nodes.spatial  # Extract spatial information
+        self.assertEqual(spatial["center"], spatial["positions"][0])  # Center will be at the position of the only node
+        self.assertEqual(spatial["extent"], tuple(extent))
 
 
 def suite():

--- a/testsuite/pytests/test_spatial/test_spatial_distributions.py
+++ b/testsuite/pytests/test_spatial/test_spatial_distributions.py
@@ -288,7 +288,8 @@ class SpatialTester:
             self._ls = nest.Create('iaf_psc_alpha',
                                    positions=nest.spatial.free(
                                        [[self._x_d, self._y_d]],
-                                       edge_wrap=False))
+                                       edge_wrap=False,
+                                       extent=[1.0, 1.0]))
             self._lt = nest.Create('iaf_psc_alpha',
                                    positions=nest.spatial.free(
                                        pos,

--- a/testsuite/pytests/test_spatial_positions.py
+++ b/testsuite/pytests/test_spatial_positions.py
@@ -41,7 +41,7 @@ def testFreePositions(reset):
 
     positions = [[0.1 * x, 0.0] for x in range(1, 10)]
     nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.free(positions))
-    pre = nest.Create('iaf_psc_alpha', positions=nest.spatial.free([[0.0, 0.0]]))
+    pre = nest.Create('iaf_psc_alpha', positions=nest.spatial.free([[0.0, 0.0]], extent=[1.0, 1.0]))
 
     conns = connect_and_get_connections(pre, nodes)
 

--- a/testsuite/regressiontests/ticket-800.sli
+++ b/testsuite/regressiontests/ticket-800.sli
@@ -182,7 +182,7 @@ def
   /conndict Set
 
   ResetKernel
-  << /elements /iaf_psc_alpha  /positions [ [0. 0. 0.] ] >> CreateLayer
+  << /elements /iaf_psc_alpha  /positions [ [0. 0. 0.] ] /extent [1.0 1.0 1.0] >> CreateLayer
   dup
   conndict ConnectLayers
 } def

--- a/testsuite/unittests/test_ntree_split.sli
+++ b/testsuite/unittests/test_ntree_split.sli
@@ -72,6 +72,7 @@ M_PROGRESS setverbosity
   <<
     /positions [ [ 1.0 0.0 0.0 ] ]
     /elements /iaf_psc_alpha
+    /extent [1.0 1.0 1.0]
     /edge_wrap true
   >>
   CreateLayer /post Set

--- a/testsuite/unittests/test_rows_cols_pos.sli
+++ b/testsuite/unittests/test_rows_cols_pos.sli
@@ -35,7 +35,7 @@
 % correct, positions
 {
   ResetKernel
-  << /positions [[0. 0.]] /elements /iaf_psc_alpha >> CreateLayer
+  << /positions [[0. 0.]] /extent [1.0 1.0] /elements /iaf_psc_alpha >> CreateLayer
 } pass_or_die
 
 % incorrect, shape and positions


### PR DESCRIPTION
Fixes #2359 by removing padding of extent if no extent is specified when creating the positions. Extent is instead rounded up and adjusted to a rounded centre. If only a single node is created, extent must be specified.