### PR TITLE
Serialize all responses

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -54,7 +54,7 @@ __all__ = [
     "NodeCollection",
     "Parameter",
     "Receptors",
-    "serializable",
+    "serialize_data",
     "SynapseCollection",
     "to_json",
 ]
@@ -317,7 +317,7 @@ class NodeCollection:
               This is for hierarchical addressing.
         output : str, ['pandas','json'], optional
              If the returned data should be in a Pandas DataFrame or in a
-             JSON serializable format.
+             JSON string format.
 
         Returns
         -------
@@ -768,7 +768,7 @@ class SynapseCollection:
             belonging to the given `keys`.
         output : str, ['pandas','json'], optional
             If the returned data should be in a Pandas DataFrame or in a
-            JSON serializable format.
+            JSON string format.
 
         Returns
         -------
@@ -1212,8 +1212,8 @@ class Receptors(CmBase):
     pass
 
 
-def serializable(data):
-    """Make data serializable for JSON.
+def serialize_data(data):
+    """Serialize data for JSON.
 
     Parameters
     ----------
@@ -1227,21 +1227,21 @@ def serializable(data):
 
     if isinstance(data, (numpy.ndarray, NodeCollection)):
         return data.tolist()
-    if isinstance(data, SynapseCollection):
+    elif isinstance(data, SynapseCollection):
         # Get full information from SynapseCollection
-        return serializable(data.get())
-    if isinstance(data, kernel.SLILiteral):
+        return serialize_data(data.get())
+    elif isinstance(data, kernel.SLILiteral):
         # Get name of SLILiteral.
         return data.name
-    if isinstance(data, (list, tuple)):
-        return [serializable(d) for d in data]
-    if isinstance(data, dict):
-        return dict([(key, serializable(value)) for key, value in data.items()])
+    elif isinstance(data, (list, tuple)):
+        return [serialize_data(d) for d in data]
+    elif isinstance(data, dict):
+        return dict([(key, serialize_data(value)) for key, value in data.items()])
     return data
 
 
 def to_json(data, **kwargs):
-    """Serialize data to JSON.
+    """Convert the object to a JSON string.
 
     Parameters
     ----------
@@ -1252,9 +1252,9 @@ def to_json(data, **kwargs):
     Returns
     -------
     data_json : str
-        JSON format of the data
+        JSON string format of the data
     """
 
-    data_serialized = serializable(data)
+    data_serialized = serialize_data(data)
     data_json = json.dumps(data_serialized, **kwargs)
     return data_json

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -104,7 +104,7 @@ def do_exec(args, kwargs):
                     data[variable] = locals_.get(variable, None)
             else:
                 data = locals_.get(kwargs["return"], None)
-            response["data"] = nest.serializable(data)
+            response["data"] = nest.serialize_data(data)
         return response
 
     except Exception as e:
@@ -355,7 +355,7 @@ def api_client(call_name, args, kwargs):
     else:
         response = call
 
-    return nest.serializable(response)
+    return nest.serialize_data(response)
 
 
 def set_mpi_comm(comm):

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -355,7 +355,7 @@ def api_client(call_name, args, kwargs):
     else:
         response = call
 
-    return response
+    return nest.serializable(response)
 
 
 def set_mpi_comm(comm):

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -155,7 +155,7 @@ def do_call(call_name, args=[], kwargs={}):
         log(call_name, f"local call, args={args}, kwargs={kwargs}")
         master_response = call(*args, **kwargs)
 
-    response = [nest.serializable(master_response)]
+    response = [master_response]
     if mpi_comm is not None:
         log(call_name, "waiting for response gather")
         response = mpi_comm.gather(response[0], root=0)


### PR DESCRIPTION
It shows a usecase that `NodeCollection` or other NEST objects are stored in `userdict`.
Then the user wants to get `userdict` via API-requests.

Example:
```
curl localhost:52425/api/userdict
```

It produces server error because the data in `userdict` cannot be transformed for JSON when they are `NodeCollection` or other NEST objects.

