### PR TITLE
Removing well-proven and therefore outdated asserts

### DIFF
--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -201,8 +201,6 @@ nest::ac_generator::pre_run_hook()
 void
 nest::ac_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   long start = origin.get_steps();
 

--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -201,7 +201,6 @@ nest::ac_generator::pre_run_hook()
 void
 nest::ac_generator::update( Time const& origin, const long from, const long to )
 {
-
   long start = origin.get_steps();
 
   CurrentEvent ce;

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -444,7 +444,7 @@ nest::aeif_cond_alpha::pre_run_hook()
 void
 nest::aeif_cond_alpha::update( Time const& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -444,9 +444,7 @@ nest::aeif_cond_alpha::pre_run_hook()
 void
 nest::aeif_cond_alpha::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -484,7 +484,7 @@ aeif_cond_alpha_multisynapse::pre_run_hook()
 void
 aeif_cond_alpha_multisynapse::update( Time const& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag ) // proceed by stepsize B_.step_
   {

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -484,9 +484,7 @@ aeif_cond_alpha_multisynapse::pre_run_hook()
 void
 aeif_cond_alpha_multisynapse::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag ) // proceed by stepsize B_.step_
   {

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -493,7 +493,7 @@ aeif_cond_beta_multisynapse::pre_run_hook()
 void
 aeif_cond_beta_multisynapse::update( Time const& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag ) // proceed by stepsize B_.step_
   {

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -493,9 +493,7 @@ aeif_cond_beta_multisynapse::pre_run_hook()
 void
 aeif_cond_beta_multisynapse::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag ) // proceed by stepsize B_.step_
   {

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -437,7 +437,7 @@ nest::aeif_cond_exp::pre_run_hook()
 void
 nest::aeif_cond_exp::update( const Time& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -437,9 +437,7 @@ nest::aeif_cond_exp::pre_run_hook()
 void
 nest::aeif_cond_exp::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -434,9 +434,7 @@ nest::aeif_psc_alpha::pre_run_hook()
 void
 nest::aeif_psc_alpha::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -434,7 +434,7 @@ nest::aeif_psc_alpha::pre_run_hook()
 void
 nest::aeif_psc_alpha::update( Time const& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -413,7 +413,6 @@ void
 nest::aeif_psc_delta::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
-  
 
   const double h = Time::get_resolution().get_ms();
   const double tau_m_ = P_.C_m / P_.g_L;

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -413,6 +413,7 @@ void
 nest::aeif_psc_delta::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
+  
 
   const double h = Time::get_resolution().get_ms();
   const double tau_m_ = P_.C_m / P_.g_L;

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -412,9 +412,7 @@ nest::aeif_psc_delta::pre_run_hook()
 void
 nest::aeif_psc_delta::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
   const double h = Time::get_resolution().get_ms();
   const double tau_m_ = P_.C_m / P_.g_L;
   for ( long lag = from; lag < to; ++lag )

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -412,7 +412,7 @@ nest::aeif_psc_delta::pre_run_hook()
 void
 nest::aeif_psc_delta::update( const Time& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
   const double h = Time::get_resolution().get_ms();
   const double tau_m_ = P_.C_m / P_.g_L;
   for ( long lag = from; lag < to; ++lag )

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -413,6 +413,7 @@ void
 nest::aeif_psc_delta::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
+
   const double h = Time::get_resolution().get_ms();
   const double tau_m_ = P_.C_m / P_.g_L;
   for ( long lag = from; lag < to; ++lag )

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -471,9 +471,7 @@ nest::aeif_psc_delta_clopath::pre_run_hook()
 void
 nest::aeif_psc_delta_clopath::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -471,7 +471,7 @@ nest::aeif_psc_delta_clopath::pre_run_hook()
 void
 nest::aeif_psc_delta_clopath::update( const Time& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -427,9 +427,7 @@ nest::aeif_psc_exp::pre_run_hook()
 void
 nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( State_::V_M == 0 );
+      assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -427,7 +427,7 @@ nest::aeif_psc_exp::pre_run_hook()
 void
 nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
 {
-      assert( State_::V_M == 0 );
+  assert( State_::V_M == 0 );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -361,8 +361,6 @@ nest::amat2_psc_exp::pre_run_hook()
 void
 nest::amat2_psc_exp::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -361,7 +361,6 @@ nest::amat2_psc_exp::pre_run_hook()
 void
 nest::amat2_psc_exp::update( Time const& origin, const long from, const long to )
 {
-
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -456,8 +456,6 @@ template < class TGainfunction >
 void
 binary_neuron< TGainfunction >::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -456,7 +456,6 @@ template < class TGainfunction >
 void
 binary_neuron< TGainfunction >::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     // update the input current

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -304,7 +304,6 @@ nest::cm_default::pre_run_hook()
 void
 nest::cm_default::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     const double v_0_prev = c_tree_.get_root()->v_comp;

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -304,8 +304,6 @@ nest::cm_default::pre_run_hook()
 void
 nest::cm_default::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -70,7 +70,6 @@ nest::Compartment::Compartment( const long compartment_index,
   , hh( 0.0 )
   , n_passed( 0 )
 {
-
   updateValue< double >( compartment_params, names::C_m, ca );
   updateValue< double >( compartment_params, names::g_C, gc );
   updateValue< double >( compartment_params, names::g_L, gl );

--- a/models/cm_tree.h
+++ b/models/cm_tree.h
@@ -111,9 +111,7 @@ public:
 Short helper functions for solving the matrix equation. Can hopefully be inlined
 */
 inline void
-nest::Compartment::gather_input( const std::pair< double, double >& in )
-{
-  xx_ += in.first;
+nest::Compartment::gather_input( const std::pair< double, double >& in )  xx_ += in.first;
   yy_ += in.second;
 }
 inline std::pair< double, double >

--- a/models/cm_tree.h
+++ b/models/cm_tree.h
@@ -111,9 +111,12 @@ public:
 Short helper functions for solving the matrix equation. Can hopefully be inlined
 */
 inline void
-nest::Compartment::gather_input( const std::pair< double, double >& in )  xx_ += in.first;
+nest::Compartment::gather_input( const std::pair< double, double >& in )
+{
+  xx_ += in.first;
   yy_ += in.second;
 }
+
 inline std::pair< double, double >
 nest::Compartment::io()
 {
@@ -127,6 +130,7 @@ nest::Compartment::io()
 
   return std::make_pair( g_val, f_val );
 }
+
 inline double
 nest::Compartment::calc_v( const double v_in )
 {

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -213,7 +213,6 @@ nest::correlospinmatrix_detector::State_::set( const DictionaryDatum&, const Par
 void
 nest::correlospinmatrix_detector::State_::reset( const Parameters_& p )
 {
-
   last_i_ = 0;
   tentative_down_ = false;
   t_last_in_spike_ = Time::neg_inf();

--- a/models/dc_generator.cpp
+++ b/models/dc_generator.cpp
@@ -161,7 +161,6 @@ nest::dc_generator::pre_run_hook()
 void
 nest::dc_generator::update( Time const& origin, const long from, const long to )
 {
-
   long start = origin.get_steps();
 
   CurrentEvent ce;

--- a/models/dc_generator.cpp
+++ b/models/dc_generator.cpp
@@ -161,8 +161,6 @@ nest::dc_generator::pre_run_hook()
 void
 nest::dc_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   long start = origin.get_steps();
 

--- a/models/gamma_sup_generator.cpp
+++ b/models/gamma_sup_generator.cpp
@@ -229,7 +229,6 @@ nest::gamma_sup_generator::pre_run_hook()
 void
 nest::gamma_sup_generator::update( Time const& T, const long from, const long to )
 {
-
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {
     return;

--- a/models/gamma_sup_generator.cpp
+++ b/models/gamma_sup_generator.cpp
@@ -229,8 +229,6 @@ nest::gamma_sup_generator::pre_run_hook()
 void
 nest::gamma_sup_generator::update( Time const& T, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -473,8 +473,6 @@ void
 nest::gif_cond_exp::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -471,7 +471,6 @@ nest::gif_cond_exp::pre_run_hook()
 void
 nest::gif_cond_exp::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -228,7 +228,6 @@ nest::gif_cond_exp::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::gif_cond_exp::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-
   updateValueParam< double >( d, names::I_e, I_e_, node );
   updateValueParam< double >( d, names::E_L, E_L_, node );
   updateValueParam< double >( d, names::g_L, g_L_, node );
@@ -472,7 +471,6 @@ nest::gif_cond_exp::pre_run_hook()
 void
 nest::gif_cond_exp::update( Time const& origin, const long from, const long to )
 {
-
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -475,7 +475,6 @@ nest::gif_cond_exp_multisynapse::pre_run_hook()
 void
 nest::gif_cond_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -476,8 +476,6 @@ void
 nest::gif_cond_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -476,7 +476,6 @@ void
 nest::gif_cond_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -488,8 +488,6 @@ nest::gif_pop_psc_exp::get_history_size()
 void
 nest::gif_pop_psc_exp::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -488,7 +488,6 @@ nest::gif_pop_psc_exp::get_history_size()
 void
 nest::gif_pop_psc_exp::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     // main update routine, see Fig. 11 of [1]

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -321,8 +321,6 @@ void
 nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -132,7 +132,6 @@ nest::gif_psc_exp::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::gif_psc_exp::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-
   updateValueParam< double >( d, names::I_e, I_e_, node );
   updateValueParam< double >( d, names::E_L, E_L_, node );
   updateValueParam< double >( d, names::g_L, g_L_, node );
@@ -320,7 +319,6 @@ nest::gif_psc_exp::pre_run_hook()
 void
 nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
 {
-
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -319,7 +319,6 @@ nest::gif_psc_exp::pre_run_hook()
 void
 nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -343,7 +343,6 @@ nest::gif_psc_exp_multisynapse::pre_run_hook()
 void
 nest::gif_psc_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -344,8 +344,6 @@ void
 nest::gif_psc_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -344,7 +344,6 @@ void
 nest::gif_psc_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -464,7 +464,6 @@ nest::glif_psc::pre_run_hook()
 void
 nest::glif_psc::update( Time const& origin, const long from, const long to )
 {
-
   double v_old = S_.U_;
 
   for ( long lag = from; lag < to; ++lag )

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -470,7 +470,6 @@ nest::hh_cond_beta_gap_traub::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -471,8 +471,6 @@ nest::hh_cond_beta_gap_traub::update_( Time const& origin,
   const bool called_from_wfr_update )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -471,7 +471,6 @@ nest::hh_cond_beta_gap_traub::update_( Time const& origin,
   const bool called_from_wfr_update )
 {
 
-
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -380,7 +380,6 @@ nest::hh_cond_exp_traub::pre_run_hook()
 void
 nest::hh_cond_exp_traub::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -380,8 +380,6 @@ nest::hh_cond_exp_traub::pre_run_hook()
 void
 nest::hh_cond_exp_traub::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -384,8 +384,6 @@ void
 nest::hh_psc_alpha::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -383,7 +383,6 @@ nest::hh_psc_alpha::pre_run_hook()
 void
 nest::hh_psc_alpha::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -384,7 +384,6 @@ void
 nest::hh_psc_alpha::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -412,8 +412,6 @@ void
 nest::hh_psc_alpha_clopath::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -411,7 +411,6 @@ nest::hh_psc_alpha_clopath::pre_run_hook()
 void
 nest::hh_psc_alpha_clopath::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -412,7 +412,6 @@ void
 nest::hh_psc_alpha_clopath::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -450,7 +450,6 @@ bool
 nest::hh_psc_alpha_gap::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
 
-
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -450,8 +450,6 @@ bool
 nest::hh_psc_alpha_gap::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -449,7 +449,6 @@ nest::hh_psc_alpha_gap::pre_run_hook()
 bool
 nest::hh_psc_alpha_gap::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
-
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -770,7 +770,6 @@ nest::ht_neuron::set_status( const DictionaryDatum& d )
 void
 ht_neuron::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     double tt = 0.0; // it's all relative!

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -770,8 +770,6 @@ nest::ht_neuron::set_status( const DictionaryDatum& d )
 void
 ht_neuron::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -217,8 +217,6 @@ nest::iaf_chs_2007::pre_run_hook()
 void
 nest::iaf_chs_2007::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -217,7 +217,6 @@ nest::iaf_chs_2007::pre_run_hook()
 void
 nest::iaf_chs_2007::update( const Time& origin, const long from, const long to )
 {
-
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -353,8 +353,6 @@ void
 nest::iaf_chxk_2008::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -352,7 +352,6 @@ nest::iaf_chxk_2008::pre_run_hook()
 void
 nest::iaf_chxk_2008::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -353,7 +353,6 @@ void
 nest::iaf_chxk_2008::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -370,7 +370,6 @@ void
 nest::iaf_cond_alpha::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -370,8 +370,6 @@ void
 nest::iaf_cond_alpha::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -369,7 +369,6 @@ nest::iaf_cond_alpha::pre_run_hook()
 void
 nest::iaf_cond_alpha::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -574,7 +574,6 @@ nest::iaf_cond_alpha_mc::pre_run_hook()
 void
 nest::iaf_cond_alpha_mc::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -575,8 +575,6 @@ void
 nest::iaf_cond_alpha_mc::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -575,7 +575,6 @@ void
 nest::iaf_cond_alpha_mc::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -383,8 +383,6 @@ void
 nest::iaf_cond_beta::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -382,7 +382,6 @@ nest::iaf_cond_beta::pre_run_hook()
 void
 nest::iaf_cond_beta::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -383,7 +383,6 @@ void
 nest::iaf_cond_beta::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -345,8 +345,6 @@ void
 nest::iaf_cond_exp::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -344,7 +344,6 @@ nest::iaf_cond_exp::pre_run_hook()
 void
 nest::iaf_cond_exp::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -345,7 +345,6 @@ void
 nest::iaf_cond_exp::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -381,7 +381,6 @@ void
 nest::iaf_cond_exp_sfa_rr::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -380,7 +380,6 @@ nest::iaf_cond_exp_sfa_rr::pre_run_hook()
 void
 nest::iaf_cond_exp_sfa_rr::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -381,8 +381,6 @@ void
 nest::iaf_cond_exp_sfa_rr::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -299,9 +299,6 @@ iaf_psc_alpha::pre_run_hook()
 void
 iaf_psc_alpha::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-
   for ( long lag = from; lag < to; ++lag )
   {
     if ( S_.r_ == 0 )

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -324,7 +324,6 @@ iaf_psc_alpha_multisynapse::pre_run_hook()
 void
 iaf_psc_alpha_multisynapse::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     if ( S_.refractory_steps_ == 0 )

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -324,8 +324,6 @@ iaf_psc_alpha_multisynapse::pre_run_hook()
 void
 iaf_psc_alpha_multisynapse::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -298,7 +298,6 @@ nest::iaf_psc_alpha_ps::get_next_event_( const long T, double& ev_offset, double
 void
 nest::iaf_psc_alpha_ps::update( Time const& origin, const long from, const long to )
 {
-
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
   {

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -298,9 +298,6 @@ nest::iaf_psc_alpha_ps::get_next_event_( const long T, double& ev_offset, double
 void
 nest::iaf_psc_alpha_ps::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 );
-  assert( static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -267,7 +267,6 @@ nest::iaf_psc_delta::pre_run_hook()
 void
 nest::iaf_psc_delta::update( Time const& origin, const long from, const long to )
 {
-
   const double h = Time::get_resolution().get_ms();
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -267,8 +267,6 @@ nest::iaf_psc_delta::pre_run_hook()
 void
 nest::iaf_psc_delta::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const double h = Time::get_resolution().get_ms();
   for ( long lag = from; lag < to; ++lag )

--- a/models/iaf_psc_delta_ps.cpp
+++ b/models/iaf_psc_delta_ps.cpp
@@ -257,10 +257,6 @@ iaf_psc_delta_ps::pre_run_hook()
 void
 iaf_psc_delta_ps::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 );
-  assert( static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
   {

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -283,8 +283,6 @@ nest::iaf_psc_exp::pre_run_hook()
 void
 nest::iaf_psc_exp::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const double h = Time::get_resolution().get_ms();
 

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -283,7 +283,6 @@ nest::iaf_psc_exp::pre_run_hook()
 void
 nest::iaf_psc_exp::update( const Time& origin, const long from, const long to )
 {
-
   const double h = Time::get_resolution().get_ms();
 
   // evolve from timestep 'from' to timestep 'to' with steps of h each

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -291,7 +291,6 @@ nest::iaf_psc_exp_htum::pre_run_hook()
 void
 nest::iaf_psc_exp_htum::update( Time const& origin, const long from, const long to )
 {
-
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -291,8 +291,6 @@ nest::iaf_psc_exp_htum::pre_run_hook()
 void
 nest::iaf_psc_exp_htum::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -299,7 +299,6 @@ nest::iaf_psc_exp_multisynapse::pre_run_hook()
 void
 iaf_psc_exp_multisynapse::update( const Time& origin, const long from, const long to )
 {
-
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -299,8 +299,6 @@ nest::iaf_psc_exp_multisynapse::pre_run_hook()
 void
 iaf_psc_exp_multisynapse::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -274,7 +274,6 @@ nest::iaf_psc_exp_ps::pre_run_hook()
 void
 nest::iaf_psc_exp_ps::update( const Time& origin, const long from, const long to )
 {
-
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
   {

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -274,9 +274,6 @@ nest::iaf_psc_exp_ps::pre_run_hook()
 void
 nest::iaf_psc_exp_ps::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 );
-  assert( static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -315,9 +315,6 @@ nest::iaf_psc_exp_ps_lossless::pre_run_hook()
 void
 nest::iaf_psc_exp_ps_lossless::update( const Time& origin, const long from, const long to )
 {
-  assert( to >= 0 );
-  assert( static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -315,7 +315,6 @@ nest::iaf_psc_exp_ps_lossless::pre_run_hook()
 void
 nest::iaf_psc_exp_ps_lossless::update( const Time& origin, const long from, const long to )
 {
-
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
   {

--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -236,7 +236,7 @@ nest::inhomogeneous_poisson_generator::pre_run_hook()
 void
 nest::inhomogeneous_poisson_generator::update( Time const& origin, const long from, const long to )
 {
-      assert( P_.rate_times_.size() == P_.rate_values_.size() );
+  assert( P_.rate_times_.size() == P_.rate_values_.size() );
 
   const long t0 = origin.get_steps();
 

--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -236,9 +236,7 @@ nest::inhomogeneous_poisson_generator::pre_run_hook()
 void
 nest::inhomogeneous_poisson_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-  assert( P_.rate_times_.size() == P_.rate_values_.size() );
+      assert( P_.rate_times_.size() == P_.rate_values_.size() );
 
   const long t0 = origin.get_steps();
 

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -101,7 +101,6 @@ nest::izhikevich::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::izhikevich::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-
   updateValueParam< double >( d, names::V_th, V_th_, node );
   updateValueParam< double >( d, names::V_min, V_min_, node );
   updateValueParam< double >( d, names::I_e, I_e_, node );
@@ -188,7 +187,6 @@ nest::izhikevich::pre_run_hook()
 void
 nest::izhikevich::update( Time const& origin, const long from, const long to )
 {
-
   const double h = Time::get_resolution().get_ms();
   double v_old, u_old;
 

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -188,8 +188,6 @@ nest::izhikevich::pre_run_hook()
 void
 nest::izhikevich::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const double h = Time::get_resolution().get_ms();
   double v_old, u_old;

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -302,7 +302,6 @@ nest::mat2_psc_exp::pre_run_hook()
 void
 nest::mat2_psc_exp::update( Time const& origin, const long from, const long to )
 {
-
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -302,8 +302,6 @@ nest::mat2_psc_exp::pre_run_hook()
 void
 nest::mat2_psc_exp::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )

--- a/models/mip_generator.cpp
+++ b/models/mip_generator.cpp
@@ -119,9 +119,6 @@ nest::mip_generator::pre_run_hook()
 void
 nest::mip_generator::update( Time const& T, const long from, const long to )
 {
-  assert( to >= 0 and static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-
   for ( long lag = from; lag < to; ++lag )
   {
     if ( not StimulationDevice::is_active( T ) or P_.rate_ <= 0 )

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -116,7 +116,6 @@ nest::music_cont_out_proxy::Parameters_::set( const DictionaryDatum& d,
   const State_& state,
   const Buffers_& buffers )
 {
-
   if ( state.published_ == false )
   {
     updateValue< string >( d, names::port_name, port_name_ );
@@ -219,7 +218,6 @@ nest::music_cont_out_proxy::finalize()
 nest::port
 nest::music_cont_out_proxy::send_test_event( Node& target, rport receptor_type, synindex, bool )
 {
-
   DataLoggingRequest e( P_.interval_, P_.record_from_ );
   e.set_sender( *this );
   port p = target.handles_test_event( e, receptor_type );

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -223,7 +223,6 @@ nest::music_rate_out_proxy::set_status( const DictionaryDatum& d )
 void
 nest::music_rate_out_proxy::handle( InstantaneousRateConnectionEvent& e )
 {
-
   // propagate last rate in min delay interval to MUSIC port; we can not use
   // e.end() - 1 since the iterator is defined in terms of unsigned ints, not
   // the event DataType; instead we forward iterate using e.get_coeffvalue and

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -288,8 +288,6 @@ nest::noise_generator::send_test_event( Node& target, rport receptor_type, synin
 void
 nest::noise_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const long start = origin.get_steps();
 

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -288,7 +288,6 @@ nest::noise_generator::send_test_event( Node& target, rport receptor_type, synin
 void
 nest::noise_generator::update( Time const& origin, const long from, const long to )
 {
-
   const long start = origin.get_steps();
 
   for ( long offs = from; offs < to; ++offs )

--- a/models/parrot_neuron.cpp
+++ b/models/parrot_neuron.cpp
@@ -52,8 +52,6 @@ parrot_neuron::init_buffers_()
 void
 parrot_neuron::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/parrot_neuron.cpp
+++ b/models/parrot_neuron.cpp
@@ -52,7 +52,6 @@ parrot_neuron::init_buffers_()
 void
 parrot_neuron::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     const unsigned long current_spikes_n = static_cast< unsigned long >( B_.n_spikes_.get_value( lag ) );

--- a/models/parrot_neuron_ps.cpp
+++ b/models/parrot_neuron_ps.cpp
@@ -52,9 +52,6 @@ parrot_neuron_ps::init_buffers_()
 void
 parrot_neuron_ps::update( Time const& origin, long const from, long const to )
 {
-  assert( to >= 0 );
-  assert( static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )

--- a/models/parrot_neuron_ps.cpp
+++ b/models/parrot_neuron_ps.cpp
@@ -52,7 +52,6 @@ parrot_neuron_ps::init_buffers_()
 void
 parrot_neuron_ps::update( Time const& origin, long const from, long const to )
 {
-
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
   {

--- a/models/poisson_generator.cpp
+++ b/models/poisson_generator.cpp
@@ -117,8 +117,6 @@ nest::poisson_generator::pre_run_hook()
 void
 nest::poisson_generator::update( Time const& T, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   if ( P_.rate_ <= 0 )
   {

--- a/models/poisson_generator.cpp
+++ b/models/poisson_generator.cpp
@@ -117,7 +117,6 @@ nest::poisson_generator::pre_run_hook()
 void
 nest::poisson_generator::update( Time const& T, const long from, const long to )
 {
-
   if ( P_.rate_ <= 0 )
   {
     return;

--- a/models/poisson_generator_ps.cpp
+++ b/models/poisson_generator_ps.cpp
@@ -178,8 +178,6 @@ nest::poisson_generator_ps::pre_run_hook()
 void
 nest::poisson_generator_ps::update( Time const& T, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {

--- a/models/poisson_generator_ps.cpp
+++ b/models/poisson_generator_ps.cpp
@@ -64,7 +64,6 @@ nest::poisson_generator_ps::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::poisson_generator_ps::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-
   updateValueParam< double >( d, names::dead_time, dead_time_, node );
   if ( dead_time_ < 0 )
   {
@@ -178,7 +177,6 @@ nest::poisson_generator_ps::pre_run_hook()
 void
 nest::poisson_generator_ps::update( Time const& T, const long from, const long to )
 {
-
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {
     return;

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -573,7 +573,6 @@ nest::pp_cond_exp_mc_urbanczik::pre_run_hook()
 void
 nest::pp_cond_exp_mc_urbanczik::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -574,7 +574,6 @@ void
 nest::pp_cond_exp_mc_urbanczik::update( Time const& origin, const long from, const long to )
 {
 
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -574,8 +574,6 @@ void
 nest::pp_cond_exp_mc_urbanczik::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -141,7 +141,6 @@ nest::pp_psc_delta::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::pp_psc_delta::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-
   updateValueParam< double >( d, names::I_e, I_e_, node );
   updateValueParam< double >( d, names::C_m, c_m_, node );
   updateValueParam< double >( d, names::tau_m, tau_m_, node );
@@ -288,7 +287,6 @@ nest::pp_psc_delta::init_buffers_()
 void
 nest::pp_psc_delta::pre_run_hook()
 {
-
   B_.logger_.init();
 
   V_.h_ = Time::get_resolution().get_ms();
@@ -356,7 +354,6 @@ nest::pp_psc_delta::pre_run_hook()
 void
 nest::pp_psc_delta::update( Time const& origin, const long from, const long to )
 {
-
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -357,8 +357,6 @@ void
 nest::pp_psc_delta::update( Time const& origin, const long from, const long to )
 {
 
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -354,7 +354,6 @@ nest::pp_psc_delta::pre_run_hook()
 void
 nest::pp_psc_delta::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
 

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -231,8 +231,6 @@ nest::ppd_sup_generator::pre_run_hook()
 void
 nest::ppd_sup_generator::update( Time const& T, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -130,7 +130,6 @@ nest::ppd_sup_generator::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::ppd_sup_generator::Parameters_::set( const DictionaryDatum& d, Node* node )
 {
-
   updateValueParam< double >( d, names::dead_time, dead_time_, node );
   if ( dead_time_ < 0 )
   {
@@ -231,7 +230,6 @@ nest::ppd_sup_generator::pre_run_hook()
 void
 nest::ppd_sup_generator::update( Time const& T, const long from, const long to )
 {
-
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {
     return;

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -166,9 +166,6 @@ nest::pulsepacket_generator::pre_run_hook()
 void
 nest::pulsepacket_generator::update( Time const& T, const long from, const long to )
 {
-  assert( to >= from );
-  assert( ( to - from ) <= kernel().connection_manager.get_min_delay() );
-
   if ( ( V_.start_center_idx_ == P_.pulse_times_.size() and B_.spiketimes_.empty() )
     or ( not StimulationDevice::is_active( T ) ) )
   {

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -163,7 +163,7 @@ nest::pulsepacket_generator::pre_run_hook()
 
 
 void
-nest::pulsepacket_generator::update( Time const& T, const long from, const long to )
+nest::pulsepacket_generator::update( Time const& T, const long, const long to )
 {
   if ( ( V_.start_center_idx_ == P_.pulse_times_.size() and B_.spiketimes_.empty() )
     or ( not StimulationDevice::is_active( T ) ) )

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -74,7 +74,6 @@ nest::pulsepacket_generator::Parameters_::get( DictionaryDatum& d ) const
 void
 nest::pulsepacket_generator::Parameters_::set( const DictionaryDatum& d, pulsepacket_generator& ppg, Node* node )
 {
-
   // We cannot use a single line here since short-circuiting may stop evaluation
   // prematurely. Therefore, neednewpulse must be second arg on second line.
   bool neednewpulse = updateValueParam< long >( d, names::activity, a_, node );

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -270,8 +270,6 @@ nest::rate_neuron_ipn< TNonlinearities >::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -270,7 +270,6 @@ nest::rate_neuron_ipn< TNonlinearities >::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -246,7 +246,6 @@ nest::rate_neuron_opn< TNonlinearities >::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -246,8 +246,6 @@ nest::rate_neuron_opn< TNonlinearities >::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -181,8 +181,6 @@ nest::rate_transformer_node< TNonlinearities >::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -181,7 +181,6 @@ nest::rate_transformer_node< TNonlinearities >::update_( Time const& origin,
   const long to,
   const bool called_from_wfr_update )
 {
-
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -305,8 +305,6 @@ nest::siegert_neuron::pre_run_hook()
 bool
 nest::siegert_neuron::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -305,7 +305,6 @@ nest::siegert_neuron::pre_run_hook()
 bool
 nest::siegert_neuron::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
-
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
   bool wfr_tol_exceeded = false;

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -309,7 +309,6 @@ nest::sinusoidal_gamma_generator::hazard_( port tgt_idx ) const
 void
 nest::sinusoidal_gamma_generator::update( Time const& origin, const long from, const long to )
 {
-
   for ( long lag = from; lag < to; ++lag )
   {
     const Time t = Time( Time::step( origin.get_steps() + lag + 1 ) );

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -309,8 +309,6 @@ nest::sinusoidal_gamma_generator::hazard_( port tgt_idx ) const
 void
 nest::sinusoidal_gamma_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   for ( long lag = from; lag < to; ++lag )
   {

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -229,8 +229,6 @@ nest::sinusoidal_poisson_generator::pre_run_hook()
 void
 nest::sinusoidal_poisson_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   const long start = origin.get_steps();
 

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -229,7 +229,6 @@ nest::sinusoidal_poisson_generator::pre_run_hook()
 void
 nest::sinusoidal_poisson_generator::update( Time const& origin, const long from, const long to )
 {
-
   const long start = origin.get_steps();
 
   // random number generator

--- a/models/spike_dilutor.cpp
+++ b/models/spike_dilutor.cpp
@@ -119,9 +119,6 @@ nest::spike_dilutor::pre_run_hook()
 void
 nest::spike_dilutor::update( Time const& T, const long from, const long to )
 {
-  assert( to >= 0 and static_cast< delay >( from ) < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
-
   for ( long lag = from; lag < to; ++lag )
   {
     if ( not device_.is_active( T ) )

--- a/models/spike_dilutor.h
+++ b/models/spike_dilutor.h
@@ -163,7 +163,6 @@ private:
 inline port
 spike_dilutor::send_test_event( Node& target, rport receptor_type, synindex syn_id, bool )
 {
-
   device_.enforce_single_syn_type( syn_id );
 
   SpikeEvent e;

--- a/models/stdp_triplet_synapse.h
+++ b/models/stdp_triplet_synapse.h
@@ -255,7 +255,6 @@ template < typename targetidentifierT >
 inline void
 stdp_triplet_synapse< targetidentifierT >::send( Event& e, thread t, const CommonSynapseProperties& )
 {
-
   double t_spike = e.get_stamp().get_ms();
   double dendritic_delay = get_delay();
   Node* target = get_target( t );

--- a/models/step_current_generator.cpp
+++ b/models/step_current_generator.cpp
@@ -272,8 +272,6 @@ nest::step_current_generator::pre_run_hook()
 void
 nest::step_current_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   assert( P_.amp_time_stamps_.size() == P_.amp_values_.size() );
 

--- a/models/step_current_generator.cpp
+++ b/models/step_current_generator.cpp
@@ -272,7 +272,6 @@ nest::step_current_generator::pre_run_hook()
 void
 nest::step_current_generator::update( Time const& origin, const long from, const long to )
 {
-
   assert( P_.amp_time_stamps_.size() == P_.amp_values_.size() );
 
   const long t0 = origin.get_steps();

--- a/models/step_rate_generator.cpp
+++ b/models/step_rate_generator.cpp
@@ -273,8 +273,6 @@ nest::step_rate_generator::pre_run_hook()
 void
 nest::step_rate_generator::update( Time const& origin, const long from, const long to )
 {
-  assert( to >= 0 and ( delay ) from < kernel().connection_manager.get_min_delay() );
-  assert( from < to );
 
   assert( P_.amp_time_stamps_.size() == P_.amp_values_.size() );
 

--- a/models/step_rate_generator.cpp
+++ b/models/step_rate_generator.cpp
@@ -273,7 +273,6 @@ nest::step_rate_generator::pre_run_hook()
 void
 nest::step_rate_generator::update( Time const& origin, const long from, const long to )
 {
-
   assert( P_.amp_time_stamps_.size() == P_.amp_values_.size() );
 
   const long t0 = origin.get_steps();


### PR DESCRIPTION
The asserts in the `Node::update` method of all models derived from `Node` were checking if the parameters for the requested update interval are indeed correct. These asserts are now generally seen as superfluous, as they have not been triggered in many years now.