### PR TITLE
Fix missing colon and correct comment

### DIFF
--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -77,7 +77,7 @@ FULLY TESTED. USE AT YOUR OWN PERIL!
 
 ``iaf_cond_alpha_mc`` is an implementation of a multi-compartment spiking
 neuron using IAF dynamics with conductance-based synapses. It serves
-mainly to illustrate the implementation of ref:`multicompartment models
+mainly to illustrate the implementation of :ref:`multicompartment models
 <multicompartment-models>` in NEST.
 
 The model has three compartments: soma, proximal and distal dendrite,

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -306,7 +306,7 @@ protected:
      connection
   */
   targetidentifierT target_;
-  //! syn_id (char) and delay (24 bit) in timesteps of this connection
+  //! syn_id (9 bit), delay (21 bit) in timesteps of this connection and more_targets and disabled flags (each 1 bit)
   SynIdDelay syn_id_delay_;
 };
 


### PR DESCRIPTION
There was a missing colon in [models/iaf_cond_alpha_mc.h](https://github.com/nest/nest-simulator/compare/master...JanVogelsang:nest-simulator:comment-fixes?expand=1#diff-71d7ffa760a39bbef5e46bc776b2e5604429c0f79444615fae47e75fd9f521c2) which caused a reference to not be displayed correctly.

A comment in [nestkernel/connection.h](https://github.com/nest/nest-simulator/compare/master...JanVogelsang:nest-simulator:comment-fixes?expand=1#diff-7a75dd629d0cf1fd4cf7910456c209d29267aeec9955b87ac38abc6de527e55b) stated incorrect bit-sizes, probably an artifact of older versions.