### PR TITLE
Change order of pre_run hook in `SimulationManager`

### DIFF
--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -543,7 +543,6 @@ nest::SimulationManager::run( Time const& t )
   assert_valid_simtime( t );
 
   kernel().random_manager.check_rng_synchrony();
-  kernel().io_manager.pre_run_hook();
 
   if ( not prepared_ )
   {
@@ -559,6 +558,8 @@ nest::SimulationManager::run( Time const& t )
   {
     return;
   }
+
+  kernel().io_manager.pre_run_hook();
 
   // Reset local spike counters within event_delivery_manager
   kernel().event_delivery_manager.reset_counters();


### PR DESCRIPTION
By rearranging the pre_run hook call it allows callees to access information about the simulation time in their pre_run implementation. 
Otherwise callees are not able to reliable get these information before the run starts as the simulation time is only known when calling the run() method and the sim time is currently set after the pre_run hook.

Additionally, the pre_run hook is only called if a run will take place at all.

As far as I see the reordering should be safe as there are no dependencies between the reordered  lines.

