### PR TITLE
Refactor functions to use `MPI_Allreduce`

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -1073,16 +1073,10 @@ nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer,
   recv_buffer.swap( send_buffer );
 }
 
-double
-nest::MPIManager::min_cross_ranks( double value )
+bool
+nest::MPIManager::equal_cross_ranks( const double )
 {
-  return value;
-}
-
-double
-nest::MPIManager::max_cross_ranks( double value )
-{
-  return value;
+  return true;
 }
 
 void

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -799,21 +799,10 @@ nest::MPIManager::any_true( const bool my_bool )
     return my_bool;
   }
 
-  // since there is no MPI_BOOL we first convert to int
-  int my_int = my_bool;
-
-  std::vector< int > all_int( get_num_processes() );
-  MPI_Allgather( &my_int, 1, MPI_INT, &all_int[ 0 ], 1, MPI_INT, comm );
-  // check if any MPI process sent a "true"
-  for ( unsigned int i = 0; i < all_int.size(); ++i )
-  {
-    if ( all_int[ i ] != 0 )
-    {
-      return true;
-    }
-  }
-
-  return false;
+  const int my_int = my_bool;
+  int global_int;
+  MPI_Allreduce( &my_int, &global_int, 1, MPI_INT, MPI_LOR, comm );
+  return global_int == 1;
 }
 
 // average communication time for a packet size of num_bytes using Allgather

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -719,18 +719,15 @@ nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer,
   MPI_Allreduce( &send_buffer[ 0 ], &recv_buffer[ 0 ], send_buffer.size(), MPI_Type< double >::type, MPI_SUM, comm );
 }
 
-double
-nest::MPIManager::min_cross_ranks( double value )
+bool
+nest::MPIManager::equal_cross_ranks( const double value )
 {
-  MPI_Allreduce( MPI_IN_PLACE, &value, 1, MPI_DOUBLE, MPI_MIN, comm );
-  return value;
-}
-
-double
-nest::MPIManager::max_cross_ranks( double value )
-{
-  MPI_Allreduce( MPI_IN_PLACE, &value, 1, MPI_DOUBLE, MPI_MAX, comm );
-  return value;
+  // Flipping the sign of one argument to check both min and max values.
+  double values[ 2 ];
+  values[ 0 ] = -value;
+  values[ 1 ] = value;
+  MPI_Allreduce( MPI_IN_PLACE, &values, 2, MPI_DOUBLE, MPI_MIN, comm );
+  return values[ 0 ] == -values[ 1 ];
 }
 
 void

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -727,7 +727,7 @@ nest::MPIManager::equal_cross_ranks( const double value )
   values[ 0 ] = -value;
   values[ 1 ] = value;
   MPI_Allreduce( MPI_IN_PLACE, &values, 2, MPI_DOUBLE, MPI_MIN, comm );
-  return values[ 0 ] == -values[ 1 ];
+  return values[ 0 ] == -values[ 1 ] and values[ 1 ] != -std::numeric_limits< double >::infinity();
 }
 
 void

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -161,21 +161,12 @@ public:
   void communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer );
 
   /**
-   * Minimum across all ranks.
+   * Equal across all ranks.
    *
    * @param value value on calling rank
-   * @return minimum value across all ranks
+   * @return true if values across all ranks are equal, false otherwise
    */
-  double min_cross_ranks( double value );
-
-  /**
-   * Maximum across all ranks.
-   *
-   * @param value value on calling rank
-   * @return maximum value across all ranks
-   */
-  double max_cross_ranks( double value );
-
+  bool equal_cross_ranks( const double value );
 
   std::string get_processor_name();
 

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -164,7 +164,8 @@ public:
    * Equal across all ranks.
    *
    * @param value value on calling rank
-   * @return true if values across all ranks are equal, false otherwise
+   * @return true if values across all ranks are equal, false otherwise or if
+   *         any rank passes -inf as value
    */
   bool equal_cross_ranks( const double value );
 

--- a/nestkernel/random_manager.cpp
+++ b/nestkernel/random_manager.cpp
@@ -218,7 +218,7 @@ nest::RandomManager::check_rng_synchrony() const
     // If local values are not equal, flag this in local_min.
     if ( local_min != local_max )
     {
-      local_min = -1;
+      local_min = -std::numeric_limits< double >::infinity();
     }
 
     if ( not kernel().mpi_manager.equal_cross_ranks( local_min ) )

--- a/nestkernel/random_manager.cpp
+++ b/nestkernel/random_manager.cpp
@@ -196,9 +196,7 @@ nest::RandomManager::check_rng_synchrony() const
   for ( auto n = 0; n < NUM_ROUNDS; ++n )
   {
     const auto r = rank_synced_rng_->drand();
-    const auto min = kernel().mpi_manager.min_cross_ranks( r );
-    const auto max = kernel().mpi_manager.max_cross_ranks( r );
-    if ( min != max )
+    if ( not kernel().mpi_manager.equal_cross_ranks( r ) )
     {
       throw KernelException( "Rank-synchronized random number generators are out of sync." );
     }
@@ -217,11 +215,13 @@ nest::RandomManager::check_rng_synchrony() const
       local_max = std::max( r, local_max );
     }
 
-    // Finding the local min and max on each thread and then determining the
-    // global min/max, ensures that all ranks will learn about sync errors.
-    const long min = kernel().mpi_manager.min_cross_ranks( local_min );
-    const long max = kernel().mpi_manager.max_cross_ranks( local_max );
-    if ( min != max )
+    // If local values are not equal, flag this in local_min.
+    if ( local_min != local_max )
+    {
+      local_min = -1;
+    }
+
+    if ( not kernel().mpi_manager.equal_cross_ranks( local_min ) )
     {
       throw KernelException( "Thread-synchronized random number generators are out of sync." );
     }


### PR DESCRIPTION
Fixes #1925 by refactoring `MPIManager::any_true()` and `RandomManager::check_rng_synchrony()` to use `MPI_Allreduce`.