### PR TITLE
Allow to disconnect with `SynapseCollection`s as arguments

### DIFF
--- a/doc/htmldoc/whats_new/v3.4/index.rst
+++ b/doc/htmldoc/whats_new/v3.4/index.rst
@@ -18,8 +18,8 @@ Documentation restructuring and new theme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 NEST documentation has a new theme! We did a major overhaul of the layout and structure of the documentation.
-The changes aim to improve findability and access of content. With a more modern 
-layout, our wide range of docs can be discovered more easily. 
+The changes aim to improve findability and access of content. With a more modern
+layout, our wide range of docs can be discovered more easily.
 The table of contents is simplified and the content is grouped based on topic (neurons, synapses etc)
 rather than type of documentation (e.g., 'guides').
 
@@ -31,13 +31,21 @@ Inferred extent of spatial layers with freely placed neurons
 ............................................................
 
 Spatial layers can be created by specifying only the node positions using ``spatial.free``,
-without explicitly specifying the ``extent``. 
+without explicitly specifying the ``extent``.
 In that case, in NEST 3.4 and later, the ``extent`` will be determined by the position of the
 lower-leftmost and upper-rightmost nodes in the layer; earlier versions of NEST added a hard-coded
 padding to the extent. The ``center`` is computed as the midpoint between the lower-leftmost and
 upper-rightmost nodes.
 
 When creating a layer with only a single node, the ``extent`` has to be specified explicitly.
+
+
+Disconnect with ``SynapseCollection``
+.....................................
+
+It is now possible to disconnect using a ``SynapseCollection``, which removes only the connections
+obtained by calling ``GetConnections()``. The ``SynapseCollection`` can either be passed to
+``nest.disconnect()``, or one may call the member function ``disconnect()`` of the ``SynapseCollection``.
 
 
 Deprecation information

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -213,6 +213,18 @@ get_connections( const DictionaryDatum& dict )
 }
 
 void
+disconnect( const ArrayDatum& conns )
+{
+  for ( size_t conn_index = 0; conn_index < conns.size(); ++conn_index )
+  {
+    const auto conn_datum = getValue< ConnectionDatum >( conns.get( conn_index ) );
+    const auto target_node = kernel().node_manager.get_node_or_proxy( conn_datum.get_target_node_id() );
+    kernel().sp_manager.disconnect(
+      conn_datum.get_source_node_id(), target_node, conn_datum.get_target_thread(), conn_datum.get_synapse_model_id() );
+  }
+}
+
+void
 simulate( const double& t )
 {
   prepare();

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -143,6 +143,8 @@ void connect_arrays( long* sources,
 
 ArrayDatum get_connections( const DictionaryDatum& dict );
 
+void disconnect( const ArrayDatum& conns );
+
 void simulate( const double& t );
 
 /**

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -897,6 +897,26 @@ NestModule::Disconnect_g_g_D_DFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 }
 
+// Disconnect for arraydatum
+void
+NestModule::Disconnect_aFunction::execute( SLIInterpreter* i ) const
+{
+  i->assert_stack_load( 1 );
+
+  const ArrayDatum conns = getValue< ArrayDatum >( i->OStack.pick( 0 ) );
+
+  for ( size_t conn_index = 0; conn_index < conns.size(); ++conn_index )
+  {
+    const ConnectionDatum conn_datum = getValue< ConnectionDatum >( conns.get( conn_index ) );
+    const auto target_node = kernel().node_manager.get_node_or_proxy( conn_datum.get_target_node_id() );
+    kernel().sp_manager.disconnect(
+      conn_datum.get_source_node_id(), target_node, conn_datum.get_target_thread(), conn_datum.get_synapse_model_id() );
+  }
+
+  i->OStack.pop( 1 );
+  i->EStack.pop();
+}
+
 // Connect for nodecollection nodecollection conn_spec syn_spec
 // See lib/sli/nest-init.sli for details
 void
@@ -3014,6 +3034,7 @@ NestModule::init( SLIInterpreter* i )
   i->createcommand( "EnableStructuralPlasticity", &enablestructuralplasticity_function );
   i->createcommand( "DisableStructuralPlasticity", &disablestructuralplasticity_function );
   i->createcommand( "Disconnect_g_g_D_D", &disconnect_g_g_D_Dfunction );
+  i->createcommand( "Disconnect_a", &disconnect_afunction );
 
   i->createcommand( "SetStdpEps", &setstdpeps_dfunction );
 

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -905,13 +905,7 @@ NestModule::Disconnect_aFunction::execute( SLIInterpreter* i ) const
 
   const ArrayDatum conns = getValue< ArrayDatum >( i->OStack.pick( 0 ) );
 
-  for ( size_t conn_index = 0; conn_index < conns.size(); ++conn_index )
-  {
-    const ConnectionDatum conn_datum = getValue< ConnectionDatum >( conns.get( conn_index ) );
-    const auto target_node = kernel().node_manager.get_node_or_proxy( conn_datum.get_target_node_id() );
-    kernel().sp_manager.disconnect(
-      conn_datum.get_source_node_id(), target_node, conn_datum.get_target_thread(), conn_datum.get_synapse_model_id() );
-  }
+  disconnect( conns );
 
   i->OStack.pop( 1 );
   i->EStack.pop();

--- a/nestkernel/nestmodule.h
+++ b/nestkernel/nestmodule.h
@@ -329,6 +329,12 @@ public:
     void execute( SLIInterpreter* ) const;
   } disconnect_g_g_D_Dfunction;
 
+  class Disconnect_aFunction : public SLIFunction
+  {
+  public:
+    void execute( SLIInterpreter* ) const;
+  } disconnect_afunction;
+
   class Connect_g_g_D_DFunction : public SLIFunction
   {
   public:

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -291,23 +291,21 @@ def Connect(pre, post, conn_spec=None, syn_spec=None,
 
 
 @check_stack
-def Disconnect(pre, post, conn_spec='one_to_one', syn_spec='static_synapse'):
-    """Disconnect `pre` neurons from `post` neurons.
+def Disconnect(*args, conn_spec=None, syn_spec=None):
+    """Disconnect connections in a SynnapseCollection, or `pre` neurons from `post` neurons.
 
-    Neurons in `pre` and `post` are disconnected using the specified disconnection
+    When specifying `pre` and `post` nodes, they are disconnected using the specified disconnection
     rule (one-to-one by default) and synapse type (:cpp:class:`static_synapse <nest::static_synapse>` by default).
     Details depend on the disconnection rule.
 
     Parameters
     ----------
-    pre : NodeCollection
-        Presynaptic nodes, given as `NodeCollection`
-    post : NodeCollection
-        Postsynaptic nodes, given as `NodeCollection`
+    args : SynapseCollection or NodeCollections
+        Either a collection of connections to disconnect, or pre- and postsynaptic nodes, given as `NodeCollection`s
     conn_spec : str or dict
-        Disconnection rule, see below
+        Disconnection rule when specifying pre- and postsynaptic nodes, see below
     syn_spec : str or dict
-        Synapse specifications, see below
+        Synapse specifications when specifying pre- and postsynaptic nodes, see below
 
     Notes
     -------

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -301,7 +301,7 @@ def Disconnect(*args, conn_spec=None, syn_spec=None):
     Parameters
     ----------
     args : SynapseCollection or NodeCollections
-        Either a collection of connections to disconnect, or pre- and postsynaptic nodes, given as `NodeCollection`s
+        Either a collection of connections to disconnect, or pre- and postsynaptic nodes given as `NodeCollection`s
     conn_spec : str or dict
         Disconnection rule when specifying pre- and postsynaptic nodes, see below
     syn_spec : str or dict

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -354,15 +354,28 @@ def Disconnect(pre, post, conn_spec='one_to_one', syn_spec='static_synapse'):
 
     """
 
-    sps(pre)
-    sps(post)
-
-    if is_string(conn_spec):
-        conn_spec = {'rule': conn_spec}
-    if is_string(syn_spec):
-        syn_spec = {'synapse_model': syn_spec}
-
-    sps(conn_spec)
-    sps(syn_spec)
-
-    sr('Disconnect_g_g_D_D')
+    if len(args) == 1:
+        synapsecollection = args[0]
+        if not isinstance(synapsecollection, SynapseCollection):
+            raise TypeError('Arguments must be either a SynapseCollection or two NodeCollections')
+        if conn_spec is not None or syn_spec is not None:
+            raise ValueError('When disconnecting with a SynapseCollection, conn_spec and syn_spec cannot be specified')
+        synapsecollection.disconnect()
+    elif len(args) == 2:
+        # Fill default values
+        conn_spec = 'one_to_one' if conn_spec is None else conn_spec
+        syn_spec = 'static_synapse' if syn_spec is None else syn_spec
+        if is_string(conn_spec):
+            conn_spec = {'rule': conn_spec}
+        if is_string(syn_spec):
+            syn_spec = {'synapse_model': syn_spec}
+        pre, post = args
+        if not isinstance(pre, NodeCollection) or not isinstance(post, NodeCollection):
+            raise TypeError('Arguments must be either a SynapseCollection or two NodeCollections')
+        sps(pre)
+        sps(post)
+        sps(conn_spec)
+        sps(syn_spec)
+        sr('Disconnect_g_g_D_D')
+    else:
+        raise TypeError('Arguments must be either a SynapseCollection or two NodeCollections')

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -899,6 +899,13 @@ class SynapseCollection:
         sr('2 arraystore')
         sr('Transpose { arrayload pop SetStatus } forall')
 
+    def disconnect(self):
+        """
+        Disconnect the connections in the `SynapseCollection`.
+        """
+        sps(self._datum)
+        sr('Disconnect_a')
+
 
 class CollocatedSynapses:
     """

--- a/testsuite/pytests/test_sp/test_disconnect_multiple.py
+++ b/testsuite/pytests/test_sp/test_disconnect_multiple.py
@@ -93,8 +93,8 @@ class TestDisconnect(unittest.TestCase):
                 nest.Disconnect(
                     src_neurons,
                     tgt_neurons,
-                    conndictionary,
-                    syndictionary
+                    conn_spec=conndictionary,
+                    syn_spec=syndictionary
                 )
                 status = nest.GetStatus(neurons, 'synaptic_elements')
                 for st_neuron in status[0:5]:
@@ -146,8 +146,8 @@ class TestDisconnect(unittest.TestCase):
                 nest.Disconnect(
                     src_neurons,
                     tgt_neurons,
-                    conndictionary,
-                    syndictionary
+                    conn_spec=conndictionary,
+                    syn_spec=syndictionary
                 )
                 status = nest.GetStatus(neurons, 'synaptic_elements')
                 for st_neuron in status[0:5]:
@@ -178,8 +178,8 @@ class TestDisconnect(unittest.TestCase):
                 nest.Disconnect(
                     src_neurons,
                     tgt_neurons,
-                    conndictionary,
-                    syndictionary
+                    conn_spec=conndictionary,
+                    syn_spec=syndictionary
                 )
 
                 conns = nest.GetConnections(src_neurons, tgt_neurons,
@@ -248,7 +248,7 @@ class TestDisconnect(unittest.TestCase):
 
         self.assertEqual(nest.num_connections, 25)
 
-        nest.Disconnect(nodes, nodes, 'all_to_all')
+        nest.Disconnect(nodes, nodes, conn_spec='all_to_all')
 
         self.assertEqual(nest.num_connections, 0)
 


### PR DESCRIPTION
Makes it possible to disconnect using a `SynapseCollection`. 

Example:
```python
nodes_a = nest.Create('iaf_psc_alpha', 10)
nodes_b = nest.Create('iaf_psc_exp', 5)
nest.Connect(nodes_a, nodes_a)
nest.Connect(nodes_a, nodes_b)

conns = nest.GetConnections(source=nodes_a, target=nodes_a)

# Only connections gathered from GetConnections() are disconnected.
nest.Disconnect(conns)  
# Alternatively:
conns.disconnect()
```

Fixes #1457.