### PR TITLE
Enhance module imports in NEST Server

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -253,7 +253,7 @@ def get_modules_from_env():
     """ Get modules from env NEST_SERVER_MODULES.
 
         It converts environment variable NEST_SERVER_MODULES:
-            "NEST_SERVER_MODULES=nest,numpy as np,random from numpy"
+            "NEST_SERVER_MODULES='nest,numpy as np,random from numpy'"
         to formatted dictionary for updating globals:
             "{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}"
     """

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -89,10 +89,12 @@ def do_exec(args, kwargs):
             if len(stdout) > 0:
                 response["stdout"] = "\n".join(stdout)
         else:
-            code = RestrictedPython.compile_restricted(source_cleaned, "<inline>", "exec")  # noqa
-            exec(code, get_restricted_globals(), locals_)
-            if "_print" in locals_:
-                response["stdout"] = "".join(locals_["_print"].txt)
+            code = RestrictedPython.compile_restricted(source_cleaned, '<inline>', 'exec')  # noqa
+            globals_ = get_restricted_globals()
+            globals_.update(get_modules_from_env())
+            exec(code, globals_, locals_)
+            if '_print' in locals_:
+                response['stdout'] = ''.join(locals_['_print'].txt)
 
         if "return" in kwargs:
             if isinstance(kwargs["return"], list):
@@ -316,7 +318,6 @@ def get_restricted_globals():
         _write_=RestrictedPython.Guards.full_write_guard,
     )
 
-    restricted_globals.update(get_modules_from_env())
     return restricted_globals
 
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -89,12 +89,12 @@ def do_exec(args, kwargs):
             if len(stdout) > 0:
                 response["stdout"] = "\n".join(stdout)
         else:
-            code = RestrictedPython.compile_restricted(source_cleaned, '<inline>', 'exec')  # noqa
+            code = RestrictedPython.compile_restricted(source_cleaned, "<inline>", "exec")  # noqa
             globals_ = get_restricted_globals()
             globals_.update(get_modules_from_env())
             exec(code, globals_, locals_)
-            if '_print' in locals_:
-                response['stdout'] = ''.join(locals_['_print'].txt)
+            if "_print" in locals_:
+                response["stdout"] = "".join(locals_["_print"].txt)
 
         if "return" in kwargs:
             if isinstance(kwargs["return"], list):
@@ -252,24 +252,24 @@ def get_arguments(request):
 
 
 def get_modules_from_env():
-    """ Get modules from environment variable NEST_SERVER_MODULES.
+    """Get modules from environment variable NEST_SERVER_MODULES.
 
-        This function converts the content of the environment variable NEST_SERVER_MODULES:
-        to a formatted dictionary for updating the Python `globals`.
+    This function converts the content of the environment variable NEST_SERVER_MODULES:
+    to a formatted dictionary for updating the Python `globals`.
 
-        Here is an example:
-            `NEST_SERVER_MODULES="nest,numpy as np,random from numpy"`
-        is converted to the following dictionary:
-            `{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}`
+    Here is an example:
+        `NEST_SERVER_MODULES="nest,numpy as np,random from numpy"`
+    is converted to the following dictionary:
+        `{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}`
     """
     modules = {}
     for module in MODULES:
-        if ' as ' in module:
-            modname, modvar = module.split(' as ')
+        if " as " in module:
+            modname, modvar = module.split(" as ")
             modules[modvar] = importlib.import_module(modname)
-        elif ' from ' in module:
-            modvar, modname = module.split(' from ')
-            modules[modvar] = importlib.import_module(f'{modname}.{modvar}')
+        elif " from " in module:
+            modvar, modname = module.split(" from ")
+            modules[modvar] = importlib.import_module(f"{modname}.{modvar}")
         else:
             modules[module] = importlib.import_module(module)
     return modules

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+import ast
 import importlib
 import inspect
 import io

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -83,7 +83,9 @@ def do_exec(args, kwargs):
         response = dict()
         if RESTRICTION_OFF:
             with Capturing() as stdout:
-                exec(source_cleaned, get_globals(globals().copy()), locals_)
+                globals_ = globals().copy()
+                globals_.update(get_modules_from_env())
+                exec(source_cleaned, globals_, locals_)
             if len(stdout) > 0:
                 response["stdout"] = "\n".join(stdout)
         else:
@@ -247,20 +249,25 @@ def get_arguments(request):
     return list(args), kwargs
 
 
-def get_globals(globalsDict={}):
-    """ Get globals for exec function.
+def get_modules_from_env():
+    """ Get modules from env NEST_SERVER_MODULES.
 
-        Convert environment variable MODULES to dict:
-        "MODULES=nest,numpy as np" to "{'nest': <module 'nest'> 'np': <module 'numpy'>}"
+        It converts environment variable NEST_SERVER_MODULES:
+            "NEST_SERVER_MODULES=nest,numpy as np,random from numpy"
+        to formatted dictionary for updating globals:
+            "{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}"
     """
-    modlist = [(module, importlib.import_module(module)) for module in MODULES if ' as ' not in module]
-    modlist.extend([
-        (module.split(' as ')[1], importlib.import_module(module.split(' as ')[0])) for module in MODULES
-        if ' as ' in module
-    ])
-    modules = dict(modlist)
-    globalsDict.update(modules)
-    return globalsDict
+    modules = {}
+    for module in MODULES:
+        if ' as ' in module:
+            modname, modvar = module.split(' as ')
+            modules[modvar] = importlib.import_module(modname)
+        elif ' from ' in module:
+            modvar, modname = module.split(' from ')
+            modules[modvar] = importlib.import_module(f'{modname}.{modvar}')
+        else:
+            modules[module] = importlib.import_module(module)
+    return modules
 
 
 def get_or_error(func):
@@ -309,7 +316,8 @@ def get_restricted_globals():
         _write_=RestrictedPython.Guards.full_write_guard,
     )
 
-    return get_globals(restricted_globals)
+    restricted_globals.update(get_modules_from_env())
+    return restricted_globals
 
 
 def nestify(call_name, args, kwargs):

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -252,11 +252,14 @@ def get_arguments(request):
 
 
 def get_modules_from_env():
-    """ Get modules from env NEST_SERVER_MODULES.
+    """ Get modules from environment variable NEST_SERVER_MODULES.
 
-        It converts environment variable NEST_SERVER_MODULES:
+        This function converts the content of the environment variable NEST_SERVER_MODULES:
+        to a formatted dictionary for updating the Python `globals`.
+        
+        Here is an example:
             `NEST_SERVER_MODULES="nest,numpy as np,random from numpy"`
-        to formatted dictionary for updating globals:
+        is converted to the following dictionary:
             `{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}`
     """
     modules = {}

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -256,7 +256,7 @@ def get_modules_from_env():
 
         This function converts the content of the environment variable NEST_SERVER_MODULES:
         to a formatted dictionary for updating the Python `globals`.
-        
+
         Here is an example:
             `NEST_SERVER_MODULES="nest,numpy as np,random from numpy"`
         is converted to the following dictionary:

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -253,9 +253,9 @@ def get_modules_from_env():
     """ Get modules from env NEST_SERVER_MODULES.
 
         It converts environment variable NEST_SERVER_MODULES:
-            "NEST_SERVER_MODULES='nest,numpy as np,random from numpy'"
+            `NEST_SERVER_MODULES="nest,numpy as np,random from numpy"`
         to formatted dictionary for updating globals:
-            "{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}"
+            `{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}`
     """
     modules = {}
     for module in MODULES:


### PR DESCRIPTION
This PR converts environment variable `NEST_SERVER_MODULES`:
    `NEST_SERVER_MODULES="nest,numpy as np,random from numpy"`
to formatted dictionary for updating `globals`:
    `{'nest': <module 'nest'> 'np': <module 'numpy'>, 'random': <module 'numpy.random'>}`


#### Test it on your computer

In Bash:
```
export NEST_SERVER_MODULES="nest,numpy as np,random from numpy"
```
In Python:
```
import nest
modules = nest.server.hl_api_server.get_modules_from_env()
globals().update(modules)
print(globals())
```