### PR TITLE
Make get_thread virtual in Node class

### DIFF
--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -723,7 +723,7 @@ public:
   /**
    * Retrieve the number of the thread to which the node is assigned.
    */
-  thread get_thread() const;
+  virtual thread get_thread() const;
 
   /**
    * Store the number of the virtual process to which the node is assigned.

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -111,12 +111,6 @@ public:
 
   bool is_proxy() const override;
 
-  thread
-  get_thread() const
-  {
-    assert( false );
-  }
-
 private:
   void
   init_state_() override


### PR DESCRIPTION
The `get_thread` function in the `Node` class is not virtual, which makes the implementation of the function in the `ProxyNode` class useless. Mainly, the `get_thread` function in the `ProxyNode` class will never be called, as we always have a pointer of `Node` type pointing to the proxy instance.

My suggested change is to make the function virtual and remove the implementation from the `ProxyNode`.