### PR TITLE
Fix for building user-level documentation local

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -90,7 +90,7 @@ if ( BUILD_SPHINX_DOCS )
     "${DOC_BUILD_DIR}"
     "${DOC_BUILD_DIR}/html"
     COMMAND cp "${DOC_BUILD_DIR}/models/*.rst" "${DOC_BUILD_DIR}/html/models"
-    COMMAND ${PYTHON_EXECUTABLE} "${DOC_BUILD_DIR}/resolve_includes.py" "${DOC_BUILD_DIR}/html/models"
+    COMMAND ${Python_EXECUTABLE} "${DOC_BUILD_DIR}/resolve_includes.py" "${DOC_BUILD_DIR}/html/models"
   )
   add_dependencies( docs sphinxdocs )
 


### PR DESCRIPTION
This PR fixes the local creation of user-level documentation with `make docs`.
Without this fix, this error will be returned:

    /bin/sh: 1: htmldoc/resolve_includes.py: Permission denied

With the fix `make docs `passes without any problems.

To test, I followed the user-level documentation workflow (https://nest-simulator.readthedocs.io/en/latest/developer_space/workflows/documentation_workflow/user_documentation_workflow.html) with a conda setup.

My system: 

- Ubuntu 22.04.1 LTS
- Python 3.9.15 (in the conda env)

@med-ayssar could you review?