### PR TITLE
Improve parameter test and implementation

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -1068,7 +1068,7 @@ class Parameter:
             expo = float(exponent)
         except TypeError:
             raise TypeError("unsupported operand type for **: only int and float allow as exponent")
-        
+
         return sli_func("pow", self._datum, float(exponent))
 
     def __rpow__(self, lhs):

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -1053,14 +1053,18 @@ class Parameter:
     def __rmul__(self, other):
         return self * other
 
-    def __div__(self, other):
-        return self._binop("div", other)
-
     def __truediv__(self, other):
         return self._binop("div", other)
 
+    def __rtruediv__(self, other):
+        rhs_inv = CreateParameter('constant', {'value': 1 / float(self.GetValue())})
+        return self._binop("mul", other)
+
     def __pow__(self, exponent):
         return sli_func("pow", self._datum, float(exponent))
+
+    def __rpow__(self, mantissa):
+        return sli_func("pow", float(mantissa), self._datum)
 
     def __lt__(self, other):
         return self._binop("compare", other, {'comparator': 0})

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -970,19 +970,19 @@ class Mask:
         self._datum = datum
 
     # Generic binary operation
-    def _binop(self, op, other):
-        if not isinstance(other, Mask):
+    def _binop(self, op, rhs):
+        if not isinstance(rhs, Mask):
             raise NotImplementedError()
-        return sli_func(op, self._datum, other._datum)
+        return sli_func(op, self._datum, rhs._datum)
 
-    def __or__(self, other):
-        return self._binop("or", other)
+    def __or__(self, rhs):
+        return self._binop("or", rhs)
 
-    def __and__(self, other):
-        return self._binop("and", other)
+    def __and__(self, rhs):
+        return self._binop("and", rhs)
 
-    def __sub__(self, other):
-        return self._binop("sub", other)
+    def __sub__(self, rhs):
+        return self._binop("sub", rhs)
 
     def Inside(self, point):
         """
@@ -1021,68 +1021,76 @@ class Parameter:
         self._datum = datum
 
     # Generic binary operation
-    def _binop(self, op, other, params=None):
-        if isinstance(other, (int, float)):
-            other = CreateParameter('constant', {'value': float(other)})
-        if not isinstance(other, Parameter):
+    def _binop(self, op, rhs, params=None):
+        if isinstance(rhs, (int, float)):
+            rhs = CreateParameter('constant', {'value': float(rhs)})
+        if not isinstance(rhs, Parameter):
             raise NotImplementedError()
 
         if params is None:
-            return sli_func(op, self._datum, other._datum)
+            return sli_func(op, self._datum, rhs._datum)
         else:
-            return sli_func(op, self._datum, other._datum, params)
+            return sli_func(op, self._datum, rhs._datum, params)
 
-    def __add__(self, other):
-        return self._binop("add", other)
+    def __add__(self, rhs):
+        return self._binop("add", rhs)
 
-    def __radd__(self, other):
-        return self + other
+    def __radd__(self, lhs):
+        return self + lhs
 
-    def __sub__(self, other):
-        return self._binop("sub", other)
+    def __sub__(self, rhs):
+        return self._binop("sub", rhs)
 
-    def __rsub__(self, other):
-        return self * (-1) + other
+    def __rsub__(self, lhs):
+        return self * (-1) + lhs
+
+    def __pos__(self):
+        return self
 
     def __neg__(self):
         return self * (-1)
 
-    def __mul__(self, other):
-        return self._binop("mul", other)
+    def __mul__(self, rhs):
+        return self._binop("mul", rhs)
 
-    def __rmul__(self, other):
-        return self * other
+    def __rmul__(self, lhs):
+        return self * lhs
 
-    def __truediv__(self, other):
-        return self._binop("div", other)
+    def __truediv__(self, rhs):
+        return self._binop("div", rhs)
 
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, lhs):
         rhs_inv = CreateParameter('constant', {'value': 1 / float(self.GetValue())})
-        return self._binop("mul", other)
+        return rhs_inv._binop("mul", lhs)
 
     def __pow__(self, exponent):
+        try:
+            expo = float(exponent)
+        except TypeError:
+            raise TypeError("unsupported operand type for **: only int and float allow as exponent")
+        
         return sli_func("pow", self._datum, float(exponent))
 
-    def __rpow__(self, mantissa):
-        return sli_func("pow", float(mantissa), self._datum)
+    def __rpow__(self, lhs):
+        raise TypeError("unsupported operand type for **: only int and float allow as exponent")
 
-    def __lt__(self, other):
-        return self._binop("compare", other, {'comparator': 0})
+    def __lt__(self, rhs):
+        return self._binop("compare", rhs, {'comparator': 0})
 
-    def __le__(self, other):
-        return self._binop("compare", other, {'comparator': 1})
+    def __le__(self, rhs):
+        return self._binop("compare", rhs, {'comparator': 1})
 
-    def __eq__(self, other):
-        return self._binop("compare", other, {'comparator': 2})
+    def __eq__(self, rhs):
+        return self._binop("compare", rhs, {'comparator': 2})
 
-    def __ne__(self, other):
-        return self._binop("compare", other, {'comparator': 3})
+    def __ne__(self, rhs):
+        return self._binop("compare", rhs, {'comparator': 3})
 
-    def __ge__(self, other):
-        return self._binop("compare", other, {'comparator': 4})
+    def __ge__(self, rhs):
+        return self._binop("compare", rhs, {'comparator': 4})
 
-    def __gt__(self, other):
-        return self._binop("compare", other, {'comparator': 5})
+    def __gt__(self, rhs):
+        return self._binop("compare", rhs, {'comparator': 5})
 
     def GetValue(self):
         """

--- a/testsuite/pytests/test_parameter.py
+++ b/testsuite/pytests/test_parameter.py
@@ -20,107 +20,92 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Simple Parameter tests
+Test that Parameters support arithmetic operations correctly.
+
+This set of tests confirms that arithmetic operations on NEST Parameter objects yield
+correct results by comparing with operations on the undelying numeric values.
+It also confirms that operations on Parameter objects and plain numbers work.
+
+@note These tests only confirm that operators on parameters work in principle. Therefore,
+      we can use constant parameters for simplicity. We need to test elsewhere that
+      other types of Parameters produce correct values.
 """
 
 import nest
 import pytest
-
-va, vb = 5, 7
-a = nest.CreateParameter('constant', {'value': va})
-b = nest.CreateParameter('constant', {'value': vb})
+import operator
 
 
-@pytest.fixture(autouse=True)
-def reset_kernel():
-    nest.ResetKernel()
+@pytest.mark.parametrize('op', [operator.pos,
+                                operator.neg])
+def test_binary_operators(op):
+    """
+    Perform tests for unary operators.
 
+    Parametrization is over operators
+    """
 
-@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
-def test_add(op_a, op_b):
-
-    try:
-        val_a = op_a.GetValue()
-    except AttributeError:
-        val_a = op_a
-    try:
-        val_b = op_b.GetValue()
-    except AttributeError:
-        val_b = op_b
+    val_a = 31
+    nest.CreateParameter('constant', {'value': val_a})
         
-    assert (op_a + op_b).GetValue() == val_a + val_b
+    assert op(a).GetValue() == op(a)
 
-    
-@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
-def test_sub(op_a, op_b):
 
+@pytest.mark.parametrize('op', [operator.add,
+                                operator.sub,
+                                operator.mul,
+                                operator.truediv,
+                                operator.mod,
+                                operator.pow])
+@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
+                                  [31, nest.CreateParameter('constant', {'value':  5})],
+                                  [nest.CreateParameter('constant', {'value': 31}), 5]])
+def test_binary_operators(op, a, b):
+    """
+    Perform tests for binary operators.
+
+    Outer parametrization is over operators, the inner over param-param, param-number and number-param combinations.
+    """
+
+    # Extract underlying numerical value if we are passed a parameter object.
     try:
-        val_a = op_a.GetValue()
+        val_a = a.GetValue()
     except AttributeError:
-        val_a = op_a
+        val_a = a
     try:
-        val_b = op_b.GetValue()
+        val_b = b.GetValue()
     except AttributeError:
-        val_b = op_b
+        val_b = b
         
-    assert (op_a - op_b).GetValue() == val_a - val_b
+    assert op(a, b).GetValue() == op(a, b)
 
 
-@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
-def test_mul(op_a, op_b):
+@pytest.mark.parametrize('op', [operator.eq,
+                                operator.ne,
+                                operator.lt,
+                                operator.le,
+                                operator.gt,
+                                operator.ge])
+@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  31})],
+                                  [nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
+                                  [nest.CreateParameter('constant', {'value': 5}), nest.CreateParameter('constant', {'value':  31})],
+                                  [31, nest.CreateParameter('constant', {'value':  5})],
+                                  [nest.CreateParameter('constant', {'value': 31}), 5]])
+def test_comparison_operators(op, a, b):
+    """
+    Perform tests for comparison operators.
 
+    Outer parametrization is over operators, the inner over param-param, param-number and number-param combinations.
+    """
+
+    # Extract underlying numerical value if we are passed a parameter object.
     try:
-        val_a = op_a.GetValue()
+        val_a = a.GetValue()
     except AttributeError:
-        val_a = op_a
+        val_a = a
     try:
-        val_b = op_b.GetValue()
+        val_b = b.GetValue()
     except AttributeError:
-        val_b = op_b
+        val_b = b
         
-    assert (op_a * op_b).GetValue() == val_a * val_b
-
-
-@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
-def test_div(op_a, op_b):
-
-    try:
-        val_a = op_a.GetValue()
-    except AttributeError:
-        val_a = op_a
-    try:
-        val_b = op_b.GetValue()
-    except AttributeError:
-        val_b = op_b
-        
-    assert (op_a / op_b).GetValue() == val_a / val_b
-
-
-@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
-def test_mod(op_a, op_b):
-
-    try:
-        val_a = op_a.GetValue()
-    except AttributeError:
-        val_a = op_a
-    try:
-        val_b = op_b.GetValue()
-    except AttributeError:
-        val_b = op_b
-        
-    assert (op_a % op_b).GetValue() == val_a % val_b
-
-
-@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
-def test_pow(op_a, op_b):
-
-    try:
-        val_a = op_a.GetValue()
-    except AttributeError:
-        val_a = op_a
-    try:
-        val_b = op_b.GetValue()
-    except AttributeError:
-        val_b = op_b
-        
-    assert (op_a ** op_b).GetValue() == val_a ** val_b
+    assert op(a, b).GetValue() == op(a, b)

--- a/testsuite/pytests/test_parameter.py
+++ b/testsuite/pytests/test_parameter.py
@@ -36,9 +36,27 @@ import pytest
 import operator
 
 
-@pytest.mark.parametrize('op', [operator.pos,
-                                operator.neg])
-def test_binary_operators(op):
+
+@pytest.mark.parametrize('op, a, b',
+                         [[operator.pow, nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
+                          [operator.pow, 31, nest.CreateParameter('constant', {'value':  5})],
+                          [operator.mod, nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
+                          [operator.mod, nest.CreateParameter('constant', {'value':  31}), 5],
+                          [operator.pow, 31, nest.CreateParameter('constant', {'value':  5})]])
+def test_unsupported_operators(op, a, b):
+    """
+    Test that unsupported operator-operand combinations raise a TypeError.
+
+    A side-purpose of this test is to document which operators are not fully supported.
+    """
+
+    with pytest.raises(TypeError):
+        op(a, b)
+
+
+@pytest.mark.parametrize('op', [operator.neg,
+                                operator.pos])
+def test_unary_operators(op):
     """
     Perform tests for unary operators.
 
@@ -46,16 +64,15 @@ def test_binary_operators(op):
     """
 
     val_a = 31
-    nest.CreateParameter('constant', {'value': val_a})
+    a = nest.CreateParameter('constant', {'value': val_a})
         
-    assert op(a).GetValue() == op(a)
+    assert op(a).GetValue() == op(val_a)
 
 
 @pytest.mark.parametrize('op', [operator.add,
                                 operator.sub,
                                 operator.mul,
-                                operator.truediv,
-                                operator.pow])
+                                operator.truediv])
 @pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
                                   [31, nest.CreateParameter('constant', {'value':  5})],
                                   [nest.CreateParameter('constant', {'value': 31}), 5]])
@@ -76,7 +93,26 @@ def test_binary_operators(op, a, b):
     except AttributeError:
         val_b = b
         
-    assert op(a, b).GetValue() == op(a, b)
+    assert op(a, b).GetValue() == op(val_a, val_b)
+
+
+@pytest.mark.parametrize('op, a, b', [[operator.pow, nest.CreateParameter('constant', {'value': 31}), 5]])
+def test_incomplete_binary_operators(op, a, b):
+    """
+    Perform tests for binary operators that do not support Parameter as any operand.
+    """
+
+    # Extract underlying numerical value if we are passed a parameter object.
+    try:
+        val_a = a.GetValue()
+    except AttributeError:
+        val_a = a
+    try:
+        val_b = b.GetValue()
+    except AttributeError:
+        val_b = b
+        
+    assert op(a, b).GetValue() == op(val_a, val_b)
 
 
 @pytest.mark.parametrize('op', [operator.eq,
@@ -107,4 +143,4 @@ def test_comparison_operators(op, a, b):
     except AttributeError:
         val_b = b
         
-    assert op(a, b).GetValue() == op(a, b)
+    assert op(a, b).GetValue() == op(val_a, val_b)

--- a/testsuite/pytests/test_parameter.py
+++ b/testsuite/pytests/test_parameter.py
@@ -24,104 +24,103 @@ Simple Parameter tests
 """
 
 import nest
-import unittest
+import pytest
+
+va, vb = 5, 7
+a = nest.CreateParameter('constant', {'value': va})
+b = nest.CreateParameter('constant', {'value': vb})
 
 
-class TestParameter(unittest.TestCase):
-
-    def setUp(self):
-        nest.ResetKernel()
-
-    def test_add(self):
-        low = 55.
-        high = 75.
-        val = 33.
-        e = nest.random.uniform(low, high) + val
-
-        self.assertGreater(e.GetValue(), low + val)
-        self.assertLess(e.GetValue(), high + val)
-
-    def test_radd(self):
-        low = 55.
-        high = 75.
-        val = 33.
-        e = val + nest.random.uniform(low, high)
-
-        self.assertGreater(e.GetValue(), low + val)
-        self.assertLess(e.GetValue(), high + val)
-
-    def test_sub(self):
-        low = 55.
-        high = 75.
-        val = 33.
-        e = nest.random.uniform(low, high) - val
-
-        self.assertGreater(e.GetValue(), low - val)
-        self.assertLess(e.GetValue(), high - val)
-
-    def test_rsub(self):
-        low = 55.
-        high = 75.
-        val = 33.
-        e = val - nest.random.uniform(low, high)
-
-        self.assertGreater(e.GetValue(), val - high)
-        self.assertLess(e.GetValue(), val - low)
-
-    def test_neg(self):
-        low = 55.
-        high = 75.
-        e = -nest.random.uniform(low, high)
-
-        self.assertGreater(e.GetValue(), -high)
-        self.assertLess(e.GetValue(), -low)
-
-    def test_rsub_all_neg(self):
-        low = -55.
-        high = -75.
-        val = -33.
-        e = val - nest.random.uniform(high, low)
-
-        self.assertGreater(e.GetValue(), val - low)
-        self.assertLess(e.GetValue(), val - high)
-
-    def test_mul(self):
-        low = 55.
-        high = 75.
-        val = 3.
-        e = nest.random.uniform(low, high) * val
-
-        self.assertGreater(e.GetValue(), low * val)
-        self.assertLess(e.GetValue(), high * val)
-
-    def test_rmul(self):
-        low = 55.
-        high = 75.
-        val = 3.
-        e = val * nest.random.uniform(low, high)
-
-        self.assertGreater(e.GetValue(), val * low)
-        self.assertLess(e.GetValue(), val * high)
-
-    def test_div(self):
-        low = 55.
-        high = 75.
-        val = 3.
-        e = nest.random.uniform(low, high) / val
-
-        self.assertGreater(e.GetValue(), low / val)
-        self.assertLess(e.GetValue(), high / val)
+@pytest.fixture(autouse=True)
+def reset_kernel():
+    nest.ResetKernel()
 
 
-def suite():
-    suite = unittest.makeSuite(TestParameter, 'test')
-    return suite
+@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
+def test_add(op_a, op_b):
+
+    try:
+        val_a = op_a.GetValue()
+    except AttributeError:
+        val_a = op_a
+    try:
+        val_b = op_b.GetValue()
+    except AttributeError:
+        val_b = op_b
+        
+    assert (op_a + op_b).GetValue() == val_a + val_b
+
+    
+@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
+def test_sub(op_a, op_b):
+
+    try:
+        val_a = op_a.GetValue()
+    except AttributeError:
+        val_a = op_a
+    try:
+        val_b = op_b.GetValue()
+    except AttributeError:
+        val_b = op_b
+        
+    assert (op_a - op_b).GetValue() == val_a - val_b
 
 
-def run():
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite())
+@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
+def test_mul(op_a, op_b):
+
+    try:
+        val_a = op_a.GetValue()
+    except AttributeError:
+        val_a = op_a
+    try:
+        val_b = op_b.GetValue()
+    except AttributeError:
+        val_b = op_b
+        
+    assert (op_a * op_b).GetValue() == val_a * val_b
 
 
-if __name__ == "__main__":
-    run()
+@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
+def test_div(op_a, op_b):
+
+    try:
+        val_a = op_a.GetValue()
+    except AttributeError:
+        val_a = op_a
+    try:
+        val_b = op_b.GetValue()
+    except AttributeError:
+        val_b = op_b
+        
+    assert (op_a / op_b).GetValue() == val_a / val_b
+
+
+@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
+def test_mod(op_a, op_b):
+
+    try:
+        val_a = op_a.GetValue()
+    except AttributeError:
+        val_a = op_a
+    try:
+        val_b = op_b.GetValue()
+    except AttributeError:
+        val_b = op_b
+        
+    assert (op_a % op_b).GetValue() == val_a % val_b
+
+
+@pytest.mark.parametrize('op_a, op_b', [[a, b], [a, vb], [vb, a]])
+def test_pow(op_a, op_b):
+
+    try:
+        val_a = op_a.GetValue()
+    except AttributeError:
+        val_a = op_a
+    try:
+        val_b = op_b.GetValue()
+    except AttributeError:
+        val_b = op_b
+        
+    assert (op_a ** op_b).GetValue() == val_a ** val_b

--- a/testsuite/pytests/test_parameter.py
+++ b/testsuite/pytests/test_parameter.py
@@ -55,7 +55,6 @@ def test_binary_operators(op):
                                 operator.sub,
                                 operator.mul,
                                 operator.truediv,
-                                operator.mod,
                                 operator.pow])
 @pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
                                   [31, nest.CreateParameter('constant', {'value':  5})],

--- a/testsuite/pytests/test_parameter_operators.py
+++ b/testsuite/pytests/test_parameter_operators.py
@@ -34,24 +34,20 @@ It also confirms that operations on Parameter objects and plain numbers work.
 
 import nest
 import pytest
-import operator
+import operator as op
 
 
-@pytest.mark.parametrize('op, a, b',
-                         [[operator.pow,
-                           nest.CreateParameter('constant', {'value': 31}),
-                           nest.CreateParameter('constant', {'value':  5})],
-                          [operator.pow,
-                           31,
-                           nest.CreateParameter('constant', {'value':  5})],
-                          [operator.mod,
-                           nest.CreateParameter('constant', {'value': 31}),
-                           nest.CreateParameter('constant', {'value':  5})],
-                          [operator.mod,
-                           nest.CreateParameter('constant', {'value':  31}), 5],
-                          [operator.pow,
-                           31,
-                           nest.CreateParameter('constant', {'value':  5})]])
+def const_param(val):
+    return nest.CreateParameter('constant', {'value': val})
+
+
+@pytest.mark.parametrize('op, a, b', [
+    [op.pow, const_param(31), const_param(5)],
+    [op.pow,             31 , const_param(5)],
+    [op.mod, const_param(31), const_param(5)],
+    [op.mod, const_param(31),             5 ],
+    [op.pow,             31 , const_param(5)]
+])
 def test_unsupported_operators(op, a, b):
     """
     Test that unsupported operator-operand combinations raise a TypeError.

--- a/testsuite/pytests/test_parameter_operators.py
+++ b/testsuite/pytests/test_parameter_operators.py
@@ -34,7 +34,7 @@ It also confirms that operations on Parameter objects and plain numbers work.
 
 import nest
 import pytest
-import operator as op
+import operator as opr
 
 
 def const_param(val):
@@ -42,11 +42,11 @@ def const_param(val):
 
 
 @pytest.mark.parametrize('op, a, b', [
-    [op.pow, const_param(31), const_param(5)],
-    [op.pow,             31 , const_param(5)],
-    [op.mod, const_param(31), const_param(5)],
-    [op.mod, const_param(31),             5 ],
-    [op.pow,             31 , const_param(5)]
+    [opr.pow, const_param(31), const_param(5)],
+    [opr.pow, 31, const_param(5)],
+    [opr.mod, const_param(31), const_param(5)],
+    [opr.mod, const_param(31), 5],
+    [opr.pow, 31, const_param(5)]
 ])
 def test_unsupported_operators(op, a, b):
     """
@@ -59,8 +59,10 @@ def test_unsupported_operators(op, a, b):
         op(a, b)
 
 
-@pytest.mark.parametrize('op', [operator.neg,
-                                operator.pos])
+@pytest.mark.parametrize('op', [
+    opr.neg,
+    opr.pos
+])
 def test_unary_operators(op):
     """
     Perform tests for unary operators.
@@ -74,16 +76,17 @@ def test_unary_operators(op):
     assert op(a).GetValue() == op(val_a)
 
 
-@pytest.mark.parametrize('op', [operator.add,
-                                operator.sub,
-                                operator.mul,
-                                operator.truediv])
-@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}),
-                                   nest.CreateParameter('constant', {'value':  5})],
-                                  [31,
-                                   nest.CreateParameter('constant', {'value':  5})],
-                                  [nest.CreateParameter('constant', {'value': 31}),
-                                   5]])
+@pytest.mark.parametrize('op', [
+    opr.add,
+    opr.sub,
+    opr.mul,
+    opr.truediv
+])
+@pytest.mark.parametrize('a, b', [
+    [const_param(31), const_param(5)],
+    [31, const_param(5)],
+    [const_param(31), 5]
+])
 def test_binary_operators(op, a, b):
     """
     Perform tests for binary operators.
@@ -104,7 +107,8 @@ def test_binary_operators(op, a, b):
     assert op(a, b).GetValue() == op(val_a, val_b)
 
 
-@pytest.mark.parametrize('op, a, b', [[operator.pow, nest.CreateParameter('constant', {'value': 31}), 5]])
+@pytest.mark.parametrize('op, a, b', [
+    [opr.pow, const_param(31), 5]])
 def test_incomplete_binary_operators(op, a, b):
     """
     Perform tests for binary operators that do not support Parameter as any operand.
@@ -123,22 +127,21 @@ def test_incomplete_binary_operators(op, a, b):
     assert op(a, b).GetValue() == op(val_a, val_b)
 
 
-@pytest.mark.parametrize('op', [operator.eq,
-                                operator.ne,
-                                operator.lt,
-                                operator.le,
-                                operator.gt,
-                                operator.ge])
-@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}),
-                                   nest.CreateParameter('constant', {'value':  31})],
-                                  [nest.CreateParameter('constant', {'value': 31}),
-                                   nest.CreateParameter('constant', {'value':  5})],
-                                  [nest.CreateParameter('constant', {'value': 5}),
-                                   nest.CreateParameter('constant', {'value':  31})],
-                                  [31,
-                                   nest.CreateParameter('constant', {'value':  5})],
-                                  [nest.CreateParameter('constant', {'value': 31}),
-                                   5]])
+@pytest.mark.parametrize('op', [
+    opr.eq,
+    opr.ne,
+    opr.lt,
+    opr.le,
+    opr.gt,
+    opr.ge
+])
+@pytest.mark.parametrize('a, b', [
+    [const_param(31), const_param(31)],
+    [const_param(31), 31],
+    [31, const_param(31)],
+    [const_param(31), const_param(5)],
+    [const_param(5), const_param(31)],
+])
 def test_comparison_operators(op, a, b):
     """
     Perform tests for comparison operators.

--- a/testsuite/pytests/test_parameter_operators.py
+++ b/testsuite/pytests/test_parameter_operators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# test_parameter.py
+# test_parameter_operators.py
 #
 # This file is part of NEST.
 #
@@ -26,9 +26,10 @@ This set of tests confirms that arithmetic operations on NEST Parameter objects 
 correct results by comparing with operations on the undelying numeric values.
 It also confirms that operations on Parameter objects and plain numbers work.
 
-@note These tests only confirm that operators on parameters work in principle. Therefore,
-      we can use constant parameters for simplicity. We need to test elsewhere that
-      other types of Parameters produce correct values.
+.. note::
+
+   These tests only confirm that operators on parameters work in principle. Therefore,
+   we can use constant parameters for simplicity.
 """
 
 import nest
@@ -36,13 +37,21 @@ import pytest
 import operator
 
 
-
 @pytest.mark.parametrize('op, a, b',
-                         [[operator.pow, nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
-                          [operator.pow, 31, nest.CreateParameter('constant', {'value':  5})],
-                          [operator.mod, nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
-                          [operator.mod, nest.CreateParameter('constant', {'value':  31}), 5],
-                          [operator.pow, 31, nest.CreateParameter('constant', {'value':  5})]])
+                         [[operator.pow,
+                           nest.CreateParameter('constant', {'value': 31}),
+                           nest.CreateParameter('constant', {'value':  5})],
+                          [operator.pow,
+                           31,
+                           nest.CreateParameter('constant', {'value':  5})],
+                          [operator.mod,
+                           nest.CreateParameter('constant', {'value': 31}),
+                           nest.CreateParameter('constant', {'value':  5})],
+                          [operator.mod,
+                           nest.CreateParameter('constant', {'value':  31}), 5],
+                          [operator.pow,
+                           31,
+                           nest.CreateParameter('constant', {'value':  5})]])
 def test_unsupported_operators(op, a, b):
     """
     Test that unsupported operator-operand combinations raise a TypeError.
@@ -65,7 +74,7 @@ def test_unary_operators(op):
 
     val_a = 31
     a = nest.CreateParameter('constant', {'value': val_a})
-        
+
     assert op(a).GetValue() == op(val_a)
 
 
@@ -73,9 +82,12 @@ def test_unary_operators(op):
                                 operator.sub,
                                 operator.mul,
                                 operator.truediv])
-@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
-                                  [31, nest.CreateParameter('constant', {'value':  5})],
-                                  [nest.CreateParameter('constant', {'value': 31}), 5]])
+@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}),
+                                   nest.CreateParameter('constant', {'value':  5})],
+                                  [31,
+                                   nest.CreateParameter('constant', {'value':  5})],
+                                  [nest.CreateParameter('constant', {'value': 31}),
+                                   5]])
 def test_binary_operators(op, a, b):
     """
     Perform tests for binary operators.
@@ -92,7 +104,7 @@ def test_binary_operators(op, a, b):
         val_b = b.GetValue()
     except AttributeError:
         val_b = b
-        
+
     assert op(a, b).GetValue() == op(val_a, val_b)
 
 
@@ -111,7 +123,7 @@ def test_incomplete_binary_operators(op, a, b):
         val_b = b.GetValue()
     except AttributeError:
         val_b = b
-        
+
     assert op(a, b).GetValue() == op(val_a, val_b)
 
 
@@ -121,11 +133,16 @@ def test_incomplete_binary_operators(op, a, b):
                                 operator.le,
                                 operator.gt,
                                 operator.ge])
-@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  31})],
-                                  [nest.CreateParameter('constant', {'value': 31}), nest.CreateParameter('constant', {'value':  5})],
-                                  [nest.CreateParameter('constant', {'value': 5}), nest.CreateParameter('constant', {'value':  31})],
-                                  [31, nest.CreateParameter('constant', {'value':  5})],
-                                  [nest.CreateParameter('constant', {'value': 31}), 5]])
+@pytest.mark.parametrize('a, b', [[nest.CreateParameter('constant', {'value': 31}),
+                                   nest.CreateParameter('constant', {'value':  31})],
+                                  [nest.CreateParameter('constant', {'value': 31}),
+                                   nest.CreateParameter('constant', {'value':  5})],
+                                  [nest.CreateParameter('constant', {'value': 5}),
+                                   nest.CreateParameter('constant', {'value':  31})],
+                                  [31,
+                                   nest.CreateParameter('constant', {'value':  5})],
+                                  [nest.CreateParameter('constant', {'value': 31}),
+                                   5]])
 def test_comparison_operators(op, a, b):
     """
     Perform tests for comparison operators.
@@ -142,5 +159,5 @@ def test_comparison_operators(op, a, b):
         val_b = b.GetValue()
     except AttributeError:
         val_b = b
-        
+
     assert op(a, b).GetValue() == op(val_a, val_b)

--- a/testsuite/pytests/test_parameter_operators.py
+++ b/testsuite/pytests/test_parameter_operators.py
@@ -34,7 +34,7 @@ It also confirms that operations on Parameter objects and plain numbers work.
 
 import nest
 import pytest
-import operator as opr
+import operator as ops
 
 
 def const_param(val):
@@ -42,11 +42,11 @@ def const_param(val):
 
 
 @pytest.mark.parametrize('op, a, b', [
-    [opr.pow, const_param(31), const_param(5)],
-    [opr.pow, 31, const_param(5)],
-    [opr.mod, const_param(31), const_param(5)],
-    [opr.mod, const_param(31), 5],
-    [opr.pow, 31, const_param(5)]
+    [ops.pow, const_param(31), const_param(5)],
+    [ops.pow, 31, const_param(5)],
+    [ops.mod, const_param(31), const_param(5)],
+    [ops.mod, const_param(31), 5],
+    [ops.pow, 31, const_param(5)]
 ])
 def test_unsupported_operators(op, a, b):
     """
@@ -60,8 +60,8 @@ def test_unsupported_operators(op, a, b):
 
 
 @pytest.mark.parametrize('op', [
-    opr.neg,
-    opr.pos
+    ops.neg,
+    ops.pos
 ])
 def test_unary_operators(op):
     """
@@ -77,10 +77,10 @@ def test_unary_operators(op):
 
 
 @pytest.mark.parametrize('op', [
-    opr.add,
-    opr.sub,
-    opr.mul,
-    opr.truediv
+    ops.add,
+    ops.sub,
+    ops.mul,
+    ops.truediv
 ])
 @pytest.mark.parametrize('a, b', [
     [const_param(31), const_param(5)],
@@ -108,7 +108,7 @@ def test_binary_operators(op, a, b):
 
 
 @pytest.mark.parametrize('op, a, b', [
-    [opr.pow, const_param(31), 5]])
+    [ops.pow, const_param(31), 5]])
 def test_incomplete_binary_operators(op, a, b):
     """
     Perform tests for binary operators that do not support Parameter as any operand.
@@ -128,12 +128,12 @@ def test_incomplete_binary_operators(op, a, b):
 
 
 @pytest.mark.parametrize('op', [
-    opr.eq,
-    opr.ne,
-    opr.lt,
-    opr.le,
-    opr.gt,
-    opr.ge
+    ops.eq,
+    ops.ne,
+    ops.lt,
+    ops.le,
+    ops.gt,
+    ops.ge
 ])
 @pytest.mark.parametrize('a, b', [
     [const_param(31), const_param(31)],


### PR DESCRIPTION
As a step towards developing good test styles, this PR provides a re-write of `test_parameter.py` using PyTest features. It extends the scope of the tests and includes minor fixes:

- float / Parameter is now supported
- when attempting ** with Parameter as exponent, a TypeError is raised to conform with usual Python practice
- 