### PR TITLE
Correct library information provided to extension modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ foreach ( def ${SIONLIB_DEFINES} )
     set( ALL_CXXFLAGS "${ALL_CXXFLAGS} ${def}" )
 endforeach ()
 
-# libraries required to link extention modules
+# libraries required to link extension modules
 set( MODULE_LINK_LIBS
   "-lnestutil"
   "-lsli"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,10 +276,9 @@ foreach ( def ${SIONLIB_DEFINES} )
     set( ALL_CXXFLAGS "${ALL_CXXFLAGS} ${def}" )
 endforeach ()
 
-# all libraries
-set( ALL_LIBS
+# libraries required to link extention modules
+set( MODULE_LINK_LIBS
   "-lnestutil"
-  "-lnest"
   "-lsli"
   "-lnestkernel"
   "${OpenMP_CXX_FLAGS}"
@@ -293,9 +292,15 @@ set( ALL_LIBS
   "${BOOST_LIBRARIES}" )
 
 if ( with-libraries )
-  set( ALL_LIBS "${ALL_LIBS};${with-libraries}" )
+  set( MODULE_LINK_LIBS "${MODULE_LINK_LIBS};${with-libraries}" )
 endif ()
-string( REPLACE ";" " " ALL_LIBS "${ALL_LIBS}" )
+string( REPLACE ";" " " MODULE_LINK_LIBS "${MODULE_LINK_LIBS}" )
+
+# libraries requied to link NEST
+set( ALL_LIBS
+  "-lnest"
+  ${MODULE_LINK_LIBS} )
+
 
 # all includes
 set( ALL_INCLUDES_tmp

--- a/bin/nest-config.in
+++ b/bin/nest-config.in
@@ -12,7 +12,7 @@ Known values for OPTION are:
 
   --prefix              NEST install prefix for architecture-independent files
   --exec-prefix         NEST install prefix for architecture-dependent files
-  --libs                print library linking information
+  --libs                print library linking information for extension modules
   --cflags              print pre-processor and compiler flags
   --includes            print includes
   --compiler            print the compiler used to compile NEST
@@ -66,7 +66,7 @@ while test $# -gt 0; do
         echo "@ALL_CXXFLAGS@"
         ;;
     --libs)
-        echo "-L$prefix/@CMAKE_INSTALL_LIBDIR@/nest @ALL_LIBS@"
+        echo "-L$prefix/@CMAKE_INSTALL_LIBDIR@/nest @MODULE_LINK_LIBS@"
         ;;
     --compiler)
         echo "@CMAKE_CXX_COMPILER@"


### PR DESCRIPTION
Until now, the library information provided by `nest-config --libs` for extension module building include `-lnest`, i.e., `libnest`. This library only includes `nest_startup.{h,cpp}` and is only needed for the NEST executable or main PyNEST module. It can lead to loading problems when included with extension modules.

This PR ensures that `-lnest` is not returned by `nest-config --libs`.