### PR TITLE
Fix badges to the differnt NEST packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Fedora package](https://img.shields.io/fedora/v/nest?logo=fedora)](https://src.fedoraproject.org/rpms/nest)
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/nest-simulator.svg?logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/nest-simulator)
 [![Homebrew version](https://img.shields.io/homebrew/v/nest.svg?logo=apple)](https://formulae.brew.sh/formula/nest)
-[![Docker Image Version](https://img.shields.io/docker/v/nestsim/nest?label=docker&sort=semver&logo=docker&logoColor=white)](https://hub.docker.com/r/nestsim/nest)
+[![Docker Image Version](https://img.shields.io/badge/docker-v3.4-blue?logo=docker)](https://docker-registry.ebrains.eu/harbor/projects/6/repositories/nest-simulator)
 [![Virtual applicance](https://img.shields.io/badge/VM-v3.4-blue?logo=CodeSandbox)](https://nest-simulator.readthedocs.io/en/latest/installation/livemedia.html#live-media)
 
 [![YouTube Video Views](https://img.shields.io/youtube/views/K7KXmIv6ROY?style=social)](https://www.youtube.com/results?search_query=nest-simulator+neurons)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/nest-simulator.svg?logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/nest-simulator)
 [![Homebrew version](https://img.shields.io/homebrew/v/nest.svg?logo=apple)](https://formulae.brew.sh/formula/nest)
 [![Docker Image Version](https://img.shields.io/docker/v/nestsim/nest?label=docker&sort=semver&logo=docker&logoColor=white)](https://hub.docker.com/r/nestsim/nest)
-[![Virtual applicance](https://img.shields.io/badge/VM-v3.1-blue?logo=CodeSandbox)](https://nest-simulator.readthedocs.io/en/latest/download.html#download-livemedia)
+[![Virtual applicance](https://img.shields.io/badge/VM-v3.4-blue?logo=CodeSandbox)](https://nest-simulator.readthedocs.io/en/latest/installation/livemedia.html#live-media)
 
 [![YouTube Video Views](https://img.shields.io/youtube/views/K7KXmIv6ROY?style=social)](https://www.youtube.com/results?search_query=nest-simulator+neurons)
 [![Twitter Follow](https://img.shields.io/twitter/follow/nestsimulator?style=social)](https://twitter.com/nestsimulator)

--- a/doc/htmldoc/installation/livemedia.rst
+++ b/doc/htmldoc/installation/livemedia.rst
@@ -51,9 +51,9 @@ Older versions of VM images
 ---------------------------
 
 
-`NEST Live Media 3.1 <https://nest-simulator.org/downloads/gplreleases/nest-3.1.ova>`_
+`NEST Live Media 3.3 <https://nest-simulator.org/downloads/gplreleases/nest-3.3.ova>`_
 
-`Checksum 3.1 <https://nest-simulator.org/downloads/gplreleases/nest-3.1.ova.sha512sum>`_
+`Checksum 3.3 <https://nest-simulator.org/downloads/gplreleases/nest-3.3.ova.sha512sum>`_
 
 `NEST Live Media 2.20.2 <https://nest-simulator.org/downloads/gplreleases/nest-2.20.2.ova>`_
 


### PR DESCRIPTION
This PR prepares the badges for the new version 3.4. This concerns the docker image and the virtual application image. For both, the version has to be changed manually.
All other badges should update themselves automatically.