### PR TITLE
Allow setting host and port for the MPI enabled NEST Server from environment variables

### DIFF
--- a/bin/nest-server-mpi
+++ b/bin/nest-server-mpi
@@ -40,7 +40,7 @@ def log(call_name, msg):
 if rank == 0:
     print("==> Starting NEST Server Master on rank 0", flush=True)
     nest.server.set_mpi_comm(comm)
-    nest.server.run_mpi_app(host=opt.get('--host', HOST), port=opt.get('--port', PORT))
+    nest.server.run_mpi_app(host=opt.get('--host', $HOST), port=opt.get('--port', $PORT))
 
 else:
     print(f"==> Starting NEST Server Worker on rank {rank}", flush=True)

--- a/bin/nest-server-mpi
+++ b/bin/nest-server-mpi
@@ -25,8 +25,10 @@ import sys
 import nest
 import nest.server
 
-HOST="${NEST_SERVER_HOST:-127.0.0.1}"
-PORT="${NEST_SERVER_PORT:-52425}"
+import os
+
+HOST = os.getenv("NEST_SERVER_HOST", "127.0.0.1")
+PORT = os.getenv("NEST_SERVER_PORT", "52425")
 
 comm = MPI.COMM_WORLD.Clone()
 rank = comm.Get_rank()

--- a/bin/nest-server-mpi
+++ b/bin/nest-server-mpi
@@ -40,7 +40,7 @@ def log(call_name, msg):
 if rank == 0:
     print("==> Starting NEST Server Master on rank 0", flush=True)
     nest.server.set_mpi_comm(comm)
-    nest.server.run_mpi_app(host=opt.get('--host', $HOST), port=opt.get('--port', $PORT))
+    nest.server.run_mpi_app(host=opt.get('--host', HOST), port=opt.get('--port', PORT))
 
 else:
     print(f"==> Starting NEST Server Worker on rank {rank}", flush=True)

--- a/bin/nest-server-mpi
+++ b/bin/nest-server-mpi
@@ -25,6 +25,8 @@ import sys
 import nest
 import nest.server
 
+HOST="${NEST_SERVER_HOST:-127.0.0.1}"
+PORT="${NEST_SERVER_PORT:-52425}"
 
 comm = MPI.COMM_WORLD.Clone()
 rank = comm.Get_rank()
@@ -38,7 +40,7 @@ def log(call_name, msg):
 if rank == 0:
     print("==> Starting NEST Server Master on rank 0", flush=True)
     nest.server.set_mpi_comm(comm)
-    nest.server.run_mpi_app(host=opt.get('--host', '127.0.0.1'), port=opt.get('--port', 52425))
+    nest.server.run_mpi_app(host=opt.get('--host', HOST), port=opt.get('--port', PORT))
 
 else:
     print(f"==> Starting NEST Server Worker on rank {rank}", flush=True)


### PR DESCRIPTION
This PR uses env variables `NEST_SERVER_HOST` and `NEST_SERVER_PORT` for NEST SERVER MPI.