### PR TITLE
Abort NEST if run using mpirun but compiled without support for MPI

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -183,15 +183,15 @@ void
 nest::MPIManager::initialize()
 {
 #ifndef HAVE_MPI
-  char* pmix_rank_set = std::getenv( "PMIX_RANK" );  // set by OpenMPI's launcher
-  char* pmi_rank_set = std::getenv( "PMI_RANK" );    // set by MPICH's launcher
+  char* pmix_rank_set = std::getenv( "PMIX_RANK" ); // set by OpenMPI's launcher
+  char* pmi_rank_set = std::getenv( "PMI_RANK" );   // set by MPICH's launcher
   if ( pmix_rank_set or pmi_rank_set )
   {
     LOG( M_FATAL,
       "MPIManager::initialize()",
       "You seem to be using NEST via an MPI launcher like mpirun, mpiexec or srun "
       "although NEST was not compiled with MPI support. Please see the NEST "
-      "documentation about parallel and distributed computing. Exiting.");
+      "documentation about parallel and distributed computing. Exiting." );
     std::exit( 127 );
   }
 #endif

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -189,7 +189,7 @@ nest::MPIManager::initialize()
   {
     LOG( M_FATAL,
       "MPIManager::initialize()",
-      "You seem to be using NEST via an MPI launcher like mpirun or mpiexec, "
+      "You seem to be using NEST via an MPI launcher like mpirun, mpiexec or srun "
       "although NEST was not compiled with MPI support. Please see the NEST "
       "documentation about parallel and distributed computing. Exiting.");
     std::exit( 127 );

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -22,6 +22,8 @@
 
 #include "mpi_manager.h"
 
+// C++ includes:
+#include <cstdlib>
 
 // Includes from libnestutil:
 #include "stopwatch.h"
@@ -180,6 +182,19 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
 void
 nest::MPIManager::initialize()
 {
+#ifndef HAVE_MPI
+  char* pmix_rank_set = std::getenv( "PMIX_RANK" );  // set by OpenMPI's launcher
+  char* pmi_rank_set = std::getenv( "PMI_RANK" );    // set by MPICH's launcher
+  if ( pmix_rank_set or pmi_rank_set )
+  {
+    LOG( M_FATAL,
+      "MPIManager::initialize()",
+      "You seem to be using NEST via an MPI launcher like mpirun or mpiexec, "
+      "although NEST was not compiled with MPI support. Please see the NEST "
+      "documentation about parallel and distributed computing. Exiting.");
+    std::exit( 127 );
+  }
+#endif
 }
 
 void


### PR DESCRIPTION
This fixes #2381.