### PR TITLE
Remove leftover reference to nosetests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,11 +96,6 @@ set( CMAKE_INSTALL_DATADIR "share/${PROJECT_NAME}" CACHE STRING "Relative direct
 ##################           Find utility programs            ##################
 ################################################################################
 
-# needed for pynest test suite
-if ( ${with-python} STREQUAL "ON" )
-  find_program( NOSETESTS NAMES nosetests )
-endif ()
-
 # needed for target doc and fulldoc
 find_package( Doxygen )
 find_program( SED NAMES sed gsed )


### PR DESCRIPTION
``nosetests`` is no longer needed or being used at all by NEST; remove this leftover reference to the package.