### PR TITLE
Fix invalid paths for cross-references in documentation

### DIFF
--- a/doc/htmldoc/developer_space/workflows/development_workflow.rst
+++ b/doc/htmldoc/developer_space/workflows/development_workflow.rst
@@ -140,7 +140,7 @@ In short:
 3. When you are satisfied with your edits, push these changes to your own GitHub fork,
    and open a pull request to notify the development team that you'd like
    to make these changes available at the ``upstream`` repository.
-   The steps for this are documented in the :ref:`pull_request` section.
+   The steps for this are documented in the :ref:`creating-a-pull-request` section.
 
 This suggested workflow helps to keep the source code repository properly
 organized. It also ensures that the history of changes that have been made to

--- a/doc/htmldoc/developer_space/workflows/development_workflow.rst
+++ b/doc/htmldoc/developer_space/workflows/development_workflow.rst
@@ -140,7 +140,7 @@ In short:
 3. When you are satisfied with your edits, push these changes to your own GitHub fork,
    and open a pull request to notify the development team that you'd like
    to make these changes available at the ``upstream`` repository.
-   The steps for this are documented in the :ref:`creating-a-pull-request` section.
+   The steps for this are documented in the :ref:`pull_request` section.
 
 This suggested workflow helps to keep the source code repository properly
 organized. It also ensures that the history of changes that have been made to

--- a/testsuite/pytests/test_regression_issue-1034.py
+++ b/testsuite/pytests/test_regression_issue-1034.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-# Please see `doc/htmldoc/model_details/test_post_trace.ipynb` for a version of this
+# Please see `doc/htmldoc/neurons/model_details/test_post_trace.ipynb` for a version of this
 # test that includes more documentation and plotting.
 
 
@@ -35,7 +35,7 @@ class PostTraceTester:
     with reference values generated in Python.
 
     For more information, please see the Jupyter notebook in
-    `doc/htmldoc/model_details/test_post_trace.ipynb`.
+    `doc/htmldoc/neurons/model_details/test_post_trace.ipynb`.
     '''
 
     def __init__(self, pre_spike_times, post_spike_times, delay, resolution,


### PR DESCRIPTION
There were two wrong paths that I hereby fixed:  
1. In the documentation on the developer workflow page, where there is a link to "Creating a pull request" that is not working.
2. In the regression test 1034.