### PR TITLE
Improved comments on weight positivity for conductance-based multisynapse models

### DIFF
--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -67,6 +67,9 @@ synaptic reversal potentials are supplied by the array ``E_rev``. Port numbers
 are automatically assigned in the range from 1 to n_receptors.
 During connection, the ports are selected with the property ``receptor_type``.
 
+When connecting to conductance-based multisynapse models, all synaptic weights
+must be non-negative.
+
 The membrane potential is given by the following differential equation:
 
 .. math::

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -83,6 +83,9 @@ reversal potentials are supplied by the array ``E_rev``. The port numbers
 are automatically assigned in the range from 1 to n_receptors.
 During connection, the ports are selected with the property ``receptor_type``.
 
+When connecting to conductance-based multisynapse models, all synaptic weights
+must be non-negative.
+
 The membrane potential is given by the following differential equation:
 
 .. math::

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -587,7 +587,7 @@ nest::gif_cond_exp_multisynapse::handle( SpikeEvent& e )
   if ( e.get_weight() < 0 )
   {
     throw BadProperty(
-      "Synaptic weights for conductance based models "
+      "Synaptic weights for conductance-based multisynapse models "
       "must be positive." );
   }
   assert( e.get_delay_steps() > 0 );

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -588,7 +588,7 @@ nest::gif_cond_exp_multisynapse::handle( SpikeEvent& e )
   {
     throw BadProperty(
       "Synaptic weights for conductance-based multisynapse models "
-      "must be positive." );
+      "must be non-negative." );
   }
   assert( e.get_delay_steps() > 0 );
   assert( ( e.get_rport() > 0 ) and ( ( size_t ) e.get_rport() <= P_.n_receptors() ) );

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -113,28 +113,31 @@ positive or negative):
  \gamma_i = \gamma_i + q_{\gamma_i} \text{ (in case of spike emission).}
 
 
-Note:
+.. note::
 
-In the current implementation of the model,
-the values of :math:`\eta_i` and :math:`\gamma_i` are affected immediately
-after spike emission. However, `GIF toolbox <http://wiki.epfl.ch/giftoolbox>`_,
-which fits the model using experimental data, requires a different set of
-:math:`\eta_i` and :math:`\gamma_i`. It applies the jump of :math:`\eta_i` and
-:math:`\gamma_i` after the refractory period. One can easily convert between
-:math:`q_{\eta/\gamma}` of these two approaches:
+   In the current implementation of the model,
+   the values of :math:`\eta_i` and :math:`\gamma_i` are affected immediately
+   after spike emission. However, `GIF toolbox <http://wiki.epfl.ch/giftoolbox>`_,
+   which fits the model using experimental data, requires a different set of
+   :math:`\eta_i` and :math:`\gamma_i`. It applies the jump of :math:`\eta_i` and
+   :math:`\gamma_i` after the refractory period. One can easily convert between
+   :math:`q_{\eta/\gamma}` of these two approaches:
 
-.. math::
+   .. math::
 
-   q_{\eta,giftoolbox} = q_{\eta,NEST} \cdot (1 - \exp( -\tau_{ref} / \tau_\eta ))
+      q_{\eta,giftoolbox} = q_{\eta,NEST} \cdot (1 - \exp( -\tau_{ref} / \tau_\eta ))
 
-The same formula applies for :math:`q_\gamma`.
+   The same formula applies for :math:`q_\gamma`.
 
-On the postsynaptic side, there can be arbitrarily many synaptic time constants
-(gif_psc_exp has exactly two: ``tau_syn_ex`` and ``tau_syn_in``). This can be reached
-by specifying separate receptor ports, each for a different time constant. The
-port number has to match the respective ``receptor_type`` in the connectors.
+On the postsynaptic side, there can be arbitrarily many synaptic time
+constants (gif_psc_exp has exactly two: ``tau_syn_ex`` and
+``tau_syn_in``). This can be reached by specifying separate receptor
+ports, each for a different time constant. The port number has to
+match the respective ``receptor_type`` in the connectors. The shape of
+synaptic conductance is exponential.
 
-The shape of synaptic conductance is exponential.
+When connecting to conductance-based multisynapse models, all synaptic weights
+must be non-negative.
 
 Parameters
 ++++++++++

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -121,7 +121,7 @@ positive or negative):
    which fits the model using experimental data, requires a different set of
    :math:`\eta_i` and :math:`\gamma_i`. It applies the jump of :math:`\eta_i` and
    :math:`\gamma_i` after the refractory period. One can easily convert between
-   :math:`q_{\eta/\gamma}` of these two approaches:
+   :math:`q_{\eta/\gamma}` with these two approaches:
 
    .. math::
 


### PR DESCRIPTION
The title says it all. This fixed #2146.