### PR TITLE
Use the PR base as reference SHA when getting changed files

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -77,7 +77,7 @@ jobs:
       - name: "Find changed files"
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          echo "$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }})" >> $GITHUB_ENV
+          echo "$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.after }})" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
           echo "GITHUB_ENV = $GITHUB_ENV"
           cat $GITHUB_ENV

--- a/testsuite/pytests/test_changing_tic_base.py
+++ b/testsuite/pytests/test_changing_tic_base.py
@@ -47,10 +47,10 @@ class TestChangingTicBase(unittest.TestCase):
         # be the same after a change of those. We therefore exclude
         # them from the checks below.
         ignored_params = {
-          "correlation_detector": ["delta_tau"],
-          "correlomatrix_detector": ["delta_tau"],
-          "correlospinmatrix_detector": ["delta_tau"],
-          "noise_generator":  ["dt"],
+            "correlation_detector": ["delta_tau"],
+            "correlomatrix_detector": ["delta_tau"],
+            "correlospinmatrix_detector": ["delta_tau"],
+            "noise_generator": ["dt"],
         }
 
         # Generate a dictionary of reference values for each model.


### PR DESCRIPTION
The PR base is the commit in master that the branch is built on. Using that as the reference for changed files ensures that the correct files are detected when getting changed files for the static code analysis. Fixes #2471.