### PR TITLE
Add `userdict` in in PyNEST to let users store custom data with the kernel

### DIFF
--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -77,8 +77,6 @@ class NestModule(types.ModuleType):
     from . import logic                              # noqa
     from .ll_api import set_communicator
 
-    userdict = {}
-
     def __init__(self, name):
         super().__init__(name)
         # Copy over the original module attributes to preserve all interpreter-given
@@ -427,6 +425,8 @@ class NestModule(types.ModuleType):
     _readonly_kernel_attrs = builtins.set(
         k for k, v in vars().items() if isinstance(v, KernelAttribute) and v._readonly
     )
+
+    userdict = {}
 
 
 def _setattr_error(self, attr, val):

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -77,6 +77,8 @@ class NestModule(types.ModuleType):
     from . import logic                              # noqa
     from .ll_api import set_communicator
 
+    userdict = {}
+
     def __init__(self, name):
         super().__init__(name)
         # Copy over the original module attributes to preserve all interpreter-given

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -427,6 +427,11 @@ class NestModule(types.ModuleType):
     )
 
     userdict = {}
+    """
+    The variable userdict allows users to store custom data with the NEST kernel.
+
+    Example: nest.userdict["nodes"] = [1,2,3,4]
+    """
 
 
 def _setattr_error(self, attr, val):


### PR DESCRIPTION
This PR adds the variable `userdict` in nest.

This feature is useful to store and transfer metadata via NEST Server
This can be applied for NEST_Desktop-NRP and NEST_Desktop / CoSim-NEST-TVB usecases.
