### PR TITLE
Add documentation about Simulate() in Run() function

### DIFF
--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -48,6 +48,7 @@ __all__ = [
 @check_stack
 def Simulate(t):
     """Simulate the network for `t` milliseconds.
+
     `Simulate` triggers `Prepare`, `Run`, and `Cleanup` following this formula:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
@@ -110,13 +111,13 @@ def Run(t):
 @check_stack
 def Prepare():
     """Calibrate the system before a `Run` call.
+
     `Prepare` is automatically triggered at beginning of call to `Simulate`:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 
     Call before the first `Run` call, or before calling `Run` after changing
     the system, calling `SetStatus` or `Cleanup`.
-
 
     See Also
     --------
@@ -130,13 +131,13 @@ def Prepare():
 @check_stack
 def Cleanup():
     """Cleans up resources after a `Run` call.
+
     `Cleanup` is automatically triggered at the end of call to `Simulate`:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 
     Closes state for a series of runs, such as flushing and closing files.
     A `Prepare` is needed after a `Cleanup` before any more calls to `Run`.
-
 
     See Also
     --------

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -78,6 +78,7 @@ def Run(t):
 
     Call between `Prepare` and `Cleanup` calls, or within a
     ``with RunManager`` clause.
+    `Run` is automatically triggered during call to `simulate`:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -49,6 +49,8 @@ __all__ = [
 def Simulate(t):
     """Simulate the network for `t` milliseconds.
 
+    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+
     Parameters
     ----------
     t : float
@@ -111,6 +113,8 @@ def Prepare():
     Call before the first `Run` call, or before calling `Run` after changing
     the system, calling `SetStatus` or `Cleanup`.
 
+    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+
     See Also
     --------
     Run, Cleanup
@@ -124,8 +128,11 @@ def Prepare():
 def Cleanup():
     """Cleans up resources after a `Run` call. Not needed for `Simulate`.
 
+    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+
     Closes state for a series of runs, such as flushing and closing files.
     A `Prepare` is needed after a `Cleanup` before any more calls to `Run`.
+
 
     See Also
     --------

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -49,9 +49,7 @@ __all__ = [
 def Simulate(t):
     """Simulate the network for `t` milliseconds.
 
-    `Simulate` triggers `Prepare`, `Run`, and `Cleanup` following this formula:
-
-    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+    `Simulate(t)` runs `Prepare()`, `Run(t)`, and `Cleanup()` in this order.
 
     Parameters
     ----------
@@ -81,10 +79,7 @@ def Run(t):
     ------
 
     Call between `Prepare` and `Cleanup` calls, or within a
-    ``with RunManager`` clause.
-    `Run` is automatically triggered during call to `Simulate`:
-
-    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+    ``with RunManager`` clause.  `Run(t)` is called once by each call to `Simulate(t)`.
 
     `Prepare` must be called before `Run` to calibrate the system, and
     `Cleanup` must be called after `Run` to close files, cleanup handles, and
@@ -112,9 +107,7 @@ def Run(t):
 def Prepare():
     """Calibrate the system before a `Run` call.
 
-    `Prepare` is automatically triggered at beginning of call to `Simulate`:
-
-    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+    `Prepare` is automatically called by `Simulate` and `RunManager`.
 
     Call before the first `Run` call, or before calling `Run` after changing
     the system, calling `SetStatus` or `Cleanup`.
@@ -130,11 +123,9 @@ def Prepare():
 
 @check_stack
 def Cleanup():
-    """Cleans up resources after a `Run` call.
+    """Cleans up resources after a `Run` calls.
 
-    `Cleanup` is automatically triggered at the end of call to `Simulate`:
-
-    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
+    `Cleanup` is automatically called by `Simulate` and `RunManager` .
 
     Closes state for a series of runs, such as flushing and closing files.
     A `Prepare` is needed after a `Cleanup` before any more calls to `Run`.

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -48,6 +48,7 @@ __all__ = [
 @check_stack
 def Simulate(t):
     """Simulate the network for `t` milliseconds.
+    `Simulate` triggers `Prepare`, `Run`, and `Cleanup` following this formula:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -80,7 +80,7 @@ def Run(t):
 
     Call between `Prepare` and `Cleanup` calls, or within a
     ``with RunManager`` clause.
-    `Run` is automatically triggered during call to `simulate`:
+    `Run` is automatically triggered during call to `Simulate`:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 
@@ -108,12 +108,14 @@ def Run(t):
 
 @check_stack
 def Prepare():
-    """Calibrate the system before a `Run` call. Not needed for `Simulate`.
+    """Calibrate the system before a `Run` call.
+    `Prepare` is automatically triggered at beginning of call to `Simulate`:
+
+    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 
     Call before the first `Run` call, or before calling `Run` after changing
     the system, calling `SetStatus` or `Cleanup`.
 
-    Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 
     See Also
     --------
@@ -126,7 +128,8 @@ def Prepare():
 
 @check_stack
 def Cleanup():
-    """Cleans up resources after a `Run` call. Not needed for `Simulate`.
+    """Cleans up resources after a `Run` call.
+    `Cleanup` is automatically triggered at the end of call to `Simulate`:
 
     Simulate(t): t' = t/m; Prepare(); for _ in range(m): Run(t'); Cleanup()
 

--- a/pynest/nest/lib/hl_api_simulation.py
+++ b/pynest/nest/lib/hl_api_simulation.py
@@ -58,7 +58,7 @@ def Simulate(t):
 
     See Also
     --------
-    RunManager
+    RunManager, Prepare, Run, Cleanup
 
     """
 
@@ -114,7 +114,7 @@ def Prepare():
 
     See Also
     --------
-    Run, Cleanup
+    Run, Cleanup, Simulate, RunManager
 
     """
 
@@ -132,7 +132,7 @@ def Cleanup():
 
     See Also
     --------
-    Run, Prepare
+    Run, Prepare, Simulate, RunManager
 
     """
     sr('Cleanup')


### PR DESCRIPTION
This PR is a followup to #2526 and adds a bit more context explaining how run is triggered during simulate. 

@JoseJVS let me know if this should be expanded upon, and if you think the `Simulate` docstring should also include more details.  