### PR TITLE
Improved clarity of `Dwith-python` error

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -415,7 +415,7 @@ function( NEST_PROCESS_WITH_PYTHON )
     endif ()
   elseif ( ${with-python} STREQUAL "OFF" )
   else ()
-    printError( "Invalid option: -Dwith-python=" ${with-python} )
+    printError( "Invalid value -Dwith-python=${with-python}, please use 'ON' or 'OFF'" )
   endif ()
 endfunction()
 


### PR DESCRIPTION
The legacy forms of `Dwith-python=2/3` still circulate. If a user now specifies `-Dwith-python=3` they are met with the message `Invalid option: -Dwith-python=3`. This message implies that the option `-Dwith-python` is invalid and unrecognized by CMake. I changed the error message to clarify that the option is valid, but the given value is invalid, and `ON` or `OFF` should be given instead.