### PR TITLE
Fix rendering of references in local build of documentation

### DIFF
--- a/doc/htmldoc/static/css/custom.css
+++ b/doc/htmldoc/static/css/custom.css
@@ -679,11 +679,11 @@ margin: 0;
 }
 .flex-control-nav {bottom: 5px;}
 
-
+/*
 aside {
 	float:right;
 	width:30%;
-}
+}*/
 
 /*** MAIN MENU - ESSENTIAL STYLES ***/
 .menu-toggle{display:none;}

--- a/doc/htmldoc/static/css/custom.css
+++ b/doc/htmldoc/static/css/custom.css
@@ -679,11 +679,6 @@ margin: 0;
 }
 .flex-control-nav {bottom: 5px;}
 
-/*
-aside {
-	float:right;
-	width:30%;
-}*/
 
 /*** MAIN MENU - ESSENTIAL STYLES ***/
 .menu-toggle{display:none;}

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -177,7 +177,7 @@ echo
 NEST_VERSION="$(sli -c "statusdict/version :: =only")"
 echo "  NEST executable .... $NEST (version $NEST_VERSION)"
 echo "  PREFIX ............. $PREFIX"
-if test "${PYTHON}"; then
+if test -n "${PYTHON}"; then
     PYTHON_VERSION="$("${PYTHON}" --version | cut -d' ' -f2)"
     echo "  Python executable .. $PYTHON (version $PYTHON_VERSION)"
     echo "  PYTHONPATH ......... `print_paths ${PYTHONPATH:-}`"
@@ -191,7 +191,7 @@ if test "${HAVE_MPI}" = "true"; then
 else
     echo "  Running MPI tests .. no (compiled without MPI support)"
 fi
-if test "${MUSIC}"; then
+if test -n "${MUSIC}"; then
     MUSIC_VERSION="$("${MUSIC}" --version | head -n1 | cut -d' ' -f2)"
     echo "  MUSIC executable ... $MUSIC (version $MUSIC_VERSION)"
 fi


### PR DESCRIPTION
This PR fixes the rendering issue in Sphinx build where the bibliography section is set to float right.
The offending lines in the CSS are removed. This seemed to be only an issue in the local build and not on Read the Docs.