### PR TITLE
Replace std::vector with std::set in SecondaryEvent

### DIFF
--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -151,7 +151,7 @@ EventDeliveryManager::send_secondary( Node& source, SecondaryEvent& e )
     // We need to consider every synapse type this event supports to
     // make sure also labeled and connection created by CopyModel are
     // considered.
-    const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
+    const std::set< synindex >& supported_syn_ids = e.get_supported_syn_ids();
     for ( const auto& syn_id : supported_syn_ids )
     {
       const std::vector< size_t >& positions =

--- a/nestkernel/secondary_event.h
+++ b/nestkernel/secondary_event.h
@@ -24,6 +24,7 @@
 #define SECONDARY_EVENT_H
 
 // c++ includes
+// C++ includes:
 #include <set>
 
 namespace nest

--- a/nestkernel/secondary_event.h
+++ b/nestkernel/secondary_event.h
@@ -23,6 +23,7 @@
 #ifndef SECONDARY_EVENT_H
 #define SECONDARY_EVENT_H
 
+// c++ includes
 #include <set>
 
 namespace nest
@@ -49,8 +50,6 @@ public:
   SecondaryEvent* clone() const override = 0;
 
   virtual void add_syn_id( const synindex synid ) = 0;
-
-  virtual bool has_synid( const synindex synid ) const = 0;
 
   //! size of event in units of unsigned int
   virtual size_t size() = 0;
@@ -156,9 +155,7 @@ read_from_comm_buffer( T& d, std::vector< unsigned int >::iterator& pos )
  * the usage of CopyModel or the creation of the labeled synapse model
  * duplicates for pyNN) which make it necessary to register several
  * SecondaryConnectorModels with one SecondaryEvent. Therefore the synindices
- * of all these models are added to supported_syn_ids_. The
- * has_synid()-function allows testing if a particular synid is mapped
- * with the SecondaryEvent in question.
+ * of all these models are added to supported_syn_ids_.
  */
 template < typename DataType, typename Subclass >
 class DataSecondaryEvent : public SecondaryEvent
@@ -200,7 +197,6 @@ public:
   void
   add_syn_id( const synindex synid ) override
   {
-
     VPManager::assert_single_threaded();
     supported_syn_ids_.insert( synid );
   }
@@ -229,14 +225,6 @@ public:
   {
     VPManager::assert_single_threaded();
     coeff_length_ = coeff_length;
-  }
-
-  bool
-  has_synid( const synindex synid ) const override
-  {
-    // Unfortunately, the set::contain function is only available as of C++20
-    auto item = supported_syn_ids_.find( synid );
-    return ( item != supported_syn_ids_.end() );
   }
 
   void

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -97,12 +97,11 @@ nest::TargetTableDevices::send_to_device( const thread tid,
   const std::vector< ConnectorModel* >& cm )
 {
   const index lid = kernel().vp_manager.node_id_to_lid( source_node_id );
-  const std::set< synindex >& supported_syn_ids = e.get_supported_syn_ids();
-  for ( auto cit = supported_syn_ids.begin(); cit != supported_syn_ids.end(); ++cit )
+  for ( auto& synid : e.get_supported_syn_ids() )
   {
-    if ( target_to_devices_[ tid ][ lid ][ *cit ] )
+    if ( target_to_devices_[ tid ][ lid ][ synid ] )
     {
-      target_to_devices_[ tid ][ lid ][ *cit ]->send_to_all( tid, cm, e );
+      target_to_devices_[ tid ][ lid ][ synid ]->send_to_all( tid, cm, e );
     }
   }
 }

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -97,8 +97,8 @@ nest::TargetTableDevices::send_to_device( const thread tid,
   const std::vector< ConnectorModel* >& cm )
 {
   const index lid = kernel().vp_manager.node_id_to_lid( source_node_id );
-  const std::vector< synindex >& supported_syn_ids = e.get_supported_syn_ids();
-  for ( std::vector< synindex >::const_iterator cit = supported_syn_ids.begin(); cit != supported_syn_ids.end(); ++cit )
+  const std::set< synindex >& supported_syn_ids = e.get_supported_syn_ids();
+  for ( auto cit = supported_syn_ids.begin(); cit != supported_syn_ids.end(); ++cit )
   {
     if ( target_to_devices_[ tid ][ lid ][ *cit ] )
     {


### PR DESCRIPTION
The `SecondaryEvent` class in `secondary_event.h`  uses the `std::vector` to implement the same logic as the `std::set`. Therefore, It is more appropriate to use directly the `set` implementation.