### PR TITLE
Refactor collocate_spike_data_buffers

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -467,7 +467,7 @@ bool
 EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
   const AssignedRanks& assigned_ranks,
   SendBufferPosition& send_buffer_position,
-  std::vector< std::vector< std::vector< std::vector< TargetT > > > >& spike_register,
+  std::vector< std::vector< std::vector< std::vector< TargetT > > > >& emitted_spikes_register,
   std::vector< SpikeDataT >& send_buffer )
 {
   reset_complete_marker_spike_data_( assigned_ranks, send_buffer_position, send_buffer );
@@ -477,15 +477,15 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
   bool is_spike_register_empty = true;
 
   // First dimension: loop over writing thread
-  for ( auto& spikes : spike_register )
+  for ( auto& emitted_spikes_per_thread : emitted_spikes_register )
   {
     // Second dimension: Set the reading thread to the current running thread
 
     // Third dimension: loop over lags
-    for ( unsigned int lag = 0; lag < ( spikes )[ tid ].size(); ++lag )
+    for ( unsigned int lag = 0; lag < ( emitted_spikes_per_thread )[ tid ].size(); ++lag )
     {
       // Fourth dimension: loop over entries
-      for ( auto& emitted_spike : ( spikes )[ tid ][ lag ] )
+      for ( auto& emitted_spike : ( emitted_spikes_per_thread )[ tid ][ lag ] )
       {
         assert( not emitted_spike.is_processed() );
 

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -501,7 +501,7 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
         }
         else
         {
-          send_buffer[ send_buffer_position.idx( rank ) ].set(emitted_spike, lag);
+          send_buffer[ send_buffer_position.idx( rank ) ].set( emitted_spike, lag );
           emitted_spike.mark_for_removal();
           send_buffer_position.increase( rank );
         }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -477,19 +477,19 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
   bool is_spike_register_empty = true;
 
   // First dimension: loop over writing thread
-  for ( auto& it : spike_register )
+  for ( auto& spikes : spike_register )
   {
-    // Second dimension: Set the reading thread to current running thread
+    // Second dimension: Set the reading thread to the current running thread
 
     // Third dimension: loop over lags
-    for ( unsigned int lag = 0; lag < ( it )[ tid ].size(); ++lag )
+    for ( unsigned int lag = 0; lag < ( spikes )[ tid ].size(); ++lag )
     {
       // Fourth dimension: loop over entries
-      for ( auto& spike : ( it )[ tid ][ lag ] )
+      for ( auto& emitted_spike : ( spikes )[ tid ][ lag ] )
       {
-        assert( not spike.is_processed() );
+        assert( not emitted_spike.is_processed() );
 
-        const thread rank = spike.get_rank();
+        const thread rank = emitted_spike.get_rank();
 
         if ( send_buffer_position.is_chunk_filled( rank ) )
         {
@@ -501,8 +501,9 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
         }
         else
         {
-          send_buffer[ send_buffer_position.idx( rank ) ].set( spike, lag );
-          spike.mark_for_removal();
+          SpikeDataT& spike_to_send = send_buffer.at( send_buffer_position.idx( rank ) );
+          spike_to_send.set( emitted_spike, lag );
+          emitted_spike.mark_for_removal();
           send_buffer_position.increase( rank );
         }
       }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -501,8 +501,7 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
         }
         else
         {
-          SpikeDataT& spike_to_send = send_buffer.at( send_buffer_position.idx( rank ) );
-          spike_to_send.set( emitted_spike, lag );
+          send_buffer[ send_buffer_position.idx( rank ) ].set(emitted_spike, lag);
           emitted_spike.mark_for_removal();
           send_buffer_position.increase( rank );
         }

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -491,7 +491,7 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
 
         const thread rank = spike.get_rank();
 
-        if ( send_buffer_position.is_chunk_filled( rank ) && send_buffer_position.are_all_chunks_filled() )
+        if ( send_buffer_position.are_all_chunks_filled() )
         {
           // All chunks are full => return false
           return false;

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -491,17 +491,10 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
 
         const thread rank = spike.get_rank();
 
-        if ( send_buffer_position.is_chunk_filled( rank ) )
+        if ( send_buffer_position.is_chunk_filled( rank ) && send_buffer_position.are_all_chunks_filled() )
         {
-          is_spike_register_empty = false;
-          if ( send_buffer_position.are_all_chunks_filled() )
-          {
-            return is_spike_register_empty;
-          }
-          else
-          {
-            continue;
-          }
+          // All chunks are full => return false
+          return false;
         }
         else
         {

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -479,7 +479,7 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
   // First dimension: loop over writing thread
   for ( auto& it : spike_register )
   {
-    // Second dimension: Set reading thread to current running thread
+    // Second dimension: Set the reading thread to current running thread
 
     // Third dimension: loop over lags
     for ( unsigned int lag = 0; lag < ( it )[ tid ].size(); ++lag )

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -491,15 +491,18 @@ EventDeliveryManager::collocate_spike_data_buffers_( const thread tid,
 
         const thread rank = spike.get_rank();
 
-        if ( send_buffer_position.are_all_chunks_filled() )
+        if ( send_buffer_position.is_chunk_filled( rank ) )
         {
-          // All chunks are full => return false
-          return false;
+          is_spike_register_empty = false;
+          if ( send_buffer_position.are_all_chunks_filled() )
+          {
+            return is_spike_register_empty;
+          }
         }
         else
         {
           send_buffer[ send_buffer_position.idx( rank ) ].set( spike, lag );
-          spike.set_status( TARGET_ID_PROCESSED ); // mark entry for removal
+          spike.mark_for_removal();
           send_buffer_position.increase( rank );
         }
       }

--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -391,7 +391,7 @@ private:
    * - Third dim: lag
    * - Fourth dim: Target (will be converted in SpikeData)
    */
-  std::vector< std::vector< std::vector< std::vector< Target > > > > spike_register_;
+  std::vector< std::vector< std::vector< std::vector< Target > > > > emitted_spikes_register_;
 
   /**
    * Register for node IDs of precise neurons that spiked. This is a 4-dim
@@ -403,7 +403,7 @@ private:
    * - Third dim: lag
    * - Fourth dim: OffGridTarget (will be converted in OffGridSpikeData)
    */
-  std::vector< std::vector< std::vector< std::vector< OffGridTarget > > > > off_grid_spike_register_;
+  std::vector< std::vector< std::vector< std::vector< OffGridTarget > > > > off_grid_emitted_spike_register_;
 
   /**
    * Buffer to collect the secondary events
@@ -447,8 +447,8 @@ private:
 inline void
 EventDeliveryManager::reset_spike_register_( const thread tid )
 {
-  for ( std::vector< std::vector< std::vector< Target > > >::iterator it = spike_register_[ tid ].begin();
-        it < spike_register_[ tid ].end();
+  for ( std::vector< std::vector< std::vector< Target > > >::iterator it = emitted_spikes_register_[ tid ].begin();
+        it < emitted_spikes_register_[ tid ].end();
         ++it )
   {
     for ( std::vector< std::vector< Target > >::iterator iit = it->begin(); iit < it->end(); ++iit )
@@ -458,8 +458,8 @@ EventDeliveryManager::reset_spike_register_( const thread tid )
   }
 
   for ( std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
-          off_grid_spike_register_[ tid ].begin();
-        it < off_grid_spike_register_[ tid ].end();
+          off_grid_emitted_spike_register_[ tid ].begin();
+        it < off_grid_emitted_spike_register_[ tid ].end();
         ++it )
   {
     for ( std::vector< std::vector< OffGridTarget > >::iterator iit = it->begin(); iit < it->end(); ++iit )
@@ -478,8 +478,8 @@ EventDeliveryManager::is_marked_for_removal_( const Target& target )
 inline void
 EventDeliveryManager::clean_spike_register_( const thread tid )
 {
-  for ( std::vector< std::vector< std::vector< Target > > >::iterator it = spike_register_[ tid ].begin();
-        it < spike_register_[ tid ].end();
+  for ( std::vector< std::vector< std::vector< Target > > >::iterator it = emitted_spikes_register_[ tid ].begin();
+        it < emitted_spikes_register_[ tid ].end();
         ++it )
   {
     for ( std::vector< std::vector< Target > >::iterator iit = it->begin(); iit < it->end(); ++iit )
@@ -489,8 +489,8 @@ EventDeliveryManager::clean_spike_register_( const thread tid )
     }
   }
   for ( std::vector< std::vector< std::vector< OffGridTarget > > >::iterator it =
-          off_grid_spike_register_[ tid ].begin();
-        it < off_grid_spike_register_[ tid ].end();
+          off_grid_emitted_spike_register_[ tid ].begin();
+        it < off_grid_emitted_spike_register_[ tid ].end();
         ++it )
   {
     for ( std::vector< std::vector< OffGridTarget > >::iterator iit = it->begin(); iit < it->end(); ++iit )

--- a/nestkernel/event_delivery_manager_impl.h
+++ b/nestkernel/event_delivery_manager_impl.h
@@ -114,7 +114,7 @@ EventDeliveryManager::send_remote( thread tid, SpikeEvent& e, const long lag )
     // Unroll spike multiplicity as plastic synapses only handle individual spikes.
     for ( int i = 0; i < e.get_multiplicity(); ++i )
     {
-      spike_register_[ tid ][ assigned_tid ][ lag ].push_back( *it );
+      emitted_spikes_register_[ tid ][ assigned_tid ][ lag ].push_back( *it );
     }
   }
 }
@@ -133,7 +133,7 @@ EventDeliveryManager::send_off_grid_remote( thread tid, SpikeEvent& e, const lon
     // Unroll spike multiplicity as plastic synapses only handle individual spikes.
     for ( int i = 0; i < e.get_multiplicity(); ++i )
     {
-      off_grid_spike_register_[ tid ][ assigned_tid ][ lag ].push_back( OffGridTarget( *it, e.get_offset() ) );
+      off_grid_emitted_spike_register_[ tid ][ assigned_tid ][ lag ].push_back( OffGridTarget( *it, e.get_offset() ) );
     }
   }
 }

--- a/nestkernel/spike_data.h
+++ b/nestkernel/spike_data.h
@@ -193,7 +193,7 @@ template < class TargetT >
 inline void
 SpikeData::set( const TargetT& target, const unsigned int lag )
 {
-  // the assertion in the above function are granted by the Target object!
+  // the assertions in the above function are granted by the TargetT object!
   assert( lag < MAX_LAG );
   lcid_ = target.get_lcid();
   marker_ = SPIKE_DATA_ID_DEFAULT;

--- a/nestkernel/spike_data.h
+++ b/nestkernel/spike_data.h
@@ -67,6 +67,9 @@ public:
 
   void set( const thread tid, const synindex syn_id, const index lcid, const unsigned int lag, const double offset );
 
+  template < class TargetT >
+  void set( const TargetT& target, const unsigned int lag );
+
   /**
    * Returns local connection ID.
    */
@@ -185,6 +188,20 @@ SpikeData::set( const thread tid, const synindex syn_id, const index lcid, const
   syn_id_ = syn_id;
 }
 
+
+template < class TargetT >
+inline void
+SpikeData::set( const TargetT& target, const unsigned int lag )
+{
+  // the assertion in the above function are granted by the Target object!
+  assert( lag < MAX_LAG );
+  lcid_ = target.get_lcid();
+  marker_ = SPIKE_DATA_ID_DEFAULT;
+  lag_ = lag;
+  tid_ = target.get_tid();
+  syn_id_ = target.get_syn_id();
+}
+
 inline index
 SpikeData::get_lcid() const
 {
@@ -270,6 +287,9 @@ public:
     const unsigned int lag,
     const double offset );
   void set( const thread tid, const synindex syn_id, const index lcid, const unsigned int lag, const double offset );
+
+  template < class TargetT >
+  void set( const TargetT& target, const unsigned int lag );
   double get_offset() const;
 };
 
@@ -292,6 +312,7 @@ inline OffGridSpikeData::OffGridSpikeData( const thread tid,
 {
 }
 
+
 inline void
 OffGridSpikeData::set( const thread tid,
   const synindex syn_id,
@@ -310,6 +331,15 @@ OffGridSpikeData::set( const thread tid,
   tid_ = tid;
   syn_id_ = syn_id;
   offset_ = offset;
+}
+
+
+template < class TargetT >
+inline void
+OffGridSpikeData::set( const TargetT& target, const unsigned int lag )
+{
+  SpikeData::set( target, lag );
+  offset_ = target.get_offset();
 }
 
 inline double

--- a/nestkernel/target.h
+++ b/nestkernel/target.h
@@ -159,6 +159,11 @@ public:
    * Return offset.
    */
   double get_offset() const;
+
+  /**
+   *  Set the status of the target identifier to processed
+   */
+  void mark_for_removal();
 };
 
 //!< check legal size
@@ -287,6 +292,13 @@ Target::get_offset() const
 {
   return 0;
 }
+
+inline void
+Target::mark_for_removal()
+{
+  set_status( TARGET_ID_PROCESSED );
+}
+
 
 class OffGridTarget : public Target
 {

--- a/nestkernel/target_table.h
+++ b/nestkernel/target_table.h
@@ -87,8 +87,8 @@ public:
   void add_target( const thread tid, const thread target_rank, const TargetData& target_data );
 
   /**
-   * Returns all targets of a neuron. Used to fill
-   * EventDeliveryManager::spike_register_.
+   * Returns all targets of a neuron. Used for filling
+   * EventDeliveryManager::emitted_spikes_register_.
    */
   const std::vector< Target >& get_targets( const thread tid, const index lid ) const;
 


### PR DESCRIPTION
Making `for-loops` iterating over `n` dimensional vector easier to read in the `EventDeliveryManager::collocate_spike_data_buffers_`