### PR TITLE
Make CMakeLists install-nodoc cmd ninja compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,8 +368,14 @@ install( FILES LICENSE README.md
     DESTINATION ${CMAKE_INSTALL_DOCDIR}
     )
 
-add_custom_target( install-nodoc
-  COMMAND $(MAKE) NEST_INSTALL_NODOC=true install
-)
+if(${CMAKE_GENERATOR} STREQUAL "Ninja")
+  add_custom_target( install-nodoc
+    COMMAND ninja NEST_INSTALL_NODOC=true install
+    )
+else()
+  add_custom_target( install-nodoc
+    COMMAND $(MAKE) NEST_INSTALL_NODOC=true install
+    )
+endif()
 
 nest_print_config_summary()


### PR DESCRIPTION
Hello everyone,

https://github.com/nest/nest-simulator/pull/2396 introduced a regression by limiting cmake generation to make-based build systems by using the Makefile specific ` $(MAKE)` variable. 
 ` $(MAKE)` is not substituted by cmake, instead it is only substitute by make-based system when encountering it in the makefile.
Therefore, cmake can only generate correct files for Makefile based build systems as ninja for example does not know how to handle ` $(MAKE)` in ninja.build files.
The breakage w.r.t. ninja was also mentioned by the PR author @Helveg.

This is a quick fix that allows using ninja again as a build system. 
While this is not an optimal and permanent solution it removes the regression introduced by https://github.com/nest/nest-simulator/pull/2396 with minimal changes while https://github.com/nest/nest-simulator/issues/1905 is still discussed.

Best,
Marcel