### PR TITLE
Add spike-transmission test to multithreading test

### DIFF
--- a/testsuite/unittests/test_multithreading.sli
+++ b/testsuite/unittests/test_multithreading.sli
@@ -31,6 +31,7 @@ correctly. The following things are tested:
   * Does setting the number of threads to x result in x threads?
   * Does ResetKernel reset the number of threads to 1?
   * Does default node distribution (modulo) work as expected?
+  * Are spikes transmitted between threads as expected?
 
 The data collection over threads is tested in a separate script. See
 SeeAlso key below.
@@ -64,3 +65,26 @@ GetKernelStatus /local_num_threads get 1 eq assert_or_die
 /iaf_psc_alpha 4 Create {
   dup threads mod exch [ /vp ] get eq assert_or_die
 } forall
+
+
+% check if spikes are transmitted between threads
+ResetKernel
+/t_spike 1. def 
+/delay 1. def
+<< /local_num_threads threads >> SetKernelStatus
+/sg /spike_generator << /spike_times [ t_spike ] >> Create def
+/pA /parrot_neuron threads Create def
+/pB /parrot_neuron threads Create def
+/sr /spike_recorder Create def
+
+sg pA /all_to_all << /delay delay >> Connect
+pA pB /all_to_all << /delay delay >> Connect
+pB sr Connect
+
+t_spike delay 3 mul add Simulate
+
+% expectation: each parrot in pA sends one spike to each parrot in pB,
+%              thus in total threads**2 spikes in pB, all at t_spike + 2*delay
+sr /events get /times get cva
+[ threads dup mul ] { ; t_spike delay 2 mul add } Table
+eq assert_or_die


### PR DESCRIPTION
`test_multithreading.sli` until now only tests that thread numbers are set correctly and that nodes are correctly assigned to VPs. This test also checks that spikes are correctly transmitted between nodes on different threads.