### PR TITLE
Ensure that test_get_set.py works also in without threading

### DIFF
--- a/testsuite/pytests/test_get_set.py
+++ b/testsuite/pytests/test_get_set.py
@@ -72,16 +72,21 @@ class TestNestGetSet(unittest.TestCase):
         Test the `nest` module's `.set` function, `KernelAttribute` assignment and errors
         on unknown attribute assignment.
         """
+
+        # Test setting one existing kernel parameter as an exemplary for all
+        # (we just want to test the Python interface, not the setting mechanism itself)
+        nest.set(rng_seed=12345)
+        self.assertEqual(nest.rng_seed, 12345, 'nest.set() failed')
+        nest.rng_seed = 345678
+        self.assertEqual(nest.rng_seed, 345678, 'Setting kernel attribute failed')
+
         # Setting the value of unknown attributes should error. Prevents user errors.
         with self.assertRaises(AttributeError, msg="arbitrary attribute assignment passed"):
             nest.absolutelyUnknownThingOnNestModule = 5
+
         # Don't allow non-KA to be replaced on the module.
         with self.assertRaises(AttributeError, msg="known attribute assignment passed"):
             nest.get = 5
-        nest.set(total_num_virtual_procs=2)
-        self.assertEqual(2, nest.total_num_virtual_procs, 'set failed')
-        nest.total_num_virtual_procs = 3
-        self.assertEqual(3, nest.total_num_virtual_procs, 'kernelattribute set failed')
 
 
 @nest.ll_api.check_stack


### PR DESCRIPTION
`test_get_set.py` currently changes `total_num_virtual_procs` to check if the Python interface for setting kernel parameters works. This fails necessarily if NEST is compiled without threads. This problem does not show up in our CI testing, because we never run a no threads+PyNEST configuration.

This PR changes the test to set `rng_seed` instead, so it will work under all configurations. I also moved that part of the test to the front, since that order fits better with the description of the test.