### PR TITLE
Fix integer type in pynestkernel to build docs

### DIFF
--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -275,7 +275,7 @@ cdef class NESTEngine:
                 new_nc_datum = node_collection_array_index(nc_datum, array_bool_ptr, len(array))
                 return sli_datum_to_object(new_nc_datum)
             elif numpy.issubdtype(array.dtype, numpy.integer):
-                array_long_mv = numpy.ascontiguousarray(array, dtype=int)
+                array_long_mv = numpy.ascontiguousarray(array, dtype=int32)
                 array_long_ptr = &array_long_mv[0]
                 new_nc_datum = node_collection_array_index(nc_datum, array_long_ptr, len(array))
                 return sli_datum_to_object(new_nc_datum)


### PR DESCRIPTION
Thanks to @steffengraber for a solution

Fixes #2576

The `dtype=int` causes the sphinx-build to fail 
We're not sure if the solution here is the best, but it does work both locally and on Read the Docs.