### PR TITLE
Fix the patch application for the documentation (again)

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from shutil import copyfile
 import json
 
+import subprocess
 from subprocess import check_output
 
 

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -29,8 +29,9 @@ from pathlib import Path
 from shutil import copyfile
 import json
 
-from subprocess import check_output, CalledProcessError
-from mock import Mock as MagicMock
+import subprocess
+from subprocess import check_output
+
 
 
 source_dir = os.environ.get('NESTSRCDIR', False)

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -376,7 +376,10 @@ def patch_documentation(patch_url):
     print("Preparing patch...")
     try:
         git_dir = str(source_dir / ".git")
-        git_hash = subprocess.check_output(f"GIT_DIR='{git_dir}' git rev-parse HEAD", shell=True, encoding='utf8').strip()
+        git_hash = subprocess.check_output(
+            f"GIT_DIR='{git_dir}' git rev-parse HEAD",
+            shell=True,
+            encoding='utf8').strip()
         print(f"  current git hash: {git_hash}")
         patch_file = f'{git_hash}_doc.patch'
         patch_url = f'{patch_url}/{patch_file}'

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -29,7 +29,6 @@ from pathlib import Path
 from shutil import copyfile
 import json
 
-import subprocess
 from subprocess import check_output
 
 

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -376,7 +376,7 @@ def patch_documentation(patch_url):
     print("Preparing patch...")
     try:
         git_dir = str(source_dir / ".git")
-        git_hash = subprocess.check_output(f"GIT_DIR={git_dir} git rev-parse HEAD", shell=True, encoding='utf8').strip()
+        git_hash = subprocess.check_output(f"GIT_DIR='{git_dir}' git rev-parse HEAD", shell=True, encoding='utf8').strip()
         print(f"  current git hash: {git_hash}")
         patch_file = f'{git_hash}_doc.patch'
         patch_url = f'{patch_url}/{patch_file}'

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -33,7 +33,6 @@ import subprocess
 from subprocess import check_output
 
 
-
 source_dir = os.environ.get('NESTSRCDIR', False)
 if source_dir:
     source_dir = Path(source_dir)

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -28,9 +28,7 @@ from urllib.request import urlretrieve
 from pathlib import Path
 from shutil import copyfile
 import json
-
 import subprocess
-from subprocess import check_output
 
 
 source_dir = os.environ.get('NESTSRCDIR', False)
@@ -378,14 +376,14 @@ def patch_documentation(patch_url):
     print("Preparing patch...")
     try:
         git_dir = str(source_dir / ".git")
-        git_hash = check_output(f"GIT_DIR={git_dir} git rev-parse HEAD", shell=True, encoding='utf8').strip()
+        git_hash = subprocess.check_output(f"GIT_DIR={git_dir} git rev-parse HEAD", shell=True, encoding='utf8').strip()
         print(f"  current git hash: {git_hash}")
         patch_file = f'{git_hash}_doc.patch'
         patch_url = f'{patch_url}/{patch_file}'
         print(f"  retrieving {patch_url}")
         urlretrieve(patch_url, patch_file)
         print(f"  applying {patch_file}")
-        result = check_output('patch -p3', stdin=open(patch_file, 'r'), stderr=subprocess.STDOUT, shell=True)
+        result = subprocess.check_output('patch -p3', stdin=open(patch_file, 'r'), stderr=subprocess.STDOUT, shell=True)
         print(f"Patch result: {result}")
     except Exception as exc:
         print(f"Error while applying patch: {exc}")


### PR DESCRIPTION
During the test of current master, the error `name 'subprocess' is not defined` occurred. This is fixed and at the same time "import mock" is removed, which is there no longer needed.

@terhorstd  Sorry for the late fix. Could you please have a look at this?