### PR TITLE
Update models to accept parameter objects as node parameters

### DIFF
--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 
 // Includes from libnestutil:
+#include "dict_util.h"
 #include "numerics.h"
 
 // Includes from nestkernel:
@@ -224,7 +225,7 @@ nest::glif_cond::Parameters_::get( DictionaryDatum& d ) const
 }
 
 double
-nest::glif_cond::Parameters_::set( const DictionaryDatum& d )
+nest::glif_cond::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -232,7 +233,7 @@ nest::glif_cond::Parameters_::set( const DictionaryDatum& d )
   updateValue< double >( d, names::E_L, E_L_ );
   const double delta_EL = E_L_ - ELold;
 
-  if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
+  if ( updateValueParam< double >( d, names::V_reset, V_reset_, node ) )
   {
     V_reset_ -= E_L_;
   }
@@ -241,7 +242,7 @@ nest::glif_cond::Parameters_::set( const DictionaryDatum& d )
     V_reset_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_th, th_inf_ ) )
+  if ( updateValueParam< double >( d, names::V_th, th_inf_, node ) )
   {
     th_inf_ -= E_L_;
   }
@@ -250,17 +251,17 @@ nest::glif_cond::Parameters_::set( const DictionaryDatum& d )
     th_inf_ -= delta_EL;
   }
 
-  updateValue< double >( d, names::g_m, G_ );
-  updateValue< double >( d, names::C_m, C_m_ );
-  updateValue< double >( d, names::t_ref, t_ref_ );
+  updateValueParam< double >( d, names::g_m, G_, node );
+  updateValueParam< double >( d, names::C_m, C_m_, node );
+  updateValueParam< double >( d, names::t_ref, t_ref_, node );
 
-  updateValue< double >( d, names::th_spike_add, th_spike_add_ );
-  updateValue< double >( d, names::th_spike_decay, th_spike_decay_ );
-  updateValue< double >( d, names::voltage_reset_fraction, voltage_reset_fraction_ );
-  updateValue< double >( d, names::voltage_reset_add, voltage_reset_add_ );
+  updateValueParam< double >( d, names::th_spike_add, th_spike_add_, node );
+  updateValueParam< double >( d, names::th_spike_decay, th_spike_decay_, node );
+  updateValueParam< double >( d, names::voltage_reset_fraction, voltage_reset_fraction_, node );
+  updateValueParam< double >( d, names::voltage_reset_add, voltage_reset_add_, node );
 
-  updateValue< double >( d, names::th_voltage_index, th_voltage_index_ );
-  updateValue< double >( d, names::th_voltage_decay, th_voltage_decay_ );
+  updateValueParam< double >( d, names::th_voltage_index, th_voltage_index_, node );
+  updateValueParam< double >( d, names::th_voltage_decay, th_voltage_decay_, node );
 
   updateValue< std::vector< double > >( d, names::asc_init, asc_init_ );
   updateValue< std::vector< double > >( d, names::asc_decay, asc_decay_ );
@@ -415,9 +416,9 @@ nest::glif_cond::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 }
 
 void
-nest::glif_cond::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
+nest::glif_cond::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL, Node* node )
 {
-  if ( updateValue< double >( d, names::V_m, y_[ V_M ] ) )
+  if ( updateValueParam< double >( d, names::V_m, y_[ V_M ], node ) )
   {
     y_[ V_M ] -= p.E_L_;
   }
@@ -442,12 +443,13 @@ nest::glif_cond::State_::set( const DictionaryDatum& d, const Parameters_& p, do
     }
   }
 
-  if ( updateValue< double >( d, names::threshold_spike, threshold_spike_ ) and not p.has_theta_spike_ )
+  if ( updateValueParam< double >( d, names::threshold_spike, threshold_spike_, node ) and not p.has_theta_spike_ )
   {
     throw BadProperty( "Threshold spike component is not supported or settable in the current model mechanisms." );
   }
 
-  if ( updateValue< double >( d, names::threshold_voltage, threshold_voltage_ ) and not p.has_theta_voltage_ )
+  if ( updateValueParam< double >( d, names::threshold_voltage, threshold_voltage_, node )
+    and not p.has_theta_voltage_ )
   {
     throw BadProperty( "Threshold voltage component is not supported or settable in the current model mechanisms." );
   }

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -277,7 +277,7 @@ private:
     Parameters_();
 
     void get( DictionaryDatum& ) const;
-    double set( const DictionaryDatum& );
+    double set( const DictionaryDatum&, Node* );
   };
 
 
@@ -319,7 +319,7 @@ private:
     State_( const Parameters_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
-    void set( const DictionaryDatum&, const Parameters_&, double );
+    void set( const DictionaryDatum&, const Parameters_&, double, Node* );
   };
 
 
@@ -480,10 +480,10 @@ glif_cond::get_status( DictionaryDatum& d ) const
 inline void
 glif_cond::set_status( const DictionaryDatum& d )
 {
-  Parameters_ ptmp = P_;                 // temporary copy in case of errors
-  const double delta_EL = ptmp.set( d ); // throws if BadProperty
-  State_ stmp = S_;                      // temporary copy in case of errors
-  stmp.set( d, ptmp, delta_EL );         // throws if BadProperty
+  Parameters_ ptmp = P_;                       // temporary copy in case of errors
+  const double delta_EL = ptmp.set( d, this ); // throws if BadProperty
+  State_ stmp = S_;                            // temporary copy in case of errors
+  stmp.set( d, ptmp, delta_EL, this );         // throws if BadProperty
 
   ArchivingNode::set_status( d );
 

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -27,6 +27,7 @@
 #include <limits>
 
 // Includes from libnestutil:
+#include "dict_util.h"
 #include "numerics.h"
 #include "propagator_stability.h"
 
@@ -148,15 +149,15 @@ nest::glif_psc::Parameters_::get( DictionaryDatum& d ) const
 }
 
 double
-nest::glif_psc::Parameters_::set( const DictionaryDatum& d )
+nest::glif_psc::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
   const double ELold = E_L_;
-  updateValue< double >( d, names::E_L, E_L_ );
+  updateValueParam< double >( d, names::E_L, E_L_, node );
   const double delta_EL = E_L_ - ELold;
 
-  if ( updateValue< double >( d, names::V_reset, V_reset_ ) )
+  if ( updateValueParam< double >( d, names::V_reset, V_reset_, node ) )
   {
     V_reset_ -= E_L_;
   }
@@ -165,7 +166,7 @@ nest::glif_psc::Parameters_::set( const DictionaryDatum& d )
     V_reset_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_th, th_inf_ ) )
+  if ( updateValueParam< double >( d, names::V_th, th_inf_, node ) )
   {
     th_inf_ -= E_L_;
   }
@@ -174,17 +175,17 @@ nest::glif_psc::Parameters_::set( const DictionaryDatum& d )
     th_inf_ -= delta_EL;
   }
 
-  updateValue< double >( d, names::g, G_ );
-  updateValue< double >( d, names::C_m, C_m_ );
-  updateValue< double >( d, names::t_ref, t_ref_ );
+  updateValueParam< double >( d, names::g, G_, node );
+  updateValueParam< double >( d, names::C_m, C_m_, node );
+  updateValueParam< double >( d, names::t_ref, t_ref_, node );
 
-  updateValue< double >( d, names::th_spike_add, th_spike_add_ );
-  updateValue< double >( d, names::th_spike_decay, th_spike_decay_ );
-  updateValue< double >( d, names::voltage_reset_fraction, voltage_reset_fraction_ );
-  updateValue< double >( d, names::voltage_reset_add, voltage_reset_add_ );
+  updateValueParam< double >( d, names::th_spike_add, th_spike_add_, node );
+  updateValueParam< double >( d, names::th_spike_decay, th_spike_decay_, node );
+  updateValueParam< double >( d, names::voltage_reset_fraction, voltage_reset_fraction_, node );
+  updateValueParam< double >( d, names::voltage_reset_add, voltage_reset_add_, node );
 
-  updateValue< double >( d, names::th_voltage_index, th_voltage_index_ );
-  updateValue< double >( d, names::th_voltage_decay, th_voltage_decay_ );
+  updateValueParam< double >( d, names::th_voltage_index, th_voltage_index_, node );
+  updateValueParam< double >( d, names::th_voltage_decay, th_voltage_decay_, node );
 
   updateValue< std::vector< double > >( d, names::asc_init, asc_init_ );
   updateValue< std::vector< double > >( d, names::asc_decay, asc_decay_ );
@@ -192,9 +193,9 @@ nest::glif_psc::Parameters_::set( const DictionaryDatum& d )
   updateValue< std::vector< double > >( d, names::asc_r, asc_r_ );
 
   // set model mechanisms
-  updateValue< bool >( d, names::spike_dependent_threshold, has_theta_spike_ );
-  updateValue< bool >( d, names::after_spike_currents, has_asc_ );
-  updateValue< bool >( d, names::adapting_threshold, has_theta_voltage_ );
+  updateValueParam< bool >( d, names::spike_dependent_threshold, has_theta_spike_, node );
+  updateValueParam< bool >( d, names::after_spike_currents, has_asc_, node );
+  updateValueParam< bool >( d, names::adapting_threshold, has_theta_voltage_, node );
 
   // check model mechanisms parameter
   if ( not( ( not has_theta_spike_ and not has_asc_ and not has_theta_voltage_ ) or // glif1
@@ -311,9 +312,9 @@ nest::glif_psc::State_::get( DictionaryDatum& d, const Parameters_& p ) const
 }
 
 void
-nest::glif_psc::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
+nest::glif_psc::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL, Node* node )
 {
-  if ( updateValue< double >( d, names::V_m, U_ ) )
+  if ( updateValueParam< double >( d, names::V_m, U_, node ) )
   {
     U_ -= p.E_L_;
   }
@@ -338,12 +339,13 @@ nest::glif_psc::State_::set( const DictionaryDatum& d, const Parameters_& p, dou
     }
   }
 
-  if ( updateValue< double >( d, names::threshold_spike, threshold_spike_ ) and not p.has_theta_spike_ )
+  if ( updateValueParam< double >( d, names::threshold_spike, threshold_spike_, node ) and not p.has_theta_spike_ )
   {
     throw BadProperty( "Threshold spike component is not supported or settable in the current model mechanisms." );
   }
 
-  if ( updateValue< double >( d, names::threshold_voltage, threshold_voltage_ ) and not p.has_theta_voltage_ )
+  if ( updateValueParam< double >( d, names::threshold_voltage, threshold_voltage_, node )
+    and not p.has_theta_voltage_ )
   {
     throw BadProperty( "Threshold voltage component is not supported or settable in the current model mechanisms." );
   }

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -267,7 +267,7 @@ private:
     Parameters_();
 
     void get( DictionaryDatum& ) const;
-    double set( const DictionaryDatum& );
+    double set( const DictionaryDatum&, Node* );
   };
 
   struct State_
@@ -287,7 +287,7 @@ private:
     State_( const Parameters_& );
 
     void get( DictionaryDatum&, const Parameters_& ) const;
-    void set( const DictionaryDatum&, const Parameters_&, double );
+    void set( const DictionaryDatum&, const Parameters_&, double, Node* );
   };
 
 
@@ -433,10 +433,10 @@ glif_psc::get_status( DictionaryDatum& d ) const
 inline void
 glif_psc::set_status( const DictionaryDatum& d )
 {
-  Parameters_ ptmp = P_;                 // temporary copy in case of errors
-  const double delta_EL = ptmp.set( d ); // throws if BadProperty
-  State_ stmp = S_;                      // temporary copy in case of errors
-  stmp.set( d, ptmp, delta_EL );         // throws if BadProperty
+  Parameters_ ptmp = P_;                       // temporary copy in case of errors
+  const double delta_EL = ptmp.set( d, this ); // throws if BadProperty
+  State_ stmp = S_;                            // temporary copy in case of errors
+  stmp.set( d, ptmp, delta_EL, this );         // throws if BadProperty
 
   ArchivingNode::set_status( d );
 

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -39,6 +39,7 @@
 
 // Includes from libnestutil:
 #include "beta_normalization_factor.h"
+#include "dict_util.h"
 #include "numerics.h"
 
 // Includes from nestkernel:
@@ -249,24 +250,24 @@ nest::hh_cond_beta_gap_traub::Parameters_::get( DictionaryDatum& d ) const
 }
 
 void
-nest::hh_cond_beta_gap_traub::Parameters_::set( const DictionaryDatum& d )
+nest::hh_cond_beta_gap_traub::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-  updateValue< double >( d, names::g_Na, g_Na );
-  updateValue< double >( d, names::g_K, g_K );
-  updateValue< double >( d, names::g_L, g_L );
-  updateValue< double >( d, names::C_m, C_m );
-  updateValue< double >( d, names::E_Na, E_Na );
-  updateValue< double >( d, names::E_K, E_K );
-  updateValue< double >( d, names::E_L, E_L );
-  updateValue< double >( d, names::V_T, V_T );
-  updateValue< double >( d, names::E_ex, E_ex );
-  updateValue< double >( d, names::E_in, E_in );
-  updateValue< double >( d, names::tau_rise_ex, tau_rise_ex );
-  updateValue< double >( d, names::tau_decay_ex, tau_decay_ex );
-  updateValue< double >( d, names::tau_rise_in, tau_rise_in );
-  updateValue< double >( d, names::tau_decay_in, tau_decay_in );
-  updateValue< double >( d, names::t_ref, t_ref_ );
-  updateValue< double >( d, names::I_e, I_e );
+  updateValueParam< double >( d, names::g_Na, g_Na, node );
+  updateValueParam< double >( d, names::g_K, g_K, node );
+  updateValueParam< double >( d, names::g_L, g_L, node );
+  updateValueParam< double >( d, names::C_m, C_m, node );
+  updateValueParam< double >( d, names::E_Na, E_Na, node );
+  updateValueParam< double >( d, names::E_K, E_K, node );
+  updateValueParam< double >( d, names::E_L, E_L, node );
+  updateValueParam< double >( d, names::V_T, V_T, node );
+  updateValueParam< double >( d, names::E_ex, E_ex, node );
+  updateValueParam< double >( d, names::E_in, E_in, node );
+  updateValueParam< double >( d, names::tau_rise_ex, tau_rise_ex, node );
+  updateValueParam< double >( d, names::tau_decay_ex, tau_decay_ex, node );
+  updateValueParam< double >( d, names::tau_rise_in, tau_rise_in, node );
+  updateValueParam< double >( d, names::tau_decay_in, tau_decay_in, node );
+  updateValueParam< double >( d, names::t_ref, t_ref_, node );
+  updateValueParam< double >( d, names::I_e, I_e, node );
 
   if ( C_m <= 0 )
   {
@@ -299,12 +300,12 @@ nest::hh_cond_beta_gap_traub::State_::get( DictionaryDatum& d ) const
 }
 
 void
-nest::hh_cond_beta_gap_traub::State_::set( const DictionaryDatum& d, const Parameters_& )
+nest::hh_cond_beta_gap_traub::State_::set( const DictionaryDatum& d, const Parameters_&, Node* node )
 {
-  updateValue< double >( d, names::V_m, y_[ V_M ] );
-  updateValue< double >( d, names::Act_m, y_[ HH_M ] );
-  updateValue< double >( d, names::Inact_h, y_[ HH_H ] );
-  updateValue< double >( d, names::Act_n, y_[ HH_N ] );
+  updateValueParam< double >( d, names::V_m, y_[ V_M ], node );
+  updateValueParam< double >( d, names::Act_m, y_[ HH_M ], node );
+  updateValueParam< double >( d, names::Inact_h, y_[ HH_H ], node );
+  updateValueParam< double >( d, names::Act_n, y_[ HH_N ], node );
   if ( y_[ HH_M ] < 0 || y_[ HH_H ] < 0 || y_[ HH_N ] < 0 )
   {
     throw BadProperty( "All (in)activation variables must be non-negative." );

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -262,8 +262,8 @@ private:
 
     Parameters_();
 
-    void get( DictionaryDatum& ) const; //!< Store current values in dictionary
-    void set( const DictionaryDatum& ); //!< Set values from dicitonary
+    void get( DictionaryDatum& ) const;        //!< Store current values in dictionary
+    void set( const DictionaryDatum&, Node* ); //!< Set values from dicitonary
   };
 
 public:
@@ -299,7 +299,7 @@ public:
     State_& operator=( const State_& );
 
     void get( DictionaryDatum& ) const;
-    void set( const DictionaryDatum&, const Parameters_& );
+    void set( const DictionaryDatum&, const Parameters_&, Node* );
   };
 
   // Variables class -------------------------------------------------------
@@ -480,10 +480,10 @@ hh_cond_beta_gap_traub::get_status( DictionaryDatum& d ) const
 inline void
 hh_cond_beta_gap_traub::set_status( const DictionaryDatum& d )
 {
-  Parameters_ ptmp = P_; // temporary copy in case of errors
-  ptmp.set( d );         // throws if BadProperty
-  State_ stmp = S_;      // temporary copy in case of errors
-  stmp.set( d, ptmp );   // throws if BadProperty
+  Parameters_ ptmp = P_;     // temporary copy in case of errors
+  ptmp.set( d, this );       // throws if BadProperty
+  State_ stmp = S_;          // temporary copy in case of errors
+  stmp.set( d, ptmp, this ); // throws if BadProperty
 
   // We now know that (ptmp, stmp) are consistent. We do not
   // write them back to (P_, S_) before we are also sure that

--- a/models/iaf_psc_alpha_canon.cpp
+++ b/models/iaf_psc_alpha_canon.cpp
@@ -26,6 +26,7 @@
 #include <limits>
 
 // Includes from libnestutil:
+#include "dict_util.h"
 #include "numerics.h"
 #include "propagator_stability.h"
 
@@ -110,21 +111,21 @@ nest::iaf_psc_alpha_canon::Parameters_::get( DictionaryDatum& d ) const
 }
 
 double
-nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d )
+nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
   const double ELold = E_L_;
-  updateValue< double >( d, names::E_L, E_L_ );
+  updateValueParam< double >( d, names::E_L, E_L_, node );
   const double delta_EL = E_L_ - ELold;
 
-  updateValue< double >( d, names::tau_m, tau_m_ );
-  updateValue< double >( d, names::tau_syn, tau_syn_ );
-  updateValue< double >( d, names::C_m, c_m_ );
-  updateValue< double >( d, names::t_ref, t_ref_ );
-  updateValue< double >( d, names::I_e, I_e_ );
+  updateValueParam< double >( d, names::tau_m, tau_m_, node );
+  updateValueParam< double >( d, names::tau_syn, tau_syn_, node );
+  updateValueParam< double >( d, names::C_m, c_m_, node );
+  updateValueParam< double >( d, names::t_ref, t_ref_, node );
+  updateValueParam< double >( d, names::I_e, I_e_, node );
 
-  if ( updateValue< double >( d, names::V_th, U_th_ ) )
+  if ( updateValueParam< double >( d, names::V_th, U_th_, node ) )
   {
     U_th_ -= E_L_;
   }
@@ -133,7 +134,7 @@ nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d )
     U_th_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_min, U_min_ ) )
+  if ( updateValueParam< double >( d, names::V_min, U_min_, node ) )
   {
     U_min_ -= E_L_;
   }
@@ -142,7 +143,7 @@ nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d )
     U_min_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_reset, U_reset_ ) )
+  if ( updateValueParam< double >( d, names::V_reset, U_reset_, node ) )
   {
     U_reset_ -= E_L_;
   }
@@ -152,7 +153,7 @@ nest::iaf_psc_alpha_canon::Parameters_::set( const DictionaryDatum& d )
   }
 
   long tmp;
-  if ( updateValue< long >( d, names::Interpol_Order, tmp ) )
+  if ( updateValueParam< long >( d, names::Interpol_Order, tmp, node ) )
   {
     if ( NO_INTERPOL <= tmp && tmp < END_INTERP_ORDER )
     {
@@ -200,9 +201,9 @@ nest::iaf_psc_alpha_canon::State_::get( DictionaryDatum& d, const Parameters_& p
 }
 
 void
-nest::iaf_psc_alpha_canon::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
+nest::iaf_psc_alpha_canon::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL, Node* node )
 {
-  if ( updateValue< double >( d, names::V_m, y3_ ) )
+  if ( updateValueParam< double >( d, names::V_m, y3_, node ) )
   {
     y3_ -= p.E_L_;
   }
@@ -211,8 +212,8 @@ nest::iaf_psc_alpha_canon::State_::set( const DictionaryDatum& d, const Paramete
     y3_ -= delta_EL;
   }
 
-  updateValue< double >( d, names::y1, y1_ );
-  updateValue< double >( d, names::y2, y2_ );
+  updateValueParam< double >( d, names::y1, y1_, node );
+  updateValueParam< double >( d, names::y2, y2_, node );
 }
 
 nest::iaf_psc_alpha_canon::Buffers_::Buffers_( iaf_psc_alpha_canon& n )

--- a/models/iaf_psc_alpha_canon.h
+++ b/models/iaf_psc_alpha_canon.h
@@ -351,7 +351,7 @@ private:
     /** Set values from dictionary.
      * @returns Change in reversal potential E_L, to be passed to State_::set()
      */
-    double set( const DictionaryDatum& );
+    double set( const DictionaryDatum&, Node* );
   };
 
   // ----------------------------------------------------------------
@@ -378,7 +378,7 @@ private:
      * @param current parameters
      * @param Change in reversal potential E_L specified by this dict
      */
-    void set( const DictionaryDatum&, const Parameters_&, double );
+    void set( const DictionaryDatum&, const Parameters_&, double, Node* );
   };
 
   // ----------------------------------------------------------------
@@ -517,10 +517,10 @@ iaf_psc_alpha_canon::get_status( DictionaryDatum& d ) const
 inline void
 iaf_psc_alpha_canon::set_status( const DictionaryDatum& d )
 {
-  Parameters_ ptmp = P_;                 // temporary copy in case of errors
-  const double delta_EL = ptmp.set( d ); // throws if BadProperty
-  State_ stmp = S_;                      // temporary copy in case of errors
-  stmp.set( d, ptmp, delta_EL );         // throws if BadProperty
+  Parameters_ ptmp = P_;                       // temporary copy in case of errors
+  const double delta_EL = ptmp.set( d, this ); // throws if BadProperty
+  State_ stmp = S_;                            // temporary copy in case of errors
+  stmp.set( d, ptmp, delta_EL, this );         // throws if BadProperty
 
   // We now know that (ptmp, stmp) are consistent. We do not
   // write them back to (P_, S_) before we are also sure that

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -26,6 +26,7 @@
 #include <limits>
 
 // Includes from libnestutil:
+#include "dict_util.h"
 #include "numerics.h"
 #include "propagator_stability.h"
 #include "regula_falsi.h"
@@ -115,22 +116,22 @@ nest::iaf_psc_alpha_ps::Parameters_::get( DictionaryDatum& d ) const
 }
 
 double
-nest::iaf_psc_alpha_ps::Parameters_::set( const DictionaryDatum& d )
+nest::iaf_psc_alpha_ps::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
   const double ELold = E_L_;
-  updateValue< double >( d, names::E_L, E_L_ );
+  updateValueParam< double >( d, names::E_L, E_L_, node );
   const double delta_EL = E_L_ - ELold;
 
-  updateValue< double >( d, names::tau_m, tau_m_ );
-  updateValue< double >( d, names::tau_syn_ex, tau_syn_ex_ );
-  updateValue< double >( d, names::tau_syn_in, tau_syn_in_ );
-  updateValue< double >( d, names::C_m, c_m_ );
-  updateValue< double >( d, names::t_ref, t_ref_ );
-  updateValue< double >( d, names::I_e, I_e_ );
+  updateValueParam< double >( d, names::tau_m, tau_m_, node );
+  updateValueParam< double >( d, names::tau_syn_ex, tau_syn_ex_, node );
+  updateValueParam< double >( d, names::tau_syn_in, tau_syn_in_, node );
+  updateValueParam< double >( d, names::C_m, c_m_, node );
+  updateValueParam< double >( d, names::t_ref, t_ref_, node );
+  updateValueParam< double >( d, names::I_e, I_e_, node );
 
-  if ( updateValue< double >( d, names::V_th, U_th_ ) )
+  if ( updateValueParam< double >( d, names::V_th, U_th_, node ) )
   {
     U_th_ -= E_L_;
   }
@@ -139,7 +140,7 @@ nest::iaf_psc_alpha_ps::Parameters_::set( const DictionaryDatum& d )
     U_th_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_min, U_min_ ) )
+  if ( updateValueParam< double >( d, names::V_min, U_min_, node ) )
   {
     U_min_ -= E_L_;
   }
@@ -148,7 +149,7 @@ nest::iaf_psc_alpha_ps::Parameters_::set( const DictionaryDatum& d )
     U_min_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_reset, U_reset_ ) )
+  if ( updateValueParam< double >( d, names::V_reset, U_reset_, node ) )
   {
     U_reset_ -= E_L_;
   }
@@ -197,9 +198,9 @@ nest::iaf_psc_alpha_ps::State_::get( DictionaryDatum& d, const Parameters_& p ) 
 }
 
 void
-nest::iaf_psc_alpha_ps::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
+nest::iaf_psc_alpha_ps::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL, Node* node )
 {
-  if ( updateValue< double >( d, names::V_m, V_m_ ) )
+  if ( updateValueParam< double >( d, names::V_m, V_m_, node ) )
   {
     V_m_ -= p.E_L_;
   }

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -317,7 +317,7 @@ private:
     /** Set values from dictionary.
      * @returns Change in reversal potential E_L, to be passed to State_::set()
      */
-    double set( const DictionaryDatum& );
+    double set( const DictionaryDatum&, Node* );
   };
 
   // ----------------------------------------------------------------
@@ -346,7 +346,7 @@ private:
      * @param current parameters
      * @param Change in reversal potential E_L specified by this dict
      */
-    void set( const DictionaryDatum&, const Parameters_&, double );
+    void set( const DictionaryDatum&, const Parameters_&, double, Node* );
   };
 
   // ----------------------------------------------------------------
@@ -504,10 +504,10 @@ iaf_psc_alpha_ps::get_status( DictionaryDatum& d ) const
 inline void
 iaf_psc_alpha_ps::set_status( const DictionaryDatum& d )
 {
-  Parameters_ ptmp = P_;                 // temporary copy in case of errors
-  const double delta_EL = ptmp.set( d ); // throws if BadProperty
-  State_ stmp = S_;                      // temporary copy in case of errors
-  stmp.set( d, ptmp, delta_EL );         // throws if BadProperty
+  Parameters_ ptmp = P_;                       // temporary copy in case of errors
+  const double delta_EL = ptmp.set( d, this ); // throws if BadProperty
+  State_ stmp = S_;                            // temporary copy in case of errors
+  stmp.set( d, ptmp, delta_EL, this );         // throws if BadProperty
 
   // We now know that (ptmp, stmp) are consistent. We do not
   // write them back to (P_, S_) before we are also sure that

--- a/models/iaf_psc_delta_ps.cpp
+++ b/models/iaf_psc_delta_ps.cpp
@@ -29,6 +29,7 @@
 #include <limits>
 
 // Includes from libnestutil:
+#include "dict_util.h"
 #include "numerics.h"
 
 // Includes from nestkernel:
@@ -106,20 +107,20 @@ nest::iaf_psc_delta_ps::Parameters_::get( DictionaryDatum& d ) const
 }
 
 double
-nest::iaf_psc_delta_ps::Parameters_::set( const DictionaryDatum& d )
+nest::iaf_psc_delta_ps::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
   const double ELold = E_L_;
-  updateValue< double >( d, names::E_L, E_L_ );
+  updateValueParam< double >( d, names::E_L, E_L_, node );
   const double delta_EL = E_L_ - ELold;
 
-  updateValue< double >( d, names::tau_m, tau_m_ );
-  updateValue< double >( d, names::C_m, c_m_ );
-  updateValue< double >( d, names::t_ref, t_ref_ );
-  updateValue< double >( d, names::I_e, I_e_ );
+  updateValueParam< double >( d, names::tau_m, tau_m_, node );
+  updateValueParam< double >( d, names::C_m, c_m_, node );
+  updateValueParam< double >( d, names::t_ref, t_ref_, node );
+  updateValueParam< double >( d, names::I_e, I_e_, node );
 
-  if ( updateValue< double >( d, names::V_th, U_th_ ) )
+  if ( updateValueParam< double >( d, names::V_th, U_th_, node ) )
   {
     U_th_ -= E_L_;
   }
@@ -128,7 +129,7 @@ nest::iaf_psc_delta_ps::Parameters_::set( const DictionaryDatum& d )
     U_th_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_min, U_min_ ) )
+  if ( updateValueParam< double >( d, names::V_min, U_min_, node ) )
   {
     U_min_ -= E_L_;
   }
@@ -137,7 +138,7 @@ nest::iaf_psc_delta_ps::Parameters_::set( const DictionaryDatum& d )
     U_min_ -= delta_EL;
   }
 
-  if ( updateValue< double >( d, names::V_reset, U_reset_ ) )
+  if ( updateValueParam< double >( d, names::V_reset, U_reset_, node ) )
   {
     U_reset_ -= E_L_;
   }
@@ -179,9 +180,9 @@ nest::iaf_psc_delta_ps::State_::get( DictionaryDatum& d, const Parameters_& p ) 
 }
 
 void
-nest::iaf_psc_delta_ps::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL )
+nest::iaf_psc_delta_ps::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL, Node* node )
 {
-  if ( updateValue< double >( d, names::V_m, U_ ) )
+  if ( updateValueParam< double >( d, names::V_m, U_, node ) )
   {
     U_ -= p.E_L_;
   }

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -282,7 +282,7 @@ private:
     /** Set values from dictionary.
      * @returns Change in reversal potential E_L, to be passed to State_::set()
      */
-    double set( const DictionaryDatum& );
+    double set( const DictionaryDatum&, Node* );
   };
 
 
@@ -319,7 +319,7 @@ private:
      * @param current parameters
      * @param Change in reversal potential E_L specified by this dict
      */
-    void set( const DictionaryDatum&, const Parameters_&, double );
+    void set( const DictionaryDatum&, const Parameters_&, double, Node* );
   };
 
   // ----------------------------------------------------------------
@@ -449,10 +449,10 @@ iaf_psc_delta_ps::get_status( DictionaryDatum& d ) const
 inline void
 iaf_psc_delta_ps::set_status( const DictionaryDatum& d )
 {
-  Parameters_ ptmp = P_;                 // temporary copy in case of errors
-  const double delta_EL = ptmp.set( d ); // throws if BadProperty
-  State_ stmp = S_;                      // temporary copy in case of errors
-  stmp.set( d, ptmp, delta_EL );         // throws if BadProperty
+  Parameters_ ptmp = P_;                       // temporary copy in case of errors
+  const double delta_EL = ptmp.set( d, this ); // throws if BadProperty
+  State_ stmp = S_;                            // temporary copy in case of errors
+  stmp.set( d, ptmp, delta_EL, this );         // throws if BadProperty
 
   // We now know that (ptmp, stmp) are consistent. We do not
   // write them back to (P_, S_) before we are also sure that

--- a/testsuite/pytests/test_nodeParametrization.py
+++ b/testsuite/pytests/test_nodeParametrization.py
@@ -26,6 +26,7 @@ Node Parametrization tests
 import nest
 import numpy as np
 import unittest
+import warnings
 
 
 class TestNodeParametrization(unittest.TestCase):
@@ -697,6 +698,31 @@ class TestNodeParametrization(unittest.TestCase):
         # Spatial nc with a single node_id, and list of positions
         distance_reference = tuple(np.sqrt(position_array[:, 0]**2 + position_array[:, 1]**2))
         self.assertAlmostEqual(distance_reference, nest.spatial.distance.apply(layer[0], positions))
+
+    def test_set_vm(self):
+        nest.set_verbosity('M_FATAL')
+        warnings.simplefilter('ignore')  # Suppress warnings
+        failing_models = []
+        for m in nest.node_models:
+            n = nest.Create(m)
+            try:
+                n.get('V_m')
+            except KeyError:
+                continue
+
+            try:
+                n.V_m = 0.5
+            except nest.NESTError:
+                failing_models.append(m)
+                print(f'Constant Failed: {m}')
+
+            try:
+                n.V_m = nest.random.uniform(0., 1.)
+            except nest.NESTError:
+                failing_models.append(m)
+                print(f'Random Failed : {m}')
+
+        self.assertEqual(failing_models, [])
 
 
 def suite():


### PR DESCRIPTION
Some models were not updated to take parameter objects when setting parameters such as `V_m`. With this PR they are updated, and a test of setting `V_m` for all relevant node models is added. Fixes #2480.