### PR TITLE
Move MUSIC status printout up in the summary

### DIFF
--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -177,6 +177,12 @@ echo
 NEST_VERSION="$(sli -c "statusdict/version :: =only")"
 echo "  NEST executable .... $NEST (version $NEST_VERSION)"
 echo "  PREFIX ............. $PREFIX"
+
+if test -n "${MUSIC}"; then
+    MUSIC_VERSION="$("${MUSIC}" --version | head -n1 | cut -d' ' -f2)"
+    echo "  MUSIC executable ... $MUSIC (version $MUSIC_VERSION)"
+fi
+
 if test -n "${PYTHON}"; then
     PYTHON_VERSION="$("${PYTHON}" --version | cut -d' ' -f2)"
     echo "  Python executable .. $PYTHON (version $PYTHON_VERSION)"
@@ -191,10 +197,7 @@ if test "${HAVE_MPI}" = "true"; then
 else
     echo "  Running MPI tests .. no (compiled without MPI support)"
 fi
-if test -n "${MUSIC}"; then
-    MUSIC_VERSION="$("${MUSIC}" --version | head -n1 | cut -d' ' -f2)"
-    echo "  MUSIC executable ... $MUSIC (version $MUSIC_VERSION)"
-fi
+
 echo "  TEST_BASEDIR ....... $TEST_BASEDIR"
 echo "  REPORTDIR .......... $REPORTDIR"
 echo "  PATH ............... `print_paths ${PATH}`"

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -177,12 +177,10 @@ echo
 NEST_VERSION="$(sli -c "statusdict/version :: =only")"
 echo "  NEST executable .... $NEST (version $NEST_VERSION)"
 echo "  PREFIX ............. $PREFIX"
-
 if test -n "${MUSIC}"; then
     MUSIC_VERSION="$("${MUSIC}" --version | head -n1 | cut -d' ' -f2)"
     echo "  MUSIC executable ... $MUSIC (version $MUSIC_VERSION)"
 fi
-
 if test -n "${PYTHON}"; then
     PYTHON_VERSION="$("${PYTHON}" --version | cut -d' ' -f2)"
     echo "  Python executable .. $PYTHON (version $PYTHON_VERSION)"

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -195,7 +195,6 @@ if test "${HAVE_MPI}" = "true"; then
 else
     echo "  Running MPI tests .. no (compiled without MPI support)"
 fi
-
 echo "  TEST_BASEDIR ....... $TEST_BASEDIR"
 echo "  REPORTDIR .......... $REPORTDIR"
 echo "  PATH ............... `print_paths ${PATH}`"


### PR DESCRIPTION
Changing the order of the version check of the `MUSIC` executable seems to work without breaking the build phase of the `full-nest-build` stage.