### PR TITLE
Modernizing the codebase - checking for nullptr

### DIFF
--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -385,7 +385,7 @@ nest::aeif_cond_alpha::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -394,7 +394,7 @@ nest::aeif_cond_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -403,7 +403,7 @@ nest::aeif_cond_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -385,7 +385,7 @@ nest::aeif_cond_alpha::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -394,7 +394,7 @@ nest::aeif_cond_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -403,7 +403,7 @@ nest::aeif_cond_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -415,7 +415,7 @@ aeif_cond_alpha_multisynapse::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -415,7 +415,7 @@ aeif_cond_alpha_multisynapse::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -464,14 +464,14 @@ aeif_cond_alpha_multisynapse::pre_run_hook()
     State_::NUMBER_OF_FIXED_STATES_ELEMENTS + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * P_.n_receptors() ), 0.0 );
 
   // reallocate instance of stepping function for ODE GSL solver
-  if ( B_.s_ != nullptr )
+  if ( B_.s_ )
   {
     gsl_odeiv_step_free( B_.s_ );
   }
   B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, S_.y_.size() );
 
   // reallocate instance of evolution function for ODE GSL solver
-  if ( B_.e_ != nullptr )
+  if ( B_.e_ )
   {
     gsl_odeiv_evolve_free( B_.e_ );
   }

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -473,14 +473,14 @@ aeif_cond_beta_multisynapse::pre_run_hook()
     State_::NUMBER_OF_FIXED_STATES_ELEMENTS + ( State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * P_.n_receptors() ), 0.0 );
 
   // reallocate instance of stepping function for ODE GSL solver
-  if ( B_.s_ != nullptr )
+  if ( B_.s_ )
   {
     gsl_odeiv_step_free( B_.s_ );
   }
   B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, S_.y_.size() );
 
   // reallocate instance of evolution function for ODE GSL solver
-  if ( B_.e_ != nullptr )
+  if ( B_.e_ )
   {
     gsl_odeiv_evolve_free( B_.e_ );
   }

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -423,7 +423,7 @@ aeif_cond_beta_multisynapse::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -423,7 +423,7 @@ aeif_cond_beta_multisynapse::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -380,7 +380,7 @@ nest::aeif_cond_exp::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -389,7 +389,7 @@ nest::aeif_cond_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -398,7 +398,7 @@ nest::aeif_cond_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -380,7 +380,7 @@ nest::aeif_cond_exp::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -389,7 +389,7 @@ nest::aeif_cond_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -398,7 +398,7 @@ nest::aeif_cond_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -375,7 +375,7 @@ nest::aeif_psc_alpha::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -384,7 +384,7 @@ nest::aeif_psc_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -393,7 +393,7 @@ nest::aeif_psc_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -375,7 +375,7 @@ nest::aeif_psc_alpha::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -384,7 +384,7 @@ nest::aeif_psc_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -393,7 +393,7 @@ nest::aeif_psc_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -352,7 +352,7 @@ nest::aeif_psc_delta::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -360,7 +360,7 @@ nest::aeif_psc_delta::init_buffers_()
   {
     gsl_odeiv_step_reset( B_.s_ );
   }
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -369,7 +369,7 @@ nest::aeif_psc_delta::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -352,7 +352,7 @@ nest::aeif_psc_delta::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -360,7 +360,7 @@ nest::aeif_psc_delta::init_buffers_()
   {
     gsl_odeiv_step_reset( B_.s_ );
   }
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -369,7 +369,7 @@ nest::aeif_psc_delta::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -418,7 +418,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -426,7 +426,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
   {
     gsl_odeiv_step_reset( B_.s_ );
   }
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -435,7 +435,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -418,7 +418,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -426,7 +426,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
   {
     gsl_odeiv_step_reset( B_.s_ );
   }
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -435,7 +435,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -370,7 +370,7 @@ nest::aeif_psc_exp::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -379,7 +379,7 @@ nest::aeif_psc_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -388,7 +388,7 @@ nest::aeif_psc_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -370,7 +370,7 @@ nest::aeif_psc_exp::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -379,7 +379,7 @@ nest::aeif_psc_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_yp_new( P_.gsl_error_tol, P_.gsl_error_tol );
   }
@@ -388,7 +388,7 @@ nest::aeif_psc_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, P_.gsl_error_tol, 0.0, 1.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -125,7 +125,7 @@ nest::cm_default::set_status( const DictionaryDatum& statusdict )
     ArrayDatum* ad = dynamic_cast< ArrayDatum* >( dat );
     DictionaryDatum* dd = dynamic_cast< DictionaryDatum* >( dat );
 
-    if ( ad != nullptr )
+    if ( ad )
     {
       // A list of compartments is provided, we add them all to the tree
       for ( Token* tt = ( *ad ).begin(); tt != ( *ad ).end(); ++tt )
@@ -135,7 +135,7 @@ nest::cm_default::set_status( const DictionaryDatum& statusdict )
         add_compartment_( *dynamic_cast< DictionaryDatum* >( tt->datum() ) );
       }
     }
-    else if ( dd != nullptr )
+    else if ( dd )
     {
       // A single compartment is provided, we add add it to the tree
       add_compartment_( *dd );
@@ -170,7 +170,7 @@ nest::cm_default::set_status( const DictionaryDatum& statusdict )
     ArrayDatum* ad = dynamic_cast< ArrayDatum* >( dat );
     DictionaryDatum* dd = dynamic_cast< DictionaryDatum* >( dat );
 
-    if ( ad != nullptr )
+    if ( ad )
     {
       for ( Token* tt = ( *ad ).begin(); tt != ( *ad ).end(); ++tt )
       {
@@ -179,7 +179,7 @@ nest::cm_default::set_status( const DictionaryDatum& statusdict )
         add_receptor_( *dynamic_cast< DictionaryDatum* >( tt->datum() ) );
       }
     }
-    else if ( dd != nullptr )
+    else if ( dd )
     {
       add_receptor_( *dd );
     }

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -190,7 +190,7 @@ nest::CompTree::add_compartment( Compartment* compartment, const long parent_ind
      * exception message
      */
     Compartment* parent = get_compartment( parent_index, get_root(), 0 );
-    if ( parent == nullptr )
+    if ( not parent )
     {
       std::string msg = "does not exist in tree, but was specified as a parent compartment";
       throw UnknownCompartment( parent_index, msg );

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -115,7 +115,7 @@ nest::Compartment::construct_matrix_element( const long lag )
   // matrix diagonal element
   gg = gg0;
 
-  if ( parent != nullptr )
+  if ( parent )
   {
     gg += gc__div__2;
     // matrix off diagonal element
@@ -130,7 +130,7 @@ nest::Compartment::construct_matrix_element( const long lag )
   // right hand side
   ff = ( ca__div__dt - gl__div__2 ) * v_comp + gl__times__el;
 
-  if ( parent != nullptr )
+  if ( parent )
   {
     ff -= gc__div__2 * ( v_comp - parent->v_comp );
   }
@@ -436,7 +436,7 @@ nest::CompTree::solve_matrix_downsweep( Compartment* compartment, std::vector< C
   std::pair< double, double > output = compartment->io();
 
   // move on to the parent layer
-  if ( compartment->parent != nullptr )
+  if ( compartment->parent )
   {
     Compartment* parent = compartment->parent;
     // gather input from child layers
@@ -488,7 +488,7 @@ nest::CompTree::print_tree() const
     std::cout << "C_m = " << compartment->ca << " nF, ";
     std::cout << "g_L = " << compartment->gl << " uS, ";
     std::cout << "e_L = " << compartment->el << " mV, ";
-    if ( compartment->parent != nullptr )
+    if ( compartment->parent )
     {
       std::cout << "Parent " << compartment->parent->comp_index << " --> ";
       std::cout << "g_c = " << compartment->gc << " uS, ";

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -410,7 +410,7 @@ nest::gif_cond_exp::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -419,7 +419,7 @@ nest::gif_cond_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( P_.gsl_error_tol, 0.0 );
   }
@@ -428,7 +428,7 @@ nest::gif_cond_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -410,7 +410,7 @@ nest::gif_cond_exp::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -419,7 +419,7 @@ nest::gif_cond_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( P_.gsl_error_tol, 0.0 );
   }
@@ -428,7 +428,7 @@ nest::gif_cond_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -412,7 +412,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, state_size );
   }
@@ -421,7 +421,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( P_.gsl_error_tol, 0.0 );
   }
@@ -430,7 +430,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( state_size );
   }

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -412,7 +412,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, state_size );
   }
@@ -421,7 +421,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( P_.gsl_error_tol, 0.0 );
   }
@@ -430,7 +430,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
     gsl_odeiv_control_init( B_.c_, P_.gsl_error_tol, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( state_size );
   }

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -531,7 +531,7 @@ nest::glif_cond::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -531,7 +531,7 @@ nest::glif_cond::init_buffers_()
   // We must integrate this model with high-precision to obtain decent results
   B_.IntegrationStep_ = std::min( 0.01, B_.step_ );
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -596,14 +596,14 @@ nest::glif_cond::pre_run_hook()
   }
 
   // reallocate instance of stepping function for ODE GSL solver
-  if ( B_.s_ != nullptr )
+  if ( B_.s_ )
   {
     gsl_odeiv_step_free( B_.s_ );
   }
   B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, S_.y_.size() );
 
   // reallocate instance of evolution function for ODE GSL solver
-  if ( B_.e_ != nullptr )
+  if ( B_.e_ )
   {
     gsl_odeiv_evolve_free( B_.e_ );
   }

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -408,7 +408,7 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -417,7 +417,7 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -426,7 +426,7 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -408,7 +408,7 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -417,7 +417,7 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -426,7 +426,7 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -340,7 +340,7 @@ nest::hh_cond_exp_traub::init_buffers_()
 
   B_.I_stim_ = 0.0;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -349,7 +349,7 @@ nest::hh_cond_exp_traub::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -358,7 +358,7 @@ nest::hh_cond_exp_traub::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -340,7 +340,7 @@ nest::hh_cond_exp_traub::init_buffers_()
 
   B_.I_stim_ = 0.0;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -349,7 +349,7 @@ nest::hh_cond_exp_traub::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -358,7 +358,7 @@ nest::hh_cond_exp_traub::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -334,7 +334,7 @@ nest::hh_psc_alpha::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -343,7 +343,7 @@ nest::hh_psc_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -352,7 +352,7 @@ nest::hh_psc_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -334,7 +334,7 @@ nest::hh_psc_alpha::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -343,7 +343,7 @@ nest::hh_psc_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -352,7 +352,7 @@ nest::hh_psc_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -360,7 +360,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -369,7 +369,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -378,7 +378,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -360,7 +360,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -369,7 +369,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -378,7 +378,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -398,7 +398,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -407,7 +407,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-6, 0.0 );
   }
@@ -416,7 +416,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-6, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -398,7 +398,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -407,7 +407,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-6, 0.0 );
   }
@@ -416,7 +416,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-6, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -663,7 +663,7 @@ nest::ht_neuron::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.integration_step_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -672,7 +672,7 @@ nest::ht_neuron::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -681,7 +681,7 @@ nest::ht_neuron::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -663,7 +663,7 @@ nest::ht_neuron::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.integration_step_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -672,7 +672,7 @@ nest::ht_neuron::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -681,7 +681,7 @@ nest::ht_neuron::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -305,7 +305,7 @@ nest::iaf_chxk_2008::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -314,7 +314,7 @@ nest::iaf_chxk_2008::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -323,7 +323,7 @@ nest::iaf_chxk_2008::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -305,7 +305,7 @@ nest::iaf_chxk_2008::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -314,7 +314,7 @@ nest::iaf_chxk_2008::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -323,7 +323,7 @@ nest::iaf_chxk_2008::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -318,7 +318,7 @@ nest::iaf_cond_alpha::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -327,7 +327,7 @@ nest::iaf_cond_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -336,7 +336,7 @@ nest::iaf_cond_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -318,7 +318,7 @@ nest::iaf_cond_alpha::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -327,7 +327,7 @@ nest::iaf_cond_alpha::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -336,7 +336,7 @@ nest::iaf_cond_alpha::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -515,7 +515,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -524,7 +524,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -533,7 +533,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -515,7 +515,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -524,7 +524,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -533,7 +533,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -325,7 +325,7 @@ nest::iaf_cond_beta::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -334,7 +334,7 @@ nest::iaf_cond_beta::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -343,7 +343,7 @@ nest::iaf_cond_beta::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -325,7 +325,7 @@ nest::iaf_cond_beta::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -334,7 +334,7 @@ nest::iaf_cond_beta::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -343,7 +343,7 @@ nest::iaf_cond_beta::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -296,7 +296,7 @@ nest::iaf_cond_exp::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -305,7 +305,7 @@ nest::iaf_cond_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -314,7 +314,7 @@ nest::iaf_cond_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -296,7 +296,7 @@ nest::iaf_cond_exp::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -305,7 +305,7 @@ nest::iaf_cond_exp::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -314,7 +314,7 @@ nest::iaf_cond_exp::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -332,7 +332,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -341,7 +341,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -350,7 +350,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -332,7 +332,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -341,7 +341,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -350,7 +350,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -516,7 +516,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( not _ )
+  if ( not B_.s_ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -525,7 +525,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( not _ )
+  if ( not B_.c_ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -534,7 +534,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( not _ )
+  if ( not B_.e_ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -516,7 +516,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
   B_.step_ = Time::get_resolution().get_ms();
   B_.IntegrationStep_ = B_.step_;
 
-  if ( B_.s_ == nullptr )
+  if ( not _ )
   {
     B_.s_ = gsl_odeiv_step_alloc( gsl_odeiv_step_rkf45, State_::STATE_VEC_SIZE );
   }
@@ -525,7 +525,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
     gsl_odeiv_step_reset( B_.s_ );
   }
 
-  if ( B_.c_ == nullptr )
+  if ( not _ )
   {
     B_.c_ = gsl_odeiv_control_y_new( 1e-3, 0.0 );
   }
@@ -534,7 +534,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
     gsl_odeiv_control_init( B_.c_, 1e-3, 0.0, 1.0, 0.0 );
   }
 
-  if ( B_.e_ == nullptr )
+  if ( not _ )
   {
     B_.e_ = gsl_odeiv_evolve_alloc( State_::STATE_VEC_SIZE );
   }

--- a/models/stdp_dopamine_synapse.cpp
+++ b/models/stdp_dopamine_synapse.cpp
@@ -55,7 +55,7 @@ void
 STDPDopaCommonProperties::get_status( DictionaryDatum& d ) const
 {
   CommonSynapseProperties::get_status( d );
-  if ( vt_ != nullptr )
+  if ( vt_ )
   {
     def< long >( d, names::vt, vt_->get_node_id() );
   }

--- a/models/stdp_dopamine_synapse.cpp
+++ b/models/stdp_dopamine_synapse.cpp
@@ -85,7 +85,7 @@ STDPDopaCommonProperties::set_status( const DictionaryDatum& d, ConnectorModel& 
     const thread tid = kernel().vp_manager.get_thread_id();
     Node* vt = kernel().node_manager.get_node_or_proxy( vtnode_id, tid );
     vt_ = dynamic_cast< volume_transmitter* >( vt );
-    if ( vt_ == nullptr )
+    if ( not vt_ )
     {
       throw BadProperty( "Dopamine source must be volume transmitter" );
     }
@@ -104,7 +104,7 @@ STDPDopaCommonProperties::set_status( const DictionaryDatum& d, ConnectorModel& 
 Node*
 STDPDopaCommonProperties::get_node()
 {
-  if ( vt_ == nullptr )
+  if ( not vt_ )
   {
     throw BadProperty( "No volume transmitter has been assigned to the dopamine synapse." );
   }

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -175,7 +175,7 @@ public:
 inline long
 STDPDopaCommonProperties::get_vt_node_id() const
 {
-  if ( vt_ != nullptr )
+  if ( vt_ )
   {
     return vt_->get_node_id();
   }

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -280,7 +280,7 @@ public:
   void
   check_connection( Node& s, Node& t, rport receptor_type, const CommonPropertiesType& cp )
   {
-    if ( not _ )
+    if ( not cp.vt_ )
     {
       throw BadProperty( "No volume transmitter has been assigned to the dopamine synapse." );
     }

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -280,7 +280,7 @@ public:
   void
   check_connection( Node& s, Node& t, rport receptor_type, const CommonPropertiesType& cp )
   {
-    if ( cp.vt_ == nullptr )
+    if ( not _ )
     {
       throw BadProperty( "No volume transmitter has been assigned to the dopamine synapse." );
     }

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -1755,14 +1755,14 @@ nest::SymmetricBernoulliBuilder::connect_()
           // if target is local: connect
           if ( target_thread == tid )
           {
-            assert( target != nullptr );
+            assert( target );
             single_connect_( snode_id, *target, target_thread, synced_rng );
           }
 
           // if source is local: connect
           if ( source_thread == tid )
           {
-            assert( source != nullptr );
+            assert( source );
             single_connect_( ( *tnode_id ).node_id, *source, source_thread, synced_rng );
           }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -233,9 +233,9 @@ nest::ConnectionManager::get_synapse_status( const index source_node_id,
 
   // synapses from neurons to neurons and from neurons to globally
   // receiving devices
-  if ( ( source->has_proxies() and target->has_proxies() and connections_[ tid ][ syn_id ] != nullptr )
+  if ( ( source->has_proxies() and target->has_proxies() and connections_[ tid ][ syn_id ] )
     or ( ( source->has_proxies() and not target->has_proxies() and not target->local_receiver()
-      and connections_[ tid ][ syn_id ] != nullptr ) ) )
+      and connections_[ tid ][ syn_id ] ) ) )
   {
     connections_[ tid ][ syn_id ]->get_synapse_status( tid, lcid, dict );
   }
@@ -274,9 +274,9 @@ nest::ConnectionManager::set_synapse_status( const index source_node_id,
     ConnectorModel& cm = kernel().model_manager.get_connection_model( syn_id, tid );
     // synapses from neurons to neurons and from neurons to globally
     // receiving devices
-    if ( ( source->has_proxies() and target->has_proxies() and connections_[ tid ][ syn_id ] != nullptr )
+    if ( ( source->has_proxies() and target->has_proxies() and connections_[ tid ][ syn_id ] )
       or ( ( source->has_proxies() and not target->has_proxies() and not target->local_receiver()
-        and connections_[ tid ][ syn_id ] != nullptr ) ) )
+        and connections_[ tid ][ syn_id ] ) ) )
     {
       connections_[ tid ][ syn_id ]->set_synapse_status( lcid, dict, cm );
     }
@@ -416,7 +416,7 @@ nest::ConnectionManager::connect( NodeCollectionPTR sources,
   const long rule_id = ( *connruledict_ )[ rule_name ];
 
   ConnBuilder* cb = connbuilder_factories_.at( rule_id )->create( sources, targets, conn_spec, syn_specs );
-  assert( cb != nullptr );
+  assert( cb );
 
   // at this point, all entries in conn_spec and syn_spec have been checked
   ALL_ENTRIES_ACCESSED( *conn_spec, "Connect", "Unread dictionary entries in conn_spec: " );
@@ -611,7 +611,7 @@ nest::ConnectionManager::connect_arrays( long* sources,
       }
 
       // If the default value is an integer, the synapse parameter must also be an integer.
-      if ( dynamic_cast< IntegerDatum* >( syn_model_default_it->second.datum() ) != nullptr )
+      if ( dynamic_cast< IntegerDatum* >( syn_model_default_it->second.datum() ) )
       {
         param_pointers[ param_key ].second = true;
         ( *param_dicts[ i ] )[ param_key ] = Token( new IntegerDatum( 0 ) );
@@ -626,11 +626,11 @@ nest::ConnectionManager::connect_arrays( long* sources,
   // Increments pointers to weight and delay, if they are specified.
   auto increment_wd = [ weights, delays ]( decltype( weights ) & w, decltype( delays ) & d )
   {
-    if ( weights != nullptr )
+    if ( weights )
     {
       ++w;
     }
-    if ( delays != nullptr )
+    if ( delays )
     {
       ++d;
     }
@@ -674,11 +674,11 @@ nest::ConnectionManager::connect_arrays( long* sources,
 
         // If weights or delays are specified, the buffers are replaced with the values.
         // If not, the buffers will be NaN and replaced by a default value by the connect function.
-        if ( weights != nullptr )
+        if ( weights )
         {
           weight_buffer = *w;
         }
-        if ( delays != nullptr )
+        if ( delays )
         {
           delay_buffer = *d;
         }
@@ -909,7 +909,7 @@ nest::ConnectionManager::get_num_target_data( const thread tid ) const
   size_t num_connections = 0;
   for ( synindex syn_id = 0; syn_id < connections_[ tid ].size(); ++syn_id )
   {
-    if ( connections_[ tid ][ syn_id ] != nullptr )
+    if ( connections_[ tid ][ syn_id ] )
     {
       num_connections += source_table_.num_unique_sources( tid, syn_id );
     }
@@ -1092,7 +1092,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
       std::deque< ConnectionID > conns_in_thread;
 
       ConnectorBase* connections = connections_[ tid ][ syn_id ];
-      if ( connections != nullptr )
+      if ( connections )
       {
         // Passing target_node_id = 0 ignores target_node_id while getting connections.
         const size_t num_connections_in_thread = connections->size();
@@ -1130,7 +1130,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
 
       // Getting regular connections, if they exist.
       ConnectorBase* connections = connections_[ tid ][ syn_id ];
-      if ( connections != nullptr )
+      if ( connections )
       {
         const size_t num_connections_in_thread = connections->size();
         for ( index lcid = 0; lcid < num_connections_in_thread; ++lcid )
@@ -1182,7 +1182,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
       }
 
       const ConnectorBase* connections = connections_[ tid ][ syn_id ];
-      if ( connections != nullptr )
+      if ( connections )
       {
         const size_t num_connections_in_thread = connections->size();
         for ( index lcid = 0; lcid < num_connections_in_thread; ++lcid )
@@ -1254,7 +1254,7 @@ nest::ConnectionManager::get_source_node_ids_( const thread tid,
   std::vector< index >& sources )
 {
   std::vector< index > source_lcids;
-  if ( connections_[ tid ][ syn_id ] != nullptr )
+  if ( connections_[ tid ][ syn_id ] )
   {
     connections_[ tid ][ syn_id ]->get_source_lcids( tid, tnode_id, source_lcids );
     source_table_.get_source_node_ids( tid, syn_id, source_lcids, sources );
@@ -1314,7 +1314,7 @@ nest::ConnectionManager::sort_connections( const thread tid )
   {
     for ( synindex syn_id = 0; syn_id < connections_[ tid ].size(); ++syn_id )
     {
-      if ( connections_[ tid ][ syn_id ] != nullptr )
+      if ( connections_[ tid ][ syn_id ] )
       {
         connections_[ tid ][ syn_id ]->sort_connections( source_table_.get_thread_local_sources( tid )[ syn_id ] );
       }
@@ -1372,7 +1372,7 @@ nest::ConnectionManager::compute_compressed_secondary_recv_buffer_positions( con
   {
     std::vector< size_t >& positions = secondary_recv_buffer_pos_[ tid ][ syn_id ];
 
-    if ( connections_[ tid ][ syn_id ] != nullptr )
+    if ( connections_[ tid ][ syn_id ] )
     {
       if ( not kernel().model_manager.get_connection_model( syn_id, tid ).is_primary() )
       {

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1575,7 +1575,7 @@ nest::ConnectionManager::remove_disabled_connections( const thread tid )
 
   for ( synindex syn_id = 0; syn_id < connectors.size(); ++syn_id )
   {
-    if ( connectors[ syn_id ] == nullptr )
+    if ( not connectors[ syn_id ] )
     {
       continue;
     }

--- a/nestkernel/connection_manager_impl.h
+++ b/nestkernel/connection_manager_impl.h
@@ -44,7 +44,7 @@ ConnectionManager::register_conn_builder( const std::string& name )
 {
   assert( not connruledict_->known( name ) );
   GenericConnBuilderFactory* cb = new ConnBuilderFactory< ConnBuilder >();
-  assert( cb != nullptr );
+  assert( cb );
   const int id = connbuilder_factories_.size();
   connbuilder_factories_.push_back( cb );
   connruledict_->insert( name, id );

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -264,7 +264,7 @@ GenericConnectorModel< ConnectionT >::add_connection_( Node& src,
 {
   assert( syn_id != invalid_synindex );
 
-  if ( thread_local_connectors[ syn_id ] == nullptr )
+  if ( not thread_local_connectors[ syn_id ] )
   {
     // No homogeneous Connector with this syn_id exists, we need to create a new
     // homogeneous Connector.

--- a/nestkernel/connector_model_impl.h
+++ b/nestkernel/connector_model_impl.h
@@ -275,7 +275,7 @@ GenericConnectorModel< ConnectionT >::add_connection_( Node& src,
   // The following line will throw an exception, if it does not work.
   connection.check_connection( src, tgt, receptor_type, get_common_properties() );
 
-  assert( connector != nullptr );
+  assert( connector );
 
   Connector< ConnectionT >* vc = static_cast< Connector< ConnectionT >* >( connector );
   vc->push_back( connection );

--- a/nestkernel/dynamicloader.cpp
+++ b/nestkernel/dynamicloader.cpp
@@ -103,7 +103,7 @@ DynamicLoaderModule::~DynamicLoaderModule()
   // unload all loaded modules
   for ( vecDynModules::iterator it = dyn_modules.begin(); it != dyn_modules.end(); ++it )
   {
-    if ( it->handle != nullptr )
+    if ( it->handle )
     {
       lt_dlclose( it->handle );
       it->handle = nullptr;
@@ -284,7 +284,7 @@ DynamicLoaderModule::init( SLIInterpreter* i )
 int
 DynamicLoaderModule::registerLinkedModule( SLIModule* pModule )
 {
-  assert( pModule != nullptr );
+  assert( pModule );
   getLinkedModules().push_back( pModule );
   return getLinkedModules().size();
 }

--- a/nestkernel/event.h
+++ b/nestkernel/event.h
@@ -680,7 +680,7 @@ DataLoggingRequest::record_from() const
 {
   // During simulation, events are created without recordables
   // information. On these, record_from() must not be called.
-  assert( record_from_ != nullptr );
+  assert( record_from_ );
 
   return *record_from_;
 }
@@ -1278,13 +1278,13 @@ DiffusionConnectionEvent::get_diffusion_factor() const
 inline bool
 Event::sender_is_valid() const
 {
-  return sender_ != nullptr;
+  return sender_;
 }
 
 inline bool
 Event::receiver_is_valid() const
 {
-  return receiver_ != nullptr;
+  return receiver_;
 }
 
 inline bool

--- a/nestkernel/io_manager.cpp
+++ b/nestkernel/io_manager.cpp
@@ -83,7 +83,7 @@ IOManager::set_data_path_prefix_( const DictionaryDatum& dict )
   if ( updateValue< std::string >( dict, names::data_path, tmp ) )
   {
     DIR* testdir = opendir( tmp.c_str() );
-    if ( testdir != nullptr )
+    if ( testdir )
     {
       data_path_ = tmp;    // absolute path & directory exists
       closedir( testdir ); // we only opened it to check it exists

--- a/nestkernel/kernel_manager.cpp
+++ b/nestkernel/kernel_manager.cpp
@@ -29,7 +29,7 @@ nest::KernelManager::create_kernel_manager()
 {
 #pragma omp critical( create_kernel_manager )
   {
-    if ( kernel_manager_instance_ == nullptr )
+    if ( not kernel_manager_instance_ )
     {
       kernel_manager_instance_ = new KernelManager();
       assert( kernel_manager_instance_ );

--- a/nestkernel/layer_impl.h
+++ b/nestkernel/layer_impl.h
@@ -117,7 +117,7 @@ Layer< D >::connect( NodeCollectionPTR source_nc,
   // We need to extract the real pointer here to be able to cast to the
   // dimension-specific subclass.
   AbstractLayer* target_abs = target_layer.get();
-  assert( target_abs != nullptr );
+  assert( target_abs );
 
   try
   {

--- a/nestkernel/logging_manager.cpp
+++ b/nestkernel/logging_manager.cpp
@@ -68,7 +68,7 @@ nest::LoggingManager::get_status( DictionaryDatum& dict )
 void
 nest::LoggingManager::register_logging_client( const deliver_logging_event_ptr callback )
 {
-  assert( callback != nullptr );
+  assert( callback );
 
   client_callbacks_.push_back( callback );
 }

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -60,7 +60,7 @@ ModelManager::~ModelManager()
   clear_connection_models_();
   for ( auto&& connection_model : builtin_connection_models_ )
   {
-    if ( connection_model != nullptr )
+    if ( connection_model )
     {
       delete connection_model;
     }
@@ -69,7 +69,7 @@ ModelManager::~ModelManager()
   clear_node_models_();
   for ( auto&& node_model : builtin_node_models_ )
   {
-    if ( node_model != nullptr )
+    if ( node_model )
     {
       delete node_model;
     }
@@ -120,7 +120,7 @@ ModelManager::initialize()
   // (re-)append all synapse prototypes
   for ( auto&& connection_model : builtin_connection_models_ )
   {
-    if ( connection_model != nullptr )
+    if ( connection_model )
     {
       std::string name = connection_model->get_name();
       for ( thread t = 0; t < static_cast< thread >( kernel().vp_manager.get_num_threads() ); ++t )
@@ -377,7 +377,7 @@ ModelManager::get_node_model_id( const Name name ) const
   const Name model_name( name );
   for ( int i = 0; i < ( int ) node_models_.size(); ++i )
   {
-    assert( node_models_[ i ] != nullptr );
+    assert( node_models_[ i ] );
     if ( model_name == node_models_[ i ]->get_name() )
     {
       return i;
@@ -450,7 +450,7 @@ ModelManager::clear_node_models_()
   // init()
   for ( auto&& node_model : node_models_ )
   {
-    if ( node_model != nullptr )
+    if ( node_model )
     {
       delete node_model;
     }
@@ -474,7 +474,7 @@ ModelManager::clear_connection_models_()
   {
     for ( auto&& connection_model : connection_models_[ t ] )
     {
-      if ( connection_model != nullptr )
+      if ( connection_model )
       {
         delete connection_model;
       }
@@ -495,7 +495,7 @@ ModelManager::calibrate( const TimeConverter& tc )
   {
     for ( auto&& connection_model : connection_models_[ t ] )
     {
-      if ( connection_model != nullptr )
+      if ( connection_model )
       {
         connection_model->calibrate( tc );
       }

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -79,7 +79,7 @@ ModelManager::~ModelManager()
 void
 ModelManager::initialize()
 {
-  if ( proxynode_model_ == nullptr )
+  if ( not proxynode_model_ )
   {
     proxynode_model_ = new GenericModel< proxynode >( "proxynode", "" );
     proxynode_model_->set_type_id( 1 );

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -325,7 +325,7 @@ ModelManager::get_num_connection_models() const
 inline void
 ModelManager::assert_valid_syn_id( synindex syn_id, thread t ) const
 {
-  if ( syn_id >= connection_models_[ t ].size() or connection_models_[ t ][ syn_id ] == nullptr )
+  if ( syn_id >= connection_models_[ t ].size() or not connection_models_[ t ][ syn_id ] )
   {
     throw UnknownSynapseType( syn_id );
   }

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -209,7 +209,7 @@ NestModule::create_mask( const Token& t )
       else
       {
 
-        if ( mask != nullptr )
+        if ( mask )
         { // mask has already been defined
           throw BadProperty( "Mask definition dictionary contains extraneous items." );
         }

--- a/nestkernel/nestmodule.cpp
+++ b/nestkernel/nestmodule.cpp
@@ -184,7 +184,7 @@ NestModule::create_mask( const Token& t )
   {
 
     DictionaryDatum* dd = dynamic_cast< DictionaryDatum* >( t.datum() );
-    if ( dd == nullptr )
+    if ( not dd )
     {
       throw BadProperty( "Mask must be masktype or dictionary." );
     }

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -456,7 +456,7 @@ NodeCollectionPrimitive::slice( size_t start, size_t end, size_t step ) const
   }
 
   NodeCollectionPTR sliced_nc;
-  if ( step == 1 and metadata_ == nullptr )
+  if ( step == 1 and not metadata_ )
   {
     // Create primitive NodeCollection passing node IDs.
     // Subtract 1 because "end" is one past last element to take while constructor expects ID of last node.

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -883,7 +883,7 @@ NodeCollectionComposite::operator==( NodeCollectionPTR rhs ) const
 
   // Checking if rhs_ptr is invalid first, to avoid segfaults. If rhs is a NodeCollectionPrimitive,
   // rhs_ptr will be a null pointer.
-  if ( rhs_ptr == nullptr or size_ != rhs_ptr->size() or parts_.size() != rhs_ptr->parts_.size() )
+  if ( not rhs_ptr or size_ != rhs_ptr->size() or parts_.size() != rhs_ptr->parts_.size() )
   {
     return false;
   }

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -94,7 +94,7 @@ NodeManager::get_status( index idx )
 {
   Node* target = get_mpi_local_node_or_device_head( idx );
 
-  assert( target != nullptr );
+  assert( target );
 
   DictionaryDatum d = target->get_status_base();
 
@@ -114,7 +114,7 @@ NodeManager::add_node( index model_id, long n )
   }
 
   Model* model = kernel().model_manager.get_node_model( model_id );
-  assert( model != nullptr );
+  assert( model );
   model->deprecation_warning( "Create" );
 
   const index min_node_id = local_nodes_.at( 0 ).get_max_node_id() + 1;
@@ -753,7 +753,7 @@ NodeManager::set_status( index node_id, const DictionaryDatum& d )
   for ( thread t = 0; t < kernel().vp_manager.get_num_threads(); ++t )
   {
     Node* node = local_nodes_[ t ].get_node_by_node_id( node_id );
-    if ( node != nullptr )
+    if ( node )
     {
       set_status_single_node_( *node, d );
     }

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -425,7 +425,7 @@ NodeManager::get_node_or_proxy( index node_id, thread t )
   assert( 0 < node_id and node_id <= size() );
 
   Node* node = local_nodes_[ t ].get_node_by_node_id( node_id );
-  if ( node == nullptr )
+  if ( not node )
   {
     return kernel().model_manager.get_proxy_node( t, node_id );
   }
@@ -446,7 +446,7 @@ NodeManager::get_node_or_proxy( index node_id )
 
   thread t = kernel().vp_manager.vp_to_thread( vp );
   Node* node = local_nodes_[ t ].get_node_by_node_id( node_id );
-  if ( node == nullptr )
+  if ( not node )
   {
     return kernel().model_manager.get_proxy_node( t, node_id );
   }
@@ -461,7 +461,7 @@ NodeManager::get_mpi_local_node_or_device_head( index node_id )
 
   Node* node = local_nodes_[ t ].get_node_by_node_id( node_id );
 
-  if ( node == nullptr )
+  if ( not node )
   {
     return kernel().model_manager.get_proxy_node( t, node_id );
   }
@@ -481,7 +481,7 @@ NodeManager::get_thread_siblings( index node_id ) const
   for ( size_t t = 0; t < num_threads; ++t )
   {
     Node* node = local_nodes_[ t ].get_node_by_node_id( node_id );
-    if ( node == nullptr )
+    if ( not node )
     {
       throw NoThreadSiblingsAvailable( node_id );
     }

--- a/nestkernel/parameter.h
+++ b/nestkernel/parameter.h
@@ -375,7 +375,7 @@ public:
     {
       throw BadParameterValue( "Source or target position parameter can only be used when connecting." );
     }
-    if ( node == nullptr )
+    if ( not node )
     {
       throw KernelException( "Node position parameter can only be used when connecting spatially distributed nodes." );
     }

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -315,7 +315,7 @@ SPManager::disconnect( NodeCollectionPTR sources,
   {
     cb = kernel().connection_manager.get_conn_builder( rule_name, sources, targets, conn_spec, { syn_spec } );
   }
-  assert( cb != nullptr );
+  assert( cb );
 
   // at this point, all entries in conn_spec and syn_spec have been checked
   ALL_ENTRIES_ACCESSED( *conn_spec, "Connect", "Unread dictionary entries: " );

--- a/nestkernel/sp_manager_impl.h
+++ b/nestkernel/sp_manager_impl.h
@@ -41,7 +41,7 @@ SPManager::register_growth_curve( const std::string& name )
 {
   assert( not growthcurvedict_->known( name ) );
   GenericGrowthCurveFactory* nc = new GrowthCurveFactory< GrowthCurve >();
-  assert( nc != nullptr );
+  assert( nc );
   const int id = growthcurve_factories_.size();
   growthcurve_factories_.push_back( nc );
   growthcurvedict_->insert( name, id );

--- a/nestkernel/sparse_node_array.h
+++ b/nestkernel/sparse_node_array.h
@@ -263,7 +263,7 @@ nest::SparseNodeArray::is_consistent_() const
 inline nest::Node*
 nest::SparseNodeArray::NodeEntry::get_node() const
 {
-  assert( node_ != nullptr );
+  assert( node_ );
   return node_;
 }
 

--- a/nestkernel/spatial.h
+++ b/nestkernel/spatial.h
@@ -95,7 +95,7 @@ public:
   operator==( const NodeCollectionMetadataPTR rhs ) const override
   {
     const auto rhs_layer_metadata = dynamic_cast< LayerMetadata* >( rhs.get() );
-    if ( rhs_layer_metadata == nullptr )
+    if ( not rhs_layer_metadata )
     {
       return false;
     }

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -354,7 +354,7 @@ nest::StimulationBackendMPI::update_device( int* array_index,
   std::vector< int >& devices_id,
   std::pair< int*, double* > data )
 {
-  if ( data.first != nullptr )
+  if ( data.first )
   {
     // if there is some device
     if ( data.first[ 0 ] != 0 )
@@ -400,13 +400,13 @@ nest::StimulationBackendMPI::clean_memory_input_data( std::vector< std::pair< in
   // for all the pairs of data, free the memory of data and the array with the size
   for ( auto pair_data : data )
   {
-    if ( pair_data.first != nullptr )
+    if ( pair_data.first )
     {
       // clean the memory allocated in the function receive_spike_train
       delete[] pair_data.first;
       pair_data.first = nullptr;
     }
-    if ( pair_data.second != nullptr )
+    if ( pair_data.second )
     {
       // clean the memory allocated in the function receive_spike_train
       delete[] pair_data.second;

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -61,7 +61,7 @@ nest::SynapticElement::SynapticElement( const SynapticElement& se )
   , tau_vacant_( se.tau_vacant_ )
 {
   growth_curve_ = kernel().sp_manager.new_growth_curve( se.growth_curve_->get_name() );
-  assert( growth_curve_ != nullptr );
+  assert( growth_curve_ );
   DictionaryDatum nc_parameters = DictionaryDatum( new Dictionary );
   se.get( nc_parameters );
   growth_curve_->set( nc_parameters );

--- a/nestkernel/target_identifier.h
+++ b/nestkernel/target_identifier.h
@@ -63,7 +63,7 @@ public:
   get_status( DictionaryDatum& d ) const
   {
     // Do nothing if called on synapse prototype
-    if ( target_ != nullptr )
+    if ( target_ )
     {
       def< long >( d, names::rport, rport_ );
       def< long >( d, names::target, target_->get_node_id() );

--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -142,7 +142,7 @@ nest::TargetTableDevices::get_connections_to_device_for_lid_( const index lid,
   {
     const index source_node_id = kernel().vp_manager.lid_to_node_id( lid );
     // not the valid connector
-    if ( source_node_id > 0 and target_to_devices_[ tid ][ lid ][ syn_id ] != nullptr )
+    if ( source_node_id > 0 and target_to_devices_[ tid ][ lid ][ syn_id ] )
     {
       target_to_devices_[ tid ][ lid ][ syn_id ]->get_all_connections(
         source_node_id, requested_target_node_id, tid, synapse_label, conns );
@@ -171,7 +171,7 @@ nest::TargetTableDevices::get_connections_from_devices_( const index requested_s
       if ( target_from_devices_[ tid ][ ldid ].size() > 0 )
       {
         // not the valid connector
-        if ( target_from_devices_[ tid ][ ldid ][ syn_id ] != nullptr )
+        if ( target_from_devices_[ tid ][ ldid ][ syn_id ] )
         {
           target_from_devices_[ tid ][ ldid ][ syn_id ]->get_all_connections(
             source_node_id, requested_target_node_id, tid, synapse_label, conns );

--- a/nestkernel/target_table_devices.h
+++ b/nestkernel/target_table_devices.h
@@ -251,7 +251,7 @@ TargetTableDevices::is_device_connected( const thread tid, const index lcid ) co
 {
   for ( auto& synapse : target_from_devices_[ tid ][ lcid ] )
   {
-    if ( synapse != nullptr )
+    if ( synapse )
     {
       std::deque< ConnectionID > conns;
       synapse->get_all_connections( lcid, 0, tid, UNLABELED_CONNECTION, conns );

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -100,7 +100,7 @@ nest::TargetTableDevices::send_to_device( const thread tid,
   const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
   for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin(); cit != supported_syn_ids.end(); ++cit )
   {
-    if ( target_to_devices_[ tid ][ lid ][ *cit ] != nullptr )
+    if ( target_to_devices_[ tid ][ lid ][ *cit ] )
     {
       target_to_devices_[ tid ][ lid ][ *cit ]->send_to_all( tid, cm, e );
     }
@@ -115,7 +115,7 @@ nest::TargetTableDevices::get_synapse_status_to_device( const thread tid,
   const index lcid ) const
 {
   const index lid = kernel().vp_manager.node_id_to_lid( source_node_id );
-  if ( target_to_devices_[ tid ][ lid ][ syn_id ] != nullptr )
+  if ( target_to_devices_[ tid ][ lid ][ syn_id ] )
   {
     target_to_devices_[ tid ][ lid ][ syn_id ]->get_synapse_status( tid, lcid, dict );
   }
@@ -130,7 +130,7 @@ nest::TargetTableDevices::set_synapse_status_to_device( const thread tid,
   const index lcid )
 {
   const index lid = kernel().vp_manager.node_id_to_lid( source_node_id );
-  if ( target_to_devices_[ tid ][ lid ][ syn_id ] != nullptr )
+  if ( target_to_devices_[ tid ][ lid ][ syn_id ] )
   {
     target_to_devices_[ tid ][ lid ][ syn_id ]->set_synapse_status( lcid, dict, cm );
   }

--- a/sli/aggregatedatum.h
+++ b/sli/aggregatedatum.h
@@ -117,7 +117,7 @@ public:
   static void
   operator delete( void* p, size_t size )
   {
-    if ( p == nullptr )
+    if ( not p )
     {
       return;
     }

--- a/sli/allocator.h
+++ b/sli/allocator.h
@@ -155,7 +155,7 @@ inline void*
 pool::alloc()
 {
 
-  if ( head == nullptr )
+  if ( not head )
   {
     grow( block_size );
     block_size *= growth_factor;

--- a/sli/booldatum.cc
+++ b/sli/booldatum.cc
@@ -77,7 +77,7 @@ BoolDatum::operator new( size_t size )
 void
 BoolDatum::operator delete( void* p, size_t size )
 {
-  if ( p == nullptr )
+  if ( not p )
   {
     return;
   }

--- a/sli/dictstack.cc
+++ b/sli/dictstack.cc
@@ -156,7 +156,7 @@ void
 DictionaryStack::push( Token& d )
 {
   DictionaryDatum* dd = dynamic_cast< DictionaryDatum* >( d.datum() );
-  assert( dd != nullptr );
+  assert( dd );
   push( *dd );
 }
 

--- a/sli/dictutils.cc
+++ b/sli/dictutils.cc
@@ -61,7 +61,7 @@ provide_property( DictionaryDatum& d, Name propname, const std::vector< double >
   Token t = d->lookup2( propname );
 
   DoubleVectorDatum* arrd = dynamic_cast< DoubleVectorDatum* >( t.datum() );
-  assert( arrd != nullptr );
+  assert( arrd );
 
   if ( ( *arrd )->empty() && not prop.empty() ) // not data from before, add
   {
@@ -79,7 +79,7 @@ provide_property( DictionaryDatum& d, Name propname, const std::vector< long >& 
   Token t = d->lookup2( propname );
 
   IntVectorDatum* arrd = dynamic_cast< IntVectorDatum* >( t.datum() );
-  assert( arrd != nullptr );
+  assert( arrd );
 
   if ( ( *arrd )->empty() && not prop.empty() ) // not data from before, add
   {
@@ -96,7 +96,7 @@ accumulate_property( DictionaryDatum& d, Name propname, const std::vector< doubl
   Token t = d->lookup2( propname );
 
   DoubleVectorDatum* arrd = dynamic_cast< DoubleVectorDatum* >( t.datum() );
-  assert( arrd != nullptr );
+  assert( arrd );
 
   if ( ( *arrd )->empty() ) // first data, copy
   {

--- a/sli/dictutils.h
+++ b/sli/dictutils.h
@@ -93,7 +93,7 @@ get_double_in_range( const DictionaryDatum& d, Name const n, double min, double 
   DoubleDatum* dd = dynamic_cast< DoubleDatum* >( t.datum() );
   double x = std::numeric_limits< double >::quiet_NaN();
 
-  if ( dd != nullptr )
+  if ( dd )
   {
     x = dd->get();
   }
@@ -157,7 +157,7 @@ get_long_in_range( const DictionaryDatum& d, Name const n, long min, long max, i
   DoubleDatum* dd = dynamic_cast< DoubleDatum* >( t.datum() );
   long x = std::numeric_limits< long >::min();
 
-  if ( dd != nullptr )
+  if ( dd )
   {
     x = dd->get();
   }
@@ -303,7 +303,7 @@ append_property( DictionaryDatum& d, Name propname, const PropT& prop )
   assert( not t.empty() );
 
   ArrayDatum* arrd = dynamic_cast< ArrayDatum* >( t.datum() );
-  assert( arrd != nullptr );
+  assert( arrd );
 
   Token prop_token( prop );
   arrd->push_back_dont_clone( prop_token );
@@ -321,7 +321,7 @@ append_property< std::vector< double > >( DictionaryDatum& d, Name propname, con
   assert( not t.empty() );
 
   DoubleVectorDatum* arrd = dynamic_cast< DoubleVectorDatum* >( t.datum() );
-  assert( arrd != nullptr );
+  assert( arrd );
 
   ( *arrd )->insert( ( *arrd )->end(), prop.begin(), prop.end() );
 }
@@ -339,7 +339,7 @@ append_property< std::vector< long > >( DictionaryDatum& d, Name propname, const
   assert( not t.empty() );
 
   IntVectorDatum* arrd = dynamic_cast< IntVectorDatum* >( t.datum() );
-  assert( arrd != nullptr );
+  assert( arrd );
 
   ( *arrd )->insert( ( *arrd )->end(), prop.begin(), prop.end() );
 }

--- a/sli/dictutils.h
+++ b/sli/dictutils.h
@@ -100,7 +100,7 @@ get_double_in_range( const DictionaryDatum& d, Name const n, double min, double 
   else
   {
     IntegerDatum* id = dynamic_cast< IntegerDatum* >( t.datum() );
-    if ( id == nullptr )
+    if ( not id )
     {
       throw TypeMismatch();
     }
@@ -164,7 +164,7 @@ get_long_in_range( const DictionaryDatum& d, Name const n, long min, long max, i
   else
   {
     IntegerDatum* id = dynamic_cast< IntegerDatum* >( t.datum() );
-    if ( id == nullptr )
+    if ( not id )
     {
       throw TypeMismatch();
     }

--- a/sli/fdstream.cc
+++ b/sli/fdstream.cc
@@ -129,7 +129,7 @@ fdbuf::close()
 void
 ofdstream::close()
 {
-  if ( rdbuf()->close() == nullptr )
+  if ( not rdbuf()->close() )
   {
     setstate( failbit );
   }
@@ -139,7 +139,7 @@ ofdstream::close()
 void
 ifdstream::close()
 {
-  if ( rdbuf()->close() == nullptr )
+  if ( not rdbuf()->close() )
   {
     setstate( failbit );
   }
@@ -148,7 +148,7 @@ ifdstream::close()
 void
 fdstream::close()
 {
-  if ( rdbuf()->close() == nullptr )
+  if ( not rdbuf()->close() )
   {
     setstate( failbit );
   }

--- a/sli/fdstream.h
+++ b/sli/fdstream.h
@@ -226,7 +226,7 @@ public:
   void
   open( const char* s, std::ios_base::openmode mode = std::ios_base::out )
   {
-    if ( rdbuf()->open( s, mode | std::ios_base::out ) == nullptr )
+    if ( not rdbuf()->open( s, mode | std::ios_base::out ) )
     {
       setstate( failbit );
     }
@@ -283,7 +283,7 @@ public:
   void
   open( const char* s, std::ios_base::openmode mode = std::ios_base::in )
   {
-    if ( rdbuf()->open( s, mode | std::ios_base::in ) == nullptr )
+    if ( not rdbuf()->open( s, mode | std::ios_base::in ) )
     {
       setstate( failbit );
     }
@@ -341,7 +341,7 @@ public:
   void
   open( const char* s, std::ios_base::openmode mode )
   {
-    if ( rdbuf()->open( s, mode ) == nullptr )
+    if ( not rdbuf()->open( s, mode ) )
     {
       setstate( failbit );
     }

--- a/sli/filesystem.cc
+++ b/sli/filesystem.cc
@@ -139,7 +139,7 @@ FilesystemModule::DirectoryFunction::execute( SLIInterpreter* i ) const
 
   int size = SIZE;
   char* path_buffer = new char[ size ];
-  while ( getcwd( path_buffer, size - 1 ) == nullptr )
+  while ( not getcwd( path_buffer, size - 1 ) )
   { // try again with a bigger buffer!
     if ( errno != ERANGE )
     {

--- a/sli/filesystem.cc
+++ b/sli/filesystem.cc
@@ -76,16 +76,16 @@ void
 FilesystemModule::FileNamesFunction::execute( SLIInterpreter* i ) const
 {
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
 
   DIR* TheDirectory = opendir( sd->c_str() );
-  if ( TheDirectory != nullptr )
+  if ( TheDirectory )
   {
     ArrayDatum* a = new ArrayDatum();
     i->EStack.pop();
     i->OStack.pop();
     dirent* TheEntry;
-    while ( ( TheEntry = readdir( TheDirectory ) ) != nullptr )
+    while ( ( TheEntry = readdir( TheDirectory ) ) )
     {
       Token string_token( new StringDatum( TheEntry->d_name ) );
       a->push_back_move( string_token );
@@ -104,7 +104,7 @@ FilesystemModule::SetDirectoryFunction::execute( SLIInterpreter* i ) const
 // string -> boolean
 {
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   int s = chdir( sd->c_str() );
   i->OStack.pop();
   if ( not s )
@@ -148,7 +148,7 @@ FilesystemModule::DirectoryFunction::execute( SLIInterpreter* i ) const
     delete[] path_buffer;
     size += SIZE;
     path_buffer = new char[ size ];
-    assert( path_buffer != nullptr );
+    assert( path_buffer );
   }
   Token sd( new StringDatum( path_buffer ) );
   delete[]( path_buffer );
@@ -162,8 +162,8 @@ FilesystemModule::MoveFileFunction::execute( SLIInterpreter* i ) const
 {
   StringDatum* src = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* dst = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( src != nullptr );
-  assert( dst != nullptr );
+  assert( src );
+  assert( dst );
   int s = link( src->c_str(), dst->c_str() );
   if ( not s )
   {
@@ -192,8 +192,8 @@ FilesystemModule::CopyFileFunction::execute( SLIInterpreter* i ) const
 {
   StringDatum* src = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* dst = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( src != nullptr );
-  assert( dst != nullptr );
+  assert( src );
+  assert( dst );
 
   std::ofstream deststream( dst->c_str() );
   if ( not deststream )
@@ -232,7 +232,7 @@ FilesystemModule::DeleteFileFunction::execute( SLIInterpreter* i ) const
 // string -> boolean
 {
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   int s = unlink( sd->c_str() );
   i->OStack.pop();
   if ( not s )
@@ -251,7 +251,7 @@ FilesystemModule::MakeDirectoryFunction::execute( SLIInterpreter* i ) const
 // string -> Boolean
 {
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   int s = mkdir( sd->c_str(), S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP );
   i->OStack.pop();
   if ( not s )
@@ -270,7 +270,7 @@ FilesystemModule::RemoveDirectoryFunction::execute( SLIInterpreter* i ) const
 // string -> Boolean
 {
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   int s = rmdir( sd->c_str() );
   i->OStack.pop();
   if ( not s )

--- a/sli/functiondatum.h
+++ b/sli/functiondatum.h
@@ -137,7 +137,7 @@ public:
   equals( Datum const* dat ) const override
   {
     const FunctionDatum* fd = dynamic_cast< FunctionDatum* >( const_cast< Datum* >( dat ) );
-    if ( fd == nullptr )
+    if ( not fd )
     {
       return false;
     }
@@ -166,7 +166,7 @@ public:
   static void
   operator delete( void* p, size_t size )
   {
-    if ( p == nullptr )
+    if ( not p )
     {
       return;
     }

--- a/sli/gnureadline.cc
+++ b/sli/gnureadline.cc
@@ -57,7 +57,7 @@ GNUReadline::GNUReadlineFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   char* line_read = readline( sd->c_str() );
   if ( line_read == nullptr )
   {
@@ -97,7 +97,7 @@ GNUReadline::GNUAddhistoryFunction::execute( SLIInterpreter* i ) const
   i->assert_stack_load( 1 );
   i->EStack.pop();
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   add_history( sd->c_str() );
   char* home = std::getenv( "HOME" );
   std::string hist_file = std::string( home ) + std::string( "/.nest_history" );

--- a/sli/gnureadline.cc
+++ b/sli/gnureadline.cc
@@ -59,7 +59,7 @@ GNUReadline::GNUReadlineFunction::execute( SLIInterpreter* i ) const
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
   assert( sd );
   char* line_read = readline( sd->c_str() );
-  if ( line_read == nullptr )
+  if ( not line_read )
   {
     // We have received EOF (Ctrl-D), so we quit.
     std::cout << std::endl;

--- a/sli/interpret.cc
+++ b/sli/interpret.cc
@@ -188,7 +188,7 @@ SLIInterpreter::initdictionaries()
   assert( DStack == nullptr );
 
   DStack = new DictionaryStack();
-  assert( DStack != nullptr );
+  assert( DStack );
 
   errordict = new Dictionary();
   DictionaryDatum sysdict( new Dictionary() );
@@ -528,7 +528,7 @@ SLIInterpreter::addmodule( SLIModule* m )
   if ( not( m->commandstring().empty() ) )
   {
     ArrayDatum* ad = dynamic_cast< ArrayDatum* >( baselookup( commandstring_name ).datum() );
-    assert( ad != nullptr );
+    assert( ad );
     ad->push_back( new StringDatum( m->commandstring() ) );
   }
 }
@@ -543,7 +543,7 @@ SLIInterpreter::addlinkedusermodule( SLIModule* m )
   if ( not( m->commandstring().empty() ) )
   {
     ArrayDatum* ad = dynamic_cast< ArrayDatum* >( baselookup( commandstring_name ).datum() );
-    assert( ad != nullptr );
+    assert( ad );
     ad->push_back( new StringDatum( m->commandstring() ) );
   }
 }
@@ -596,7 +596,7 @@ SLIInterpreter::raiseerror( std::exception& err )
 {
   Name caller = getcurrentname();
 
-  assert( errordict != nullptr );
+  assert( errordict );
   errordict->insert( "command", EStack.top() ); // store the func/trie that caused the error.
 
   // SLIException provide addtional information
@@ -623,7 +623,7 @@ SLIInterpreter::raiseerror( Name cmd, Name err )
   // All error related symbols are now in their correct dictionary,
   // the error dictionary $errordict ( see Bug #4)
 
-  assert( errordict != nullptr );
+  assert( errordict );
 
   if ( errordict->lookup( newerror_name ) == baselookup( false_name ) )
   {
@@ -699,14 +699,14 @@ SLIInterpreter::print_error( Token cmd )
 
       // Command information is only printed if the
       // command is of trietype
-      if ( command.datum() != nullptr )
+      if ( command.datum() )
       {
         if ( command->gettypename() == Name( "trietype" ) )
         {
           msg << "\n\nCandidates for " << command << " are:\n";
 
           TrieDatum* trie = dynamic_cast< TrieDatum* >( command.datum() );
-          assert( trie != nullptr );
+          assert( trie );
 
           trie->get().info( msg );
         }
@@ -724,7 +724,7 @@ SLIInterpreter::print_error( Token cmd )
 void
 SLIInterpreter::raiseagain()
 {
-  assert( errordict != nullptr );
+  assert( errordict );
 
   if ( errordict->known( commandname_name ) )
   {
@@ -931,12 +931,12 @@ Name
 SLIInterpreter::getcurrentname() const
 {
   FunctionDatum* func = dynamic_cast< FunctionDatum* >( EStack.top().datum() );
-  if ( func != nullptr )
+  if ( func )
   {
     return ( func->getname() );
   }
   TrieDatum* trie = dynamic_cast< TrieDatum* >( EStack.top().datum() );
-  if ( trie != nullptr )
+  if ( trie )
   {
     return ( trie->getname() );
   }
@@ -1000,13 +1000,13 @@ SLIInterpreter::stack_backtrace( int n )
     }
 
     FunctionDatum* fd = dynamic_cast< FunctionDatum* >( EStack.pick( p ).datum() );
-    if ( fd != nullptr )
+    if ( fd )
     {
       fd->backtrace( this, p );
       continue;
     }
     NameDatum* nd = dynamic_cast< NameDatum* >( EStack.pick( p ).datum() );
-    if ( nd != nullptr )
+    if ( nd )
     {
       std::cerr << "While executing: ";
       nd->print( std::cerr );
@@ -1014,7 +1014,7 @@ SLIInterpreter::stack_backtrace( int n )
       continue;
     }
     TrieDatum* td = dynamic_cast< TrieDatum* >( EStack.pick( p ).datum() );
-    if ( td != nullptr )
+    if ( td )
     {
       std::cerr << "While executing: ";
       td->print( std::cerr );

--- a/sli/interpret.cc
+++ b/sli/interpret.cc
@@ -185,7 +185,7 @@ SLIInterpreter::inittypes()
 void
 SLIInterpreter::initdictionaries()
 {
-  assert( DStack == nullptr );
+  assert( not DStack );
 
   DStack = new DictionaryStack();
   assert( DStack );

--- a/sli/numericdatum.h
+++ b/sli/numericdatum.h
@@ -100,7 +100,7 @@ public:
   static void
   operator delete( void* p, size_t size )
   {
-    if ( p == nullptr )
+    if ( not p )
     {
       return;
     }

--- a/sli/oosupport.cc
+++ b/sli/oosupport.cc
@@ -55,13 +55,13 @@ OOSupportModule::CallMemberFunction::execute( SLIInterpreter* i ) const
   //  call: dict key call -> unknown
 
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( dict != nullptr );
+  assert( dict );
   LiteralDatum* key = dynamic_cast< LiteralDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( key != nullptr );
+  assert( key );
 
   Token value = ( *dict )->lookup( *key );
 
-  if ( value.datum() != nullptr )
+  if ( value.datum() )
   {
     Token nt( new NameDatum( *key ) );
     i->DStack->push( *dict );

--- a/sli/parser.cc
+++ b/sli/parser.cc
@@ -60,7 +60,7 @@ Parser::Parser( std::istream& is )
   , ParseStack( 128 )
 {
   init( is );
-  assert( s != nullptr );
+  assert( s );
 }
 
 Parser::Parser()
@@ -68,14 +68,14 @@ Parser::Parser()
   , ParseStack( 128 )
 {
   init( std::cin );
-  assert( s != nullptr );
+  assert( s );
 }
 
 
 bool
 Parser::operator()( Token& t )
 {
-  assert( s != nullptr );
+  assert( s );
 
   Token pt;
 
@@ -158,13 +158,13 @@ Parser::operator()( Token& t )
           if ( pt->isoftype( SLIInterpreter::Arraytype ) )
           {
             ArrayDatum* pa = dynamic_cast< ArrayDatum* >( pt.datum() );
-            assert( pa != nullptr );
+            assert( pa );
             pa->push_back( t );
           }
           else // now it must be a procedure
           {
             LitprocedureDatum* pp = dynamic_cast< LitprocedureDatum* >( pt.datum() );
-            assert( pp != nullptr );
+            assert( pp );
             pp->set_executable();
             pp->push_back( t );
           }

--- a/sli/parser.h
+++ b/sli/parser.h
@@ -86,7 +86,7 @@ public:
   void
   clear_context()
   {
-    if ( s != nullptr )
+    if ( s )
     {
       s->clear_context();
     }

--- a/sli/processes.cc
+++ b/sli/processes.cc
@@ -100,7 +100,7 @@ const std::string
 Processes::systemerror( SLIInterpreter* i )
 {
   Token errordict_t( i->baselookup( i->errordict_name ) );
-  assert( errordict_t.datum() != nullptr );
+  assert( errordict_t.datum() );
   DictionaryDatum errordict_d = *dynamic_cast< DictionaryDatum* >( errordict_t.datum() );
 
   std::string ErrorMessage( std::strerror( errno ) );
@@ -121,7 +121,7 @@ Processes::fd( std::istream* s )
   else
   {
     ifdstream* fs = dynamic_cast< ifdstream* >( s );
-    assert( fs != nullptr );
+    assert( fs );
     return fs->rdbuf()->fd();
   }
 }
@@ -140,7 +140,7 @@ Processes::fd( std::ostream* s )
   else
   {
     ofdstream* fs = dynamic_cast< ofdstream* >( s );
-    assert( fs != nullptr );
+    assert( fs );
     return fs->rdbuf()->fd();
   }
 }
@@ -196,7 +196,7 @@ Processes::init( SLIInterpreter* i )
   // create variables "sys_errname" and "sys_errno"
   //  and all needed errornumbers in errordict
   Token errordict_t( i->baselookup( i->errordict_name ) );
-  assert( errordict_t.datum() != nullptr );
+  assert( errordict_t.datum() );
   DictionaryDatum errordict_d = *dynamic_cast< DictionaryDatum* >( errordict_t.datum() );
 
   errordict_d->insert( sys_errname, new LiteralDatum( "" ) );
@@ -338,7 +338,7 @@ Processes::Sysexec_aFunction::execute( SLIInterpreter* i ) const
 
   // this is an array of tokens (to names)
   ArrayDatum* array = dynamic_cast< ArrayDatum* >( array_token.datum() );
-  assert( array != nullptr );
+  assert( array );
 
   assert( array->size() > 0 ); // need at least the commandname
 
@@ -355,7 +355,7 @@ Processes::Sysexec_aFunction::execute( SLIInterpreter* i ) const
   for ( unsigned int j = 0; j < array->size(); j++ ) // forall in array
   {
     StringDatum* nd = dynamic_cast< StringDatum* >( ( *array )[ j ].datum() );
-    assert( nd != nullptr );
+    assert( nd );
     // StringDatum is derived from class string.
     argv[ j ] = const_cast< char* >( nd->c_str() );
   }
@@ -383,10 +383,10 @@ Processes::WaitPIDFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   IntegerDatum* pidin_d = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( pidin_d != nullptr );
+  assert( pidin_d );
 
   BoolDatum* nohangflag_d = dynamic_cast< BoolDatum* >( i->OStack.top().datum() );
-  assert( nohangflag_d != nullptr );
+  assert( nohangflag_d );
 
   // call waitpid()
   int stat_value;
@@ -455,10 +455,10 @@ Processes::KillFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   IntegerDatum* pid_d = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( pid_d != nullptr );
+  assert( pid_d );
 
   IntegerDatum* signal_d = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( signal_d != nullptr );
+  assert( signal_d );
 
   // call kill()
   int result = kill( pid_d->get(), signal_d->get() );
@@ -510,9 +510,9 @@ Processes::Dup2_is_isFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   IstreamDatum* s_d1 = dynamic_cast< IstreamDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( s_d1 != nullptr );
+  assert( s_d1 );
   IstreamDatum* s_d2 = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
-  assert( s_d2 != nullptr );
+  assert( s_d2 );
 
   // call dup2();
   // int result = dup2( fd(s_d1->get()) , fd(s_d2->get()) );//using get() on a
@@ -544,9 +544,9 @@ Processes::Dup2_os_osFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   OstreamDatum* s_d1 = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( s_d1 != nullptr );
+  assert( s_d1 );
   OstreamDatum* s_d2 = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
-  assert( s_d2 != nullptr );
+  assert( s_d2 );
 
   // call dup2();
   // for comments on LockPTRs see Dup2_is_isFunction::execute
@@ -572,9 +572,9 @@ Processes::Dup2_is_osFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   IstreamDatum* s_d1 = dynamic_cast< IstreamDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( s_d1 != nullptr );
+  assert( s_d1 );
   OstreamDatum* s_d2 = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
-  assert( s_d2 != nullptr );
+  assert( s_d2 );
 
   // call dup2();
   // int result = dup2( fd(s_d1->get()) , fd(s_d2->get()) );//using get() on a
@@ -606,9 +606,9 @@ Processes::Dup2_os_isFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   OstreamDatum* s_d1 = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( s_d1 != nullptr );
+  assert( s_d1 );
   IstreamDatum* s_d2 = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
-  assert( s_d2 != nullptr );
+  assert( s_d2 );
 
   // call dup2();
   // for comments on LockPTRs see Dup2_is_isFunction::execute
@@ -633,7 +633,7 @@ Processes::AvailableFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  assert( istreamdatum != nullptr );
+  assert( istreamdatum );
   assert( istreamdatum->valid() );
 
   if ( not( **istreamdatum ).good() )
@@ -797,7 +797,7 @@ Processes::MkfifoFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   StringDatum* s_d = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( s_d != nullptr );
+  assert( s_d );
 
   // call mkfifo();
   mode_t mode = S_IRWXU | S_IRWXG | S_IRWXO; // Try to give all permissions,
@@ -841,11 +841,11 @@ Processes::SetNonblockFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() >= 2 ); // setNONBLOCK takes 2 arguments
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( istreamdatum != nullptr );
+  assert( istreamdatum );
   assert( istreamdatum->valid() );
 
   BoolDatum* newflag_d = dynamic_cast< BoolDatum* >( i->OStack.top().datum() );
-  assert( newflag_d != nullptr );
+  assert( newflag_d );
 
   // get filedescriptor:
   // istreamdatum is a pointer to a LockPTR
@@ -907,7 +907,7 @@ Processes::Isatty_osFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   OstreamDatum* s_d1 = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( s_d1 != nullptr );
+  assert( s_d1 );
 
   int fd = Processes::fd( **s_d1 ); // Get FileDescriptor
 
@@ -932,7 +932,7 @@ Processes::Isatty_isFunction::execute( SLIInterpreter* i ) const
 
   // Read arguments from operand Stack, but leave tokens on stack:
   IstreamDatum* s_d1 = dynamic_cast< IstreamDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( s_d1 != nullptr );
+  assert( s_d1 );
 
   int fd = Processes::fd( **s_d1 ); // Get FileDescriptor
 

--- a/sli/sli_io.cc
+++ b/sli/sli_io.cc
@@ -79,7 +79,7 @@ MathLinkPutStringFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr )
+  if ( not sd )
   {
     StringDatum const d;
     Token t = i->OStack.top();
@@ -113,7 +113,7 @@ XIfstreamFunction::execute( SLIInterpreter* i ) const
   //              -> false
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr )
+  if ( not sd )
   {
     StringDatum const d;
     Token t = i->OStack.top();
@@ -157,7 +157,7 @@ IfstreamFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr )
+  if ( not sd )
   {
     StringDatum const d;
     Token t = i->OStack.top();
@@ -205,7 +205,7 @@ OfstreamFunction::execute( SLIInterpreter* i ) const
   //              -> false
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr )
+  if ( not sd )
   {
     StringDatum const d;
     Token t = i->OStack.top();
@@ -267,7 +267,7 @@ OfsopenFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* md = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr or md == nullptr )
+  if ( not sd or md == nullptr )
   {
     StringDatum const d;
     Token t1 = i->OStack.pick( 1 );
@@ -330,7 +330,7 @@ IsstreamFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr )
+  if ( not sd )
   {
     StringDatum const d;
     Token t = i->OStack.top();
@@ -404,7 +404,7 @@ StrSStreamFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr )
+  if ( not ostreamdatum )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -564,7 +564,7 @@ PrintFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( ostreamdatum == nullptr )
+  if ( not ostreamdatum )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -610,7 +610,7 @@ PrettyprintFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.pick( 1 );
@@ -642,7 +642,7 @@ FlushFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -682,7 +682,7 @@ EndlFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -710,7 +710,7 @@ EndsFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.pick( 1 );
@@ -735,7 +735,7 @@ EatwhiteFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr or not istreamdatum->valid() )
+  if ( not istreamdatum or not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -766,7 +766,7 @@ CloseistreamFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr or not istreamdatum->valid() )
+  if ( not istreamdatum or not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -814,7 +814,7 @@ CloseostreamFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr )
+  if ( not ostreamdatum )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -855,7 +855,7 @@ SetwFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.pick( 1 );
@@ -864,7 +864,7 @@ SetwFunction::execute( SLIInterpreter* i ) const
 
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
 
-  if ( id == nullptr )
+  if ( not id )
   {
     IntegerDatum const d;
     Token t = i->OStack.top();
@@ -906,7 +906,7 @@ SetprecisionFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.pick( 1 );
@@ -915,7 +915,7 @@ SetprecisionFunction::execute( SLIInterpreter* i ) const
 
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
 
-  if ( id == nullptr )
+  if ( not id )
   {
     IntegerDatum const d;
     Token t = i->OStack.top();
@@ -943,7 +943,7 @@ IOSFixedFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr or not ostreamdatum->valid() )
+  if ( not ostreamdatum or not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.pick( 1 );
@@ -971,7 +971,7 @@ IOSScientificFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -999,7 +999,7 @@ IOSDefaultFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1027,7 +1027,7 @@ IOSShowpointFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1054,7 +1054,7 @@ IOSNoshowpointFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1082,7 +1082,7 @@ IOSOctFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1109,7 +1109,7 @@ IOSHexFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1136,7 +1136,7 @@ IOSDecFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1163,7 +1163,7 @@ IOSShowbaseFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1190,7 +1190,7 @@ IOSNoshowbaseFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1217,7 +1217,7 @@ IOSLeftFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1246,7 +1246,7 @@ IOSRightFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1275,7 +1275,7 @@ IOSInternalFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1316,7 +1316,7 @@ GetcFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1356,7 +1356,7 @@ GetsFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1405,7 +1405,7 @@ GetlineFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1459,7 +1459,7 @@ IGoodFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1500,7 +1500,7 @@ IClearFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1534,7 +1534,7 @@ OClearFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1569,7 +1569,7 @@ IFailFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1611,7 +1611,7 @@ OGoodFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1652,7 +1652,7 @@ IEofFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1694,7 +1694,7 @@ OEofFunction::execute( SLIInterpreter* i ) const
 
   OstreamDatum* ostreamdatum = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
 
-  if ( ostreamdatum == nullptr || not ostreamdatum->valid() )
+  if ( not ostreamdatum || not ostreamdatum->valid() )
   {
     OstreamDatum const d;
     Token t = i->OStack.top();
@@ -1749,7 +1749,7 @@ In_AvailFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1775,7 +1775,7 @@ ReadDoubleFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr )
+  if ( not istreamdatum )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1817,7 +1817,7 @@ ReadIntFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr )
+  if ( not istreamdatum )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();
@@ -1866,7 +1866,7 @@ ReadWordFunction::execute( SLIInterpreter* i ) const
 
   IstreamDatum* istreamdatum = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
 
-  if ( istreamdatum == nullptr || not istreamdatum->valid() )
+  if ( not istreamdatum || not istreamdatum->valid() )
   {
     IstreamDatum const d;
     Token t = i->OStack.top();

--- a/sli/sli_io.cc
+++ b/sli/sli_io.cc
@@ -292,7 +292,7 @@ OfsopenFunction::execute( SLIInterpreter* i ) const
     return;
   }
 
-  if ( out != nullptr )
+  if ( out )
   {
     i->OStack.pop( 2 );
     if ( out->good() )
@@ -416,10 +416,10 @@ StrSStreamFunction::execute( SLIInterpreter* i ) const
 #else
   std::ostrstream* out = dynamic_cast< std::ostrstream* >( ostreamdatum->get() );
 #endif
-  assert( out != nullptr );
+  assert( out );
   ostreamdatum->unlock();
 
-  if ( out != nullptr )
+  if ( out )
   {
     if ( out->good() )
     {
@@ -781,7 +781,7 @@ CloseistreamFunction::execute( SLIInterpreter* i ) const
     // the datum conatains &std::cin !!
     ifdstream* ifs = dynamic_cast< ifdstream* >( istreamdatum->get() );
     istreamdatum->unlock();
-    if ( ifs != nullptr )
+    if ( ifs )
     {
       ifs->close();
       // iostreamhandle->destroy();
@@ -829,7 +829,7 @@ CloseostreamFunction::execute( SLIInterpreter* i ) const
     ofdstream* ofs = dynamic_cast< ofdstream* >( ostreamdatum->get() );
     ostreamdatum->unlock();
 
-    if ( ofs != nullptr )
+    if ( ofs )
     {
       ofs->close();
       i->OStack.pop();
@@ -1720,7 +1720,7 @@ Cvx_fFunction::execute( SLIInterpreter* i ) const
   i->assert_stack_load( 1 );
 
   IstreamDatum* sd = dynamic_cast< IstreamDatum* >( i->OStack.top().datum() );
-  if ( sd != nullptr )
+  if ( sd )
   {
     Token handle_token( new XIstreamDatum( *sd ) );
     i->OStack.pop();

--- a/sli/sli_io.cc
+++ b/sli/sli_io.cc
@@ -267,7 +267,7 @@ OfsopenFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* md = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( not sd or md == nullptr )
+  if ( not sd or not md )
   {
     StringDatum const d;
     Token t1 = i->OStack.pick( 1 );

--- a/sli/sliactions.cc
+++ b/sli/sliactions.cc
@@ -89,7 +89,7 @@ FunctiontypeFunction::execute( SLIInterpreter* i ) const
   if ( i->step_mode() )
   {
     std::cerr << "Calling builtin function: ";
-    if ( fd != nullptr )
+    if ( fd )
     {
       fd->pprint( std::cerr );
     }

--- a/sli/sliarray.cc
+++ b/sli/sliarray.cc
@@ -67,11 +67,11 @@ SLIArrayModule::RangeFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( ad != nullptr );
+  assert( ad );
   if ( ad->size() == 1 ) // Construct an array of elements 1 ... N
   {
     IntegerDatum* nd = dynamic_cast< IntegerDatum* >( ad->get( 0 ).datum() );
-    if ( nd != nullptr )
+    if ( nd )
     {
       long n = nd->get();
       ad->erase();
@@ -106,7 +106,7 @@ SLIArrayModule::RangeFunction::execute( SLIInterpreter* i ) const
   {
     IntegerDatum* n1d = dynamic_cast< IntegerDatum* >( ad->get( 0 ).datum() );
     IntegerDatum* n2d = dynamic_cast< IntegerDatum* >( ad->get( 1 ).datum() );
-    if ( ( n1d != nullptr ) && ( n2d != nullptr ) )
+    if ( ( n1d ) && ( n2d ) )
     {
       long n = 1 + n2d->get() - n1d->get();
 
@@ -130,7 +130,7 @@ SLIArrayModule::RangeFunction::execute( SLIInterpreter* i ) const
     {
       DoubleDatum* n1d = dynamic_cast< DoubleDatum* >( ad->get( 0 ).datum() );
       DoubleDatum* n2d = dynamic_cast< DoubleDatum* >( ad->get( 1 ).datum() );
-      if ( ( n1d != nullptr ) && ( n2d != nullptr ) )
+      if ( ( n1d ) && ( n2d ) )
       {
         long n = 1 + static_cast< long >( n2d->get() - n1d->get() );
 
@@ -161,7 +161,7 @@ SLIArrayModule::RangeFunction::execute( SLIInterpreter* i ) const
     IntegerDatum* n1d = dynamic_cast< IntegerDatum* >( ad->get( 0 ).datum() );
     IntegerDatum* n2d = dynamic_cast< IntegerDatum* >( ad->get( 1 ).datum() );
     IntegerDatum* n3d = dynamic_cast< IntegerDatum* >( ad->get( 2 ).datum() );
-    if ( ( n1d != nullptr ) && ( n2d != nullptr ) && ( n3d != nullptr ) )
+    if ( ( n1d ) && ( n2d ) && ( n3d ) )
     {
       long di = n3d->get();
       long start = n1d->get();
@@ -192,7 +192,7 @@ SLIArrayModule::RangeFunction::execute( SLIInterpreter* i ) const
       DoubleDatum* n1d = dynamic_cast< DoubleDatum* >( ad->get( 0 ).datum() );
       DoubleDatum* n2d = dynamic_cast< DoubleDatum* >( ad->get( 1 ).datum() );
       DoubleDatum* n3d = dynamic_cast< DoubleDatum* >( ad->get( 2 ).datum() );
-      if ( ( n1d != nullptr ) && ( n2d != nullptr ) && ( n3d != nullptr ) )
+      if ( ( n1d ) && ( n2d ) && ( n3d ) )
       {
         double di = n3d->get();
         double start = n1d->get();
@@ -240,11 +240,11 @@ SLIArrayModule::ArangeFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( ad != nullptr );
+  assert( ad );
   if ( ad->size() == 1 ) // Construct an array of elements 1 ... N
   {
     IntegerDatum* nd = dynamic_cast< IntegerDatum* >( ad->get( 0 ).datum() );
-    if ( nd != nullptr )
+    if ( nd )
     {
       long n = nd->get();
       if ( n < 0 )
@@ -286,7 +286,7 @@ SLIArrayModule::ArangeFunction::execute( SLIInterpreter* i ) const
   {
     IntegerDatum* n1d = dynamic_cast< IntegerDatum* >( ad->get( 0 ).datum() );
     IntegerDatum* n2d = dynamic_cast< IntegerDatum* >( ad->get( 1 ).datum() );
-    if ( ( n1d != nullptr ) && ( n2d != nullptr ) )
+    if ( ( n1d ) && ( n2d ) )
     {
       const long start = n1d->get();
       const long stop = n2d->get();
@@ -310,7 +310,7 @@ SLIArrayModule::ArangeFunction::execute( SLIInterpreter* i ) const
     {
       DoubleDatum* n1d = dynamic_cast< DoubleDatum* >( ad->get( 0 ).datum() );
       DoubleDatum* n2d = dynamic_cast< DoubleDatum* >( ad->get( 1 ).datum() );
-      if ( ( n1d != nullptr ) && ( n2d != nullptr ) )
+      if ( ( n1d ) && ( n2d ) )
       {
         double start = n1d->get();
         double stop = n2d->get();
@@ -338,7 +338,7 @@ SLIArrayModule::ArangeFunction::execute( SLIInterpreter* i ) const
     IntegerDatum* n1d = dynamic_cast< IntegerDatum* >( ad->get( 0 ).datum() );
     IntegerDatum* n2d = dynamic_cast< IntegerDatum* >( ad->get( 1 ).datum() );
     IntegerDatum* n3d = dynamic_cast< IntegerDatum* >( ad->get( 2 ).datum() );
-    if ( ( n1d != nullptr ) && ( n2d != nullptr ) && ( n3d != nullptr ) )
+    if ( ( n1d ) && ( n2d ) && ( n3d ) )
     {
       long di = n3d->get();
       long start = n1d->get();
@@ -372,7 +372,7 @@ SLIArrayModule::ArangeFunction::execute( SLIInterpreter* i ) const
       DoubleDatum* n1d = dynamic_cast< DoubleDatum* >( ad->get( 0 ).datum() );
       DoubleDatum* n2d = dynamic_cast< DoubleDatum* >( ad->get( 1 ).datum() );
       DoubleDatum* n3d = dynamic_cast< DoubleDatum* >( ad->get( 2 ).datum() );
-      if ( ( n1d != nullptr ) && ( n2d != nullptr ) && ( n3d != nullptr ) )
+      if ( ( n1d ) && ( n2d ) && ( n3d ) )
       {
         double di = n3d->get();
         double start = n1d->get();
@@ -421,7 +421,7 @@ SLIArrayModule::ReverseFunction::execute( SLIInterpreter* i ) const
   i->assert_stack_load( 1 );
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( ad != nullptr );
+  assert( ad );
   ad->reverse();
   i->EStack.pop();
 }
@@ -447,7 +447,7 @@ SLIArrayModule::FlattenFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( ad != nullptr );
+  assert( ad );
   ArrayDatum* ta = new ArrayDatum();
   Token at( ta );
 
@@ -457,7 +457,7 @@ SLIArrayModule::FlattenFunction::execute( SLIInterpreter* i ) const
   for ( Token const* t = ad->begin(); t != ad->end(); ++t )
   {
     ArrayDatum* ad1 = dynamic_cast< ArrayDatum* >( t->datum() );
-    if ( ad1 != nullptr )
+    if ( ad1 )
     {
       size += ad1->size();
     }
@@ -480,7 +480,7 @@ SLIArrayModule::FlattenFunction::execute( SLIInterpreter* i ) const
     for ( Token* t = ad->begin(); t != ad->end(); ++t )
     {
       ArrayDatum* ad1 = dynamic_cast< ArrayDatum* >( t->datum() );
-      if ( ad1 != nullptr )
+      if ( ad1 )
       {
         if ( ad1->references() > 1 )
         {
@@ -508,7 +508,7 @@ SLIArrayModule::FlattenFunction::execute( SLIInterpreter* i ) const
     for ( Token const* t = ad->begin(); t != ad->end(); ++t )
     {
       ArrayDatum* ad1 = dynamic_cast< ArrayDatum* >( t->datum() );
-      if ( ad1 != nullptr )
+      if ( ad1 )
       {
         for ( Token const* t1 = ad1->begin(); t1 != ad1->end(); ++t1 )
         {
@@ -648,10 +648,10 @@ SLIArrayModule::TransposeFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ArrayDatum* sd = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
 
   ArrayDatum* hd = dynamic_cast< ArrayDatum* >( sd->begin()->datum() );
-  assert( hd != nullptr );
+  assert( hd );
 
   // size of source first level
   size_t m = sd->size();
@@ -664,7 +664,7 @@ SLIArrayModule::TransposeFunction::execute( SLIInterpreter* i ) const
 
 
   ArrayDatum* td = new ArrayDatum();
-  assert( td != nullptr );
+  assert( td );
 
   Token tt( td );
 
@@ -675,7 +675,7 @@ SLIArrayModule::TransposeFunction::execute( SLIInterpreter* i ) const
   for ( size_t j = 0; j < n; j++ )
   {
     hd = new ArrayDatum();
-    assert( td != nullptr );
+    assert( td );
 
     hd->reserve( m );
 
@@ -687,7 +687,7 @@ SLIArrayModule::TransposeFunction::execute( SLIInterpreter* i ) const
     hd = dynamic_cast< ArrayDatum* >( sr->datum() );
 
     // raiseerror instead
-    assert( hd != nullptr );
+    assert( hd );
 
     Token* sc;
     Token* tr;
@@ -698,7 +698,7 @@ SLIArrayModule::TransposeFunction::execute( SLIInterpreter* i ) const
       ArrayDatum* trd = dynamic_cast< ArrayDatum* >( tr->datum() );
 
       // raiseerror instead
-      assert( trd != nullptr );
+      assert( trd );
 
       trd->push_back( *sc );
     }
@@ -719,11 +719,11 @@ SLIArrayModule::PartitionFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 2 );
 
   IntegerDatum* dd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( dd != nullptr );
+  assert( dd );
   IntegerDatum* nd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( nd != nullptr );
+  assert( nd );
   ArrayDatum* source = dynamic_cast< ArrayDatum* >( i->OStack.pick( 2 ).datum() );
-  assert( source != nullptr );
+  assert( source );
   ArrayDatum* target = new ArrayDatum;
 
   long n = nd->get();
@@ -805,7 +805,7 @@ SLIArrayModule::ArrayloadFunction::execute( SLIInterpreter* i ) const
   at.move( i->OStack.top() );
   i->OStack.pop();
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( at.datum() );
-  assert( ad != nullptr );
+  assert( ad );
   i->EStack.pop();
   int arraysize = ad->size();
   i->OStack.reserve_token( arraysize );
@@ -861,7 +861,7 @@ SLIArrayModule::ArraystoreFunction::execute( SLIInterpreter* i ) const
   i->assert_stack_load( 1 );
 
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( id != nullptr );
+  assert( id );
 
   long n = id->get();
   if ( n >= 0 )
@@ -938,13 +938,13 @@ void
 SLIArrayModule::IMapFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
   std::cerr << "During Map at iteration " << count->get() << "." << std::endl;
 
@@ -1036,7 +1036,7 @@ SLIArrayModule::IMapFunction::execute( SLIInterpreter* i ) const
         char cmd = i->debug_commandline( i->EStack.top() );
         if ( cmd == 'l' ) // List the procedure
         {
-          if ( proc != nullptr )
+          if ( proc )
           {
             proc->list( std::cerr, "   ", pos );
             std::cerr << std::endl;
@@ -1058,13 +1058,13 @@ void
 SLIArrayModule::IMap_ivFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
   std::cerr << "During Map at iteration " << count->get() << "." << std::endl;
 
@@ -1174,7 +1174,7 @@ SLIArrayModule::IMap_ivFunction::execute( SLIInterpreter* i ) const
         char cmd = i->debug_commandline( i->EStack.top() );
         if ( cmd == 'l' ) // List the procedure
         {
-          if ( proc != nullptr )
+          if ( proc )
           {
             proc->list( std::cerr, "   ", pos );
             std::cerr << std::endl;
@@ -1197,13 +1197,13 @@ void
 SLIArrayModule::IMap_dvFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
   std::cerr << "During Map at iteration " << count->get() << "." << std::endl;
 
@@ -1309,7 +1309,7 @@ SLIArrayModule::IMap_dvFunction::execute( SLIInterpreter* i ) const
         char cmd = i->debug_commandline( i->EStack.top() );
         if ( cmd == 'l' ) // List the procedure
         {
-          if ( proc != nullptr )
+          if ( proc )
           {
             proc->list( std::cerr, "   ", pos );
             std::cerr << std::endl;
@@ -1388,7 +1388,7 @@ SLIArrayModule::MapFunction::execute( SLIInterpreter* i ) const
 {
   i->EStack.pop();
   ProcedureDatum* proc = dynamic_cast< ProcedureDatum* >( i->OStack.top().datum() );
-  assert( proc != nullptr );
+  assert( proc );
 
   if ( proc->size() == 0 )
   {
@@ -1426,7 +1426,7 @@ SLIArrayModule::ValidFunction::execute( SLIInterpreter* i ) const
 {
   assert( i->OStack.load() > 0 );
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( ad != nullptr );
+  assert( ad );
   i->OStack.push( ad->valid() );
 
   i->EStack.pop();
@@ -1436,13 +1436,13 @@ void
 SLIArrayModule::IMapIndexedFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
 
   std::cerr << "During MapIndexed at iteration " << count->get() << "." << std::endl;
@@ -1538,7 +1538,7 @@ SLIArrayModule::IMapIndexedFunction::execute( SLIInterpreter* i ) const
         char cmd = i->debug_commandline( i->EStack.top() );
         if ( cmd == 'l' ) // List the procedure
         {
-          if ( proc != nullptr )
+          if ( proc )
           {
             proc->list( std::cerr, "   ", pos );
             std::cerr << std::endl;
@@ -1563,7 +1563,7 @@ SLIArrayModule::MapIndexedFunction::execute( SLIInterpreter* i ) const
 {
   i->EStack.pop();
   ProcedureDatum* proc = dynamic_cast< ProcedureDatum* >( i->OStack.top().datum() );
-  assert( proc != nullptr );
+  assert( proc );
 
   if ( proc->size() == 0 )
   {
@@ -1588,13 +1588,13 @@ void
 SLIArrayModule::IMapThreadFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
 
   std::cerr << "During MapThread at iteration " << count->get() << "." << std::endl;
@@ -1710,7 +1710,7 @@ SLIArrayModule::IMapThreadFunction::execute( SLIInterpreter* i ) const
         char cmd = i->debug_commandline( i->EStack.top() );
         if ( cmd == 'l' ) // List the procedure
         {
-          if ( procd != nullptr )
+          if ( procd )
           {
             procd->list( std::cerr, "   ", proccount );
             std::cerr << std::endl;
@@ -1756,7 +1756,7 @@ SLIArrayModule::MapThreadFunction::execute( SLIInterpreter* i ) const
 {
   assert( i->OStack.load() >= 2 );
   ProcedureDatum* proc = dynamic_cast< ProcedureDatum* >( i->OStack.top().datum() );
-  assert( proc != nullptr );
+  assert( proc );
 
   if ( proc->size() == 0 )
   {
@@ -1767,7 +1767,7 @@ SLIArrayModule::MapThreadFunction::execute( SLIInterpreter* i ) const
   }
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( ad != nullptr );
+  assert( ad );
 
   if ( ad->size() > 0 )
   {
@@ -1853,7 +1853,7 @@ SLIArrayModule::Put_a_a_tFunction::execute( SLIInterpreter* i ) const
 
   for ( Token* t = pos->begin(); t != pos->end(); ++t )
   {
-    assert( t != nullptr );
+    assert( t );
     IntegerDatum* idx = dynamic_cast< IntegerDatum* >( t->datum() );
     if ( idx == nullptr )
     {
@@ -4006,7 +4006,7 @@ void
 SLIArrayModule::Iforall_ivFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   std::cerr << "During forall (IntVector) at iteration " << count->get() << "." << std::endl;
 }
@@ -4082,7 +4082,7 @@ void
 SLIArrayModule::Iforall_dvFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   std::cerr << "During forall (DoubleVector) at iteration " << count->get() << "." << std::endl;
 }

--- a/sli/sliarray.cc
+++ b/sli/sliarray.cc
@@ -1773,7 +1773,7 @@ SLIArrayModule::MapThreadFunction::execute( SLIInterpreter* i ) const
   {
     // check if the components are arrays of equal length.
     ArrayDatum* ad1 = dynamic_cast< ArrayDatum* >( ad->get( 0 ).datum() );
-    if ( ad1 == nullptr )
+    if ( not ad1 )
     {
       i->raiseerror( i->ArgumentTypeError );
       return;
@@ -1782,7 +1782,7 @@ SLIArrayModule::MapThreadFunction::execute( SLIInterpreter* i ) const
     for ( size_t j = 1; j < ad->size(); ++j )
     {
       ArrayDatum* ad2 = dynamic_cast< ArrayDatum* >( ad->get( j ).datum() );
-      if ( ad2 == nullptr )
+      if ( not ad2 )
       {
         i->raiseerror( i->ArgumentTypeError );
         return;
@@ -1829,7 +1829,7 @@ SLIArrayModule::Put_a_a_tFunction::execute( SLIInterpreter* i ) const
   }
 
   ArrayDatum* source = dynamic_cast< ArrayDatum* >( i->OStack.pick( 2 ).datum() );
-  if ( source == nullptr )
+  if ( not source )
   {
     i->message( SLIInterpreter::M_ERROR, "Put", "First argument must be an array." );
     i->message( SLIInterpreter::M_ERROR, "Put", "Usage: [array] [d1 ...dn]  obj Put -> [array]" );
@@ -1840,7 +1840,7 @@ SLIArrayModule::Put_a_a_tFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* pos = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( pos == nullptr )
+  if ( not pos )
   {
     i->message( SLIInterpreter::M_ERROR,
       "Put",
@@ -1855,7 +1855,7 @@ SLIArrayModule::Put_a_a_tFunction::execute( SLIInterpreter* i ) const
   {
     assert( t );
     IntegerDatum* idx = dynamic_cast< IntegerDatum* >( t->datum() );
-    if ( idx == nullptr )
+    if ( not idx )
     {
       i->message( SLIInterpreter::M_ERROR, "Put", "Non integer index found." );
       i->message( SLIInterpreter::M_ERROR, "Put", "Source array is unchanged." );
@@ -1884,7 +1884,7 @@ SLIArrayModule::Put_a_a_tFunction::execute( SLIInterpreter* i ) const
     if ( t < pos->end() - 1 )
     {
       source = dynamic_cast< ArrayDatum* >( ( *source )[ j ].datum() );
-      if ( source == nullptr )
+      if ( not source )
       {
         i->message( SLIInterpreter::M_ERROR, "Put", "Dimensions of index and array do not match." );
         i->message( SLIInterpreter::M_ERROR, "Put", "Source array is unchanged." );
@@ -2078,37 +2078,37 @@ SLIArrayModule::AreaFunction::execute( SLIInterpreter* i ) const
   //     i->raiseerror(i->ArgumentTypeError);
   //     return;
   //   }
-  if ( s_w_d == nullptr )
+  if ( not s_w_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( s_y_d == nullptr )
+  if ( not s_y_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( s_x_d == nullptr )
+  if ( not s_x_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_h_d == nullptr )
+  if ( not a_h_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_w_d == nullptr )
+  if ( not a_w_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_y_d == nullptr )
+  if ( not a_y_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_x_d == nullptr )
+  if ( not a_x_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -2347,32 +2347,32 @@ SLIArrayModule::Area2Function::execute( SLIInterpreter* i ) const
   //     i->raiseerror(i->ArgumentTypeError);
   //     return;
   //   }
-  if ( s_y_d == nullptr )
+  if ( not s_y_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( s_x_d == nullptr )
+  if ( not s_x_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_h_d == nullptr )
+  if ( not a_h_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_w_d == nullptr )
+  if ( not a_w_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_y_d == nullptr )
+  if ( not a_y_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
-  if ( a_x_d == nullptr )
+  if ( not a_x_d )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -2446,7 +2446,7 @@ SLIArrayModule::Cv1dFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* x = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* y = dynamic_cast< IntegerDatum* >( i->OStack.pick( 2 ).datum() );
 
-  if ( w == nullptr )
+  if ( not w )
   {
     i->message( SLIInterpreter::M_ERROR, "cv1d", "integertype expected" );
     i->message( SLIInterpreter::M_ERROR, "cv1d", "Usage: y x w cv1d" );
@@ -2454,7 +2454,7 @@ SLIArrayModule::Cv1dFunction::execute( SLIInterpreter* i ) const
     return;
   }
 
-  if ( x == nullptr )
+  if ( not x )
   {
     i->message( SLIInterpreter::M_ERROR, "cv1d", "integertype expected" );
     i->message( SLIInterpreter::M_ERROR, "cv1d", "Usage: y x w cv1d" );
@@ -2462,7 +2462,7 @@ SLIArrayModule::Cv1dFunction::execute( SLIInterpreter* i ) const
     return;
   }
 
-  if ( y == nullptr )
+  if ( not y )
   {
     i->message( SLIInterpreter::M_ERROR, "cv1d", "integertype expected" );
     i->message( SLIInterpreter::M_ERROR, "cv1d", "Usage: y x w cv1d" );
@@ -2516,7 +2516,7 @@ SLIArrayModule::Cv2dFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* w = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
   IntegerDatum* in = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( w == nullptr )
+  if ( not w )
   {
     i->message( SLIInterpreter::M_ERROR, "cv2d", "integertype expected" );
     i->message( SLIInterpreter::M_ERROR, "cv2d", "Usage: i w cv2d" );
@@ -2524,7 +2524,7 @@ SLIArrayModule::Cv2dFunction::execute( SLIInterpreter* i ) const
     return;
   }
 
-  if ( in == nullptr )
+  if ( not in )
   {
     i->message( SLIInterpreter::M_ERROR, "cv2d", "integertype expected" );
     i->message( SLIInterpreter::M_ERROR, "cv2d", "Usage: i w cv2d" );
@@ -2567,7 +2567,7 @@ SLIArrayModule::GetMaxFunction::execute( SLIInterpreter* i ) const
   }
 
   ArrayDatum* a = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  if ( a == nullptr )
+  if ( not a )
   {
     i->message( SLIInterpreter::M_ERROR, "GetMax", "argument must be an array" );
     i->raiseerror( i->ArgumentTypeError );
@@ -2575,7 +2575,7 @@ SLIArrayModule::GetMaxFunction::execute( SLIInterpreter* i ) const
   }
 
   IntegerDatum* tmp = dynamic_cast< IntegerDatum* >( a->begin()->datum() );
-  if ( tmp == nullptr )
+  if ( not tmp )
   {
     i->message( SLIInterpreter::M_ERROR, "GetMax", "argument array may only contain integers" );
     i->raiseerror( i->ArgumentTypeError );
@@ -2587,7 +2587,7 @@ SLIArrayModule::GetMaxFunction::execute( SLIInterpreter* i ) const
   while ( pos < a->size() )
   {
     tmp2 = dynamic_cast< IntegerDatum* >( a->get( pos ).datum() );
-    if ( tmp2 == nullptr )
+    if ( not tmp2 )
     {
       i->message( SLIInterpreter::M_ERROR, "GetMax", "argument array may only contain integers" );
       i->raiseerror( i->ArgumentTypeError );
@@ -2629,7 +2629,7 @@ SLIArrayModule::GetMinFunction::execute( SLIInterpreter* i ) const
   }
 
   ArrayDatum* a = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  if ( a == nullptr )
+  if ( not a )
   {
     i->message( SLIInterpreter::M_ERROR, "GetMin", "argument must be an array" );
     i->raiseerror( i->ArgumentTypeError );
@@ -2638,7 +2638,7 @@ SLIArrayModule::GetMinFunction::execute( SLIInterpreter* i ) const
 
 
   IntegerDatum* tmp = dynamic_cast< IntegerDatum* >( a->begin()->datum() );
-  if ( tmp == nullptr )
+  if ( not tmp )
   {
     i->message( SLIInterpreter::M_ERROR, "GetMin", "argument array may only contain integers" );
     i->raiseerror( i->ArgumentTypeError );
@@ -2650,7 +2650,7 @@ SLIArrayModule::GetMinFunction::execute( SLIInterpreter* i ) const
   while ( pos < a->size() )
   {
     tmp2 = dynamic_cast< IntegerDatum* >( a->get( pos ).datum() );
-    if ( tmp2 == nullptr )
+    if ( not tmp2 )
     {
       i->message( SLIInterpreter::M_ERROR, "GetMin", "argument array may only contain integers" );
       i->raiseerror( i->ArgumentTypeError );
@@ -2942,7 +2942,7 @@ SLIArrayModule::IntVector2ArrayFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd = dynamic_cast< IntVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -2962,13 +2962,13 @@ SLIArrayModule::Add_iv_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd1 = dynamic_cast< IntVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd1 == nullptr )
+  if ( not ivd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd2 = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( ivd2 == nullptr )
+  if ( not ivd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3000,13 +3000,13 @@ SLIArrayModule::Add_i_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( id == nullptr )
+  if ( not id )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3034,7 +3034,7 @@ SLIArrayModule::Neg_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3061,13 +3061,13 @@ SLIArrayModule::Sub_iv_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd1 = dynamic_cast< IntVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd1 == nullptr )
+  if ( not ivd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd2 = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( ivd2 == nullptr )
+  if ( not ivd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3099,13 +3099,13 @@ SLIArrayModule::Mul_iv_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd1 = dynamic_cast< IntVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd1 == nullptr )
+  if ( not ivd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd2 = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( ivd2 == nullptr )
+  if ( not ivd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3138,13 +3138,13 @@ SLIArrayModule::Mul_i_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( id == nullptr )
+  if ( not id )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3172,13 +3172,13 @@ SLIArrayModule::Mul_d_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleDatum* dd = dynamic_cast< DoubleDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dd == nullptr )
+  if ( not dd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3206,13 +3206,13 @@ SLIArrayModule::Div_iv_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd1 = dynamic_cast< IntVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd1 == nullptr )
+  if ( not ivd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* ivd2 = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( ivd2 == nullptr )
+  if ( not ivd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3252,7 +3252,7 @@ SLIArrayModule::Length_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* ivd = dynamic_cast< IntVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3275,13 +3275,13 @@ SLIArrayModule::Add_dv_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd1 = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd1 == nullptr )
+  if ( not dvd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd2 = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dvd2 == nullptr )
+  if ( not dvd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3313,13 +3313,13 @@ SLIArrayModule::Sub_dv_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd1 = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd1 == nullptr )
+  if ( not dvd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd2 = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dvd2 == nullptr )
+  if ( not dvd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3351,13 +3351,13 @@ SLIArrayModule::Add_d_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleDatum* dd = dynamic_cast< DoubleDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dd == nullptr )
+  if ( not dd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( dvd == nullptr )
+  if ( not dvd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3387,13 +3387,13 @@ SLIArrayModule::Mul_d_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleDatum* dd = dynamic_cast< DoubleDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dd == nullptr )
+  if ( not dd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( dvd == nullptr )
+  if ( not dvd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3423,7 +3423,7 @@ SLIArrayModule::Neg_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd == nullptr )
+  if ( not dvd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3451,7 +3451,7 @@ SLIArrayModule::Inv_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd == nullptr )
+  if ( not dvd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3486,13 +3486,13 @@ SLIArrayModule::Mul_dv_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd1 = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd1 == nullptr )
+  if ( not dvd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd2 = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dvd2 == nullptr )
+  if ( not dvd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3524,13 +3524,13 @@ SLIArrayModule::Div_dv_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd1 = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd1 == nullptr )
+  if ( not dvd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd2 = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dvd2 == nullptr )
+  if ( not dvd2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3570,7 +3570,7 @@ SLIArrayModule::Length_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* dvd1 = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( dvd1 == nullptr )
+  if ( not dvd1 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3592,13 +3592,13 @@ SLIArrayModule::Get_dv_iFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( id == nullptr )
+  if ( not id )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* dvd = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( dvd == nullptr )
+  if ( not dvd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3625,13 +3625,13 @@ SLIArrayModule::Get_iv_iFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( id == nullptr )
+  if ( not id )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* vd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( vd == nullptr )
+  if ( not vd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3658,13 +3658,13 @@ SLIArrayModule::Get_iv_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* id = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( id == nullptr )
+  if ( not id )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* vd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( vd == nullptr )
+  if ( not vd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3698,13 +3698,13 @@ SLIArrayModule::Get_dv_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntVectorDatum* id = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( id == nullptr )
+  if ( not id )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* vd = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( vd == nullptr )
+  if ( not vd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3739,19 +3739,19 @@ SLIArrayModule::Put_dv_i_dFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleDatum* val = dynamic_cast< DoubleDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( val == nullptr )
+  if ( not val )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntegerDatum* idxd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( idxd == nullptr )
+  if ( not idxd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   DoubleVectorDatum* vecd = dynamic_cast< DoubleVectorDatum* >( i->OStack.pick( 2 ).datum() );
-  if ( vecd == nullptr )
+  if ( not vecd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3774,19 +3774,19 @@ SLIArrayModule::Put_iv_i_iFunction::execute( SLIInterpreter* i ) const
 {
 
   IntegerDatum* val = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( val == nullptr )
+  if ( not val )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntegerDatum* idxd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( idxd == nullptr )
+  if ( not idxd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
   }
   IntVectorDatum* vecd = dynamic_cast< IntVectorDatum* >( i->OStack.pick( 2 ).datum() );
-  if ( vecd == nullptr )
+  if ( not vecd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3813,7 +3813,7 @@ SLIArrayModule::DoubleVector2ArrayFunction::execute( SLIInterpreter* i ) const
     return;
   }
   DoubleVectorDatum* ivd = dynamic_cast< DoubleVectorDatum* >( i->OStack.top().datum() );
-  if ( ivd == nullptr )
+  if ( not ivd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3833,7 +3833,7 @@ SLIArrayModule::Zeros_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* num = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  if ( num == nullptr )
+  if ( not num )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3858,7 +3858,7 @@ SLIArrayModule::Ones_dvFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* num = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  if ( num == nullptr )
+  if ( not num )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3883,7 +3883,7 @@ SLIArrayModule::Zeros_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* num = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  if ( num == nullptr )
+  if ( not num )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -3908,7 +3908,7 @@ SLIArrayModule::Ones_ivFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* num = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  if ( num == nullptr )
+  if ( not num )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;

--- a/sli/slibuiltins.cc
+++ b/sli/slibuiltins.cc
@@ -46,7 +46,7 @@ IsetcallbackFunction::execute( SLIInterpreter* i ) const
   // move the hopefully present callback action
   // into the interpreters callback token.
   i->EStack.pop();
-  assert( dynamic_cast< CallbackDatum* >( i->EStack.top().datum() ) != nullptr );
+  assert( dynamic_cast< CallbackDatum* >( i->EStack.top().datum() ) );
   i->EStack.pop_move( i->ct );
 }
 
@@ -54,10 +54,10 @@ void
 IiterateFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   ProcedureDatum const* pd = dynamic_cast< ProcedureDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   std::cerr << "In procedure:" << std::endl;
 
@@ -133,10 +133,10 @@ void
 IloopFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   ProcedureDatum const* pd = dynamic_cast< ProcedureDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   std::cerr << "During loop:" << std::endl;
 
@@ -185,13 +185,13 @@ void
 IrepeatFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
 
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   std::cerr << "During repeat with " << count->get() << " iterations remaining." << std::endl;
 
@@ -252,11 +252,11 @@ void
 IforFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( count != nullptr );
+  assert( count );
   ProcedureDatum const* pd = static_cast< ProcedureDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( pd != nullptr );
+  assert( pd );
   IntegerDatum* id = static_cast< IntegerDatum* >( i->EStack.pick( p + 1 ).datum() );
-  assert( id != nullptr );
+  assert( id );
 
   std::cerr << "During for at iterator value " << count->get() << "." << std::endl;
 
@@ -315,7 +315,7 @@ void
 IforallarrayFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 3 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   std::cerr << "During forall (array) at iteration " << count->get() << "." << std::endl;
 }
@@ -353,7 +353,7 @@ void
 IforallindexedarrayFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   std::cerr << "During forallindexed (array) at iteration " << count->get() - 1 << "." << std::endl;
 }
@@ -362,7 +362,7 @@ void
 IforallindexedstringFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   std::cerr << "During forallindexed (string) at iteration " << count->get() - 1 << "." << std::endl;
 }
@@ -405,7 +405,7 @@ void
 IforallstringFunction::backtrace( SLIInterpreter* i, int p ) const
 {
   IntegerDatum* count = static_cast< IntegerDatum* >( i->EStack.pick( p + 2 ).datum() );
-  assert( count != nullptr );
+  assert( count );
 
   std::cerr << "During forall (string) at iteration " << count->get() - 1 << "." << std::endl;
 }

--- a/sli/slicontrol.cc
+++ b/sli/slicontrol.cc
@@ -343,7 +343,7 @@ RepeatFunction::execute( SLIInterpreter* i ) const
     if ( proc )
     {
       IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-      if ( id == nullptr )
+      if ( not id )
       {
         throw ArgumentType( 1 );
       }

--- a/sli/slidata.cc
+++ b/sli/slidata.cc
@@ -62,9 +62,9 @@ Get_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   IntegerDatum* idx = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( idx != nullptr );
+  assert( idx );
   ArrayDatum* obj = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( obj != nullptr );
+  assert( obj );
 
 
   if ( ( idx->get() >= 0 ) && ( ( size_t ) idx->get() < obj->size() ) )
@@ -154,9 +154,9 @@ Get_pFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   IntegerDatum* idx = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( idx != nullptr );
+  assert( idx );
   ProcedureDatum* obj = dynamic_cast< ProcedureDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( obj != nullptr );
+  assert( obj );
 
 
   if ( ( idx->get() >= 0 ) && ( ( size_t ) idx->get() < obj->size() ) )
@@ -179,9 +179,9 @@ Get_lpFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   IntegerDatum* idx = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( idx != nullptr );
+  assert( idx );
   LitprocedureDatum* obj = dynamic_cast< LitprocedureDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( obj != nullptr );
+  assert( obj );
 
   if ( ( idx->get() >= 0 ) && ( ( size_t ) idx->get() < obj->size() ) )
   {
@@ -204,7 +204,7 @@ Append_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   ArrayDatum* obj = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( obj != nullptr );
+  assert( obj );
 
 
   obj->push_back_move( i->OStack.top() );
@@ -219,7 +219,7 @@ Append_pFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   ProcedureDatum* obj = dynamic_cast< ProcedureDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( obj != nullptr );
+  assert( obj );
 
 
   obj->push_back_move( i->OStack.top() );
@@ -251,7 +251,7 @@ Append_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( sd != nullptr && id != nullptr );
+  assert( sd && id );
 
   ( *sd ) += static_cast< char >( id->get() );
 
@@ -307,7 +307,7 @@ Join_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* a1 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
   ArrayDatum* a2 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( a1 != nullptr && a2 != nullptr );
+  assert( a1 && a2 );
 
   a1->append_move( *a2 );
 
@@ -325,7 +325,7 @@ Join_pFunction::execute( SLIInterpreter* i ) const
   ProcedureDatum* a1 = dynamic_cast< ProcedureDatum* >( i->OStack.pick( 1 ).datum() );
   ProcedureDatum* a2 = dynamic_cast< ProcedureDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( a1 != nullptr && a2 != nullptr );
+  assert( a1 && a2 );
 
   a1->append_move( *a2 );
 
@@ -355,7 +355,7 @@ Insert_sFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* s2 = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && s2 != nullptr );
+  assert( s1 && id && s2 );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -391,7 +391,7 @@ InsertElement_sFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* c = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && c != nullptr );
+  assert( s1 && id && c );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -430,7 +430,7 @@ Prepend_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* s1 = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* c = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && c != nullptr );
+  assert( s1 && c );
 
   s1->insert( ( size_t ) 0, 1, static_cast< char >( c->get() ) );
 
@@ -447,7 +447,7 @@ Insert_aFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   ArrayDatum* a2 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( a1 != nullptr && id != nullptr && a2 != nullptr );
+  assert( a1 && id && a2 );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < a1->size() ) )
   {
@@ -470,7 +470,7 @@ InsertElement_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* a1 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 2 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( a1 != nullptr && id != nullptr );
+  assert( a1 && id );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < a1->size() ) )
   {
@@ -494,7 +494,7 @@ Prepend_aFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* a1 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( a1 != nullptr );
+  assert( a1 );
 
   a1->insert_move( 0, i->OStack.top() );
 
@@ -511,7 +511,7 @@ Prepend_pFunction::execute( SLIInterpreter* i ) const
 
   ProcedureDatum* a1 = dynamic_cast< ProcedureDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( a1 != nullptr );
+  assert( a1 );
 
   a1->insert_move( 0, i->OStack.top() );
 
@@ -544,7 +544,7 @@ Replace_sFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* n = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* s2 = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && n != nullptr && s2 != nullptr );
+  assert( s1 && id && n && s2 );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -576,7 +576,7 @@ Replace_aFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* n = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   ArrayDatum* s2 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && n != nullptr && s2 != nullptr );
+  assert( s1 && id && n && s2 );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -621,7 +621,7 @@ Erase_sFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* n = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && n != nullptr );
+  assert( s1 && id && n );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -652,7 +652,7 @@ Erase_aFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* n = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && n != nullptr );
+  assert( s1 && id && n );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -683,7 +683,7 @@ Erase_pFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* n = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && n != nullptr );
+  assert( s1 && id && n );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -715,7 +715,7 @@ Put_sFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* cd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && id != nullptr && cd != nullptr );
+  assert( s1 && id && cd );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < s1->size() ) )
   {
@@ -739,7 +739,7 @@ Put_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 2 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < ad->size() ) )
   {
@@ -763,7 +763,7 @@ Put_pFunction::execute( SLIInterpreter* i ) const
   ProcedureDatum* ad = dynamic_cast< ProcedureDatum* >( i->OStack.pick( 2 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < ad->size() ) )
   {
@@ -787,7 +787,7 @@ Put_lpFunction::execute( SLIInterpreter* i ) const
   LitprocedureDatum* ad = dynamic_cast< LitprocedureDatum* >( i->OStack.pick( 2 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
 
   if ( ( id->get() >= 0 ) && ( ( size_t ) id->get() < ad->size() ) )
   {
@@ -819,7 +819,7 @@ Length_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   StringDatum* s = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->length() ) );
 
@@ -845,7 +845,7 @@ Length_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ArrayDatum* s = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->size() ) );
 
@@ -871,7 +871,7 @@ Length_pFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ProcedureDatum* s = dynamic_cast< ProcedureDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->size() ) );
 
@@ -901,7 +901,7 @@ Length_lpFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   LitprocedureDatum* s = dynamic_cast< LitprocedureDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->size() ) );
 
@@ -931,7 +931,7 @@ Capacity_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ArrayDatum* s = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->capacity() ) );
 
@@ -958,7 +958,7 @@ Size_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ArrayDatum* s = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->size() ) );
 
@@ -983,7 +983,7 @@ Reserve_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
   if ( id->get() >= 0 )
   {
     i->EStack.pop();
@@ -1018,7 +1018,7 @@ Resize_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
   if ( id->get() >= 0 )
   {
     i->EStack.pop();
@@ -1040,7 +1040,7 @@ Empty_aFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
 
-  assert( ad != nullptr );
+  assert( ad );
 
   if ( ad->empty() )
   {
@@ -1061,7 +1061,7 @@ References_aFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
 
-  assert( ad != nullptr );
+  assert( ad );
 
   Token t( new IntegerDatum( ad->references() ) );
 
@@ -1084,7 +1084,7 @@ Shrink_aFunction::execute( SLIInterpreter* i ) const
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
 
-  assert( ad != nullptr );
+  assert( ad );
 
   if ( ad->shrink() )
   {
@@ -1104,7 +1104,7 @@ Capacity_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   StringDatum* s = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->capacity() ) );
 
@@ -1119,7 +1119,7 @@ Size_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   StringDatum* s = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( s != nullptr );
+  assert( s );
 
   Token t( new IntegerDatum( s->size() ) );
 
@@ -1135,7 +1135,7 @@ Reserve_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* ad = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
 
   if ( id->get() >= 0 )
   {
@@ -1158,7 +1158,7 @@ Resize_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* ad = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( ad != nullptr && id != nullptr );
+  assert( ad && id );
 
   if ( id->get() >= 0 )
   {
@@ -1182,7 +1182,7 @@ Empty_sFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* ad = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  assert( ad != nullptr );
+  assert( ad );
 
   if ( ad->empty() )
   {
@@ -1229,7 +1229,7 @@ Getinterval_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.pick( 2 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* cd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( sd != nullptr && id != nullptr && cd != nullptr );
+  assert( sd && id && cd );
 
   if ( cd->get() >= 0 )
   {
@@ -1261,7 +1261,7 @@ Getinterval_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* sd = dynamic_cast< ArrayDatum* >( i->OStack.pick( 2 ).datum() );
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* cd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( sd != nullptr && id != nullptr && cd != nullptr );
+  assert( sd && id && cd );
 
   if ( cd->get() >= 0 )
   {
@@ -1293,7 +1293,7 @@ Cvx_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ArrayDatum* obj = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new ProcedureDatum( *obj ) );
   t->set_executable();
   i->OStack.top().swap( t );
@@ -1305,7 +1305,7 @@ Cvlit_nFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   NameDatum* obj = dynamic_cast< NameDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new LiteralDatum( *obj ) );
   i->OStack.top().swap( t );
   i->EStack.pop();
@@ -1317,7 +1317,7 @@ Cvn_lFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   LiteralDatum* obj = dynamic_cast< LiteralDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new NameDatum( *obj ) );
   i->OStack.top().swap( t );
   i->EStack.pop();
@@ -1329,7 +1329,7 @@ Cvn_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   StringDatum* obj = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new NameDatum( *obj ) );
   i->OStack.top().swap( t );
   i->EStack.pop();
@@ -1341,7 +1341,7 @@ Cvlit_pFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ProcedureDatum* obj = dynamic_cast< ProcedureDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new ArrayDatum( *obj ) );
   i->OStack.top().swap( t );
   i->EStack.pop();
@@ -1356,7 +1356,7 @@ Cvlp_pFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   ProcedureDatum* obj = dynamic_cast< ProcedureDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new LitprocedureDatum( *obj ) );
   t->set_executable();
   i->OStack.top().swap( t );
@@ -1370,7 +1370,7 @@ Cvi_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   StringDatum* obj = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new IntegerDatum( std::atoi( obj->c_str() ) ) );
   i->OStack.top().swap( t );
   i->EStack.pop();
@@ -1383,7 +1383,7 @@ Cvd_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 0 );
 
   StringDatum* obj = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( obj != nullptr );
+  assert( obj );
   Token t( new DoubleDatum( std::atof( obj->c_str() ) ) );
   i->OStack.top().swap( t );
   i->EStack.pop();
@@ -1397,10 +1397,10 @@ Get_sFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   IntegerDatum* idx = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( idx != nullptr );
+  assert( idx );
 
   StringDatum* obj = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( obj != nullptr );
+  assert( obj );
 
 
   if ( ( idx->get() >= 0 ) && ( ( size_t ) idx->get() < obj->size() ) )
@@ -1439,7 +1439,7 @@ Search_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* s1 = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* s2 = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && s2 != nullptr );
+  assert( s1 && s2 );
 
   size_t p = s1->find( *s2 );
 
@@ -1474,7 +1474,7 @@ Search_aFunction::execute( SLIInterpreter* i ) const
   ArrayDatum* s1 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
   ArrayDatum* s2 = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( s1 != nullptr && s2 != nullptr );
+  assert( s1 && s2 );
 
   Token* p = std::search( s1->begin(), s1->end(), s2->begin(), s2->end() );
 

--- a/sli/slidata.cc
+++ b/sli/slidata.cc
@@ -87,7 +87,7 @@ Get_a_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
 
   ArrayDatum* idx = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  if ( idx == nullptr )
+  if ( not idx )
   {
     i->message( SLIInterpreter::M_ERROR, "get_a_a", "Second argument must be an array of indices." );
     i->message( SLIInterpreter::M_ERROR, "get_a_a", "Usage: [a] [i1 .. in] get -> [a[i1] ... a[in]]" );
@@ -96,7 +96,7 @@ Get_a_aFunction::execute( SLIInterpreter* i ) const
   }
 
   ArrayDatum* obj = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( obj == nullptr )
+  if ( not obj )
   {
     i->message( SLIInterpreter::M_ERROR, "get_a_a", "Usage: [a] [i1 .. in] get -> [a[i1] ... a[in]]" );
     i->message( SLIInterpreter::M_ERROR, "get_a_a", "First argument must be an array." );
@@ -110,7 +110,7 @@ Get_a_aFunction::execute( SLIInterpreter* i ) const
   for ( Token* t = idx->begin(); t != idx->end(); ++t )
   {
     IntegerDatum* id = dynamic_cast< IntegerDatum* >( t->datum() );
-    if ( id == nullptr )
+    if ( not id )
     {
       std::ostringstream sout;
 
@@ -284,7 +284,7 @@ Join_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* s1 = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* s2 = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( s1 == nullptr || s2 == nullptr )
+  if ( not s1 || s2 == nullptr )
   {
     i->message( SLIInterpreter::M_ERROR, "join_s", "Usage: (string1) (string2) join_s" );
     i->raiseerror( i->ArgumentTypeError );

--- a/sli/slidata.cc
+++ b/sli/slidata.cc
@@ -284,7 +284,7 @@ Join_sFunction::execute( SLIInterpreter* i ) const
   StringDatum* s1 = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* s2 = dynamic_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( not s1 || s2 == nullptr )
+  if ( not s1 or not s2 )
   {
     i->message( SLIInterpreter::M_ERROR, "join_s", "Usage: (string1) (string2) join_s" );
     i->raiseerror( i->ArgumentTypeError );

--- a/sli/slidict.cc
+++ b/sli/slidict.cc
@@ -649,7 +649,7 @@ DictconstructFunction::execute( SLIInterpreter* i ) const
   {
     Token& val = ( i->OStack.pick( n ) );
     key = dynamic_cast< LiteralDatum* >( i->OStack.pick( n + 1 ).datum() );
-    if ( key == nullptr )
+    if ( not key )
     {
       i->message( 30, "DictConstruct", "Literal expected. Maybe initializer list is in the wrong order." );
       i->raiseerror( i->ArgumentTypeError );

--- a/sli/slidict.cc
+++ b/sli/slidict.cc
@@ -105,10 +105,10 @@ DictputFunction::execute( SLIInterpreter* i ) const
   {
     //  call: dict key val
     DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.pick( 2 ).datum() );
-    if ( dict != nullptr )
+    if ( dict )
     {
       LiteralDatum* key = dynamic_cast< LiteralDatum* >( i->OStack.pick( 1 ).datum() );
-      if ( key != nullptr )
+      if ( key )
       {
         ( *dict )->insert_move( *key, i->OStack.top() );
 #ifdef DICTSTACK_CACHE
@@ -172,10 +172,10 @@ DictgetFunction::execute( SLIInterpreter* i ) const
   if ( i->OStack.load() >= 2 )
   {
     DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.pick( 1 ).datum() );
-    if ( dict != nullptr )
+    if ( dict )
     {
       LiteralDatum* key = dynamic_cast< LiteralDatum* >( i->OStack.pick( 0 ).datum() );
-      if ( key != nullptr )
+      if ( key )
       {
         Token value = ( *dict )->lookup2( *key );
         i->EStack.pop(); // never forget me
@@ -235,8 +235,8 @@ DictinfoFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() > 1 );
   OstreamDatum* outd = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
-  assert( outd != nullptr );
+  assert( dict );
+  assert( outd );
   i->EStack.pop();
   ( *dict )->info( **outd );
   i->OStack.pop( 2 );
@@ -263,7 +263,7 @@ Length_dFunction::execute( SLIInterpreter* i ) const
 
   assert( i->OStack.load() > 0 );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
+  assert( dict );
   i->EStack.pop();
   Token st( new IntegerDatum( ( *dict )->size() ) );
   i->OStack.pop();
@@ -278,7 +278,7 @@ Empty_DFunction::execute( SLIInterpreter* i ) const
 
   DictionaryDatum const* const dd = dynamic_cast< DictionaryDatum const* const >( i->OStack.top().datum() );
 
-  assert( dd != nullptr );
+  assert( dd );
 
   i->OStack.push_by_pointer( new BoolDatum( ( *dd )->empty() ) );
 
@@ -397,7 +397,7 @@ DicttopinfoFunction::execute( SLIInterpreter* i ) const
 
   assert( i->OStack.load() > 0 );
   OstreamDatum* outd = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
-  assert( outd != nullptr );
+  assert( outd );
   i->EStack.pop();
   i->DStack->top_info( **outd );
   i->OStack.pop();
@@ -426,7 +426,7 @@ WhoFunction::execute( SLIInterpreter* i ) const
 
   assert( i->OStack.load() > 0 );
   OstreamDatum* outd = dynamic_cast< OstreamDatum* >( i->OStack.top().datum() );
-  assert( outd != nullptr );
+  assert( outd );
   i->EStack.pop();
   i->DStack->info( **outd );
   i->OStack.pop();
@@ -455,7 +455,7 @@ DictbeginFunction::execute( SLIInterpreter* i ) const
   if ( i->OStack.load() > 0 )
   {
     DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-    if ( dict != nullptr )
+    if ( dict )
     {
       i->EStack.pop();
       i->DStack->push( *dict );
@@ -550,10 +550,10 @@ UndefFunction::execute( SLIInterpreter* i ) const
   if ( i->OStack.load() > 1 )
   {
     DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.pick( 1 ).datum() );
-    if ( dict != nullptr )
+    if ( dict )
     {
       LiteralDatum* key = dynamic_cast< LiteralDatum* >( i->OStack.pick( 0 ).datum() );
-      if ( key != nullptr )
+      if ( key )
       {
         i->EStack.pop();
 #ifdef DICTSTACK_CACHE
@@ -722,7 +722,7 @@ CleardictFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 1 );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
+  assert( dict );
 #ifdef DICTSTACK_CACHE
   if ( ( *dict )->is_on_dictstack() )
   {
@@ -762,7 +762,7 @@ ClonedictFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 1 );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
+  assert( dict );
 
   i->OStack.push( DictionaryDatum( new Dictionary( *( *dict ) ) ) );
   i->EStack.pop(); // never forget me
@@ -831,7 +831,7 @@ Cva_dFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
   assert( i->OStack.load() > 0 );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
+  assert( dict );
   ArrayDatum* ad = new ArrayDatum();
   ad->reserve( ( *dict )->size() * 2 );
 
@@ -882,7 +882,7 @@ KeysFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
   assert( i->OStack.load() > 0 );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
+  assert( dict );
   ArrayDatum* ad = new ArrayDatum();
 
   for ( TokenMap::const_iterator t = ( *dict )->begin(); t != ( *dict )->end(); ++t )
@@ -932,7 +932,7 @@ ValuesFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
   assert( i->OStack.load() > 0 );
   DictionaryDatum* dict = dynamic_cast< DictionaryDatum* >( i->OStack.top().datum() );
-  assert( dict != nullptr );
+  assert( dict );
   ArrayDatum* ad = new ArrayDatum();
 
   for ( TokenMap::const_iterator t = ( *dict )->begin(); t != ( *dict )->end(); ++t )
@@ -948,7 +948,7 @@ RestoredstackFunction::execute( SLIInterpreter* i ) const
 {
   i->assert_stack_load( 1 );
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( ad != nullptr );
+  assert( ad );
   TokenArray ta = *ad;
   DictionaryStack* olddstack = i->DStack; // copy current dstack
   i->DStack = new DictionaryStack;

--- a/sli/sligraphics.cc
+++ b/sli/sligraphics.cc
@@ -81,7 +81,7 @@ SLIgraphics::ReadPGMFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
 
-  if ( sd == nullptr )
+  if ( not sd )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;

--- a/sli/slimath.cc
+++ b/sli/slimath.cc
@@ -269,7 +269,7 @@ Mod_iiFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* op1 = static_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* op2 = static_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( op1 == nullptr || op2 == nullptr )
+  if ( not op1 || op2 == nullptr )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -859,7 +859,7 @@ Inv_dFunction::execute( SLIInterpreter* i ) const
 
 
   DoubleDatum* op = static_cast< DoubleDatum* >( i->OStack.top().datum() );
-  if ( op == nullptr )
+  if ( not op )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;

--- a/sli/slimath.cc
+++ b/sli/slimath.cc
@@ -269,7 +269,7 @@ Mod_iiFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* op1 = static_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* op2 = static_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  if ( not op1 || op2 == nullptr )
+  if ( not op1 or not op2 )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;

--- a/sli/slimath.cc
+++ b/sli/slimath.cc
@@ -47,7 +47,7 @@ IntegerFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 
   DoubleDatum* op = dynamic_cast< DoubleDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( op != nullptr )
+  if ( op )
   {
     Token res( new IntegerDatum( op->get() ) );
     i->OStack.top().swap( res );
@@ -61,7 +61,7 @@ DoubleFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 
   IntegerDatum* op = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  if ( op != nullptr )
+  if ( op )
   {
 
     Token res( new DoubleDatum( op->get() ) );
@@ -1119,7 +1119,7 @@ OrFunction::execute( SLIInterpreter* i ) const
 
   BoolDatum* op1 = static_cast< BoolDatum* >( i->OStack.pick( 1 ).datum() );
   BoolDatum* op2 = static_cast< BoolDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   op1->get() = ( op1->get() or op2->get() );
 
@@ -1261,7 +1261,7 @@ Gt_iiFunction::execute( SLIInterpreter* i ) const
 
   IntegerDatum* op1 = static_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* op2 = static_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = op1->get() > op2->get();
 
@@ -1278,7 +1278,7 @@ Gt_ddFunction::execute( SLIInterpreter* i ) const
 
   DoubleDatum* op1 = static_cast< DoubleDatum* >( i->OStack.pick( 1 ).datum() );
   DoubleDatum* op2 = static_cast< DoubleDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = op1->get() > op2->get();
 
@@ -1296,7 +1296,7 @@ Gt_ssFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* op1 = static_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* op2 = static_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = *op1 > *op2;
 
@@ -1323,7 +1323,7 @@ Lt_idFunction::execute( SLIInterpreter* i ) const
 
   IntegerDatum* op1 = static_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   DoubleDatum* op2 = static_cast< DoubleDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = op1->get() < op2->get();
 
@@ -1340,7 +1340,7 @@ Lt_diFunction::execute( SLIInterpreter* i ) const
 
   IntegerDatum* op2 = static_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
   DoubleDatum* op1 = static_cast< DoubleDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = op1->get() < op2->get();
 
@@ -1358,7 +1358,7 @@ Lt_iiFunction::execute( SLIInterpreter* i ) const
 
   IntegerDatum* op1 = static_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* op2 = static_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = op1->get() < op2->get();
 
@@ -1375,7 +1375,7 @@ Lt_ddFunction::execute( SLIInterpreter* i ) const
 
   DoubleDatum* op1 = static_cast< DoubleDatum* >( i->OStack.pick( 1 ).datum() );
   DoubleDatum* op2 = static_cast< DoubleDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = op1->get() < op2->get();
 
@@ -1393,7 +1393,7 @@ Lt_ssFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* op1 = static_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
   StringDatum* op2 = static_cast< StringDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( op1 != nullptr && op2 != nullptr );
+  assert( op1 && op2 );
 
   bool result = *op1 < *op2;
 
@@ -1432,7 +1432,7 @@ UnitStep_iFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() >= 1 );
 
   IntegerDatum* x = static_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( x != nullptr );
+  assert( x );
 
   bool result = x->get() >= 0;
 
@@ -1456,14 +1456,14 @@ UnitStep_daFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() >= 1 );
 
   TokenArray* a = dynamic_cast< TokenArray* >( i->OStack.pick( 0 ).datum() );
-  assert( a != nullptr );
+  assert( a );
 
   bool result = true;
 
   for ( size_t j = 0; j < a->size(); ++j )
   {
     DoubleDatum* x = static_cast< DoubleDatum* >( ( *a )[ j ].datum() );
-    assert( x != nullptr );
+    assert( x );
     if ( x->get() < 0.0 )
     {
       result = false;
@@ -1490,14 +1490,14 @@ UnitStep_iaFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.load() >= 1 );
 
   TokenArray* a = dynamic_cast< TokenArray* >( i->OStack.pick( 0 ).datum() );
-  assert( a != nullptr );
+  assert( a );
 
   bool result = true;
 
   for ( size_t j = 0; j < a->size(); ++j )
   {
     IntegerDatum* x = static_cast< IntegerDatum* >( ( *a )[ j ].datum() );
-    assert( x != nullptr );
+    assert( x );
     if ( x->get() < 0 )
     {
       result = false;

--- a/sli/sliregexp.cc
+++ b/sli/sliregexp.cc
@@ -117,8 +117,8 @@ RegexpModule::RegcompFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( sd != nullptr );
-  assert( id != nullptr );
+  assert( sd );
+  assert( id );
 
 
   Regex* MyRegex = new Regex;
@@ -147,8 +147,8 @@ RegexpModule::RegerrorFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
   RegexDatum* rd = dynamic_cast< RegexDatum* >( i->OStack.pick( 1 ).datum() );
 
-  assert( rd != nullptr );
-  assert( id != nullptr );
+  assert( rd );
+  assert( id );
 
   char* error_buffer = new char[ 256 ];
   regerror( id->get(), rd->get()->get(), error_buffer, 256 );
@@ -178,16 +178,16 @@ RegexpModule::RegexecFunction::execute( SLIInterpreter* i ) const
   IntegerDatum* sized = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
   IntegerDatum* eflagsd = dynamic_cast< IntegerDatum* >( i->OStack.pick( 0 ).datum() );
 
-  assert( rd != nullptr );
-  assert( sd != nullptr );
-  assert( sized != nullptr );
-  assert( eflagsd != nullptr );
+  assert( rd );
+  assert( sd );
+  assert( sized );
+  assert( eflagsd );
 
   int size = sized->get();
   regmatch_t* pm = new regmatch_t[ size ];
 
   Regex* r = rd->get();
-  assert( r != nullptr );
+  assert( r );
   rd->unlock();
 
   int e = regexec( r->get(), sd->c_str(), size, pm, eflagsd->get() );

--- a/sli/slistack.cc
+++ b/sli/slistack.cc
@@ -253,13 +253,13 @@ RollFunction::execute( SLIInterpreter* i ) const
   }
 
   IntegerDatum* idn = dynamic_cast< IntegerDatum* >( i->OStack.pick( 1 ).datum() );
-  if ( idn == nullptr )
+  if ( not idn )
   {
     throw ArgumentType( 1 );
   }
 
   IntegerDatum* idk = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  if ( idk == nullptr )
+  if ( not idk )
   {
     throw ArgumentType( 0 );
   }

--- a/sli/slistack.cc
+++ b/sli/slistack.cc
@@ -75,7 +75,7 @@ NpopFunction::execute( SLIInterpreter* i ) const
   }
 
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( id != nullptr );
+  assert( id );
   size_t n = id->get();
   if ( n < i->OStack.load() )
   {
@@ -166,7 +166,7 @@ IndexFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( id != nullptr );
+  assert( id );
   size_t pos = id->get();
 
   if ( pos + 1 < i->OStack.load() )
@@ -201,7 +201,7 @@ CopyFunction::execute( SLIInterpreter* i ) const
     return;
   }
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( i->OStack.top().datum() );
-  assert( id != nullptr );
+  assert( id );
   size_t n = id->get();
   if ( n < i->OStack.load() )
   {
@@ -404,7 +404,7 @@ RestoreestackFunction::execute( SLIInterpreter* i ) const
   }
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( ad != nullptr );
+  assert( ad );
   TokenArray ta = *ad;
   i->OStack.pop();
   i->EStack = ta;
@@ -434,7 +434,7 @@ RestoreostackFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.top().datum() );
-  assert( ad != nullptr );
+  assert( ad );
   TokenArray ta = *ad;
   i->OStack = ta;
 }

--- a/sli/slistartup.cc
+++ b/sli/slistartup.cc
@@ -116,10 +116,10 @@ SLIStartup::GetenvFunction::execute( SLIInterpreter* i ) const
   i->assert_stack_load( 1 );
 
   StringDatum* sd = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
-  assert( sd != nullptr );
+  assert( sd );
   const char* s = ::getenv( sd->c_str() );
   i->OStack.pop();
-  if ( s != nullptr )
+  if ( s )
   {
     Token t( new StringDatum( s ) );
     i->OStack.push_move( t );

--- a/sli/slitype.cc
+++ b/sli/slitype.cc
@@ -59,7 +59,7 @@ SLIType::deletetypename()
 void
 SLIType::setdefaultaction( SLIFunction& c )
 {
-  if ( defaultaction == nullptr )
+  if ( not defaultaction )
   {
     defaultaction = &c;
   }

--- a/sli/slitypecheck.cc
+++ b/sli/slitypecheck.cc
@@ -205,7 +205,7 @@ Cva_tFunction::execute( SLIInterpreter* i ) const
   i->OStack.pop();
 
   TrieDatum* trie = dynamic_cast< TrieDatum* >( trietoken.datum() );
-  assert( trie != nullptr );
+  assert( trie );
 
   Name triename( trie->getname() );
   i->OStack.push( LiteralDatum( triename ) );
@@ -222,13 +222,13 @@ TrieInfoFunction::execute( SLIInterpreter* i ) const
   i->EStack.pop();
 
   OstreamDatum* osd = dynamic_cast< OstreamDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( osd != nullptr );
+  assert( osd );
 
   Token trietoken;
   trietoken.move( i->OStack.top() );
 
   TrieDatum* trie = dynamic_cast< TrieDatum* >( trietoken.datum() );
-  assert( trie != nullptr );
+  assert( trie );
 
   trie->get().info( **osd );
   i->OStack.pop( 2 );
@@ -305,12 +305,12 @@ Cvt_aFunction::execute( SLIInterpreter* i ) const
   assert( i->OStack.size() > 1 );
 
   LiteralDatum* name = dynamic_cast< LiteralDatum* >( i->OStack.pick( 1 ).datum() );
-  assert( name != nullptr );
+  assert( name );
   ArrayDatum* arr = dynamic_cast< ArrayDatum* >( i->OStack.pick( 0 ).datum() );
-  assert( arr != nullptr );
+  assert( arr );
 
   TrieDatum* trie = new TrieDatum( *name, *arr );
-  assert( trie != nullptr );
+  assert( trie );
   Token tmp( trie );
   i->OStack.pop();
   i->OStack.push_move( tmp );

--- a/sli/slitypecheck.cc
+++ b/sli/slitypecheck.cc
@@ -56,7 +56,7 @@ TrieFunction::execute( SLIInterpreter* i ) const
 
   LiteralDatum* name = dynamic_cast< LiteralDatum* >( i->OStack.top().datum() );
 
-  if ( name == nullptr )
+  if ( not name )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -97,7 +97,7 @@ AddtotrieFunction::execute( SLIInterpreter* i ) const
 
   TrieDatum* trie = dynamic_cast< TrieDatum* >( i->OStack.pick( 2 ).datum() );
 
-  if ( trie == nullptr )
+  if ( not trie )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -108,7 +108,7 @@ AddtotrieFunction::execute( SLIInterpreter* i ) const
   // Construct a TypeArray from the TokenArray
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( i->OStack.pick( 1 ).datum() );
 
-  if ( ad == nullptr )
+  if ( not ad )
   {
     i->raiseerror( i->ArgumentTypeError );
     return;
@@ -127,7 +127,7 @@ AddtotrieFunction::execute( SLIInterpreter* i ) const
   {
     LiteralDatum* nd = dynamic_cast< LiteralDatum* >( t->datum() );
 
-    if ( nd == nullptr )
+    if ( not nd )
     {
       std::ostringstream message;
       message << "In trie " << trie->getname() << ". "

--- a/sli/tarrayobj.cc
+++ b/sli/tarrayobj.cc
@@ -53,7 +53,7 @@ TokenArrayObj::TokenArrayObj( const TokenArrayObj& a )
   , alloc_block_size( ARRAY_ALLOC_SIZE )
   , refs_( 1 )
 {
-  if ( a.p != nullptr )
+  if ( a.p )
   {
     resize( a.size(), a.alloc_block_size, Token() );
     Token* from = a.p;
@@ -102,7 +102,7 @@ TokenArrayObj::allocate( size_t new_s, size_t new_c, size_t new_a, const Token& 
   end_of_free_storage = h + new_c; // [,) convention
   begin_of_free_storage = h + new_s;
 
-  if ( p != nullptr )
+  if ( p )
   {
 
     size_t min_l;
@@ -170,7 +170,7 @@ TokenArrayObj::operator=( const TokenArrayObj& a )
   else
   {
 
-    if ( p != nullptr )
+    if ( p )
     {
       delete[] p;
       p = nullptr;

--- a/sli/tarrayobj.cc
+++ b/sli/tarrayobj.cc
@@ -662,19 +662,19 @@ TokenArrayObj::info( std::ostream& out ) const
 bool
 TokenArrayObj::valid() const
 {
-  if ( p == nullptr )
+  if ( not p )
   {
     std::cerr << "TokenArrayObj::valid: Data pointer missing!" << std::endl;
     return false;
   }
 
-  if ( begin_of_free_storage == nullptr )
+  if ( not begin_of_free_storage )
   {
     std::cerr << "TokenArrayObj::valid: begin of free storage pointer missing!" << std::endl;
     return false;
   }
 
-  if ( end_of_free_storage == nullptr )
+  if ( not end_of_free_storage )
   {
     std::cerr << "TokenArrayObj::valid: end of free storage pointer missing!" << std::endl;
     return false;

--- a/sli/token.h
+++ b/sli/token.h
@@ -347,13 +347,13 @@ public:
   bool
   empty() const
   {
-    return p == nullptr;
+    return not p;
   }
 
   bool
   operator not() const
   {
-    return p == nullptr;
+    return not p;
   }
 
   Datum*
@@ -401,7 +401,7 @@ public:
       return *this;
     }
 
-    if ( c_s.p == nullptr )
+    if ( not p )
     {
       clear();
       return *this;

--- a/sli/token.h
+++ b/sli/token.h
@@ -401,7 +401,7 @@ public:
       return *this;
     }
 
-    if ( not p )
+    if ( not c_s.p )
     {
       clear();
       return *this;

--- a/sli/token.h
+++ b/sli/token.h
@@ -312,7 +312,7 @@ public:
   void
   assign_by_pointer( Datum* rhs )
   {
-    assert( rhs != nullptr );
+    assert( rhs );
     rhs->addReference();
     if ( p )
     {
@@ -341,7 +341,7 @@ public:
   bool
   contains( const Datum& d ) const
   {
-    return ( p != nullptr ) and p->equals( &d );
+    return ( p ) and p->equals( &d );
   }
 
   bool

--- a/sli/tokenarray.cc
+++ b/sli/tokenarray.cc
@@ -43,7 +43,7 @@ TokenArray::operator=( const TokenArray& a )
 TokenArray::TokenArray( const std::vector< long >& a )
   : data( new TokenArrayObj( a.size(), Token(), 0 ) )
 {
-  assert( data != nullptr );
+  assert( data );
   for ( size_t i = 0; i < a.size(); ++i )
   {
     Token idt( new IntegerDatum( a[ i ] ) );
@@ -54,7 +54,7 @@ TokenArray::TokenArray( const std::vector< long >& a )
 TokenArray::TokenArray( const std::vector< size_t >& a )
   : data( new TokenArrayObj( a.size(), Token(), 0 ) )
 {
-  assert( data != nullptr );
+  assert( data );
   for ( size_t i = 0; i < a.size(); ++i )
   {
     Token idt( new IntegerDatum( a[ i ] ) );
@@ -65,7 +65,7 @@ TokenArray::TokenArray( const std::vector< size_t >& a )
 TokenArray::TokenArray( const std::vector< double >& a )
   : data( new TokenArrayObj( a.size(), Token(), 0 ) )
 {
-  assert( data != nullptr );
+  assert( data );
   for ( size_t i = 0; i < a.size(); ++i )
   {
     Token ddt( new DoubleDatum( a[ i ] ) );

--- a/sli/tokenarray.cc
+++ b/sli/tokenarray.cc
@@ -81,7 +81,7 @@ TokenArray::toVector( std::vector< long >& a ) const
   for ( Token* idx = begin(); idx != end(); ++idx )
   {
     IntegerDatum* targetid = dynamic_cast< IntegerDatum* >( idx->datum() );
-    if ( targetid == nullptr )
+    if ( not targetid )
     {
       IntegerDatum const d;
       throw TypeMismatch( d.gettypename().toString(), idx->datum()->gettypename().toString() );
@@ -99,7 +99,7 @@ TokenArray::toVector( std::vector< size_t >& a ) const
   for ( Token* idx = begin(); idx != end(); ++idx )
   {
     IntegerDatum* targetid = dynamic_cast< IntegerDatum* >( idx->datum() );
-    if ( targetid == nullptr )
+    if ( not targetid )
     {
       IntegerDatum const d;
       throw TypeMismatch( d.gettypename().toString(), idx->datum()->gettypename().toString() );
@@ -141,7 +141,7 @@ TokenArray::toVector( std::vector< std::string >& a ) const
   for ( Token* idx = begin(); idx != end(); ++idx )
   {
     std::string* target = dynamic_cast< std::string* >( idx->datum() );
-    if ( target == nullptr )
+    if ( not target )
     {
       StringDatum const d;
       throw TypeMismatch( d.gettypename().toString(), idx->datum()->gettypename().toString() );
@@ -154,7 +154,7 @@ TokenArray::toVector( std::vector< std::string >& a ) const
 bool
 TokenArray::valid() const
 {
-  if ( data == nullptr )
+  if ( not data )
   {
     return false;
   }

--- a/sli/tokenutils.cc
+++ b/sli/tokenutils.cc
@@ -41,7 +41,7 @@ long
 getValue< long >( const Token& t )
 {
   const IntegerDatum* id = dynamic_cast< const IntegerDatum* >( t.datum() );
-  if ( id == nullptr )
+  if ( not id )
   { // We have to create a Datum object to get the name...
     IntegerDatum const d;
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );
@@ -53,7 +53,7 @@ void
 setValue< long >( const Token& t, long const& value )
 {
   IntegerDatum* id = dynamic_cast< IntegerDatum* >( t.datum() );
-  if ( id == nullptr )
+  if ( not id )
   { // We have to create a Datum object to get the name...
     IntegerDatum const d;
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );
@@ -95,7 +95,7 @@ void
 setValue< double >( const Token& t, double const& value )
 {
   DoubleDatum* id = dynamic_cast< DoubleDatum* >( t.datum() );
-  if ( id == nullptr )
+  if ( not id )
   { // We have to create a Datum object to get the name...
     DoubleDatum const d;
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );
@@ -115,7 +115,7 @@ bool
 getValue< bool >( const Token& t )
 {
   BoolDatum* bd = dynamic_cast< BoolDatum* >( t.datum() );
-  if ( bd == nullptr )
+  if ( not bd )
   { // We have to create a Datum object to get the name...
     BoolDatum const d( false );
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );
@@ -128,7 +128,7 @@ void
 setValue< bool >( const Token& t, bool const& value )
 {
   BoolDatum* bd = dynamic_cast< BoolDatum* >( t.datum() );
-  if ( bd == nullptr )
+  if ( not bd )
   { // We have to create a Datum object to get the name...
     BoolDatum const d( false );
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );
@@ -275,7 +275,7 @@ void
 setValue< std::vector< double > >( const Token& t, std::vector< double > const& value )
 {
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( t.datum() );
-  if ( ad == nullptr )
+  if ( not ad )
   { // We have to create a Datum object to get the name...
     ArrayDatum const d;
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );
@@ -332,7 +332,7 @@ void
 setValue< std::vector< long > >( const Token& t, std::vector< long > const& value )
 {
   ArrayDatum* ad = dynamic_cast< ArrayDatum* >( t.datum() );
-  if ( ad == nullptr )
+  if ( not ad )
   { // We have to create a Datum object to get the name...
     ArrayDatum const d;
     throw TypeMismatch( d.gettypename().toString(), t.datum()->gettypename().toString() );

--- a/sli/tokenutils.cc
+++ b/sli/tokenutils.cc
@@ -155,7 +155,7 @@ getValue< std::string >( const Token& t )
 {
   // If it is a StringDatum, it can be casted to a string:
   std::string* s = dynamic_cast< std::string* >( t.datum() );
-  if ( s != nullptr )
+  if ( s )
   {
     return *s;
   }
@@ -164,7 +164,7 @@ getValue< std::string >( const Token& t )
     // If it is a NameDatum, LiteralDatum or SymbolDatum,
     // (or even a BoolDatum!) it can be casted to a Name:
     Name* n = dynamic_cast< Name* >( t.datum() );
-    if ( n != nullptr )
+    if ( n )
     {
       return n->toString();
     }
@@ -188,7 +188,7 @@ setValue< std::string >( const Token& t, std::string const& value )
 {
   // If it is a StringDatum, it can be casted to a string:
   std::string* s = dynamic_cast< std::string* >( t.datum() );
-  if ( s != nullptr )
+  if ( s )
   {
     *s = value;
   }
@@ -197,7 +197,7 @@ setValue< std::string >( const Token& t, std::string const& value )
     // If it is a BoolDatum, it -could- be set from a string, but
     // this operation shall not be allowed!
     BoolDatum* b = dynamic_cast< BoolDatum* >( t.datum() );
-    if ( b != nullptr )
+    if ( b )
     {
       // We have to create Datum objects to get the expected names...
       StringDatum const d1;
@@ -213,7 +213,7 @@ setValue< std::string >( const Token& t, std::string const& value )
       // If it is a NameDatum, LiteralDatum or SymbolDatum,
       // it can be casted to a Name:
       Name* n = dynamic_cast< Name* >( t.datum() );
-      if ( n != nullptr )
+      if ( n )
       {
         *n = Name( value );
       }

--- a/sli/triedatum.cc
+++ b/sli/triedatum.cc
@@ -36,5 +36,5 @@ TrieDatum::equals( Datum const* dat ) const
 
   const TrieDatum* fd = dynamic_cast< TrieDatum* >( const_cast< Datum* >( dat ) );
 
-  return fd != nullptr and tree == fd->tree;
+  return fd and tree == fd->tree;
 }

--- a/sli/triedatum.h
+++ b/sli/triedatum.h
@@ -146,7 +146,7 @@ public:
   static void
   operator delete( void* p, size_t size )
   {
-    if ( p == nullptr )
+    if ( not p )
     {
       return;
     }

--- a/sli/typechk.cc
+++ b/sli/typechk.cc
@@ -68,7 +68,7 @@ void
 TypeTrie::TypeNode::toTokenArray( TokenArray& a ) const
 {
   assert( a.size() == 0 );
-  if ( not next and alt == nullptr ) // Leaf node
+  if ( not next and not alt ) // Leaf node
   {
     a.push_back( func );
   }
@@ -92,7 +92,7 @@ TypeTrie::TypeNode::toTokenArray( TokenArray& a ) const
 void
 TypeTrie::TypeNode::info( std::ostream& out, std::vector< TypeNode const* >& tl ) const
 {
-  if ( not next and alt == nullptr ) // Leaf node
+  if ( not next and not alt ) // Leaf node
   {
     // print type list then function
     for ( int i = tl.size() - 1; i >= 0; --i )
@@ -173,7 +173,7 @@ TypeTrie::getalternative( TypeTrie::TypeNode* pos, const Name& type )
 
   while ( type != pos->type )
   {
-    if ( pos->alt == nullptr )
+    if ( not pos->alt )
     {
       pos->alt = new TypeNode( type );
     }
@@ -245,7 +245,7 @@ TypeTrie::insert_move( const TypeArray& a, Token& f )
   {
 
     pos = getalternative( pos, a[ level ] );
-    if ( pos->next == nullptr )
+    if ( not pos->next )
     {
       pos->next = new TypeNode( empty );
     }
@@ -258,7 +258,7 @@ TypeTrie::insert_move( const TypeArray& a, Token& f )
      2. If pos->alt != NULL, something undefined must have happened.
      This should be impossible.
   */
-  if ( pos->next == nullptr )
+  if ( not pos->next )
   {
     pos->type = sli::object;
     pos->func.move( f );

--- a/sli/typechk.cc
+++ b/sli/typechk.cc
@@ -74,12 +74,12 @@ TypeTrie::TypeNode::toTokenArray( TokenArray& a ) const
   }
   else
   {
-    assert( next != nullptr );
+    assert( next );
     a.push_back( LiteralDatum( type ) );
     TokenArray a_next;
     next->toTokenArray( a_next );
     a.push_back( ArrayDatum( a_next ) );
-    if ( alt != nullptr )
+    if ( alt )
     {
       TokenArray a_alt;
       alt->toTokenArray( a_alt );
@@ -103,11 +103,11 @@ TypeTrie::TypeNode::info( std::ostream& out, std::vector< TypeNode const* >& tl 
   }
   else
   {
-    assert( next != nullptr );
+    assert( next );
     tl.push_back( this );
     next->info( out, tl );
     tl.pop_back();
-    if ( alt != nullptr )
+    if ( alt )
     {
       alt->info( out, tl );
     }
@@ -130,15 +130,15 @@ TypeTrie::newnode( const TokenArray& ta ) const
     // first object in the array must be a literal, indicating the type
     // the second and third object must be an array.
     LiteralDatum* typed = dynamic_cast< LiteralDatum* >( ta[ 0 ].datum() );
-    assert( typed != nullptr );
+    assert( typed );
     ArrayDatum* nextd = dynamic_cast< ArrayDatum* >( ta[ 1 ].datum() );
-    assert( nextd != nullptr );
+    assert( nextd );
     n = new TypeNode( *typed );
     n->next = newnode( *nextd );
     if ( ta.size() == 3 )
     {
       ArrayDatum* altd = dynamic_cast< ArrayDatum* >( ta[ 2 ].datum() );
-      assert( altd != nullptr );
+      assert( altd );
       n->alt = newnode( *altd );
     }
   }
@@ -235,7 +235,7 @@ TypeTrie::insert_move( const TypeArray& a, Token& f )
   TypeNode* pos = root;
   const Name empty;
 
-  assert( root != nullptr );
+  assert( root );
 
   // Functions with no parameters are possible, but useless in trie
   // structures, so it is best to forbid them!
@@ -280,7 +280,7 @@ void
 TypeTrie::toTokenArray( TokenArray& a ) const
 {
   a.clear();
-  if ( root != nullptr )
+  if ( root )
   {
     root->toTokenArray( a );
   }
@@ -291,7 +291,7 @@ TypeTrie::info( std::ostream& out ) const
 {
   std::vector< TypeNode const* > tl;
   tl.reserve( 5 );
-  if ( root != nullptr )
+  if ( root )
   {
     root->info( out, tl );
   }

--- a/sli/typechk.cc
+++ b/sli/typechk.cc
@@ -68,7 +68,7 @@ void
 TypeTrie::TypeNode::toTokenArray( TokenArray& a ) const
 {
   assert( a.size() == 0 );
-  if ( next == nullptr and alt == nullptr ) // Leaf node
+  if ( not next and alt == nullptr ) // Leaf node
   {
     a.push_back( func );
   }
@@ -92,7 +92,7 @@ TypeTrie::TypeNode::toTokenArray( TokenArray& a ) const
 void
 TypeTrie::TypeNode::info( std::ostream& out, std::vector< TypeNode const* >& tl ) const
 {
-  if ( next == nullptr and alt == nullptr ) // Leaf node
+  if ( not next and alt == nullptr ) // Leaf node
   {
     // print type list then function
     for ( int i = tl.size() - 1; i >= 0; --i )

--- a/sli/typechk.h
+++ b/sli/typechk.h
@@ -121,11 +121,11 @@ private:
 
     ~TypeNode()
     {
-      if ( next != nullptr )
+      if ( next )
       {
         next->removereference();
       }
-      if ( alt != nullptr )
+      if ( alt )
       {
         alt->removereference();
       }
@@ -156,7 +156,7 @@ public:
   TypeTrie( const TypeTrie& tt )
     : root( tt.root )
   {
-    if ( root != nullptr )
+    if ( root )
     {
       root->addreference();
     }
@@ -185,7 +185,7 @@ public:
 
 inline TypeTrie::~TypeTrie()
 {
-  if ( root != nullptr )
+  if ( root )
   {
     root->removereference();
   }
@@ -233,7 +233,7 @@ TypeTrie::lookup( const TokenStack& st ) const
 
     while ( not equals( find_type, pos->type ) )
     {
-      if ( pos->alt != nullptr )
+      if ( pos->alt )
       {
         pos = pos->alt;
       }

--- a/sli/utils.cc
+++ b/sli/utils.cc
@@ -34,7 +34,7 @@ array2vector( std::vector< long >& v, const TokenArray a )
   for ( Token* t = a.begin(); t != a.end(); ++t )
   {
     IntegerDatum* id = dynamic_cast< IntegerDatum* >( t->datum() );
-    if ( id == nullptr )
+    if ( not id )
     {
       status = false;
       break;


### PR DESCRIPTION
**This PR is based on PR #2493.**  
In the C++ standard it is defined that `if ( ptr != nullptr )` gives the same result as `if ( ptr )` as `ptr` is converted to a `bool` in the latter case, which per standard evaluates to `true` only if `ptr != nullptr`.  
We can therefore convert all occurrences of
`if ( ptr != nullptr )` to ` if ( ptr )`
and
`if ( ptr == nullptr )` to `if ( not ptr )`
which makes it quite clear in which cases a pointer is expected to be valid and when not.