### PR TITLE
Make helper libraries static and don't install the archive files

### DIFF
--- a/libnestutil/CMakeLists.txt
+++ b/libnestutil/CMakeLists.txt
@@ -39,7 +39,6 @@ add_library( nestutil STATIC ${nestutil_sources} )
 
 set_target_properties( nestutil
     PROPERTIES
-    VERSION ${NEST_VERSION}
     POSITION_INDEPENDENT_CODE ON
     )
 

--- a/libnestutil/CMakeLists.txt
+++ b/libnestutil/CMakeLists.txt
@@ -35,26 +35,19 @@ set( nestutil_sources
     vector_util.h
     )
 
-add_library( nestutil ${nestutil_sources} )
+add_library( nestutil STATIC ${nestutil_sources} )
 
 set_target_properties( nestutil
     PROPERTIES
     VERSION ${NEST_VERSION}
-    SOVERSION 3
+    POSITION_INDEPENDENT_CODE ON
     )
-
 
 target_link_libraries( nestutil ${GSL_LIBRARIES} ${SIONLIB_LIBS} )
 
 target_include_directories( nestutil PRIVATE
     ${PROJECT_BINARY_DIR}/libnestutil
     ${Boost_INCLUDE_DIRS}
-    )
-
-install( TARGETS nestutil
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/nest
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/nest
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
 FILTER_HEADERS("${nestutil_sources}" install_headers )

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -141,12 +141,13 @@ set(models_sources
     spike_dilutor.h spike_dilutor.cpp
 )
 
-add_library(models ${models_sources})
+add_library(models STATIC ${models_sources})
 set_target_properties(models
     PROPERTIES
     VERSION ${NEST_VERSION}
-    SOVERSION 3
+    POSITION_INDEPENDENT_CODE ON
 )
+
 target_link_libraries(models nestutil sli_lib nestkernel)
 
 target_include_directories(models PRIVATE
@@ -155,12 +156,6 @@ target_include_directories(models PRIVATE
     ${PROJECT_BINARY_DIR}/libnestutil
     ${PROJECT_SOURCE_DIR}/sli
     ${PROJECT_SOURCE_DIR}/nestkernel
-)
-
-install(TARGETS models
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/nest
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/nest
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 FILTER_HEADERS("${models_sources}" install_headers)

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -144,7 +144,6 @@ set(models_sources
 add_library(models STATIC ${models_sources})
 set_target_properties(models
     PROPERTIES
-    VERSION ${NEST_VERSION}
     POSITION_INDEPENDENT_CODE ON
 )
 

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -136,12 +136,13 @@ endif ()
 set_source_files_properties( dynamicloader.cpp PROPERTIES COMPILE_OPTIONS "-O0" )
 
 
-add_library( nestkernel ${nestkernel_sources} )
+add_library( nestkernel STATIC ${nestkernel_sources} )
 set_target_properties( nestkernel
     PROPERTIES
     VERSION ${NEST_VERSION}
-    SOVERSION 3
+    POSITION_INDEPENDENT_CODE ON
     )
+
 target_link_libraries( nestkernel
     nestutil sli_lib
     ${LTDL_LIBRARIES} ${MPI_CXX_LIBRARIES} ${MUSIC_LIBRARIES} ${SIONLIB_LIBRARIES} ${LIBNEUROSIM_LIBRARIES}
@@ -154,12 +155,6 @@ target_include_directories( nestkernel PRIVATE
     ${PROJECT_SOURCE_DIR}/sli
     ${PROJECT_SOURCE_DIR}/nestkernel
     ${PROJECT_SOURCE_DIR}/nestkernel/spatial
-    )
-
-install( TARGETS nestkernel
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/nest
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/nest
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
 
 FILTER_HEADERS("${nestkernel_sources}" install_headers )

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -139,7 +139,6 @@ set_source_files_properties( dynamicloader.cpp PROPERTIES COMPILE_OPTIONS "-O0" 
 add_library( nestkernel STATIC ${nestkernel_sources} )
 set_target_properties( nestkernel
     PROPERTIES
-    VERSION ${NEST_VERSION}
     POSITION_INDEPENDENT_CODE ON
     )
 


### PR DESCRIPTION
This fixes #1182 by making `libmodels`, `libnestutil` and `libnestkernel` static libraries that are directly included wherever they are needed. As these are only internal helper libraries, there is no need to install them.

The remaining libraries `libnest`, `libsli` and `libsli_readline` will be taken care of by the [PyNEST NG](https://github.com/nest/nest-simulator/projects/24) project.

@sanjayankur31:  I assume that with these changes, also the `VERSION ${NEST_VERSION}` line could go away, can't it?