### PR TITLE
Improve documentation on some HH models

### DIFF
--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -72,45 +72,47 @@ Description
 ``hh_cond_beta_gap_traub`` is an implementation of a modified Hodgkin-Huxley model
 that also supports gap junctions.
 
-This model was specifically developed for a major review of simulators [1]_,
-based on a model of hippocampal pyramidal cells by Traub and Miles [2]_.
-The key differences between the current model and the model in [2]_ are:
+This model is derived from ``hh_conda_exp`` model, but supports double-exponential-shaped
+(beta-shaped) synaptic conductances and also support gap junctions. The model is originally
+based on a model of hippocampal pyramidal cells by Traub and Miles [1]_.
+The key differences between the current model and the model in [1]_ are:
 
 - This model is a point neuron, not a compartmental model.
 - This model includes only ``I_Na`` and ``I_K``, with simpler ``I_K`` dynamics than
-  in [2]_, so it has only three instead of eight gating variables;
+  in [1]_, so it has only three instead of eight gating variables;
   in particular, all Ca dynamics have been removed.
 - Incoming spikes induce an instantaneous conductance change followed by
   exponential decay instead of activation over time.
 
-This model is primarily provided as reference implementation for hh_coba
-example of the Brette et al (2007) review. Default parameter values are chosen
-to match those used with NEST 1.9.10 when preparing data for [1]_. Code for all
-simulators covered is available from ModelDB [3]_.
-
-Note:
-In this model, a spike is emitted if :math:`V_m \geq V_T + 30` mV and
-:math:`V_m` has fallen during the current time step.
-
-To avoid that this leads to multiple spikes during the falling flank of a
-spike, it is essential to chose a sufficiently long refractory period.
-Traub and Miles used :math:`t_{ref} = 3` ms ([2]_, p 118), while we used
-:math:`t_{ref} = 2` ms in [2]_.
-
 Postsynaptic currents
+---------------------
+
 Incoming spike events induce a postsynaptic change of conductance modelled by a
-beta function as outlined in [4]_ [5]_. The beta function is normalized such that an
+beta function as outlined in [3]_ [4]_. The beta function is normalized such that an
 event of weight 1.0 results in a peak current of 1 nS at :math:`t = \tau_{rise,xx}`
 where xx is ex or in.
 
 Spike Detection
+---------------
+
 Spike detection is done by a combined threshold-and-local-maximum search: if
 there is a local maximum above a certain threshold of the membrane potential,
 it is considered a spike.
 
 Gap Junctions
+-------------
+
 Gap Junctions are implemented by a gap current of the form
 :math:`g_{ij}( V_i - V_j)`.
+
+.. note::
+   In this model, a spike is emitted if :math:`V_m \geq V_T + 30` mV and
+   :math:`V_m` has fallen during the current time step.
+
+   To avoid that this leads to multiple spikes during the falling flank of a
+   spike, it is essential to chose a sufficiently long refractory period.
+   Traub and Miles used :math:`t_{ref} = 3` ms ([1]_, p 118), while we used
+   :math:`t_{ref} = 2` ms in [1]_.
 
 Parameters
 ++++++++++
@@ -142,16 +144,13 @@ I_e          pA      External input current
 References
 ++++++++++
 
-.. [1] Brette R et al (2007). Simulation of networks of spiking neurons: A
-       review of tools and strategies. Journal of Computational Neuroscience
-       23:349-98. DOI: https://doi.org/10.1007/s10827-007-0038-6
-.. [2] Traub RD and Miles R (1991). Neuronal Networks of the Hippocampus.
+.. [1] Traub RD and Miles R (1991). Neuronal Networks of the Hippocampus.
        Cambridge University Press, Cambridge UK.
-.. [3] http://modeldb.yale.edu/83319
-.. [4] Rotter S and Diesmann M (1999). Exact digital simulation of
+.. [2] http://modeldb.yale.edu/83319
+.. [3] Rotter S and Diesmann M (1999). Exact digital simulation of
        time-invariant linear systems with applications to neuronal modeling.
        Biological Cybernetics 81:381 DOI: https://doi.org/10.1007/s004220050570
-.. [5] Roth A and van Rossum M (2010). Chapter 6: Modeling synapses.
+.. [4] Roth A and van Rossum M (2010). Chapter 6: Modeling synapses.
        in De Schutter, Computational Modeling Methods for Neuroscientists,
        MIT Press.
 

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -83,14 +83,14 @@ example of the Brette et al (2007) review. Default parameter values are chosen
 to match those used with NEST 1.9.10 when preparing data for [1]_. Code for all
 simulators covered is available from ModelDB [3]_.
 
-Note:
-In this model, a spike is emitted if :math:`V_m \geq V_T + 30` mV and :math:`V_m`
-has fallen during the current time step.
+.. note::
+   In this model, a spike is emitted if :math:`V_m \geq V_T + 30` mV and :math:`V_m`
+   has fallen during the current time step.
 
-To avoid that this leads to multiple spikes during the falling flank of a
-spike, it is essential to chose a sufficiently long refractory period.
-Traub and Miles used  :math:`t_{ref} = 3` ms ([2]_, p 118), while we used
-:math:`t_{ref} = 2` ms in [2]_.
+   To avoid that this leads to multiple spikes during the falling flank of a
+   spike, it is essential to chose a sufficiently long refractory period.
+   Traub and Miles used  :math:`t_{ref} = 3` ms ([2]_, p 118), while we used
+   :math:`t_{ref} = 2` ms in [2]_.
 
 Parameters
 ++++++++++


### PR DESCRIPTION
This PR fixes #329 by making the documentation of the spike-emission mechanism of `hh_cond_exp_traub` even more visible and also fixes documentation for `hh_cond_beta_gap_traub`. Further work on better spike detection methods for these models seems not warranted at this time, also to not break the behaviour of existing code.