### PR TITLE
Revise some spatial tests to pytest style; avoids numercial issues due to float comparisons

### DIFF
--- a/testsuite/pytests/test_spatial/test_SynapseCollection_distance.py
+++ b/testsuite/pytests/test_spatial/test_SynapseCollection_distance.py
@@ -23,159 +23,152 @@
 Tests distance between sources and targets of SynapseCollection
 """
 
-import unittest
+import pytest
 import math
 import nest
 
 
-class SynapseCollectionDistance(unittest.TestCase):
-
-    def setUp(self):
-        nest.ResetKernel()
-
-    def calculate_distance(self, conns, s_nodes, t_nodes):
-        """Calculate a reference distance between source and target nodes"""
-
-        s_pos = nest.GetPosition(s_nodes)
-        t_pos = nest.GetPosition(t_nodes)
-
-        src = conns.source
-        trgt = conns.target
-
-        in_3d = len(s_pos[0]) == 3
-
-        ref_distance = []
-        for s, t in zip(src, trgt):
-            x_ref = t_pos[t_nodes.index(t)][0] - s_pos[s_nodes.index(s)][0]
-            y_ref = t_pos[t_nodes.index(t)][1] - s_pos[s_nodes.index(s)][1]
-            z_ref = 0.0
-            if in_3d:
-                z_ref = t_pos[t_nodes.index(t)][2] - s_pos[s_nodes.index(s)][2]
-
-            ref_dist = math.sqrt(x_ref * x_ref + y_ref * y_ref + z_ref * z_ref)
-            ref_distance.append(ref_dist)
-
-        return tuple(ref_distance)
-
-    def test_SynapseCollection_distance_simple(self):
-        """Test distance on SynapseCollection where source and target are equal"""
-
-        s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 3]))
-
-        nest.Connect(s_nodes, s_nodes, {'rule': 'one_to_one'})
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        self.assertTrue(all([dd == 0. for dd in dist]))
-
-    def test_SynapseCollection_distance(self):
-        """Test SynapseCollection distance function for grid positions"""
-
-        s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 1]))
-        t_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[1, 3]))
-
-        nest.Connect(s_nodes, t_nodes)
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
-
-        self.assertEqual(ref_distance, dist)
-
-    def test_SynapseCollection_distance_free(self):
-        """Test SynapseCollection distance function for positions placed freely in space"""
-
-        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        s_nodes = nest.Create('iaf_psc_alpha', n=5, positions=positions)
-        t_nodes = nest.Create('iaf_psc_alpha', n=7, positions=positions)
-
-        nest.Connect(s_nodes, t_nodes, {'rule': 'pairwise_bernoulli', 'p': 0.7})
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
-
-        self.assertEqual(ref_distance, dist)
-
-    def test_SynapseCollection_distance_3D(self):
-        """Test SynapseCollection distance function for spatial nodes in 3D"""
-
-        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=3)
-        s_nodes = nest.Create('iaf_psc_alpha', n=8, positions=positions)
-        t_nodes = nest.Create('iaf_psc_alpha', n=11, positions=positions)
-
-        nest.Connect(s_nodes, t_nodes)
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        ref_distance = self.calculate_distance(conns, s_nodes, t_nodes)
-
-        self.assertEqual(ref_distance, dist)
-
-    def test_SynapseCollection_distance_non_spatial(self):
-        """Test SynapseCollection distance function on non-spatial nodes"""
-
-        s_nodes = nest.Create('iaf_psc_alpha', 3)
-        t_nodes = nest.Create('iaf_psc_alpha', 2)
-
-        nest.Connect(s_nodes, t_nodes)
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        dist_is_nan = [math.isnan(d) for d in dist]
-
-        self.assertTrue(dist_is_nan)
-
-    def test_SynapseCollection_distance_mixed(self):
-        """Test SynapseCollection distance function on non-spatial and spatial nodes"""
-
-        num_snodes_nonspatial = 3
-        num_tnodes_nonspatial = 2
-        num_conns_nonsparial = num_snodes_nonspatial * num_tnodes_nonspatial
-        s_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_snodes_nonspatial)
-        t_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_tnodes_nonspatial)
-
-        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        s_nodes_spatial = nest.Create('iaf_psc_alpha', n=6, positions=positions)
-        t_nodes_spatial = nest.Create('iaf_psc_alpha', n=7, positions=positions)
-
-        nest.Connect(s_nodes_nonspatial, t_nodes_nonspatial)
-        nest.Connect(s_nodes_spatial, t_nodes_spatial)
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        # Check part that is spatial
-        ref_distance = self.calculate_distance(conns[num_conns_nonsparial:], s_nodes_spatial, t_nodes_spatial)
-        self.assertEqual(ref_distance, dist[num_conns_nonsparial:])
-
-        # Check part that is non-spatial
-        dist_is_nan = [math.isnan(d) for d in dist[:num_conns_nonsparial]]
-        self.assertTrue(dist_is_nan)
-
-    def test_SynapseCollection_distance_spatial_nonspatial_connected(self):
-        """Test SynapseCollection distance function on non-spatial and spatial nodes that are connected"""
-
-        num_snodes = 5
-        num_tnodes = 11
-        s_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_snodes)
-
-        positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        t_nodes_spatial = nest.Create('iaf_psc_alpha', n=num_tnodes, positions=positions)
-
-        nest.Connect(s_nodes_nonspatial, t_nodes_spatial)
-        conns = nest.GetConnections()
-        dist = conns.distance
-
-        # All should be nan
-        dist_is_nan = [math.isnan(d) for d in dist]
-        self.assertTrue(dist_is_nan)
+@pytest.fixture(autouse=True)
+def _reset_kernel():
+    nest.ResetKernel()
 
 
-def suite():
-    suite = unittest.makeSuite(SynapseCollectionDistance, 'test')
-    return suite
+def _calculate_distance(conns, s_nodes, t_nodes):
+    """Calculate a reference distance between source and target nodes"""
+
+    s_pos = nest.GetPosition(s_nodes)
+    t_pos = nest.GetPosition(t_nodes)
+
+    src = conns.source
+    trgt = conns.target
+
+    in_3d = len(s_pos[0]) == 3
+
+    ref_distance = []
+    for s, t in zip(src, trgt):
+        x_ref = t_pos[t_nodes.index(t)][0] - s_pos[s_nodes.index(s)][0]
+        y_ref = t_pos[t_nodes.index(t)][1] - s_pos[s_nodes.index(s)][1]
+        z_ref = 0.0
+        if in_3d:
+            z_ref = t_pos[t_nodes.index(t)][2] - s_pos[s_nodes.index(s)][2]
+
+        ref_dist = math.sqrt(x_ref * x_ref + y_ref * y_ref + z_ref * z_ref)
+        ref_distance.append(ref_dist)
+
+    return tuple(ref_distance)
 
 
-if __name__ == "__main__":
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite())
+def test_SynapseCollection_distance_simple():
+    """Test distance on SynapseCollection where source and target are equal"""
+
+    s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 3]))
+
+    nest.Connect(s_nodes, s_nodes, {'rule': 'one_to_one'})
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    assert all(d == 0 for d in dist)
+
+
+def test_SynapseCollection_distance():
+    """Test SynapseCollection distance function for grid positions"""
+
+    s_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[3, 1]))
+    t_nodes = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid(shape=[1, 3]))
+
+    nest.Connect(s_nodes, t_nodes)
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    ref_distance = _calculate_distance(conns, s_nodes, t_nodes)
+
+    assert dist == pytest.approx(ref_distance)
+
+
+def test_SynapseCollection_distance_free():
+    """Test SynapseCollection distance function for positions placed freely in space"""
+
+    positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    s_nodes = nest.Create('iaf_psc_alpha', n=5, positions=positions)
+    t_nodes = nest.Create('iaf_psc_alpha', n=7, positions=positions)
+
+    nest.Connect(s_nodes, t_nodes, {'rule': 'pairwise_bernoulli', 'p': 0.7})
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    ref_distance = _calculate_distance(conns, s_nodes, t_nodes)
+
+    assert dist == pytest.approx(ref_distance)
+
+
+def test_SynapseCollection_distance_3D():
+    """Test SynapseCollection distance function for spatial nodes in 3D"""
+
+    positions = nest.spatial.free(nest.random.uniform(), num_dimensions=3)
+    s_nodes = nest.Create('iaf_psc_alpha', n=8, positions=positions)
+    t_nodes = nest.Create('iaf_psc_alpha', n=11, positions=positions)
+
+    nest.Connect(s_nodes, t_nodes)
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    ref_distance = _calculate_distance(conns, s_nodes, t_nodes)
+
+    assert dist == pytest.approx(ref_distance)
+
+
+def test_SynapseCollection_distance_non_spatial():
+    """Test SynapseCollection distance function on non-spatial nodes"""
+
+    s_nodes = nest.Create('iaf_psc_alpha', 3)
+    t_nodes = nest.Create('iaf_psc_alpha', 2)
+
+    nest.Connect(s_nodes, t_nodes)
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    assert all(math.isnan(d) for d in dist)
+
+
+def test_SynapseCollection_distance_mixed():
+    """Test SynapseCollection distance function on non-spatial and spatial nodes"""
+
+    num_snodes_nonspatial = 3
+    num_tnodes_nonspatial = 2
+    num_conns_nonspatial = num_snodes_nonspatial * num_tnodes_nonspatial
+    s_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_snodes_nonspatial)
+    t_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_tnodes_nonspatial)
+
+    positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    s_nodes_spatial = nest.Create('iaf_psc_alpha', n=6, positions=positions)
+    t_nodes_spatial = nest.Create('iaf_psc_alpha', n=7, positions=positions)
+
+    nest.Connect(s_nodes_nonspatial, t_nodes_nonspatial)
+    nest.Connect(s_nodes_spatial, t_nodes_spatial)
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    # Check part that is spatial
+    ref_distance = _calculate_distance(conns[num_conns_nonspatial:], s_nodes_spatial, t_nodes_spatial)
+    assert dist[num_conns_nonspatial:] == pytest.approx(ref_distance)
+
+    # Check part that is non-spatial
+    assert all(math.isnan(d) for d in dist[:num_conns_nonspatial])
+
+
+def test_SynapseCollection_distance_spatial_nonspatial_connected():
+    """Test SynapseCollection distance function on non-spatial and spatial nodes that are connected"""
+
+    num_snodes = 5
+    num_tnodes = 11
+    s_nodes_nonspatial = nest.Create('iaf_psc_alpha', num_snodes)
+
+    positions = nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    t_nodes_spatial = nest.Create('iaf_psc_alpha', n=num_tnodes, positions=positions)
+
+    nest.Connect(s_nodes_nonspatial, t_nodes_spatial)
+    conns = nest.GetConnections()
+    dist = conns.distance
+
+    # All should be nan
+    assert all(math.isnan(d) for d in dist)

--- a/testsuite/pytests/test_spatial/test_SynapseCollection_distance.py
+++ b/testsuite/pytests/test_spatial/test_SynapseCollection_distance.py
@@ -25,6 +25,7 @@ Tests distance between sources and targets of SynapseCollection
 
 import pytest
 import math
+import numpy as np
 import nest
 
 
@@ -42,20 +43,12 @@ def _calculate_distance(conns, s_nodes, t_nodes):
     src = conns.source
     trgt = conns.target
 
-    in_3d = len(s_pos[0]) == 3
+    dim = len(s_pos[0])
 
-    ref_distance = []
-    for s, t in zip(src, trgt):
-        x_ref = t_pos[t_nodes.index(t)][0] - s_pos[s_nodes.index(s)][0]
-        y_ref = t_pos[t_nodes.index(t)][1] - s_pos[s_nodes.index(s)][1]
-        z_ref = 0.0
-        if in_3d:
-            z_ref = t_pos[t_nodes.index(t)][2] - s_pos[s_nodes.index(s)][2]
+    ref_distance = [np.linalg.norm(np.array(t_pos[t_nodes.index(t)]) - np.array(s_pos[s_nodes.index(s)]), ord=2)
+                    for s, t in zip(conns.source, conns.target)]
 
-        ref_dist = math.sqrt(x_ref * x_ref + y_ref * y_ref + z_ref * z_ref)
-        ref_distance.append(ref_dist)
-
-    return tuple(ref_distance)
+    return ref_distance
 
 
 def test_SynapseCollection_distance_simple():

--- a/testsuite/pytests/test_spatial/test_plotting.py
+++ b/testsuite/pytests/test_spatial/test_plotting.py
@@ -23,161 +23,154 @@
 Tests for basic spatial plotting functions.
 """
 
-import unittest
+import pytest
 import nest
 import numpy as np
 
 try:
+    import matplotlib
+    matplotlib.use('Agg')   # backend without window
     import matplotlib.pyplot as plt
 
-    tmp_fig = plt.figure()  # make sure we can open a window; DISPLAY may not be set
+    tmp_fig = plt.figure()  # make sure we can open a figure
     plt.close(tmp_fig)
     PLOTTING_POSSIBLE = True
 except ImportError:
     PLOTTING_POSSIBLE = False
 
 
-@unittest.skipIf(not PLOTTING_POSSIBLE,
-                 'Plotting impossible because matplotlib or display missing')
-class PlottingTestCase(unittest.TestCase):
+# skip all test if plotting impossible
+pytestmark = pytest.mark.skipif(not PLOTTING_POSSIBLE,
+                                reason='Plotting impossible because matplotlib or display missing')
+
+
+class TestLayerPlot:
+
+    @pytest.fixture(autouse=True)
+    def _prep(self):
+        nest.ResetKernel()
+        self.layer = nest.Create('iaf_psc_alpha',
+                                 positions=nest.spatial.grid(shape=[3, 3],
+                                                             extent=[2., 2.],
+                                                             edge_wrap=True))
+
     def test_PlotLayer(self):
         """Test plotting layer."""
-        nest.ResetKernel()
-        layer = nest.Create('iaf_psc_alpha',
-                            positions=nest.spatial.grid(shape=[3, 3],
-                                                        extent=[2., 2.],
-                                                        edge_wrap=True))
-        nest.PlotLayer(layer)
 
-        plotted_datapoints = plt.gca().collections[-1].get_offsets().data
-        reference_datapoints = nest.GetPosition(layer)
-        self.assertTrue(np.allclose(plotted_datapoints, reference_datapoints))
+        nest.PlotLayer(self.layer)
+
+        plotted_datapoints = np.array(plt.gca().collections[-1].get_offsets().data)
+        reference_datapoints = np.array(nest.GetPosition(self.layer))
+        assert plotted_datapoints == pytest.approx(reference_datapoints)
 
     def test_PlotTargets(self):
         """Test plotting targets."""
+
         delta = 0.05
         mask = {'rectangular': {'lower_left': [-delta, -2/3 - delta], 'upper_right': [2/3 + delta, delta]}}
-        cdict = {'rule': 'pairwise_bernoulli', 'p': 1.,
-                 'mask': mask}
+        cdict = {'rule': 'pairwise_bernoulli', 'p': 1., 'mask': mask}
         sdict = {'synapse_model': 'stdp_synapse'}
-        nest.ResetKernel()
-        layer = nest.Create('iaf_psc_alpha',
-                            positions=nest.spatial.grid(shape=[3, 3],
-                                                        extent=[2., 2.],
-                                                        edge_wrap=True))
 
         # connect layer -> layer
-        nest.Connect(layer, layer, cdict, sdict)
+        nest.Connect(self.layer, self.layer, cdict, sdict)
 
-        ctr = nest.FindCenterElement(layer)
-        fig = nest.PlotTargets(ctr, layer)
+        ctr = nest.FindCenterElement(self.layer)
+        fig = nest.PlotTargets(ctr, self.layer)
         fig.gca().set_title('Plain call')
 
         plotted_datapoints = plt.gca().collections[0].get_offsets().data
         eps = 0.01
-        pos = np.array(nest.GetPosition(layer))
+        pos = np.array(nest.GetPosition(self.layer))
         pos_xmask = pos[np.where(pos[:, 0] > -eps)]
         reference_datapoints = pos_xmask[np.where(pos_xmask[:, 1] < eps)][::-1]
-        self.assertTrue(np.array_equal(np.sort(plotted_datapoints, axis=0), np.sort(reference_datapoints, axis=0)))
+        assert np.sort(plotted_datapoints, axis=0) == pytest.approx(np.sort(reference_datapoints, axis=0))
 
-        fig = nest.PlotTargets(ctr, layer, mask=mask)
+        fig = nest.PlotTargets(ctr, self.layer, mask=mask)
         ax = fig.gca()
         ax.set_title('Call with mask')
-        self.assertGreaterEqual(len(ax.patches), 1)
+        assert len(ax.patches) >= 1
 
     def test_PlotSources(self):
         """Test plotting sources"""
+
         delta = 0.05
         mask = {'rectangular': {'lower_left': [-delta, -2/3 - delta], 'upper_right': [2/3 + delta, delta]}}
-        cdict = {'rule': 'pairwise_bernoulli', 'p': 1.,
-                 'mask': mask}
+        cdict = {'rule': 'pairwise_bernoulli', 'p': 1., 'mask': mask}
         sdict = {'synapse_model': 'stdp_synapse'}
-        nest.ResetKernel()
-        layer = nest.Create('iaf_psc_alpha',
-                            positions=nest.spatial.grid(shape=[3, 3],
-                                                        extent=[2., 2.],
-                                                        edge_wrap=True))
 
         # connect layer -> layer
-        nest.Connect(layer, layer, cdict, sdict)
+        nest.Connect(self.layer, self.layer, cdict, sdict)
 
-        ctr = nest.FindCenterElement(layer)
-        fig = nest.PlotSources(layer, ctr)
+        ctr = nest.FindCenterElement(self.layer)
+        fig = nest.PlotSources(self.layer, ctr)
         fig.gca().set_title('Plain call')
 
         plotted_datapoints = plt.gca().collections[0].get_offsets().data
         eps = 0.01
-        pos = np.array(nest.GetPosition(layer))
+        pos = np.array(nest.GetPosition(self.layer))
         pos_xmask = pos[np.where(pos[:, 0] < eps)]
         reference_datapoints = pos_xmask[np.where(pos_xmask[:, 1] > - eps)][::-1]
-        self.assertTrue(np.array_equal(np.sort(plotted_datapoints, axis=0), np.sort(reference_datapoints, axis=0)))
+        assert np.sort(plotted_datapoints, axis=0) == pytest.approx(np.sort(reference_datapoints, axis=0))
 
-        fig = nest.PlotSources(layer, ctr, mask=mask)
+        fig = nest.PlotSources(self.layer, ctr, mask=mask)
         ax = fig.gca()
         ax.set_title('Call with mask')
-        self.assertGreaterEqual(len(ax.patches), 1)
+        assert len(ax.patches) >= 1
+
+
+class TestKernelProbabilityPlot:
+
+    @pytest.fixture(autouse=True)
+    def _prep(self):
+        nest.ResetKernel()
+        self.plot_shape = [10, 10]
+        self.plot_edges = [-0.5, 0.5, -0.5, 0.5]
+        self.layer = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid([10, 10], edge_wrap=False))
+        self.source = self.layer[25]
+
+    @staticmethod
+    def _probability_calculation(distance):
+        return 1 - 1.5 * distance
 
     def test_plot_probability_kernel(self):
         """Plot parameter probability"""
-        nest.ResetKernel()
-        plot_shape = [10, 10]
-        plot_edges = [-0.5, 0.5, -0.5, 0.5]
 
-        def probability_calculation(distance):
-            return 1 - 1.5*distance
-
-        layer = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid([10, 10], edge_wrap=False))
-        source = layer[25]
-        source_pos = np.array(nest.GetPosition(source))
-        source_x, source_y = source_pos
+        source_x, source_y = nest.GetPosition(self.source)
 
         # Calculate reference values
-        ref_probability = np.zeros(plot_shape[::-1])
-        for i, x in enumerate(np.linspace(plot_edges[0], plot_edges[1], plot_shape[0])):
-            positions = np.array([[x, y] for y in np.linspace(plot_edges[2], plot_edges[3], plot_shape[1])])
+        ref_probability = np.zeros(self.plot_shape[::-1])
+        for i, x in enumerate(np.linspace(self.plot_edges[0], self.plot_edges[1], self.plot_shape[0])):
+            positions = np.array([[x, y]
+                                  for y in np.linspace(self.plot_edges[2], self.plot_edges[3], self.plot_shape[1])])
             ref_distances = np.sqrt((positions[:, 0] - source_x)**2 + (positions[:, 1] - source_y)**2)
-            values = probability_calculation(ref_distances)
+            values = self._probability_calculation(ref_distances)
             ref_probability[:, i] = np.maximum(np.minimum(np.array(values), 1.0), 0.0)
 
         # Create the parameter
-        parameter = probability_calculation(nest.spatial.distance)
+        parameter = self._probability_calculation(nest.spatial.distance)
 
         fig, ax = plt.subplots()
-        nest.PlotProbabilityParameter(source, parameter, ax=ax, shape=plot_shape, edges=plot_edges)
+        nest.PlotProbabilityParameter(self.source, parameter, ax=ax, shape=self.plot_shape, edges=self.plot_edges)
 
-        self.assertEqual(len(ax.images), 1)
+        assert len(ax.images) >= 1
         img = ax.images[0]
         img_data = img.get_array().data
-        self.assertTrue(np.array_equal(img_data, ref_probability))
+        assert img_data == pytest.approx(ref_probability)
 
     def test_plot_probability_kernel_with_mask(self):
         """Plot parameter probability with mask"""
-        nest.ResetKernel()
-        plot_shape = [10, 10]
-        plot_edges = [-0.5, 0.5, -0.5, 0.5]
 
-        layer = nest.Create('iaf_psc_alpha', positions=nest.spatial.grid([10, 10], edge_wrap=False))
-        parameter = 1 - 1.5*nest.spatial.distance
+        parameter = self._probability_calculation(1 - 1.5 * nest.spatial.distance)
 
-        source = layer[25]
         masks = [{'circular': {'radius': 0.4}},
                  {'doughnut': {'inner_radius': 0.2, 'outer_radius': 0.45}},
                  {'rectangular': {'lower_left': [-.3, -.3], 'upper_right': [0.3, 0.3]}},
                  {'elliptical': {'major_axis': 0.8, 'minor_axis': 0.4}}]
         fig, axs = plt.subplots(2, 2)
+
         for mask, ax in zip(masks, axs.flatten()):
-            nest.PlotProbabilityParameter(source, parameter, mask=mask, ax=ax, shape=plot_shape, edges=plot_edges)
-            self.assertEqual(len(ax.images), 1)
-            self.assertGreaterEqual(len(ax.patches), 1)
+            nest.PlotProbabilityParameter(self.source, parameter, mask=mask, ax=ax,
+                                          shape=self.plot_shape, edges=self.plot_edges)
 
-
-def suite():
-    suite = unittest.makeSuite(PlottingTestCase, 'test')
-    return suite
-
-
-if __name__ == "__main__":
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite())
-
-    plt.show()
+            assert len(ax.images) >= 1
+            assert len(ax.patches) >= 1


### PR DESCRIPTION
The main motivation for this PR is that tests from two modules failed on Apple silicon after upgrading to macOS 13.3.1 and XCode 14.3 because some distance values returned by NEST differ in the last decimal (mantissa bit). The difference occurs with Apple Clang 14.0.3 and GCC 12.2.0; it does not occur on Intel silicon.

All comparisons (except where exact zero is expected) now use `pytest.approx()`. The tests are also restructured in PyTest form and grouped in two classes according to the network setup they require.

The tests could probably be revised further, but this is a bug fix and should therefore not be delayed.