### PR TITLE
Correct documentation for aeif_psc models

### DIFF
--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -78,14 +78,19 @@ The membrane potential is given by the following differential equation:
 
 .. math::
 
- C dV/dt= -g_L(V-E_L)+g_L\cdot\Delta_T\cdot\exp((V-V_T)/\Delta_T)-g_e(t)(V-E_e) \\
-                                                     -g_i(t)(V-E_i)-w +I_e
+ C dV/dt= -g_L(V-E_L)+g_L\cdot\Delta_T\cdot\exp((V-V_T)/\Delta_T) - w(t) + I_syn(t) + I_e
 
 and
 
 .. math::
 
- \tau_w \cdot dw/dt= a(V-E_L) -W
+ \tau_w \cdot dw/dt= a(V-E_L) - w
+
+.. math::
+
+ I_{syn}(t) ~ \sum_k (t-t^k) \exp((t-t^k)/\tau_{syn})H(t - t^k) .
+
+Here :math:`H(t)` is the Heaviside step function and `k` indexes incoming spikes.
 
 For implementation details see the
 `aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -78,20 +78,19 @@ The membrane potential is given by the following differential equation:
 
 .. math::
 
- C dV/dt= -g_L(V-E_L)+g_L\cdot\Delta_T\cdot\exp((V-V_T)/\Delta_T)-g_e(t)(V-E_e) \\
-                                                     -g_i(t)(V-E_i)-w +I_e
+ C dV/dt= -g_L(V-E_L)+g_L\cdot\Delta_T\cdot\exp((V-V_T)/\Delta_T) - w(t) + I_{syn}(t) + I_e
 
 and
 
 .. math::
 
- \tau_w \cdot dw/dt= a(V-E_L) -W
+ \tau_w \cdot dw/dt= a(V-E_L) - w
 
 .. math::
 
- I(t) = J \sum_k \delta(t - t^k).
+ I_{syn}(t) = J \sum_k \delta(t - t^k).
 
-Here delta is the dirac delta function and `k` indexes incoming
+Here delta is the Dirac delta function and `k` indexes incoming
 spikes. This is implemented such that ``V_m`` will be incremented/decremented by
 the value of `J` after a spike.
 

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -78,8 +78,7 @@ The membrane potential is given by the following differential equation:
 
 .. math::
 
- C dV/dt= -g_L(V-E_L)+g_L\cdot\Delta_T\cdot\exp((V-V_T)/\Delta_T)-g_e(t)(V-E_e) \\
-                                                     -g_i(t)(V-E_i)-w +I_e
+ C dV/dt= -g_L(V-E_L)+g_L\cdot\Delta_T\cdot\exp((V-V_T)/\Delta_T) - w(t) + I_{syn}(t) + I_e
 
 and
 
@@ -87,10 +86,11 @@ and
 
  \tau_w \cdot dw/dt= a(V-E_L) -W
 
+.. math::
 
-Note that the spike detection threshold ``V_peak`` is automatically set to
-:math:`V_th+10` mV to avoid numerical instabilites that may result from
-setting ``V_peak`` too high.
+ I_{syn}(t) ~ \sum_k \exp((t-t^k)/\tau_{syn})H(t - t^k) .
+
+Here :math:`H(t)` is the Heaviside step function and `k` indexes incoming spikes.
 
 For implementation details see the
 `aeif_models_implementation <../model_details/aeif_models_implementation.ipynb>`_ notebook.

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -84,7 +84,7 @@ and
 
 .. math::
 
- \tau_w \cdot dw/dt= a(V-E_L) -W
+ \tau_w \cdot dw/dt= a(V-E_L) - w
 
 .. math::
 


### PR DESCRIPTION
This corrects documentation for current-based AEIF neurons anf fixes #2486.