### PR TITLE
Use std::max and std::min

### DIFF
--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -569,16 +569,8 @@ nest::SimulationManager::run( Time const& t )
   // of a simulation, it has been reset properly elsewhere.  If
   // a simulation was ended and is now continued, from_step_ will
   // have the proper value.  to_step_ is set as in advance_time().
+  to_step_ = std::min( from_step_ + to_do_, kernel().connection_manager.get_min_delay() );
 
-  delay end_sim = from_step_ + to_do_;
-  if ( kernel().connection_manager.get_min_delay() < end_sim )
-  {
-    to_step_ = kernel().connection_manager.get_min_delay(); // update to end of time slice
-  }
-  else
-  {
-    to_step_ = end_sim; // update to end of simulation time
-  }
 
   // Warn about possible inconsistencies, see #504.
   // This test cannot come any earlier, because we first need to compute

--- a/nestkernel/vp_manager_impl.h
+++ b/nestkernel/vp_manager_impl.h
@@ -113,16 +113,6 @@ VPManager::get_end_rank_per_thread( const thread rank_start, const thread num_as
   {
     rank_end = std::max( rank_start, kernel().mpi_manager.get_num_processes() );
   }
-  // while ( rank_end > kernel().mpi_manager.get_num_processes() )
-  // {
-  //   --rank_end;
-  //   // we use rank_end == rank_start, as a sign, that this thread
-  //   // does not do any work
-  //   if ( rank_end == rank_start )
-  //   {
-  //     break;
-  //   }
-  // }
 
   return rank_end;
 }

--- a/nestkernel/vp_manager_impl.h
+++ b/nestkernel/vp_manager_impl.h
@@ -109,16 +109,20 @@ VPManager::get_end_rank_per_thread( const thread rank_start, const thread num_as
   // if we have more threads than ranks, or if ranks can not be
   // distributed evenly on threads, we need to make sure, that all
   // threads care only about existing ranks
-  while ( rank_end > kernel().mpi_manager.get_num_processes() )
+  if ( rank_end > kernel().mpi_manager.get_num_processes() )
   {
-    --rank_end;
-    // we use rank_end == rank_start, as a sign, that this thread
-    // does not do any work
-    if ( rank_end == rank_start )
-    {
-      break;
-    }
+    rank_end = std::max( rank_start, kernel().mpi_manager.get_num_processes() );
   }
+  // while ( rank_end > kernel().mpi_manager.get_num_processes() )
+  // {
+  //   --rank_end;
+  //   // we use rank_end == rank_start, as a sign, that this thread
+  //   // does not do any work
+  //   if ( rank_end == rank_start )
+  //   {
+  //     break;
+  //   }
+  // }
 
   return rank_end;
 }


### PR DESCRIPTION
#### Replace the `while-loop` in the `VPManager::get_end_rank_per_thread` with `std::max`
```cpp

VPManager::get_end_rank_per_thread( const thread rank_start, const thread num_assigned_ranks_per_thread ) const
{
  thread rank_end = rank_start + num_assigned_ranks_per_thread;

  // if we have more threads than ranks, or if ranks can not be
  // distributed evenly on threads, we need to make sure, that all
  // threads care only about existing ranks
   while ( rank_end > kernel().mpi_manager.get_num_processes() )
  {
    --rank_end;
    // we use rank_end == rank_start, as a sign, that this thread
    // does not do any work
    if ( rank_end == rank_start )
    {
      break;
    }
  }

  return rank_end;
}

```

Here, first we check if the `rank_end` is greater than the number of MPI processes (`MPI`).  If it is the case, we keep decreasing `rank_end` by one until either reaching the `MPI` or `rank_start `, else we do nothing, and we use the initial value of the `rank_end`. 

If `rank_start ` is greater than the `MPI`, then `rank_end` will be also greater than `MPI`. Therefore, by decreasing `rank_end` by one, we will first reach the value `rank_start `. Otherwise, when  `rank_start ` is less than `MPI`, but the value of `rank_end` is greater than `MPI`, then we will first reach the value of `MPI`. 

Therefore, as long as  `rank_end` is greater than the `MPI`, the new value of  `rank_end` will be the maximum between `rank_start `  and `MPI`, and no `while-loop` will be needed.

#### Replace the `if-else` in the `SimulationManager::run` with `std::min`

```cpp
  delay end_sim = from_step_ + to_do_;
  if ( kernel().connection_manager.get_min_delay() < end_sim )
  {
    to_step_ = kernel().connection_manager.get_min_delay(); // update to end of time slice
  }
  else
  {
    to_step_ = end_sim; // update to end of simulation time
  }
```
Here, if `end_sim` is larger than the min-delay, then `to_step` is set to min-delay, otherwise  `to_step`  is set to  `end_sim`. In short, `to_step` is set to the minimum between `end_sim` and the min-delay.