### PR TITLE
Invert delay-related documentation tagging logic for rate connections

### DIFF
--- a/models/rate_connection_delayed.h
+++ b/models/rate_connection_delayed.h
@@ -29,7 +29,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: synapse, connection with delay, rate
+/* BeginUserDocs: synapse, rate
 
 Short description
 +++++++++++++++++

--- a/models/rate_connection_instantaneous.h
+++ b/models/rate_connection_instantaneous.h
@@ -29,7 +29,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: synapse, rate
+/* BeginUserDocs: synapse, rate, instantaneous
 
 Short description
 +++++++++++++++++


### PR DESCRIPTION
All synapse types but the `rate_connection_instantaneous` types in NEST have a delay. This PR inverts the tagging for the rate connections, so that we don't have to add a tag to *all* connection types. The former tagging was misleading in that it suggested that only the one tagged synapse type actually has a delay.