### PR TITLE
Correctly build connection infrastructure in GetConnections also when secondary events in use

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -976,6 +976,11 @@ nest::ConnectionManager::get_connections( const DictionaryDatum& params )
   // as this may involve sorting connections by source node IDs.
   if ( connections_have_changed() )
   {
+    // check whether waveform relaxation is used on any MPI process;
+    // needs to be called before update_connection_intrastructure_since
+    // it resizes coefficient arrays for secondary events
+    kernel().node_manager.check_wfr_use();
+
 #pragma omp parallel
     {
       const thread tid = kernel().vp_manager.get_thread_id();

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -981,7 +981,7 @@ nest::ConnectionManager::get_connections( const DictionaryDatum& params )
     update_delay_extrema_();
 
     // Check whether waveform relaxation is used on any MPI process;
-    // needs to be called before update_connection_intrastructure_since
+    // needs to be called before update_connection_infrastructure since
     // it resizes coefficient arrays for secondary events
     kernel().node_manager.check_wfr_use();
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -976,7 +976,11 @@ nest::ConnectionManager::get_connections( const DictionaryDatum& params )
   // as this may involve sorting connections by source node IDs.
   if ( connections_have_changed() )
   {
-    // check whether waveform relaxation is used on any MPI process;
+    // We need to update min_delay because it is used by check_wfr_use() below
+    // to set secondary event data size.
+    update_delay_extrema_();
+
+    // Check whether waveform relaxation is used on any MPI process;
     // needs to be called before update_connection_intrastructure_since
     // it resizes coefficient arrays for secondary events
     kernel().node_manager.check_wfr_use();

--- a/pynest/examples/CampbellSiegert.py
+++ b/pynest/examples/CampbellSiegert.py
@@ -94,7 +94,7 @@ mu = 0.0
 sigma2 = 0.0
 J = []
 
-assert(len(weights) == len(rates))
+assert len(weights) == len(rates)
 
 ###############################################################################
 # In the following we analytically compute the firing rate of the neuron

--- a/testsuite/pytests/test_rate_instantaneous_and_delayed.py
+++ b/testsuite/pytests/test_rate_instantaneous_and_delayed.py
@@ -99,7 +99,7 @@ class RateInstantaneousAndDelayedTestCase(unittest.TestCase):
         # adjust length of rate_1 to be able to substract
         rate_1 = rate_1[:len(rate_2)]
 
-        assert(np.sum(np.abs(rate_2 - rate_1)) < 1e-12)
+        assert np.sum(np.abs(rate_2 - rate_1)) < 1e-12
 
 
 def suite():

--- a/testsuite/unittests/test_hh_psc_alpha_gap.sli
+++ b/testsuite/unittests/test_hh_psc_alpha_gap.sli
@@ -85,6 +85,9 @@ neuron1 neuron2
 Connect
 vm neuron2     1.0 h Connect
 
+% The following call to GetConnections makes Simulate crash
+% or generate results containing NaNs, see #2614.
+<< >> GetConnections ; 
 
 20 Simulate
 


### PR DESCRIPTION
This PR fixes #2614 with a straightforward solution: `update_delay_extrema_()` and `check_wfr_use()` are now called before `update_connection_infrastructure()` also when the connection infrastructure is built by `get_connections()`.  This is necessary because if no nodes or connections are added between a `GetConnections` and a `Simulate` call, the infrastructure built by `get_connections()` is used. This requires information about the data size in secondary events, which again depends on `min_delay`.

PEP8 fixes in two unrelated files because they were detected by check_code_style.

This entire process needs to be refactored at a later stage, this is just a bug fix.

