### PR TITLE
Fix various typos

### DIFF
--- a/build_support/check_copyright_headers.py
+++ b/build_support/check_copyright_headers.py
@@ -34,8 +34,8 @@ In order to ease error reporting in this context, this script uses two
 distinct output channels: messages meant for immediate display are
 printed to stderr using the helper function eprint(). Messages meant
 for the summary at the end of static_code_analysis.sh are printed to
-stdout instead so they can be more easily captured and only printed if
-errors occured.
+stdout instead, so they can be more easily captured and only printed if
+errors occurred.
 
 """
 

--- a/build_support/check_copyright_headers.py
+++ b/build_support/check_copyright_headers.py
@@ -34,7 +34,7 @@ In order to ease error reporting in this context, this script uses two
 distinct output channels: messages meant for immediate display are
 printed to stderr using the helper function eprint(). Messages meant
 for the summary at the end of static_code_analysis.sh are printed to
-stdout instead, so they can be more easily captured and only printed if
+stdout instead so they can be more easily captured and only printed if
 errors occurred.
 
 """

--- a/build_support/check_unused_names.py
+++ b/build_support/check_unused_names.py
@@ -35,7 +35,7 @@ In order to ease error reporting in this context, this script uses two
 distinct output channels: messages meant for immediate display are
 printed to stderr using the helper function eprint(). Messages meant
 for the summary at the end of static_code_analysis.sh are printed to
-stdout instead, so they can be more easily captured and only printed if
+stdout instead so they can be more easily captured and only printed if
 errors occurred.
 
 """

--- a/build_support/check_unused_names.py
+++ b/build_support/check_unused_names.py
@@ -35,8 +35,8 @@ In order to ease error reporting in this context, this script uses two
 distinct output channels: messages meant for immediate display are
 printed to stderr using the helper function eprint(). Messages meant
 for the summary at the end of static_code_analysis.sh are printed to
-stdout instead so they can be more easily captured and only printed if
-errors occured.
+stdout instead, so they can be more easily captured and only printed if
+errors occurred.
 
 """
 

--- a/build_support/static_code_analysis.sh
+++ b/build_support/static_code_analysis.sh
@@ -42,9 +42,9 @@ PEP8=${7}                     # Name of the PEP8 executable.
 PERFORM_CPPCHECK=${8}         # true or false, indicating whether CPPCHECK analysis is performed or not.
 PERFORM_CLANG_FORMAT=${9}     # true or false, indicating whether CLANG-FORMAT analysis is performed or not.
 PERFORM_PEP8=${10}            # true or false, indicating whether PEP8 analysis is performed or not.
-IGNORE_MSG_CPPCHECK=${11}     # true or false, indicating whether CPPCHECK messages should accout for the build result.
-IGNORE_MSG_CLANG_FORMAT=${12} # true or false, indicating whether CLANG-FORMAT messages should accout for the build result.
-IGNORE_MSG_PYCODESTYLE=${13}  # true or false, indicating whether pycodestyle messages should accout for the build result.
+IGNORE_MSG_CPPCHECK=${11}     # true or false, indicating whether CPPCHECK messages should account for the build result.
+IGNORE_MSG_CLANG_FORMAT=${12} # true or false, indicating whether CLANG-FORMAT messages should account for the build result.
+IGNORE_MSG_PYCODESTYLE=${13}  # true or false, indicating whether pycodestyle messages should account for the build result.
 PYCODESTYLE_IGNORES=${14}     # The list of pycodestyle error and warning codes to ignore.
 
 # PYCODESTYLE rules to ignore.

--- a/doc/htmldoc/citing-nest.rst
+++ b/doc/htmldoc/citing-nest.rst
@@ -5,7 +5,7 @@ Cite NEST
 
 Please cite the *version of NEST you used in your work*. 
 
-For all versions from 2.8 onwards, you can find the full citation `on Zenondo <https://zenodo.org/search?page=1&size=20&q=title:NEST%20AND%20-description:graphical%20AND%20simulator&file_type=gz&sort=-publication_date>`_
+For all versions from 2.8 onwards, you can find the full citation `on Zenodo <https://zenodo.org/search?page=1&size=20&q=title:NEST%20AND%20-description:graphical%20AND%20simulator&file_type=gz&sort=-publication_date>`_
 You can also specify the commit hash for work done in the development branches.
 
 You can :ref:`let us know <contact_us>` about your publications that used NEST, and we

--- a/doc/htmldoc/connect_nest/nest_server.rst
+++ b/doc/htmldoc/connect_nest/nest_server.rst
@@ -476,7 +476,7 @@ line. For such situations, we recommend using a JSON file as input for
     }
 
 If we assume that the above JSON object is stored in a file called
-``simulation_script.json``, you can execute it using the follwing
+``simulation_script.json``, you can execute it using the following
 command:
 
 .. code-block:: sh

--- a/doc/htmldoc/connect_nest/using_nest_with_music.rst
+++ b/doc/htmldoc/connect_nest/using_nest_with_music.rst
@@ -92,7 +92,7 @@ generator.
 
    nest.Connect(sg, n, 'one_to_one', {'weight': 750.0, 'delay': 1.0})
 
-We then create a voltmeter, which will measure the membrane potenial, and
+We then create a voltmeter, which will measure the membrane potential, and
 connect it with the neuron.
 
 ::

--- a/doc/htmldoc/developer_space/guidelines/coding_guidelines_cpp.rst
+++ b/doc/htmldoc/developer_space/guidelines/coding_guidelines_cpp.rst
@@ -597,7 +597,7 @@ For example, the ``stopwatch.h`` file could look like:
       }
       else
       {
-        // stopped before, get time of current measurment + last measurments
+        // stopped before, get time of current measurement + last measurements
         return _end - _beg + _prev_elapsed;
       }
     #else
@@ -611,7 +611,7 @@ For example, the ``stopwatch.h`` file could look like:
     #ifndef DISABLE_TIMING
       _beg = 0; // invariant: _end >= _beg
       _end = 0;
-      _prev_elapsed = 0; // erase all prev. measurments
+      _prev_elapsed = 0; // erase all prev. measurements
       _running = false;  // of course not running.
     #endif
     }

--- a/doc/htmldoc/faqs/faqs.rst
+++ b/doc/htmldoc/faqs/faqs.rst
@@ -41,7 +41,7 @@ Installation
    which compiler was used. Then re-build NEST with the same compiler
    version.
 
-6. **I get a segmentation fault wher I use SciPy in the same script
+6. **I get a segmentation fault where I use SciPy in the same script
    together with PyNEST**. We recently observed that if PyNEST is used
    with some versions of SciPy, a segmentation fault is caused. A
    workaround for the problem is to import SciPy before PyNEST. See

--- a/doc/htmldoc/faqs/faqs.rst
+++ b/doc/htmldoc/faqs/faqs.rst
@@ -41,8 +41,7 @@ Installation
    which compiler was used. Then re-build NEST with the same compiler
    version.
 
-6. **I get a segmentation fault where I use SciPy in the same script
-   together with PyNEST**. We recently observed that if PyNEST is used
+6. **I get a segmentation fault when I use SciPy and PyNEST in the same script**. We recently observed that if PyNEST is used
    with some versions of SciPy, a segmentation fault is caused. A
    workaround for the problem is to import SciPy before PyNEST. See
    https://github.com/numpy/numpy/issues/2521 for the official bug

--- a/doc/htmldoc/installation/conda_tips.rst
+++ b/doc/htmldoc/installation/conda_tips.rst
@@ -74,7 +74,7 @@ This will create an environment in the folder ``conda/``. If you would like to a
 
    conda activate conda/
 
-Note that the trailing slash is required for conda not to confuse the path with a named envionment (for example when
+Note that the trailing slash is required for conda not to confuse the path with a named environment (for example when
 using ``--name``).
 
 

--- a/doc/htmldoc/model_details/HillTononiModels.ipynb
+++ b/doc/htmldoc/model_details/HillTononiModels.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "This notebook describes the neuron and synapse model proposed by Hill and Tononi in *J Neurophysiol* 93:1671-1698, 2005 ([doi:10.1152/jn.00915.2004](http://dx.doi.org/doi:10.1152/jn.00915.2004)) and their implementation in NEST. The notebook also contains some tests.\n",
     "\n",
-    "This description is based on the original publication and publications cited therein, an analysis of the source code of the original Synthesis implementation kindly provided by Sean Hill, and plausiblity arguments.\n",
+    "This description is based on the original publication and publications cited therein, an analysis of the source code of the original Synthesis implementation kindly provided by Sean Hill, and plausibility arguments.\n",
     "\n",
     "In what follows, we will refer to the original paper as [HT05].\n",
     "\n",

--- a/doc/htmldoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/htmldoc/model_details/aeif_models_implementation.ipynb
@@ -36,7 +36,7 @@
     "## Tested solutions\n",
     "\n",
     "### Old implementation (before September 2016)\n",
-    "The orginal solution was to bind the exponential argument to be smaller than 10 (ad hoc value to be close to the original implementation in BRIAN).\n",
+    "The original solution was to bind the exponential argument to be smaller than 10 (ad hoc value to be close to the original implementation in BRIAN).\n",
     "As will be shown in the notebook, this solution does not converge to the reference LSODAR solution.\n",
     "\n",
     "### New implementation\n",

--- a/doc/htmldoc/neurons/exact-integration.rst
+++ b/doc/htmldoc/neurons/exact-integration.rst
@@ -11,7 +11,7 @@ For the simple integrate-and-fire model the voltage :math:`V` is given as a solu
 .. math::
     C\frac{dV}{dt}=I.
 
-This is just the derivate of the law of capacitance :math:`Q=CV`. When an input current is applied, the membrane voltage increases with time until it reaches a constant threshold :math:`V_{\text{th}}`, at which point a delta function spike occurs.
+This is just the derivative of the law of capacitance :math:`Q=CV`. When an input current is applied, the membrane voltage increases with time until it reaches a constant threshold :math:`V_{\text{th}}`, at which point a delta function spike occurs.
 
 A shortcoming of the simple integrate-and-fire model is that it implements no time-dependent memory. If the model receives a below-threshold signal at some time, it will retain that voltage boost until it fires again. This characteristic is not in line with observed neuronal behavior.
 

--- a/doc/htmldoc/synapses/handling_connections.rst
+++ b/doc/htmldoc/synapses/handling_connections.rst
@@ -150,7 +150,7 @@ Setting and getting attributes directly
 
 Getting connection parameters
     Just as with NodeCollection, you can get parameters of the connections with
-    :py:meth:`~.SynpaseCollection.get`. The same function arguments as for :ref:`NodeCollections get() <get_param>`
+    :py:meth:`~.SynapseCollection.get`. The same function arguments as for :ref:`NodeCollections get() <get_param>`
     apply here. The returned values also follow the same rules.
 
     If you call ``get()`` without any arguments, a dictionary with all parameters is

--- a/doc/htmldoc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
@@ -53,7 +53,7 @@ exploit the optional arguments of :py:func:`.Create`:
 The variable ``neuronpop`` is a NodeCollection representing all the ids of the created
 neurons.
 
-Parameterising the neurons at creation is more efficient than using
+Parametrizing the neurons at creation is more efficient than using
 :py:func:`.SetStatus` after creation, so try to do this wherever possible.
 
 We can also set the parameters of a neuron model *before* creation,

--- a/doc/htmldoc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
@@ -29,7 +29,7 @@ Networks <pynest_examples>`, or
 have a look at at the source directory of your NEST installation in the
 subdirectory: ``pynest/examples/``.
 
-Parameterising synapse models
+Parametrizing synapse models
 -----------------------------
 
 NEST provides a variety of different synapse models. You can see the
@@ -74,7 +74,7 @@ as follows:
 
     nest.Create("iaf_psc_alpha", params={"tau_minus": 30.0})
 
-or by using any of the other methods of parameterising neurons
+or by using any of the other methods of parametrizing neurons
 demonstrated in the first two parts of this introduction.
 
 Connecting with synapse models

--- a/examples/nest/Potjans_2014/microcircuit.sli
+++ b/examples/nest/Potjans_2014/microcircuit.sli
@@ -40,7 +40,7 @@
     Please see the file README.txt for details.
 */
 
-% CheckParameters - This function perfoms a (non-exhaustive) check of
+% CheckParameters - This function performs a (non-exhaustive) check of
 % parameter dimensions and values.
 %
 % In particular, the following is checked:

--- a/examples/nest/balancedneuron-2.sli
+++ b/examples/nest/balancedneuron-2.sli
@@ -37,7 +37,7 @@
 
 ResetKernel
 
- 1000 ms   /t_relax Set % how long to wait for the state to stabiluze before reording the spikes
+ 1000 ms   /t_relax Set % how long to wait for the state to stabilize before reordering the spikes
  100 s    /t_sim Set % how long we simulate to compute the rate (1000 sec)
  1000 ms   /t_memmeasure Set % how long to measure the membrane potential
  16000     /n_ex  Set % size of the excitatory population

--- a/examples/nest/balancedneuron.sli
+++ b/examples/nest/balancedneuron.sli
@@ -24,7 +24,7 @@
 
 ResetKernel
 
- 1000.   ms /t_relax Set % how long to wait for the state to stabiluze before reording the spikes
+ 1000.   ms /t_relax Set % how long to wait for the state to stabilize before reordering the spikes
  100000. ms /t_sim Set % how long we simulate to compute the rate (1000 sec)
  16000     /n_ex  Set % size of the excitatory population
  4000      /n_in  Set % size of the inhibitory population

--- a/lib/sli/FormattedIO.sli
+++ b/lib/sli/FormattedIO.sli
@@ -178,7 +178,7 @@ Options
 /** @BeginDocumentation
 Name: SaveDictionary - Save contents of a dictionary to a file.
 Synopsis: dict (fname) SaveDictionary -> -
-Description: SaveDictionary tries to save the contents of the dicitonary
+Description: SaveDictionary tries to save the contents of the dictionary
  to a file. For this, it reproduces the input syntax of the dictionary.
  Thus, the resulting file is a readable ASCII-file. 
  
@@ -236,7 +236,7 @@ SeeAlso: RestoreDictionary, MergeDictionary
 %/_:out load def
 
 /** @BeginDocumentation
-Name: MergeDictionary - Merge all definitions of a dictionary with the current dicitonary.
+Name: MergeDictionary - Merge all definitions of a dictionary with the current dictionary.
 Synopsis: dict MergeDictionary -> -
 SeeAlso: SaveDictionary, RestoreDictionary
 */

--- a/lib/sli/arraylib.sli
+++ b/lib/sli/arraylib.sli
@@ -222,7 +222,7 @@ SeeAlso: arraylib::Product, arraylib::Sum, arraylib::Mean, arraylib::Var
 %----------------------------------------------------------------------------
 /** @BeginDocumentation
 
-Name: arraylib::Reform - Reform the dimensions of a hyperrectengular array
+Name: arraylib::Reform - Reform the dimensions of a hyperrectangular array
 
 Synopsis: [array] [dim1 dim2 ... dimn] Reform -> [reformedArray]
 

--- a/lib/sli/mathematica.sli
+++ b/lib/sli/mathematica.sli
@@ -32,7 +32,7 @@ certain functions. Within the dictionary each
 function name is associated with a dictionary
 which contains the options for that function.
 
-Note that the accessibility, i.e. the dicitonary
+Note that the accessibility, i.e. the dictionary
 in which a function is defined is not accounted for.
 
 It is suggested that you use a C++-like notation to indicate the
@@ -99,7 +99,7 @@ Synopsis: /f  optiondict SetOptions -> --
 Description:
 SetOptions set all option values given in
 the supplied dictionary. Options which are not listed
-in this dicitonary are not modified.
+in this dictionary are not modified.
 Note that only those options can be modified which were
 initially defined by the Options command.
 
@@ -2450,7 +2450,7 @@ def
      [ [22 9] [53 31] [47 56] [39 57] ]
     ]
 
-  Bugs: Bad performace: TensorRank should be rewritten in C++
+  Bugs: Bad performance: TensorRank should be rewritten in C++
    not yet protected by trie
   Author: Diesmann
   FirstVersion: 31.5.2000
@@ -2689,7 +2689,7 @@ Description: add can be used to add numbers and arrays.
   If applied to numbers, add returns the sum of the numbers. If one
   of the arguments is a double, the result is also a double.
 
-  Applied to arrays, add perfoms a per-component addition of the two
+  Applied to arrays, add performs a per-component addition of the two
   arrays. The components must be numbers, however, integer and double
   values may be mixed.
 
@@ -2742,7 +2742,7 @@ Description: sub can be used to subtract numbers and arrays.
   If applied to numbers, sub returns the difference of the numbers. If one
   of the arguments is a double, the result is also a double.
 
-  Applied to arrays, sub perfoms a per-component subtraction of the two
+  Applied to arrays, sub performs a per-component subtraction of the two
   arrays. The components must be numbers, however, integer and double
   values may be mixed.
 

--- a/lib/sli/misc_helpers.sli
+++ b/lib/sli/misc_helpers.sli
@@ -590,7 +590,7 @@ Name: oldgetline - "old", ignorant version of getline
 Synopsis: istream getline -> istream string
 
 Description: 
-  Reads a string from the supplied stream. If an error occured
+  Reads a string from the supplied stream. If an error occurred
   during the read process, an empty string is returned.
 
   This function is for compatibility. Eventually, all

--- a/lib/sli/nest-init.sli
+++ b/lib/sli/nest-init.sli
@@ -1178,7 +1178,7 @@ def
                 effect, the element keeps its state intact as if it was "frozen".
 		This is the only state which can directly be set by the user.
    buffers_initialized - the buffers of the node have been initialized
-   err        - some unspecified error condition has occured.
+   err        - some unspecified error condition has occurred.
 
    Examples: elementstates info
 

--- a/lib/sli/processes.sli
+++ b/lib/sli/processes.sli
@@ -178,7 +178,7 @@ trie
     %stack: Command PID
     pop %stack: Command
     {exec} stopped %protect from errors!
-    {% an error occured.
+    {% an error occurred.
      % define error message:
        /errormessage
        (SLI CHILD PROCESS ) getPID cvs join

--- a/lib/sli/sli-init.sli
+++ b/lib/sli/sli-init.sli
@@ -732,7 +732,7 @@ def
 
 /** @BeginDocumentation
 
-   Name: who - list contents of  the top-level dicitonary
+   Name: who - list contents of  the top-level dictionary
 
    Synopsis: who -> -
 
@@ -756,7 +756,7 @@ def
 
 /** @BeginDocumentation
 
-   Name: whos - list contents of all dictionaries on the dicitonary stack
+   Name: whos - list contents of all dictionaries on the dictionary stack
 
    Synopsis: whos -> -
 
@@ -1325,7 +1325,7 @@ Description:
   It issues error messages according to the
   state of the errordict.
   The command that caused the error is left at the
-  top of the dicitonary stack.
+  top of the dictionary stack.
 
   An error is raised by the command 
      /func /error raiseerror
@@ -2130,7 +2130,7 @@ moduleinitializers
 
       % Execute in stopped context so we can detect uncaught errors
       % We also check if /newerror is set in errordict. This in case
-      % an error occured in a stopped context without proper error 
+      % an error occurred in a stopped context without proper error
       % handler.
       { { run } forall } stopped { handleerror scripterror quit_i } if
       quit    

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -57,7 +57,7 @@ template <>
 void
 RecordablesMap< aeif_cond_alpha >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &aeif_cond_alpha::get_y_elem_< aeif_cond_alpha::State_::V_M > );
   insert_( names::g_ex, &aeif_cond_alpha::get_y_elem_< aeif_cond_alpha::State_::G_EXC > );
   insert_( names::g_in, &aeif_cond_alpha::get_y_elem_< aeif_cond_alpha::State_::G_INH > );

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -261,7 +261,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -327,7 +327,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing the GSL system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -321,7 +321,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< simulation step size in ms

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -324,7 +324,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< simulation step size in ms

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -61,7 +61,7 @@ template <>
 void
 RecordablesMap< aeif_cond_exp >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &aeif_cond_exp::get_y_elem_< aeif_cond_exp::State_::V_M > );
   insert_( names::g_ex, &aeif_cond_exp::get_y_elem_< aeif_cond_exp::State_::G_EXC > );
   insert_( names::g_in, &aeif_cond_exp::get_y_elem_< aeif_cond_exp::State_::G_INH > );
@@ -176,7 +176,7 @@ nest::aeif_cond_exp::State_::operator=( const State_& s )
 }
 
 /* ----------------------------------------------------------------
- * Paramater and state extractions and manipulation functions
+ * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
 
 void

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -99,7 +99,7 @@ and
  \tau_w \cdot dw/dt= a(V-E_L) -W
 
 Note that the spike detection threshold V_peak is automatically set to
-:math:`V_th+10 mV` to avoid numerical instabilites that may result from
+:math:`V_th+10 mV` to avoid numerical instabilities that may result from
 setting V_peak too high.
 
 For implementation details see the
@@ -262,7 +262,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -326,7 +326,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing the GSL system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -57,7 +57,7 @@ template <>
 void
 RecordablesMap< aeif_psc_alpha >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &aeif_psc_alpha::get_y_elem_< aeif_psc_alpha::State_::V_M > );
   insert_( names::I_syn_ex, &aeif_psc_alpha::get_y_elem_< aeif_psc_alpha::State_::I_EXC > );
   insert_( names::I_syn_in, &aeif_psc_alpha::get_y_elem_< aeif_psc_alpha::State_::I_INH > );

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -250,7 +250,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -316,7 +316,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing the GSL system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -61,7 +61,7 @@ template <>
 void
 RecordablesMap< aeif_psc_delta >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &aeif_psc_delta::get_y_elem_< aeif_psc_delta::State_::V_M > );
   insert_( names::w, &aeif_psc_delta::get_y_elem_< aeif_psc_delta::State_::W > );
 }
@@ -162,7 +162,7 @@ nest::aeif_psc_delta::State_::operator=( const State_& s )
 }
 
 /* ----------------------------------------------------------------
- * Paramater and state extractions and manipulation functions
+ * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
 
 void

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -305,7 +305,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing the GSL system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -61,7 +61,7 @@ template <>
 void
 RecordablesMap< aeif_psc_delta_clopath >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &aeif_psc_delta_clopath::get_y_elem_< aeif_psc_delta_clopath::State_::V_M > );
   insert_( names::w, &aeif_psc_delta_clopath::get_y_elem_< aeif_psc_delta_clopath::State_::W > );
   insert_( names::z, &aeif_psc_delta_clopath::get_y_elem_< aeif_psc_delta_clopath::State_::Z > );
@@ -196,7 +196,7 @@ nest::aeif_psc_delta_clopath::State_::operator=( const State_& s )
 }
 
 /* ----------------------------------------------------------------
- * Paramater and state extractions and manipulation functions
+ * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
 
 void

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -74,8 +74,8 @@ connecting to a Clopath synapse.
 
 Note that there are two points that are not mentioned in the paper but
 present in a MATLAB implementation by Claudia Clopath [3]_. The first one is the
-clamping of the membrane potential to a fixed value after a spike occured to
-mimik a real spike and not just the upswing. This is important since the finite
+clamping of the membrane potential to a fixed value after a spike occurred to
+mimic a real spike and not just the upswing. This is important since the finite
 duration of the spike influences the evolution of the convolved versions
 (``u_bar_[plus/minus]``) of the membrane potential and thus the change of the
 synaptic weight. Secondly, there is a delay with which ``u_bar_[plus/minus]`` are
@@ -134,7 +134,7 @@ tau_w      ms      Adaptation time constant
 tau_z      ms      Spike afterpotential current time constant
 I_sp       pA      Depolarizing spike afterpotential current magnitude
 V_peak     mV      Spike detection threshold
-V_th_max   mV      Value of V_th afer a spike
+V_th_max   mV      Value of V_th after a spike
 V_th_rest  mV      Resting value of V_th
 ========== ======  ===================================================
 
@@ -260,7 +260,7 @@ private:
     double tau_w;           //!< Adaptation time constant in ms
     double tau_z;           //!< Spike afterpotential current time constant in ms
     double tau_V_th;        //!< Adaptive threshold time constant in ms
-    double V_th_max;        //!< Value of V_th afer a spike in mV
+    double V_th_max;        //!< Value of V_th after a spike in mV
     double V_th_rest;       //!< Resting value of V_th in mV
     double tau_u_bar_plus;  //!< Time constant of u_bar_plus in ms
     double tau_u_bar_minus; //!< Time constant of u_bar_minus in ms
@@ -279,7 +279,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -346,7 +346,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing the GSL system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -61,7 +61,7 @@ template <>
 void
 RecordablesMap< aeif_psc_exp >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &aeif_psc_exp::get_y_elem_< aeif_psc_exp::State_::V_M > );
   insert_( names::I_syn_ex, &aeif_psc_exp::get_y_elem_< aeif_psc_exp::State_::I_EXC > );
   insert_( names::I_syn_in, &aeif_psc_exp::get_y_elem_< aeif_psc_exp::State_::I_INH > );
@@ -170,7 +170,7 @@ nest::aeif_psc_exp::State_::operator=( const State_& s )
 }
 
 /* ----------------------------------------------------------------
- * Paramater and state extractions and manipulation functions
+ * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
 
 void

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -247,7 +247,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -311,7 +311,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing the GSL system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -114,7 +114,7 @@ The following parameters can be set in the status dictionary:
 
 .. note::
 
-   - The time constants in the model must fullfill the following conditions:
+   - The time constants in the model must fulfill the following conditions:
      - :math:`\tau_m != {\tau_{syn_{ex}}, \tau_{syn_{in}}}`
      - :math:`\tau_v != {\tau_{syn_{ex}}, \tau_{syn_{in}}}`
      - :math:`\tau_m != \tau_v`
@@ -252,7 +252,7 @@ private:
     /** Set values from dictionary.
      * @returns Change in reversal potential E_L, to be passed to State_::set()
      */
-    double set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    double set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ----------------------------------------------------------------

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -140,7 +140,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ----------------------------------------------------------------

--- a/models/clopath_synapse.h
+++ b/models/clopath_synapse.h
@@ -79,7 +79,7 @@ Wmin     real    Minimum allowed weight
 =======  ======  ==========================================================
 
 Other parameters like the amplitudes for long-term potentiation (LTP) and
-depression (LTD) are stored in in the neuron models that are compatible with the
+depression (LTD) are stored in the neuron models that are compatible with the
 Clopath synapse.
 
 Transmits

--- a/models/cm_compartmentcurrents.h
+++ b/models/cm_compartmentcurrents.h
@@ -276,7 +276,7 @@ public:
   // numerical integration step
   std::pair< double, double > f_numstep( const double v_comp, const long lag );
 
-  // synapse specific funtion
+  // synapse specific function
   inline std::pair< double, double >
   NMDA_sigmoid__and__d_NMDAsigmoid_dv( double v_comp )
   {
@@ -349,7 +349,7 @@ public:
   // numerical integration step
   std::pair< double, double > f_numstep( const double v_comp, const long lag );
 
-  // synapse specific funtion
+  // synapse specific function
   inline std::pair< double, double >
   NMDA_sigmoid__and__d_NMDAsigmoid_dv( double v_comp )
   {

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -107,7 +107,7 @@ nest::cm_default::set_status( const DictionaryDatum& statusdict )
    * Add a compartment (or compartments) to the tree, so that the new compartment
    * has the compartment specified by "parent_idx" as parent. The parent
    * has to be in the tree, otherwise an error will be raised.  We add either a
-   * single compartment or multiple compartments, depending on wether the
+   * single compartment or multiple compartments, depending on whether the
    * entry was a list of dicts or a single dict
    */
   const auto add_compartments_list_or_dict = [ this, statusdict ]( const Name name )
@@ -143,7 +143,7 @@ nest::cm_default::set_status( const DictionaryDatum& statusdict )
    * Add a receptor (or receptors) to the tree, so that the new receptor
    * targets the compartment specified by "comp_idx". The compartment
    * has to be in the tree, otherwise an error will be raised.  We add either a
-   * single receptor or multiple receptors, depending on wether the
+   * single receptor or multiple receptors, depending on whether the
    * entry was a list of dicts or a single dict
    */
   const auto add_receptors_list_or_dict = [ this, statusdict ]( const Name name )

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -160,7 +160,7 @@ nest::CompTree::CompTree()
 
 /**
  * Add a compartment to the tree structure via the python interface
- * root shoud have -1 as parent index. Add root compartment first.
+ * root should have -1 as parent index. Add root compartment first.
  * Assumes parent of compartment is already added
  */
 void

--- a/models/correlation_detector.h
+++ b/models/correlation_detector.h
@@ -252,7 +252,7 @@ private:
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**
-     * Set values from dicitonary.
+     * Set values from dictionary.
      * @returns true if the state needs to be reset after a change of
      *          binwidth or tau_max.
      */

--- a/models/correlomatrix_detector.h
+++ b/models/correlomatrix_detector.h
@@ -245,7 +245,7 @@ private:
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**
-     * Set values from dicitonary.
+     * Set values from dictionary.
      * @returns true if the state needs to be reset after a change of
      *          binwidth or tau_max.
      */
@@ -270,7 +270,7 @@ private:
     std::vector< long > n_events_; //!< spike counters
     SpikelistType incoming_;       //!< incoming spikes, sorted
                                    /** Weighted covariance matrix.
-                                    *  @note Data type is double to accomodate weights.
+                                    *  @note Data type is double to accommodate weights.
                                     */
     std::vector< std::vector< std::vector< double > > > covariance_;
 

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -340,7 +340,7 @@ nest::correlospinmatrix_detector::handle( SpikeEvent& e )
       {
         // count this event negatively, assuming it comes as single event
         // transition 1->0
-        // assume it will stay alone, so meaning a down tansition
+        // assume it will stay alone, so meaning a down transition
 
         if ( S_.tentative_down_ ) // really was a down transition, because we
                                   // now have another event

--- a/models/correlospinmatrix_detector.h
+++ b/models/correlospinmatrix_detector.h
@@ -229,7 +229,7 @@ private:
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**
-     * Set values from dicitonary.
+     * Set values from dictionary.
      * @returns true if the state needs to be reset after a change of
      *          binwidth or tau_max.
      */

--- a/models/erfc_neuron.cpp
+++ b/models/erfc_neuron.cpp
@@ -47,7 +47,7 @@ template <>
 void
 RecordablesMap< nest::erfc_neuron >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::S, &nest::erfc_neuron::get_output_state__ );
   insert_( names::h, &nest::erfc_neuron::get_input__ );
 }

--- a/models/gauss_rate.cpp
+++ b/models/gauss_rate.cpp
@@ -49,7 +49,7 @@ template <>
 void
 RecordablesMap< nest::gauss_rate_ipn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::gauss_rate_ipn::get_rate_ );
   insert_( names::noise, &nest::gauss_rate_ipn::get_noise_ );
 }
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< nest::rate_transformer_gauss >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::rate_transformer_gauss::get_rate_ );
 }
 

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -371,7 +371,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -380,7 +380,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -55,7 +55,7 @@ template <>
 void
 RecordablesMap< gif_pop_psc_exp >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &gif_pop_psc_exp::get_V_m_ );
   insert_( names::n_events, &gif_pop_psc_exp::get_n_events_ );
   insert_( names::E_sfa, &gif_pop_psc_exp::get_E_sfa_ );

--- a/models/ginzburg_neuron.cpp
+++ b/models/ginzburg_neuron.cpp
@@ -51,7 +51,7 @@ template <>
 void
 RecordablesMap< nest::ginzburg_neuron >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::S, &nest::ginzburg_neuron::get_output_state__ );
   insert_( names::h, &nest::ginzburg_neuron::get_input__ );
 }

--- a/models/ginzburg_neuron.h
+++ b/models/ginzburg_neuron.h
@@ -160,7 +160,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   bool operator()( RngPtr rng, double h ) const;
 };

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -340,7 +340,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // IntergrationStep_ should be reset with the neuron on ResetNetwork,
+    // IntegrationStep_ should be reset with the neuron on ResetNetwork,
     // but remain unchanged during calibration. Since it is initialized with
     // step_, and the resolution cannot change after nodes have been created,
     // it is safe to place both here.

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -57,7 +57,7 @@ template <>
 void
 RecordablesMap< hh_cond_beta_gap_traub >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &hh_cond_beta_gap_traub::get_y_elem_< hh_cond_beta_gap_traub::State_::V_M > );
   insert_( names::g_ex, &hh_cond_beta_gap_traub::get_y_elem_< hh_cond_beta_gap_traub::State_::G_EXC > );
   insert_( names::g_in, &hh_cond_beta_gap_traub::get_y_elem_< hh_cond_beta_gap_traub::State_::G_INH > );

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -262,7 +262,7 @@ private:
     Parameters_();
 
     void get( DictionaryDatum& ) const;        //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* ); //!< Set values from dictionary
   };
 
 public:
@@ -351,7 +351,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -53,7 +53,7 @@ template <>
 void
 RecordablesMap< hh_cond_exp_traub >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &hh_cond_exp_traub::get_y_elem_< hh_cond_exp_traub::State_::V_M > );
   insert_( names::g_ex, &hh_cond_exp_traub::get_y_elem_< hh_cond_exp_traub::State_::G_EXC > );
   insert_( names::g_in, &hh_cond_exp_traub::get_y_elem_< hh_cond_exp_traub::State_::G_INH > );

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -222,7 +222,7 @@ private:
     Parameters_();
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -294,7 +294,7 @@ public:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -52,7 +52,7 @@ template <>
 void
 RecordablesMap< hh_psc_alpha >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &hh_psc_alpha::get_y_elem_< hh_psc_alpha::State_::V_M > );
   insert_( names::I_syn_ex, &hh_psc_alpha::get_y_elem_< hh_psc_alpha::State_::I_EXC > );
   insert_( names::I_syn_in, &hh_psc_alpha::get_y_elem_< hh_psc_alpha::State_::I_INH > );

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -208,7 +208,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -278,7 +278,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -52,7 +52,7 @@ template <>
 void
 RecordablesMap< hh_psc_alpha_clopath >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &hh_psc_alpha_clopath::get_y_elem_< hh_psc_alpha_clopath::State_::V_M > );
   insert_( names::I_syn_ex, &hh_psc_alpha_clopath::get_y_elem_< hh_psc_alpha_clopath::State_::I_EXC > );
   insert_( names::I_syn_in, &hh_psc_alpha_clopath::get_y_elem_< hh_psc_alpha_clopath::State_::I_INH > );

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -249,7 +249,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -322,7 +322,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -53,7 +53,7 @@ template <>
 void
 RecordablesMap< hh_psc_alpha_gap >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &hh_psc_alpha_gap::get_y_elem_< hh_psc_alpha_gap::State_::V_M > );
   insert_( names::I_syn_ex, &hh_psc_alpha_gap::get_y_elem_< hh_psc_alpha_gap::State_::I_EXC > );
   insert_( names::I_syn_in, &hh_psc_alpha_gap::get_y_elem_< hh_psc_alpha_gap::State_::I_INH > );

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -234,7 +234,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -305,7 +305,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -250,7 +250,7 @@ private:
     Parameters_();
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
     // Note: Conductances are unitless
     // Leaks
@@ -396,7 +396,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;             //!< step size in ms

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -196,7 +196,7 @@ nest::iaf_chs_2007::pre_run_hook()
 
   const double h = Time::get_resolution().get_ms();
 
-  // numbering of state vaiables: i_0 = 0, i_syn_ = 1, V_syn_ = 2, V_spike _= 3,
+  // numbering of state variables: i_0 = 0, i_syn_ = 1, V_syn_ = 2, V_spike _= 3,
   // V_m_ = 4
 
   // these P are independent

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -295,7 +295,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -57,7 +57,7 @@ template <>
 void
 RecordablesMap< iaf_cond_alpha >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_cond_alpha::get_y_elem_< iaf_cond_alpha::State_::V_M > );
   insert_( names::g_ex, &iaf_cond_alpha::get_y_elem_< iaf_cond_alpha::State_::G_EXC > );
   insert_( names::g_in, &iaf_cond_alpha::get_y_elem_< iaf_cond_alpha::State_::G_INH > );

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -198,7 +198,7 @@ private:
     Parameters_(); //!< Set default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // State variables class --------------------------------------------
@@ -274,7 +274,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -312,7 +312,7 @@ private:
     Parameters_& operator=( const Parameters_& ); //!< needed to copy C-arrays
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 
@@ -397,7 +397,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< iaf_cond_beta >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_cond_beta::get_y_elem_< iaf_cond_beta::State_::V_M > );
   insert_( names::g_ex, &iaf_cond_beta::get_y_elem_< iaf_cond_beta::State_::G_EXC > );
   insert_( names::g_in, &iaf_cond_beta::get_y_elem_< iaf_cond_beta::State_::G_INH > );

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -220,7 +220,7 @@ private:
     Parameters_(); //!< Set default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // State variables class --------------------------------------------
@@ -296,7 +296,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -55,7 +55,7 @@ template <>
 void
 RecordablesMap< iaf_cond_exp >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_cond_exp::get_y_elem_< iaf_cond_exp::State_::V_M > );
   insert_( names::g_ex, &iaf_cond_exp::get_y_elem_< iaf_cond_exp::State_::G_EXC > );
   insert_( names::g_in, &iaf_cond_exp::get_y_elem_< iaf_cond_exp::State_::G_INH > );

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -188,7 +188,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -247,7 +247,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -55,7 +55,7 @@ template <>
 void
 RecordablesMap< iaf_cond_exp_sfa_rr >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_cond_exp_sfa_rr::get_y_elem_< iaf_cond_exp_sfa_rr::State_::V_M > );
   insert_( names::g_ex, &iaf_cond_exp_sfa_rr::get_y_elem_< iaf_cond_exp_sfa_rr::State_::G_EXC > );
   insert_( names::g_in, &iaf_cond_exp_sfa_rr::get_y_elem_< iaf_cond_exp_sfa_rr::State_::G_INH > );

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -220,7 +220,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
 public:
@@ -282,7 +282,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // Since IntergrationStep_ is initialized with step_, and the resolution
+    // Since IntegrationStep_ is initialized with step_, and the resolution
     // cannot change after nodes have been created, it is safe to place both
     // here.
     double step_;            //!< step size in ms

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -50,7 +50,7 @@ template <>
 void
 RecordablesMap< iaf_psc_alpha >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_alpha::get_V_m_ );
   insert_( names::I_syn_ex, &iaf_psc_alpha::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_psc_alpha::get_I_syn_in_ );

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -54,7 +54,7 @@ template <>
 void
 RecordablesMap< iaf_psc_delta >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_delta::get_V_m_ );
 }
 

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -92,7 +92,7 @@ The following parameters can be set in the status dictionary.
  V_th             mV      Spike threshold
  V_reset          mV      Reset potential of the membrane
  I_e              pA      Constant input current
- V_min            mV      Absolute lower value for the membrane potenial
+ V_min            mV      Absolute lower value for the membrane potential
  refractory_input boolean If true, do not discard input during
                           refractory period. Default: false
 ================= ======= ======================================================

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -53,7 +53,7 @@ template <>
 void
 RecordablesMap< iaf_psc_exp >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_exp::get_V_m_ );
   insert_( names::I_syn_ex, &iaf_psc_exp::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_psc_exp::get_I_syn_in_ );

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -48,7 +48,7 @@ template <>
 void
 RecordablesMap< iaf_psc_exp_htum >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_exp_htum::get_V_m_ );
   insert_( names::I_syn_ex, &iaf_psc_exp_htum::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_psc_exp_htum::get_I_syn_in_ );

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -53,7 +53,7 @@ template <>
 void
 RecordablesMap< iaf_psc_exp_ps >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_exp_ps::get_V_m_ );
 }
 }

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -53,7 +53,7 @@ template <>
 void
 RecordablesMap< iaf_psc_exp_ps_lossless >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_exp_ps_lossless::get_V_m_ );
   insert_( names::I_syn, &iaf_psc_exp_ps_lossless::get_I_syn_ );
   insert_( names::I_syn_ex, &iaf_psc_exp_ps_lossless::get_I_syn_ex_ );

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -320,7 +320,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;               //!< Store current values in dictionary
-    double set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    double set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ----------------------------------------------------------------

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -52,7 +52,7 @@ template <>
 void
 RecordablesMap< izhikevich >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &izhikevich::get_V_m_ );
   insert_( names::U_m, &izhikevich::get_U_m_ );
 }

--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -188,7 +188,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ----------------------------------------------------------------

--- a/models/lin_rate.cpp
+++ b/models/lin_rate.cpp
@@ -53,7 +53,7 @@ template <>
 void
 RecordablesMap< nest::lin_rate_ipn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::lin_rate_ipn::get_rate_ );
   insert_( names::noise, &nest::lin_rate_ipn::get_noise_ );
 }
@@ -62,7 +62,7 @@ template <>
 void
 RecordablesMap< nest::lin_rate_opn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::lin_rate_opn::get_rate_ );
   insert_( names::noise, &nest::lin_rate_opn::get_noise_ );
   insert_( names::noisy_rate, &nest::lin_rate_opn::get_noisy_rate_ );
@@ -72,7 +72,7 @@ template <>
 void
 RecordablesMap< nest::rate_transformer_lin >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::rate_transformer_lin::get_rate_ );
 }
 

--- a/models/lin_rate.h
+++ b/models/lin_rate.h
@@ -151,7 +151,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   double input( double h );               // non-linearity on input
   double mult_coupling_ex( double rate ); // factor of multiplicative coupling

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -51,7 +51,7 @@ template <>
 void
 RecordablesMap< mat2_psc_exp >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &mat2_psc_exp::get_V_m_ );
   insert_( names::V_th, &mat2_psc_exp::get_V_th_ );
 }

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -227,7 +227,7 @@ private:
     /** Set values from dictionary.
      * @returns Change in reversal potential E_L, to be passed to State_::set()
      */
-    double set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    double set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ----------------------------------------------------------------

--- a/models/mcculloch_pitts_neuron.cpp
+++ b/models/mcculloch_pitts_neuron.cpp
@@ -45,7 +45,7 @@ template <>
 void
 RecordablesMap< nest::mcculloch_pitts_neuron >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::S, &nest::mcculloch_pitts_neuron::get_output_state__ );
   insert_( names::h, &nest::mcculloch_pitts_neuron::get_input__ );
 }

--- a/models/mcculloch_pitts_neuron.h
+++ b/models/mcculloch_pitts_neuron.h
@@ -135,7 +135,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   bool operator()( RngPtr, double h );
 };

--- a/models/mip_generator.h
+++ b/models/mip_generator.h
@@ -150,7 +150,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/music_cont_in_proxy.h
+++ b/models/music_cont_in_proxy.h
@@ -131,7 +131,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;                 //!< Store current values in dictionary
-    void set( const DictionaryDatum&, State_&, Node* ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, State_&, Node* ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -59,7 +59,7 @@ nest::music_event_in_proxy::State_::State_()
 
 
 /* ----------------------------------------------------------------
- * Paramater extraction and manipulation functions
+ * Parameter extraction and manipulation functions
  * ---------------------------------------------------------------- */
 
 void

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -141,7 +141,7 @@ private:
     void get( DictionaryDatum& ) const;
 
     /**
-     * Set values from dicitonary.
+     * Set values from dictionary.
      */
     void set( const DictionaryDatum&, State_& );
   };

--- a/models/music_event_out_proxy.h
+++ b/models/music_event_out_proxy.h
@@ -145,7 +145,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
-    void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, State_& ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -177,7 +177,7 @@ private:
     void get( DictionaryDatum& ) const;
 
     /**
-     * Set values from dicitonary.
+     * Set values from dictionary.
      */
     void set( const DictionaryDatum&, State_&, Node* );
   };

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -155,7 +155,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
-    void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, State_& ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -143,7 +143,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;          //!< Store current values in dictionary
-    void set( const DictionaryDatum&, State_& ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, State_& ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/poisson_generator.h
+++ b/models/poisson_generator.h
@@ -123,7 +123,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/poisson_generator_ps.h
+++ b/models/poisson_generator_ps.h
@@ -155,7 +155,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------
@@ -185,7 +185,7 @@ private:
      * @name update-hook communication.
      * The following variables are used for direct communication from
      * update() to event_hook(). They rely on the fact that event_hook()
-     * is called instantaneuously from update().
+     * is called instantaneously from update().
      * Spikes are sent at times t that fulfill
      *
      *   t_min_active_ < t <= t_max_active_

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -375,7 +375,7 @@ private:
     Parameters_& operator=( const Parameters_& ); //!< needed to copy C-arrays
 
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
-    void set( const DictionaryDatum& ); //!< Set values from dicitonary
+    void set( const DictionaryDatum& ); //!< Set values from dictionary
   };
 
 
@@ -462,7 +462,7 @@ private:
     gsl_odeiv_evolve* e_;  //!< evolution function
     gsl_odeiv_system sys_; //!< struct describing system
 
-    // IntergrationStep_ should be reset with the neuron on ResetNetwork,
+    // IntegrationStep_ should be reset with the neuron on ResetNetwork,
     // but remain unchanged during calibration. Since it is initialized with
     // step_, and the resolution cannot change after nodes have been created,
     // it is safe to place both here.

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -56,7 +56,7 @@ template <>
 void
 RecordablesMap< pp_psc_delta >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::V_m, &pp_psc_delta::get_V_m_ );
   insert_( names::E_sfa, &pp_psc_delta::get_E_sfa_ );
 }

--- a/models/ppd_sup_generator.h
+++ b/models/ppd_sup_generator.h
@@ -172,7 +172,7 @@ private:
     Parameters_(); //!< Sets default parameter values
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   // ------------------------------------------------------------

--- a/models/pulsepacket_generator.h
+++ b/models/pulsepacket_generator.h
@@ -138,7 +138,7 @@ private:
     void get( DictionaryDatum& ) const; //!< Store current values in dictionary
 
     /**
-     * Set values from dicitonary.
+     * Set values from dictionary.
      * @note Buffer is passed so that the position etc can be reset
      *       parameters have been changed.
      */

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -341,7 +341,7 @@ nest::rate_neuron_opn< TNonlinearities >::update_( Time const& origin,
     // clear last_y_values
     std::vector< double >( buffer_size, 0.0 ).swap( B_.last_y_values );
 
-    // modifiy new_rates for rate-neuron-event as proxy for next min_delay
+    // modify new_rates for rate-neuron-event as proxy for next min_delay
     for ( long temp = from; temp < to; ++temp )
     {
       new_rates[ temp ] = S_.noisy_rate_;

--- a/models/sigmoid_rate.cpp
+++ b/models/sigmoid_rate.cpp
@@ -49,7 +49,7 @@ template <>
 void
 RecordablesMap< nest::sigmoid_rate_ipn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::sigmoid_rate_ipn::get_rate_ );
   insert_( names::noise, &nest::sigmoid_rate_ipn::get_noise_ );
 }
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< nest::rate_transformer_sigmoid >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::rate_transformer_sigmoid::get_rate_ );
 }
 

--- a/models/sigmoid_rate.h
+++ b/models/sigmoid_rate.h
@@ -143,7 +143,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   double input( double h );               // non-linearity on input
   double mult_coupling_ex( double rate ); // factor of multiplicative coupling

--- a/models/sigmoid_rate_gg_1998.cpp
+++ b/models/sigmoid_rate_gg_1998.cpp
@@ -45,7 +45,7 @@ template <>
 void
 RecordablesMap< nest::sigmoid_rate_gg_1998_ipn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::sigmoid_rate_gg_1998_ipn::get_rate_ );
   insert_( names::noise, &nest::sigmoid_rate_gg_1998_ipn::get_noise_ );
 }
@@ -54,7 +54,7 @@ template <>
 void
 RecordablesMap< nest::rate_transformer_sigmoid_gg_1998 >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::rate_transformer_sigmoid_gg_1998::get_rate_ );
 }
 

--- a/models/sigmoid_rate_gg_1998.h
+++ b/models/sigmoid_rate_gg_1998.h
@@ -139,7 +139,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   double input( double h );               // non-linearity on input
   double mult_coupling_ex( double rate ); // factor of multiplicative coupling

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -137,7 +137,7 @@ private:
     Parameters_& operator=( const Parameters_& ) = default;
 
     void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-    void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+    void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
   };
 
   struct Buffers_

--- a/models/stdp_nn_restr_synapse.h
+++ b/models/stdp_nn_restr_synapse.h
@@ -56,10 +56,10 @@ pairing scheme (fig. 7C in [1]_).
 
 When a presynaptic spike occurs, it is taken into account in the depression
 part of the STDP weight change rule with the nearest preceding postsynaptic
-one, but only if the latter occured not earlier than the previous presynaptic
+one, but only if the latter occurred not earlier than the previous presynaptic
 one. When a postsynaptic spike occurs, it is accounted in the facilitation
 rule with the nearest preceding presynaptic one, but only if the latter
-occured not earlier than the previous postsynaptic one. So, a spike can
+occurred not earlier than the previous postsynaptic one. So, a spike can
 participate neither in two depression pairs nor in two potentiation pairs.
 
 The pairs exactly coinciding (so that ``presynaptic_spike == postsynaptic_spike

--- a/models/tanh_rate.cpp
+++ b/models/tanh_rate.cpp
@@ -47,7 +47,7 @@ template <>
 void
 RecordablesMap< nest::tanh_rate_ipn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::tanh_rate_ipn::get_rate_ );
   insert_( names::noise, &nest::tanh_rate_ipn::get_noise_ );
 }
@@ -56,7 +56,7 @@ template <>
 void
 RecordablesMap< nest::tanh_rate_opn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::tanh_rate_opn::get_rate_ );
   insert_( names::noise, &nest::tanh_rate_opn::get_noise_ );
   insert_( names::noisy_rate, &nest::tanh_rate_opn::get_noisy_rate_ );
@@ -66,7 +66,7 @@ template <>
 void
 RecordablesMap< nest::rate_transformer_tanh >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::rate_transformer_tanh::get_rate_ );
 }
 

--- a/models/tanh_rate.h
+++ b/models/tanh_rate.h
@@ -137,7 +137,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   double input( double h );               // non-linearity on input
   double mult_coupling_ex( double rate ); // factor of multiplicative coupling

--- a/models/threshold_lin_rate.cpp
+++ b/models/threshold_lin_rate.cpp
@@ -49,7 +49,7 @@ template <>
 void
 RecordablesMap< nest::threshold_lin_rate_ipn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::threshold_lin_rate_ipn::get_rate_ );
   insert_( names::noise, &nest::threshold_lin_rate_ipn::get_noise_ );
 }
@@ -58,7 +58,7 @@ template <>
 void
 RecordablesMap< nest::threshold_lin_rate_opn >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::threshold_lin_rate_opn::get_rate_ );
   insert_( names::noise, &nest::threshold_lin_rate_opn::get_noise_ );
   insert_( names::noisy_rate, &nest::threshold_lin_rate_opn::get_noisy_rate_ );
@@ -68,7 +68,7 @@ template <>
 void
 RecordablesMap< nest::rate_transformer_threshold_lin >::create()
 {
-  // use standard names whereever you can for consistency!
+  // use standard names wherever you can for consistency!
   insert_( names::rate, &nest::rate_transformer_threshold_lin::get_rate_ );
 }
 

--- a/models/threshold_lin_rate.h
+++ b/models/threshold_lin_rate.h
@@ -145,7 +145,7 @@ public:
   }
 
   void get( DictionaryDatum& ) const;             //!< Store current values in dictionary
-  void set( const DictionaryDatum&, Node* node ); //!< Set values from dicitonary
+  void set( const DictionaryDatum&, Node* node ); //!< Set values from dictionary
 
   double input( double h );               // non-linearity on input
   double mult_coupling_ex( double rate ); // factor of multiplicative coupling

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -66,7 +66,7 @@ void
 ArchivingNode::register_stdp_connection( double t_first_read, double delay )
 {
   // Mark all entries in the deque, which we will not read in future as read by
-  // this input input, so that we savely increment the incoming number of
+  // this input, so that we safely increment the incoming number of
   // connections afterwards without leaving spikes in the history.
   // For details see bug #218. MH 08-04-22
 

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -547,9 +547,9 @@ NodeManager::ensure_valid_thread_local_ids()
       wfr_network_size_ = size();
 
       // wfr_is_used_ indicates, whether at least one
-      // of the threads has a neuron that uses waveform relaxtion
+      // of the threads has a neuron that uses waveform relaxation
       // all threads then need to perform a wfr_update
-      // step, because gather_events() has to be done in a
+      // step, because gather_events() has to be done in an
       // openmp single section
       wfr_is_used_ = false;
       for ( thread tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -287,7 +287,7 @@ SPManager::disconnect( NodeCollectionPTR sources,
 
   if ( not kernel().connection_manager.valid_connection_rule( rule_name ) )
   {
-    throw BadProperty( "Unknown connectivty rule: " + rule_name );
+    throw BadProperty( "Unknown connectivity rule: " + rule_name );
   }
 
   if ( not sp_conn_builders_.empty() )

--- a/nestkernel/target_identifier.h
+++ b/nestkernel/target_identifier.h
@@ -155,7 +155,7 @@ public:
     if ( rprt != 0 )
     {
       throw IllegalConnection(
-        "Only rport==0 allowed for HPC synpases. Use normal synapse models "
+        "Only rport==0 allowed for HPC synapses. Use normal synapse models "
         "instead. See Kunkel et al, Front Neuroinform 8:78 (2014), Sec "
         "3.3.2." );
     }

--- a/nestkernel/target_table.h
+++ b/nestkernel/target_table.h
@@ -61,7 +61,7 @@ private:
    *   - first dim: threads
    *   - second dim: local neurons
    *   - third dim: synapse types
-   *   - forth dim: MPI send buffer positions
+   *   - fourth dim: MPI send buffer positions
    */
   std::vector< std::vector< std::vector< std::vector< size_t > > > > secondary_send_buffer_pos_;
 

--- a/pynest/examples/CampbellSiegert.py
+++ b/pynest/examples/CampbellSiegert.py
@@ -44,7 +44,7 @@ References
 Authors
 ~~~~~~~
 
-S. Schrader, Siegert implentation by T. Tetzlaff
+S. Schrader, Siegert implementation by T. Tetzlaff
 """
 
 ###############################################################################

--- a/pynest/examples/Potjans_2014/helpers.py
+++ b/pynest/examples/Potjans_2014/helpers.py
@@ -47,7 +47,7 @@ def num_synapses_from_conn_probs(conn_probs, popsize1, popsize2):
     conn_probs
         Matrix of connection probabilities.
     popsize1
-        Size of first poulation.
+        Size of first population.
     popsize2
         Size of second population.
 

--- a/pynest/examples/Potjans_2014/network_params.py
+++ b/pynest/examples/Potjans_2014/network_params.py
@@ -70,7 +70,7 @@ net_dict = {
     # mean rates of the different populations in the non-scaled version of the
     # microcircuit (in spikes/s; same order as in 'populations');
     # necessary for the scaling of the network.
-    # The values were optained by running this PyNEST microcircuit without MPI,
+    # The values were obtained by running this PyNEST microcircuit without MPI,
     # 'local_num_threads' 4 and both 'N_scaling' and 'K_scaling' set to 1.
     'full_mean_rates':
         np.array([0.903, 2.965, 4.414, 5.876, 7.569, 8.633, 1.105, 7.829]),

--- a/pynest/examples/brunel_exp_multisynapse_nest.py
+++ b/pynest/examples/brunel_exp_multisynapse_nest.py
@@ -30,7 +30,7 @@ The example demonstrate the usage of the multisynapse neuron
 model. Each spike arriving at the neuron triggers an exponential
 PSP. The time constant associated with the PSP is defined in the
 receptor type array tau_syn of each neuron. The receptor types of all
-connections are uniformally distributed, resulting in uniformally
+connections are uniformly distributed, resulting in uniformly
 distributed time constants of the PSPs.
 
 When connecting the network, customary synapse models are used, which
@@ -189,7 +189,7 @@ nest.CopyModel("static_synapse", "inhibitory",
 # generator is connected to all neurons in the population the default rule
 # (# ``all_to_all``) of ``Connect`` is used. The synaptic properties are
 # pre-defined # in a dictionary and inserted via ``syn_spec``. As synaptic model
-# the pre-defined synapses "excitatory" and "inhibitory" are choosen,
+# the pre-defined synapses "excitatory" and "inhibitory" are chosen,
 # thus setting ``weight`` and ``delay``. The receptor type is drawn from a
 # distribution for each connection, which is specified in the synapse
 # properties by assigning a dictionary to the keyword ``receptor_type``,

--- a/pynest/examples/compartmental_model/two_comps.py
+++ b/pynest/examples/compartmental_model/two_comps.py
@@ -50,8 +50,8 @@ soma_params = {
 }
 
 ###############################################################################
-# by default, active conducances are set to zero, so we don't need to specify
-# them explicitely
+# by default, active conductances are set to zero, so we don't need to specify
+# them explicitly
 dend_params_passive = {
     # passive parameters
     'C_m': 1.929929,

--- a/pynest/examples/correlospinmatrix_detector_two_neuron.py
+++ b/pynest/examples/correlospinmatrix_detector_two_neuron.py
@@ -25,7 +25,7 @@ Correlospinmatrix detector example
 
 This scripts simulates two connected binary neurons, similar
 as in [1]_. It measures and plots the auto- and cross covariance functions
-of the individual neurons and between them, repsectively.
+of the individual neurons and between them, respectively.
 
 References
 ~~~~~~~~~~

--- a/pynest/examples/pong/networks.py
+++ b/pynest/examples/pong/networks.py
@@ -297,7 +297,7 @@ class PongNetDopa(PongNet):
                          self.motor_neurons, {'rule': 'one_to_one'},
                          {"weight": self.mean_weight})
         else:
-            # Because the poisson_generators cause adtitional spikes in the
+            # Because the poisson_generators cause additional spikes in the
             # motor neurons, it is necessary to compensate for their absence by
             # slightly increasing the mean of the weights between input and
             # motor neurons

--- a/pynest/examples/spatial/connex_ew.py
+++ b/pynest/examples/spatial/connex_ew.py
@@ -20,7 +20,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Circular mask and flat probablility, with edge wrap
+Circular mask and flat probability, with edge wrap
 ---------------------------------------------------
 
 Create two populations of iaf_psc_alpha neurons on a 30x30 grid with edge_wrap,

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -195,7 +195,7 @@ def Connect(pre, post, conn_spec=None, syn_spec=None,
     will be used.
 
     Distributed parameters can be defined through NEST's different parametertypes. NEST has various
-    random parameters, spatial parameters and distributions (only accesseable for nodes with spatial positions),
+    random parameters, spatial parameters and distributions (only accessible for nodes with spatial positions),
     logical expressions and mathematical expressions, which can be used to define node and connection parameters.
 
     To see all available parameters, see documentation defined in distributions, logic, math,
@@ -292,7 +292,7 @@ def Connect(pre, post, conn_spec=None, syn_spec=None,
 
 @check_stack
 def Disconnect(*args, conn_spec=None, syn_spec=None):
-    """Disconnect connections in a SynnapseCollection, or `pre` neurons from `post` neurons.
+    """Disconnect connections in a SynapseCollection, or `pre` neurons from `post` neurons.
 
     When specifying `pre` and `post` nodes, they are disconnected using the specified disconnection
     rule (one-to-one by default) and synapse type (:cpp:class:`static_synapse <nest::static_synapse>` by default).

--- a/pynest/nest/lib/hl_api_spatial.py
+++ b/pynest/nest/lib/hl_api_spatial.py
@@ -139,7 +139,7 @@ def CreateMask(masktype, specs, anchor=None):
                 {'lower_left'  : [float, float, float],
                  'upper_right' : [float, float, float],
                  'azimuth_angle: float  # default: 0.0,
-                 'polar_angle  : float  # defualt: 0.0}
+                 'polar_angle  : float  # default: 0.0}
             #or
             'spherical' :
                 {'radius' : float}

--- a/sli/get_mem.c
+++ b/sli/get_mem.c
@@ -33,7 +33,7 @@ darwin_get_used_mem()
   mach_msg_type_number_t t_info_count = TASK_BASIC_INFO_COUNT;
 
   kern_return_t result = task_info( mach_task_self(), TASK_BASIC_INFO, ( task_info_t ) &t_info, &t_info_count );
-  assert( result == KERN_SUCCESS || "Problem occured during getting of task_info." );
+  assert( result == KERN_SUCCESS || "Problem occurred during getting of task_info." );
   return t_info.resident_size;
 }
 #else

--- a/sli/interpret.cc
+++ b/sli/interpret.cc
@@ -497,7 +497,7 @@ SLIInterpreter::addmodule( SLIModule* m )
   }
   catch ( SLIException& e )
   {
-    message( M_ERROR, "SLIInterpreter", ( "An error occured while loading module " + m->name() ).c_str() );
+    message( M_ERROR, "SLIInterpreter", ( "An error occurred while loading module " + m->name() ).c_str() );
     message( M_ERROR, "SLIInterpreter", e.what() );
     message( M_ERROR, "SLIInterpreter", e.message().c_str() );
     return;
@@ -505,14 +505,14 @@ SLIInterpreter::addmodule( SLIModule* m )
   catch ( std::exception& e )
   {
     message(
-      M_ERROR, "SLIInterpreter", ( "A C++ library exception occured while loading module " + m->name() ).c_str() );
+      M_ERROR, "SLIInterpreter", ( "A C++ library exception occurred while loading module " + m->name() ).c_str() );
     message( M_ERROR, "SLIInterpreter", e.what() );
     return;
   }
   catch ( ... )
   {
     message(
-      M_ERROR, "SLIInterpreter", ( "An unspecified exception occured while loading module " + m->name() ).c_str() );
+      M_ERROR, "SLIInterpreter", ( "An unspecified exception occurred while loading module " + m->name() ).c_str() );
     return;
   }
 
@@ -1283,7 +1283,7 @@ SLIInterpreter::execute_debug_( size_t exitlevel )
   }
   catch ( std::exception& e )
   {
-    message( M_FATAL, "SLIInterpreter", "A C++ library exception occured." );
+    message( M_FATAL, "SLIInterpreter", "A C++ library exception occurred." );
     OStack.dump( std::cerr );
     EStack.dump( std::cerr );
     message( M_FATAL, "SLIInterpreter", e.what() );
@@ -1292,7 +1292,7 @@ SLIInterpreter::execute_debug_( size_t exitlevel )
   }
   catch ( ... )
   {
-    message( M_FATAL, "SLIInterpreter", "An unknown c++ exception occured." );
+    message( M_FATAL, "SLIInterpreter", "An unknown c++ exception occurred." );
     OStack.dump( std::cerr );
     EStack.dump( std::cerr );
     exitcode = getValue< long >( *exitcodes, "exception" );
@@ -1336,7 +1336,7 @@ SLIInterpreter::execute_( size_t exitlevel )
   }
   catch ( std::exception& e )
   {
-    message( M_FATAL, "SLIInterpreter", "A C++ library exception occured." );
+    message( M_FATAL, "SLIInterpreter", "A C++ library exception occurred." );
     OStack.dump( std::cerr );
     EStack.dump( std::cerr );
     message( M_FATAL, "SLIInterpreter", e.what() );
@@ -1345,7 +1345,7 @@ SLIInterpreter::execute_( size_t exitlevel )
   }
   catch ( ... )
   {
-    message( M_FATAL, "SLIInterpreter", "An unknown c++ exception occured." );
+    message( M_FATAL, "SLIInterpreter", "An unknown c++ exception occurred." );
     OStack.dump( std::cerr );
     EStack.dump( std::cerr );
     exitcode = getValue< long >( *exitcodes, "exception" );

--- a/sli/processes.cc
+++ b/sli/processes.cc
@@ -365,7 +365,7 @@ Processes::Sysexec_aFunction::execute( SLIInterpreter* i ) const
   delete[] argv;
 
   if ( result == -1 )
-  {                                     // an error occured!
+  {                                     // an error occurred!
     i->OStack.push_move( array_token ); // restore operand stack
     i->raiseerror( systemerror( i ) );
   }
@@ -396,7 +396,7 @@ Processes::WaitPIDFunction::execute( SLIInterpreter* i ) const
   pid_t pidout = waitpid( pidin_d->get(), &stat_value, options );
 
   // Check for error
-  if ( pidout == -1 ) // an Error occured
+  if ( pidout == -1 ) // an Error occurred
   {
     i->raiseerror( systemerror( i ) );
   }
@@ -462,7 +462,7 @@ Processes::KillFunction::execute( SLIInterpreter* i ) const
   int result = kill( pid_d->get(), signal_d->get() );
 
   if ( result == -1 )
-  { // an error occured!
+  { // an error occurred!
     i->raiseerror( systemerror( i ) );
   }
   else
@@ -481,7 +481,7 @@ Processes::PipeFunction::execute( SLIInterpreter* i ) const
   int result = pipe( filedes );
 
   if ( result == -1 )
-  { // an error occured!
+  { // an error occurred!
     i->raiseerror( systemerror( i ) );
   }
   else
@@ -523,7 +523,7 @@ Processes::Dup2_is_isFunction::execute( SLIInterpreter* i ) const
   // istream)
 
   if ( result == -1 )
-  { // an error occured!
+  { // an error occurred!
     i->raiseerror( systemerror( i ) );
   }
   else
@@ -663,11 +663,11 @@ Processes::AvailableFunction::execute( SLIInterpreter* i ) const
     //       // ------------------------------
 
     //       if ( (peekchar==-1) and (errno!=EAGAIN) and (errno!=ESPIPE) )
-    //         {// some unexpected error occured!
+    //         {// some unexpected error occurred!
     //           i->raiseerror(systemerror(i));
     //         }
     //       else
-    //         {// no error or EAGAIN or ESPIPE occured
+    //         {// no error or EAGAIN or ESPIPE occurred
     //           i->EStack.pop();
     //           bool result;
     //           if ( peekchar==-1 ) // errno==EAGAIN or errno==ESPIPE
@@ -704,7 +704,7 @@ Processes::AvailableFunction::execute( SLIInterpreter* i ) const
 
     bool result;
     if ( not( **istreamdatum ).good() )
-    { // an error occured. No data can be read.
+    { // an error occurred. No data can be read.
       // no data is currently available
       result = false;             // no data is available
       ( **istreamdatum ).clear(); // Lower eof and error Flag
@@ -854,7 +854,7 @@ Processes::SetNonblockFunction::execute( SLIInterpreter* i ) const
   int flags = fcntl( fd, F_GETFL );
   if ( flags == -1 )
   {
-    i->raiseerror( systemerror( i ) ); // an error occured!
+    i->raiseerror( systemerror( i ) ); // an error occurred!
   }
 
   // modify flags to the new value:
@@ -873,7 +873,7 @@ Processes::SetNonblockFunction::execute( SLIInterpreter* i ) const
 
 
   if ( result == -1 )
-  { // an error occured!
+  { // an error occurred!
     i->raiseerror( systemerror( i ) );
   }
   else

--- a/sli/sli_io.cc
+++ b/sli/sli_io.cc
@@ -1384,7 +1384,7 @@ GetlineFunction::execute( SLIInterpreter* i ) const
      Description: getline reads a line from the supplied stream.
      If the read process was successful, a result string and
      the boolean true are returned.
-     If an error occured while reading from the stream, only the
+     If an error occurred while reading from the stream, only the
      stream and boolean false is returned.
      Diagnostics: No errors are raised. If getline is applied to an
      invalid stream, the return value is false. The return value

--- a/sli/slicontrol.cc
+++ b/sli/slicontrol.cc
@@ -74,7 +74,7 @@ Synopsis: backtrace_on -> -
 Description:
 
 This functions enables a human readable backtrace of the execution
-stack. This is useful to locate where precisely an error occured. Note
+stack. This is useful to locate where precisely an error occurred. Note
 that this function also disables the interpreter's tail recursion
 optimization and will therefore impose a small performance
 penalty. The command backtrace_off disables the stack backtrace and

--- a/sli/slidata.cc
+++ b/sli/slidata.cc
@@ -43,7 +43,7 @@
 Name: allocations - Return the number of array reallocations.
 Synopsis: - allocations -> int
 Description: This function returns the total number of array-allocations
-which have occured during the run-time of the SLI interpreter.
+which have occurred during the run-time of the SLI interpreter.
 This number is important in the context of benchmarking and optimization.
 */
 void

--- a/sli/slidict.cc
+++ b/sli/slidict.cc
@@ -402,7 +402,7 @@ DicttopinfoFunction::execute( SLIInterpreter* i ) const
 }
 
 /** @BeginDocumentation
-   Name: info_ds - print contents of all dictionaries on the dicitonary stack to
+   Name: info_ds - print contents of all dictionaries on the dictionary stack to
                    stream
 
    Synopsis: ostream info_ds -> -
@@ -513,7 +513,7 @@ DictendFunction::execute( SLIInterpreter* i ) const
 
    Description:
      undef removes the definition of a name from the supplied dictionary.
-     The name does not have to be present in the dicitonary.
+     The name does not have to be present in the dictionary.
 
    Examples:
      SLI ] /d << /a 1 /b 2 >> def

--- a/sli/sliexceptions.h
+++ b/sli/sliexceptions.h
@@ -346,7 +346,7 @@ public:
 
 // -------------------- Stack Error -------------------------
 /**
- * Exception to be thrown if an error occured while accessing the stack.
+ * Exception to be thrown if an error occurred while accessing the stack.
  * @ingroup SLIExceptions
  */
 class StackUnderflow : public InterpreterError
@@ -366,7 +366,7 @@ public:
 
 // -------------------- I/O Error -------------------------
 /**
- * Exception to be thrown if an error occured in an I/O operation.
+ * Exception to be thrown if an error occurred in an I/O operation.
  * @ingroup SLIExceptions
  */
 class IOError : public SLIException

--- a/testsuite/cpptests/test_sort.h
+++ b/testsuite/cpptests/test_sort.h
@@ -49,7 +49,7 @@ nest_quicksort( BlockVector< int >& bv0, BlockVector< int >& bv1 )
 }
 
 /**
- * Fixture filling two BlockVectors and a vector with lineary decreasing numbers.
+ * Fixture filling two BlockVectors and a vector with linearly decreasing numbers.
  * The vector is then sorted.
  */
 struct fill_bv_vec_linear

--- a/testsuite/pytests/connect_test_base.py
+++ b/testsuite/pytests/connect_test_base.py
@@ -61,7 +61,7 @@ class ConnectTestBase(unittest.TestCase):
     # number of threads
     nr_threads = 2
 
-    # for now only tests if a multi-thread connect is successfull, not whether
+    # for now only tests if a multi-thread connect is successful, not whether
     # the the threading is actually used
     def setUp(self):
         nest.ResetKernel()
@@ -130,7 +130,7 @@ class ConnectTestBase(unittest.TestCase):
         self.assertTrue(all_equal(syns))
         self.assertTrue(syns[0] == syn_params['synapse_model'])
 
-    # tested on each mpi process separatly
+    # tested on each mpi process separately
     def testDefaultParams(self):
         self.setUpNetwork(self.conn_dict)
         conns = nest.GetConnections(self.pop1, self.pop2)

--- a/testsuite/pytests/test_rate_instantaneous_and_delayed.py
+++ b/testsuite/pytests/test_rate_instantaneous_and_delayed.py
@@ -96,7 +96,7 @@ class RateInstantaneousAndDelayedTestCase(unittest.TestCase):
 
         # get shifted rate_2
         rate_2 = rate_2[times_2 > delay]
-        # adjust length of rate_1 to be able to substract
+        # adjust length of rate_1 to be able to subtract
         rate_1 = rate_1[:len(rate_2)]
 
         assert(np.sum(np.abs(rate_2 - rate_1)) < 1e-12)

--- a/testsuite/pytests/test_refractory.py
+++ b/testsuite/pytests/test_refractory.py
@@ -156,7 +156,7 @@ class TestRefractoryCase(unittest.TestCase):
             name_Vm = "V_m.s" if model in mc_models else "V_m"
             Vs = nest.GetStatus(vm, "events")[0][name_Vm]
 
-            # Get the index at which the spike occured
+            # Get the index at which the spike occurred
             idx_spike = np.argwhere(times == spike_times[0])[0][0]
 
             # Find end of refractory period between 1st and 2nd spike

--- a/testsuite/pytests/test_stdp_nn_synapses.py
+++ b/testsuite/pytests/test_stdp_nn_synapses.py
@@ -71,7 +71,7 @@ class TestSTDPNNSynapses:
         # While the random sequences, fairly long, would supposedly
         # reveal small differences in the weight change between NEST
         # and ours, some low-probability events (say, coinciding
-        # spikes) can well not have occured. To generate and
+        # spikes) can well not have occurred. To generate and
         # test every possible combination of pre/post order, we
         # append some hardcoded spike sequences:
         # pre: 1       5 6 7   9    11 12 13
@@ -175,7 +175,7 @@ class TestSTDPNNSynapses:
         n_steps = int(self.simulation_duration / self.resolution)
         for time_in_simulation_steps in range(n_steps):
             if time_in_simulation_steps in pre_spikes_forced_to_grid:
-                # A presynaptic spike occured now.
+                # A presynaptic spike occurred now.
 
                 # Adjusting the current time to make it exact.
                 t = _pre_spikes[pre_spikes_forced_to_grid.index(time_in_simulation_steps)]
@@ -203,7 +203,7 @@ class TestSTDPNNSynapses:
                 t_previous_pre = t
 
             if time_in_simulation_steps in post_spikes_forced_to_grid:
-                # A postsynaptic spike occured now.
+                # A postsynaptic spike occurred now.
 
                 # Adjusting the current time to make it exact.
                 t = _post_spikes[post_spikes_forced_to_grid.index(time_in_simulation_steps)]

--- a/testsuite/pytests/test_stdp_synapse.py
+++ b/testsuite/pytests/test_stdp_synapse.py
@@ -70,7 +70,7 @@ class TestSTDPSynapse:
         # While the random sequences, fairly long, would supposedly
         # reveal small differences in the weight change between NEST
         # and ours, some low-probability events (say, coinciding
-        # spikes) can well not have occured. To generate and
+        # spikes) can well not have occurred. To generate and
         # test every possible combination of pre/post order, we
         # append some hardcoded spike sequences:
         # pre: 1       5 6 7   9    11 12 13
@@ -93,7 +93,7 @@ class TestSTDPSynapse:
             self.init_weight,
             fname_snip=fname_snip)
 
-        # ``weight_by_nest`` containts only weight values at pre spike times, ``weight_reproduced_independently``
+        # ``weight_by_nest`` contains only weight values at pre spike times, ``weight_reproduced_independently``
         # contains the weight at pre *and* post times: check that weights are equal only for pre spike times
         assert len(weight_by_nest) > 0
         for idx_pre_spike_nest, t_pre_spike_nest in enumerate(t_weight_by_nest):

--- a/testsuite/regressiontests/ticket-537.sli
+++ b/testsuite/regressiontests/ticket-537.sli
@@ -28,7 +28,7 @@ Synopsis: (ticket-537) run -> NEST exits if test fails
 
 Description:
 This test detects a memory allocation/freeing problem introduced with the SLI modernization per r9458. 
-This bug occured only on certain Linux platforms.
+This bug occurred only on certain Linux platforms.
  
 Author: Hans Ekkehard Plesser, 2012-01-12, based on reproduces by Marc-Oliver Gewaltig
  */

--- a/testsuite/regressiontests/ticket-941.sli
+++ b/testsuite/regressiontests/ticket-941.sli
@@ -40,7 +40,7 @@ M_ERROR setverbosity
 
 /*
   We connect connect two parrot neurons to each other using
-  different synpase types. We use a different delay for each
+  different synapse types. We use a different delay for each
   pn1 -> pn2 connection so that we can detect actually
   existing connections by spike delays, thus cross-checking output
   from GetConnection.

--- a/testsuite/unittests/test_connect_with_threads.sli
+++ b/testsuite/unittests/test_connect_with_threads.sli
@@ -168,7 +168,7 @@ forall
 
   net1 net2 conn_dict syn_dict Connect % Connect source to target neurons
 
-  % Check to see if we have currect number of connections
+  % Check to see if we have correct number of connections
   /num_conn GetKernelStatus /num_connections get def
   5 num_conn eq assert_or_die
 }

--- a/testsuite/unittests/test_hpc_synapse.sli
+++ b/testsuite/unittests/test_hpc_synapse.sli
@@ -59,7 +59,7 @@ M_ERROR setverbosity
 } bind def
 
 
-% Test if synapse can be used without additional setup; stdp_dopamine_synpase does not
+% Test if synapse can be used without additional setup; stdp_dopamine_synapse does not
 /synapse_works  % expects lit specifying hpc synapse
 {
   /syn Set

--- a/testsuite/unittests/test_iaf_dc.sli
+++ b/testsuite/unittests/test_iaf_dc.sli
@@ -40,7 +40,7 @@ Description:
  The expected output is documented and briefly commented at the end of 
  the script.
 
- Cleary, the result of this script is not resolution independent. The 
+ Clearly, the result of this script is not resolution independent. The
  choice of the computation step size determines at which point in time 
  the current affects the neuron. 
 

--- a/testsuite/unittests/test_iaf_dc_aligned_automatic.sli
+++ b/testsuite/unittests/test_iaf_dc_aligned_automatic.sli
@@ -103,7 +103,7 @@ dc_visible dc_delay sub /dc_on Set
                      % the neuron at the desired time
 
 dc_delay /max_delay Set
-                     % the maximal delay tolereated by the 
+                     % the maximal delay tolerated by the
                      % simulation kernel (in ms) needs to be
                      % larger or equal to the maximal delay
                      % used in this script

--- a/testsuite/unittests/test_iaf_dc_aligned_delay.sli
+++ b/testsuite/unittests/test_iaf_dc_aligned_delay.sli
@@ -90,7 +90,7 @@ dc_visible dc_delay sub /dc_on Set
                      % the neuron at the desired time
 
 dc_delay /max_delay Set
-                     % the maximal delay tolereated by the 
+                     % the maximal delay tolerated by the
                      % simulation kernel (in ms) needs to be
                      % larger or equal to the maximal delay
                      % used in this script

--- a/testsuite/unittests/test_iaf_dc_aligned_stop.sli
+++ b/testsuite/unittests/test_iaf_dc_aligned_stop.sli
@@ -44,7 +44,7 @@ Description:
 
   See [1] for details on why the DC generator specification is
   consistent with a grid based integration scheme of systems of
-  differential equations.  In this scheme DC currents are represeted
+  differential equations.  In this scheme DC currents are represented
   by the differential equation d/dt I = 0.
 
   The resulting SLI code is independent of the resolution and
@@ -87,7 +87,7 @@ dc_on dc_duration add /dc_off Set
 
 
 dc_delay /max_delay Set
-                     % the maximal delay tolereated by the 
+                     % the maximal delay tolerated by the
                      % simulation kernel (in ms) needs to be
                      % larger or equal to the maximal delay
                      % used in this script

--- a/testsuite/unittests/test_iaf_ps_psp_poisson_accuracy.sli
+++ b/testsuite/unittests/test_iaf_ps_psp_poisson_accuracy.sli
@@ -31,7 +31,7 @@ The test probes the interaction of a spike generator implementing a
 poisson process in continuous time with a neuron model capable of
 handling off-grid spike times. The result is verified by comparing the
 superposition of postsynaptic potentials in the neuron model to the
-the corresonding analytical solution. To achieve this, spike
+the corresponding analytical solution. To achieve this, spike
 generation of the neuron mode is prevented by setting the spike
 threshold to a very high value. The test employs the parrot neuron for
 precise spike times to provide the neuron model and the spike recorder

--- a/testsuite/unittests/test_iaf_psc_exp_multisynapse.sli
+++ b/testsuite/unittests/test_iaf_psc_exp_multisynapse.sli
@@ -109,7 +109,7 @@ vm npost 1.0 h Connect
 [ 8       -70      ]
 [ 9       -70      ]
 [ 10      -70      ]
-[ 11      -70      ] % <----- The spike arrives at the first synapse but has not yet effected the snynaptic current and membrane potential.
+[ 11      -70      ] % <----- The spike arrives at the first synapse but has not yet effected the synaptic current and membrane potential.
 [ 12      -69.9960 ] % <-
 [ 13      -69.9921 ] %   |
 [ 14      -69.9882 ] %   |

--- a/testsuite/unittests/test_iaf_psc_exp_ps_lossless.sli
+++ b/testsuite/unittests/test_iaf_psc_exp_ps_lossless.sli
@@ -60,7 +60,7 @@
     see the SeeAlso key below.
 
 
-    The second part tests wether the lossless spike detection algorithm [1] is
+    The second part tests whether the lossless spike detection algorithm [1] is
     working correctly.
 
     The algorithm checks whether a spike is emitted on the basis of the neurons position 
@@ -77,7 +77,7 @@
 
     If you need to reproduce the reference data, ask the authors of [1] for the script
     regions_algorithm.py which they used to generate Fig. 6. Here you can adjust the
-    parameters as whished and obtain the respective regions. 
+    parameters as wished and obtain the respective regions.
     
 
     References:

--- a/testsuite/unittests/test_iaf_psp.sli
+++ b/testsuite/unittests/test_iaf_psp.sli
@@ -33,7 +33,7 @@ Description:
  called postsynaptic potential (PSP). In the iaf_psc_alpha model neuron
  the postsynaptic current is described by an alpha-function 
  (see [1] and references therein). The resulting PSP has a finite 
- rise-time, with voltage and current beeing zero in the initial 
+ rise-time, with voltage and current being zero in the initial
  condition (see [1]).
 
  The dynamics is tested by connecting a device that emits spikes

--- a/testsuite/unittests/test_iaf_psp_normalized.sli
+++ b/testsuite/unittests/test_iaf_psp_normalized.sli
@@ -34,7 +34,7 @@ the GNU Scientific Library (GSL) is not present the peak location is
 found by searching for the root of the derivative of the PSP. We then
 compute the peak value for a PSC with unit amplitude and show how the
 synaptic weight can be adjusted to cause a PSP of a specific
-amplitiude. Finally, we check whether the simulation indeed generates
+amplitude. Finally, we check whether the simulation indeed generates
 a PSP of the desired amplitude.
 
 In application code the test for the availability of the GSL is not

--- a/testsuite/unittests/test_mat2_psc_exp.sli
+++ b/testsuite/unittests/test_mat2_psc_exp.sli
@@ -35,7 +35,7 @@
 
     It can be observed how the current charges the membrane, a spike
     is emitted, the threshold potential is updated and evaluated whereas
-    the membrane potential is not resetted and further evaluated, too.
+    the membrane potential is not reset and further evaluated, too.
     Additionally the neuron becomes refractory after emitting a spike.
 
     The timing of the various events on the simulation grid is of

--- a/testsuite/unittests/test_spike_transmission_ps.sli
+++ b/testsuite/unittests/test_spike_transmission_ps.sli
@@ -65,7 +65,7 @@ for the kernel.
 /T         4.0 def   % simulation time
 /Tstop     3.0 def   % end of recording
 /prate 12892.3 def   % rate of Poisson generator
-/delay     1.0 def   % connection delay, needs to be set explicity due to #161
+/delay     1.0 def   % connection delay, needs to be set explicitly due to #161
 
 /resolutions [0.1 0.01 0.001] def
 


### PR DESCRIPTION
This PR fixes most of the typos anywhere in the repository (excluding thirdparty). Typos have been either identified by a spellchecker or found while reading code (e.g. forth -> fourth).