### PR TITLE
Allow setting MPI port names of MPI recording and stimulation backends from device labels

### DIFF
--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -358,15 +358,24 @@ void
 nest::RecordingBackendMPI::get_port( const RecordingDevice* device, std::string* port_name )
 {
   const std::string& label = device->get_label();
-  std::size_t address_starts_at;
+  std::size_t colon_position;
+
+  // The MPI address can be provided by two different means:
+  // a) the address is given by the label in the format: endpoint_address:address
+  // b) the file is provided via a file: {data_path}/{data_prefix}{label}/{node_id}.txt
+
   // Case a: label is the endpoint address in the following format:
   // endpoint_address:address string
-  if ((address_starts_at = label.find(":",0)) != std::string::npos) {
-    *port_name = label.substr(address_starts_at+1);
-  }
+  colon_position = label.find( ":", 0 );
 
-  // Case b: label is part of the path to a file that contains endpoint address
-  else {
+  // check if string start with "endpoint_address:" and a colon is found
+  if ( label.find( "endpoint_address:" ) == 0 )
+  {
+    *port_name = label.substr( colon_position + 1 );
+  }
+  // Case b: fallback to get_port implementation that reads the address from file
+  else
+  {
     get_port( device->get_node_id(), label, port_name );
   }
 }
@@ -400,7 +409,6 @@ nest::RecordingBackendMPI::get_port( const index index_node, const std::string& 
   {
     getline( file, *port_name );
   }
-  
   file.close();
 }
 

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -361,10 +361,10 @@ nest::RecordingBackendMPI::get_port( const RecordingDevice* device, std::string*
   std::size_t colon_position;
 
   // The MPI address can be provided by two different means:
-  // a) the address is given by the label in the format: endpoint_address:address
-  // b) the file is provided via a file: {data_path}/{data_prefix}{label}/{node_id}.txt
+  // a) the address is taken from the device's label, which then has to be in the format: endpoint_address:address
+  // b) the address is provided via a file: {data_path}/{data_prefix}{device_label}/{node_id}.txt
 
-  // Case a: label is the endpoint address in the following format:
+  // Case a: device label is the endpoint address in the following format:
   // endpoint_address:address string
   colon_position = label.find( ":", 0 );
 

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -357,7 +357,18 @@ nest::RecordingBackendMPI::set_status( const DictionaryDatum& )
 void
 nest::RecordingBackendMPI::get_port( const RecordingDevice* device, std::string* port_name )
 {
-  get_port( device->get_node_id(), device->get_label(), port_name );
+  const std::string& label = device->get_label();
+  std::size_t address_starts_at;
+  // Case a: label is the endpoint address in the following format:
+  // endpoint_address:address string
+  if ((address_starts_at = label.find(":",0)) != std::string::npos) {
+    *port_name = label.substr(address_starts_at+1);
+  }
+
+  // Case b: label is part of the path to a file that contains endpoint address
+  else {
+    get_port( device->get_node_id(), label, port_name );
+  }
 }
 
 void
@@ -389,6 +400,7 @@ nest::RecordingBackendMPI::get_port( const index index_node, const std::string& 
   {
     getline( file, *port_name );
   }
+  
   file.close();
 }
 

--- a/nestkernel/recording_backend_mpi.h
+++ b/nestkernel/recording_backend_mpi.h
@@ -46,7 +46,16 @@ Description
 
 The `mpi` recording backend sends collected data to a remote process
 using MPI.
+There are two ways to set the MPI port (if both are set, option A has precedence):
 
+A)
+The label of the recording device has the pattern:
+
+::
+
+   endpoint_address:port_name
+
+B)
 The name of the MPI port to send data to is read from a file for each
 device configured to use this backend. The file needs to be named
 according to the following pattern:

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -285,7 +285,18 @@ nest::StimulationBackendMPI::cleanup()
 void
 nest::StimulationBackendMPI::get_port( nest::StimulationDevice* device, std::string* port_name )
 {
-  get_port( device->get_node_id(), device->get_label(), port_name );
+  const std::string& label = device->get_label();
+  std::size_t address_starts_at;
+  // Case a: label is the endpoint address in the following format:
+  // endpoint_address:address string
+  if ((address_starts_at = label.find(":",0)) != std::string::npos) {
+    *port_name = label.substr(address_starts_at+1);
+  }
+
+  // Case b: label is part of the path to a file that contains endpoint address
+  else {
+    get_port( device->get_node_id(), device->get_label(), port_name );
+  }
 }
 
 void

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -286,16 +286,25 @@ void
 nest::StimulationBackendMPI::get_port( nest::StimulationDevice* device, std::string* port_name )
 {
   const std::string& label = device->get_label();
-  std::size_t address_starts_at;
+  std::size_t colon_position;
+
+  // The MPI address can be provided by two different means:
+  // a) the address is given by the label in the format: endpoint_address:address
+  // b) the file is provided via a file: {data_path}/{data_prefix}{label}/{node_id}.txt
+
   // Case a: label is the endpoint address in the following format:
   // endpoint_address:address string
-  if ((address_starts_at = label.find(":",0)) != std::string::npos) {
-    *port_name = label.substr(address_starts_at+1);
-  }
+  colon_position = label.find( ":", 0 );
 
-  // Case b: label is part of the path to a file that contains endpoint address
-  else {
-    get_port( device->get_node_id(), device->get_label(), port_name );
+  // check if string start with "endpoint_address:" and a colon is found
+  if ( label.find( "endpoint_address:" ) == 0 )
+  {
+    *port_name = label.substr( colon_position + 1 );
+  }
+  // Case b: fallback to get_port implementation that reads the address from file
+  else
+  {
+    get_port( device->get_node_id(), label, port_name );
   }
 }
 

--- a/nestkernel/stimulation_backend_mpi.h
+++ b/nestkernel/stimulation_backend_mpi.h
@@ -47,6 +47,15 @@ The `mpi` stimulation backend collects data from MPI channels and
 updates stimulation devices just before each run. This is useful for
 co-simulation or for receiving stimuli from external software.
 
+There are two ways to set the MPI port (if both are set, option A has precedence):
+
+A)
+The label of the recording device has the pattern:
+
+::
+   endpoint_address:port_name
+
+B)
 The name of the MPI port to receive data on is read from a file for
 each device configured to use this backend.  The file needs to be
 named according to the following pattern:


### PR DESCRIPTION
This is PR adds the ability to set the port name for the MPI connection additionally via the device label.

Falls back to normal file based address providing if label is not set.

Originally created for the cosim framework by @mfahdaz 