### PR TITLE
Refactor `using Node::handle…` in Model declarations

### DIFF
--- a/models/ac_generator.h
+++ b/models/ac_generator.h
@@ -121,8 +121,6 @@ public:
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( DataLoggingRequest& ) override;
 

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -195,13 +195,6 @@ public:
   aeif_cond_alpha( const aeif_cond_alpha& );
   ~aeif_cond_alpha() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -186,13 +186,6 @@ public:
 
   friend int aeif_cond_alpha_multisynapse_dynamics( double, const double*, double*, void* );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -189,13 +189,6 @@ public:
 
   friend int aeif_cond_beta_multisynapse_dynamics( double, const double*, double*, void* );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -196,13 +196,6 @@ public:
   aeif_cond_exp( const aeif_cond_exp& );
   ~aeif_cond_exp() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -186,13 +186,6 @@ public:
   aeif_psc_alpha( const aeif_psc_alpha& );
   ~aeif_psc_alpha() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -175,13 +175,6 @@ public:
   aeif_psc_delta( const aeif_psc_delta& );
   ~aeif_psc_delta() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -206,13 +206,6 @@ public:
   aeif_psc_delta_clopath( const aeif_psc_delta_clopath& );
   ~aeif_psc_delta_clopath() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -183,13 +183,6 @@ public:
   aeif_psc_exp( const aeif_psc_exp& );
   ~aeif_psc_exp() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -167,13 +167,6 @@ public:
   amat2_psc_exp();
   amat2_psc_exp( const amat2_psc_exp& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -84,13 +84,7 @@ public:
   binary_neuron();
   binary_neuron( const binary_neuron& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::receives_signal;
   using Node::sends_signal;
 

--- a/models/cm_default.h
+++ b/models/cm_default.h
@@ -232,8 +232,6 @@ public:
   cm_default();
   cm_default( const cm_default& );
 
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/correlation_detector.h
+++ b/models/correlation_detector.h
@@ -180,13 +180,6 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( SpikeEvent& ) override;
 

--- a/models/correlomatrix_detector.h
+++ b/models/correlomatrix_detector.h
@@ -170,13 +170,6 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( SpikeEvent& ) override;
 

--- a/models/correlospinmatrix_detector.h
+++ b/models/correlospinmatrix_detector.h
@@ -151,13 +151,7 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::receives_signal;
 
   void handle( SpikeEvent& ) override;

--- a/models/dc_generator.h
+++ b/models/dc_generator.h
@@ -96,8 +96,6 @@ public:
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( DataLoggingRequest& ) override;
 

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -223,13 +223,6 @@ public:
   gif_cond_exp( const gif_cond_exp& );
   ~gif_cond_exp() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -224,13 +224,6 @@ public:
   gif_cond_exp_multisynapse( const gif_cond_exp_multisynapse& );
   ~gif_cond_exp_multisynapse() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -162,13 +162,6 @@ public:
   gif_pop_psc_exp();
   gif_pop_psc_exp( const gif_pop_psc_exp& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -206,13 +206,6 @@ public:
   gif_psc_exp();
   gif_psc_exp( const gif_psc_exp& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -212,13 +212,6 @@ public:
   gif_psc_exp_multisynapse();
   gif_psc_exp_multisynapse( const gif_psc_exp_multisynapse& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -183,13 +183,7 @@ public:
   hh_cond_beta_gap_traub( const hh_cond_beta_gap_traub& );
   ~hh_cond_beta_gap_traub() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   port send_test_event( Node& target, rport receptor_type, synindex, bool ) override;

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -154,13 +154,6 @@ public:
   hh_cond_exp_traub( const hh_cond_exp_traub& );
   ~hh_cond_exp_traub() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -150,13 +150,6 @@ public:
   hh_psc_alpha( const hh_psc_alpha& );
   ~hh_psc_alpha() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -188,13 +188,6 @@ public:
   hh_psc_alpha_clopath( const hh_psc_alpha_clopath& );
   ~hh_psc_alpha_clopath() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -160,13 +160,7 @@ public:
   hh_psc_alpha_gap( const hh_psc_alpha_gap& );
   ~hh_psc_alpha_gap() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   port send_test_event( Node& target, rport receptor_type, synindex, bool ) override;

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -189,13 +189,6 @@ public:
   ht_neuron( const ht_neuron& );
   ~ht_neuron() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_chs_2007.h
+++ b/models/iaf_chs_2007.h
@@ -117,13 +117,6 @@ public:
   iaf_chs_2007();
   iaf_chs_2007( const iaf_chs_2007& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -150,13 +150,6 @@ public:
   iaf_chxk_2008( const iaf_chxk_2008& );
   ~iaf_chxk_2008() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -145,8 +145,6 @@ public:
    * see http://www.gotw.ca/gotw/005.htm.
    */
 
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node& tagret, rport receptor_type, synindex, bool ) override;
 

--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -180,13 +180,6 @@ public:
   iaf_cond_alpha_mc( const iaf_cond_alpha_mc& );
   ~iaf_cond_alpha_mc() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -164,8 +164,6 @@ public:
    * see http://www.gotw.ca/gotw/005.htm.
    */
 
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node& tagret, rport receptor_type, synindex, bool ) override;
 

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -130,13 +130,6 @@ public:
   iaf_cond_exp( const iaf_cond_exp& );
   ~iaf_cond_exp() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -153,13 +153,6 @@ public:
   iaf_cond_exp_sfa_rr( const iaf_cond_exp_sfa_rr& );
   ~iaf_cond_exp_sfa_rr() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -158,13 +158,6 @@ public:
   iaf_psc_alpha();
   iaf_psc_alpha( const iaf_psc_alpha& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_alpha_multisynapse.h
+++ b/models/iaf_psc_alpha_multisynapse.h
@@ -90,13 +90,6 @@ public:
   iaf_psc_alpha_multisynapse();
   iaf_psc_alpha_multisynapse( const iaf_psc_alpha_multisynapse& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -166,13 +166,6 @@ public:
   */
   iaf_psc_alpha_ps( const iaf_psc_alpha_ps& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -148,13 +148,6 @@ public:
   iaf_psc_delta();
   iaf_psc_delta( const iaf_psc_delta& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -172,13 +172,6 @@ public:
   */
   iaf_psc_delta_ps( const iaf_psc_delta_ps& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -181,13 +181,6 @@ public:
   iaf_psc_exp();
   iaf_psc_exp( const iaf_psc_exp& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -155,13 +155,6 @@ public:
   iaf_psc_exp_htum();
   iaf_psc_exp_htum( const iaf_psc_exp_htum& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -94,13 +94,6 @@ public:
   iaf_psc_exp_multisynapse();
   iaf_psc_exp_multisynapse( const iaf_psc_exp_multisynapse& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -160,13 +160,6 @@ public:
   */
   iaf_psc_exp_ps( const iaf_psc_exp_ps& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -156,13 +156,6 @@ public:
   */
   iaf_psc_exp_ps_lossless( const iaf_psc_exp_ps_lossless& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/inhomogeneous_poisson_generator.h
+++ b/models/inhomogeneous_poisson_generator.h
@@ -104,11 +104,7 @@ public:
   inhomogeneous_poisson_generator();
   inhomogeneous_poisson_generator( const inhomogeneous_poisson_generator& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -131,13 +131,6 @@ public:
   izhikevich();
   izhikevich( const izhikevich& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( DataLoggingRequest& ) override;
   void handle( SpikeEvent& ) override;

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -148,13 +148,6 @@ public:
   mat2_psc_exp();
   mat2_psc_exp( const mat2_psc_exp& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/mip_generator.h
+++ b/models/mip_generator.h
@@ -110,11 +110,7 @@ public:
   mip_generator();
   mip_generator( const mip_generator& rhs );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -152,13 +152,7 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_signal;
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/music_cont_out_proxy.h
+++ b/models/music_cont_out_proxy.h
@@ -131,13 +131,7 @@ public:
     return false;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_signal;
   port send_test_event( Node&, rport, synindex, bool );
 

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -105,13 +105,6 @@ public:
     return true;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( SpikeEvent& );
   port send_test_event( Node&, rport, synindex, bool );

--- a/models/music_event_out_proxy.h
+++ b/models/music_event_out_proxy.h
@@ -110,13 +110,6 @@ public:
     return true;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( SpikeEvent& );
 

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -114,13 +114,6 @@ public:
     return true;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( InstantaneousRateConnectionEvent& );
 

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -108,13 +108,6 @@ public:
     return true;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( InstantaneousRateConnectionEvent& );
 

--- a/models/noise_generator.h
+++ b/models/noise_generator.h
@@ -152,14 +152,9 @@ public:
   //! Allow multimeter to connect to local instances
   bool local_receiver() const override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_signal;
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/parrot_neuron.h
+++ b/models/parrot_neuron.h
@@ -86,8 +86,7 @@ public:
    * @see Technical Issues / Virtual Functions: Overriding,
    * Overloading, and Hiding
    */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::receives_signal;
   using Node::sends_signal;
 

--- a/models/parrot_neuron_ps.h
+++ b/models/parrot_neuron_ps.h
@@ -83,13 +83,6 @@ class parrot_neuron_ps : public ArchivingNode
 public:
   parrot_neuron_ps();
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( SpikeEvent& ) override;
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/poisson_generator.h
+++ b/models/poisson_generator.h
@@ -88,11 +88,7 @@ public:
   poisson_generator();
   poisson_generator( poisson_generator const& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -254,13 +254,6 @@ public:
   pp_cond_exp_mc_urbanczik( const pp_cond_exp_mc_urbanczik& );
   ~pp_cond_exp_mc_urbanczik() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -199,13 +199,6 @@ public:
   pp_psc_delta();
   pp_psc_delta( const pp_psc_delta& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 

--- a/models/ppd_sup_generator.h
+++ b/models/ppd_sup_generator.h
@@ -110,11 +110,7 @@ public:
 
   bool is_off_grid() const override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/rate_neuron_ipn.h
+++ b/models/rate_neuron_ipn.h
@@ -113,13 +113,7 @@ public:
   rate_neuron_ipn();
   rate_neuron_ipn( const rate_neuron_ipn& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   void handle( InstantaneousRateConnectionEvent& ) override;

--- a/models/rate_neuron_opn.h
+++ b/models/rate_neuron_opn.h
@@ -116,13 +116,7 @@ public:
   rate_neuron_opn();
   rate_neuron_opn( const rate_neuron_opn& );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   void handle( InstantaneousRateConnectionEvent& ) override;

--- a/models/rate_transformer_node.h
+++ b/models/rate_transformer_node.h
@@ -113,8 +113,7 @@ public:
    * happily live without.
    */
 
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   void handle( InstantaneousRateConnectionEvent& ) override;

--- a/models/siegert_neuron.h
+++ b/models/siegert_neuron.h
@@ -144,13 +144,7 @@ public:
 
   ~siegert_neuron() override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   void handle( DiffusionConnectionEvent& ) override;

--- a/models/sinusoidal_gamma_generator.h
+++ b/models/sinusoidal_gamma_generator.h
@@ -195,14 +195,9 @@ public:
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
-  using Node::handle;
-  using Node::handles_test_event;
+
 
   void handle( DataLoggingRequest& ) override;
 

--- a/models/sinusoidal_poisson_generator.h
+++ b/models/sinusoidal_poisson_generator.h
@@ -129,14 +129,9 @@ public:
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
+
   using Node::event_hook;
-  using Node::handle;
-  using Node::handles_test_event;
+
 
   void handle( DataLoggingRequest& ) override;
 

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -104,7 +104,7 @@ public:
   }
 
   using Node::event_hook;
-  using Node::handle;
+
   using Node::handles_test_event; // new
 
   port send_test_event( Node&, rport, synindex, bool ) override;

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -230,11 +230,6 @@ public:
   void set_data_from_stimulation_backend( std::vector< double >& input_spikes ) override;
 
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
   using Node::event_hook;
   using Node::sends_signal;
 

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -103,13 +103,7 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::receives_signal;
 
   void handle( SpikeEvent& ) override;

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -116,13 +116,7 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::receives_signal;
 
   void handle( SpikeEvent& ) override;

--- a/models/step_current_generator.h
+++ b/models/step_current_generator.h
@@ -110,8 +110,6 @@ public:
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( DataLoggingRequest& ) override;
 

--- a/models/step_rate_generator.h
+++ b/models/step_rate_generator.h
@@ -111,8 +111,7 @@ public:
   // port send_test_event( Node&, rport, synindex, bool );
   void sends_secondary_event( DelayedRateConnectionEvent& ) override {};
 
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::sends_secondary_event;
 
   void handle( DataLoggingRequest& ) override;

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -128,13 +128,6 @@ public:
     return names::other;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
 
   void handle( SpikeEvent& ) override;
 

--- a/models/weight_recorder.h
+++ b/models/weight_recorder.h
@@ -106,13 +106,7 @@ public:
     return names::recorder;
   }
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
-   * Hiding
-   */
-  using Node::handle;
-  using Node::handles_test_event;
+
   using Node::receives_signal;
 
   void handle( WeightRecorderEvent& ) override;

--- a/nestkernel/kernel_manager.cpp
+++ b/nestkernel/kernel_manager.cpp
@@ -27,13 +27,10 @@ nest::KernelManager* nest::KernelManager::kernel_manager_instance_ = nullptr;
 void
 nest::KernelManager::create_kernel_manager()
 {
-#pragma omp critical( create_kernel_manager )
+  if ( not kernel_manager_instance_ )
   {
-    if ( not kernel_manager_instance_ )
-    {
-      kernel_manager_instance_ = new KernelManager();
-      assert( kernel_manager_instance_ );
-    }
+    kernel_manager_instance_ = new KernelManager();
+    assert( kernel_manager_instance_ );
   }
 }
 

--- a/nestkernel/proxynode.h
+++ b/nestkernel/proxynode.h
@@ -66,16 +66,6 @@ public:
    */
   proxynode( index, index, index );
 
-  /**
-   * Import sets of overloaded virtual functions.
-   * We need to explicitly include sets of overloaded
-   * virtual functions into the current scope.
-   * According to the SUN C++ FAQ, this is the correct
-   * way of doing things, although all other compilers
-   * happily live without.
-   */
-  using Node::handle;
-  using Node::sends_signal;
 
   port send_test_event( Node&, rport, synindex, bool ) override;
 


### PR DESCRIPTION
In the `models` directory, all models are **re-importing** the virtual functions from the `Node` class, but it is not really necessary as we are not [ **hiding**](https://stackoverflow.com/questions/6727087/c-virtual-function-being-hidden) those functions.

In the `kernel_manager::create_kernel_manager()` function, we are using the OpenMP `critical` construct, even though the function is not being called in a **parallel region**.