### PR TITLE
Fix memory leak with `ResetKernel`

### DIFF
--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -237,7 +237,7 @@ private:
   /**
    * Memory for all nodes sorted by threads.
    */
-  std::vector< std::vector< Node* > > memory_;
+  std::vector< std::vector< std::shared_ptr< Node > > > memory_;
 };
 
 
@@ -246,7 +246,7 @@ Model::create( thread t )
 {
   assert( ( size_t ) t < memory_.size() );
   Node* n = create_();
-  memory_[ t ].push_back( n );
+  memory_[ t ].emplace_back( n );
   return n;
 }
 

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -237,7 +237,7 @@ private:
   /**
    * Memory for all nodes sorted by threads.
    */
-  std::vector< std::vector< std::shared_ptr< Node > > > memory_;
+  std::vector< std::vector< Node* > > memory_;
 };
 
 

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -568,8 +568,12 @@ NodeManager::destruct_nodes_()
 {
 #pragma omp parallel
   {
-    const index t = kernel().vp_manager.get_thread_id();
-    local_nodes_[ t ].clear();
+    const index tid = kernel().vp_manager.get_thread_id();
+    for ( auto node : local_nodes_[ tid ] )
+    {
+      delete node.get_node();
+    }
+    local_nodes_[ tid ].clear();
   } // omp parallel
 }
 

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -568,17 +568,7 @@ NodeManager::destruct_nodes_()
 {
 #pragma omp parallel
   {
-    index t = kernel().vp_manager.get_thread_id();
-    SparseNodeArray::const_iterator n;
-    for ( n = local_nodes_[ t ].begin(); n != local_nodes_[ t ].end(); ++n )
-    {
-      // We call the destructor for each node excplicitly. This
-      // destroys the objects without releasing their memory. Since
-      // the Memory is owned by the Model objects, we must not call
-      // delete on the Node objects!
-      n->get_node()->~Node();
-    }
-
+    const index t = kernel().vp_manager.get_thread_id();
     local_nodes_[ t ].clear();
   } // omp parallel
 }


### PR DESCRIPTION
Nodes are created with `new` in `GenericModel`:
https://github.com/nest/nest-simulator/blob/d7ef15baf1ce6b4453a10a0b9708b4e9477abc56/nestkernel/genericmodel.h#L154-L158

Then the node pointers are stored in `memory_` in `Model`. However the nodes are never deleted, which leads to a memory leak when calling `ResetKernel`. With only a few thousand nodes, calling `ResetKernel` multiple times can add up to hundreds of MB of leaked memory.

This PR puts Node pointers in smart pointers within `memory_`, so that the Nodes are automatically deleted when the model is destroyed. The explicit call to the node destructor in `NodeManager` is removed because it interferes with the deletion of the nodes at the end of `Model`s lifetime. This fixes #2519. @ChenK19 Can you check if #2512 is fixed by this as well?