### PR TITLE
Make it an error to set multiple threads if NEST was built without thread support

### DIFF
--- a/nestkernel/vp_manager.cpp
+++ b/nestkernel/vp_manager.cpp
@@ -95,9 +95,7 @@ nest::VPManager::set_status( const DictionaryDatum& d )
 
   if ( force_singlethreading_ and n_threads > 1 )
   {
-    std::string msg = "Multithreading requested, but unavailable. Using a single thread.";
-    LOG( M_WARNING, "VPManager::set_status", msg );
-    n_threads = 1;
+    throw BadProperty( "This installation of NEST was built without support for multiple threads." ); 
   }
 
   // We only want to act if new values differ from the old

--- a/nestkernel/vp_manager.cpp
+++ b/nestkernel/vp_manager.cpp
@@ -95,7 +95,7 @@ nest::VPManager::set_status( const DictionaryDatum& d )
 
   if ( force_singlethreading_ and n_threads > 1 )
   {
-    throw BadProperty( "This installation of NEST was built without support for multiple threads." ); 
+    throw BadProperty( "This installation of NEST was built without support for multiple threads." );
   }
 
   // We only want to act if new values differ from the old

--- a/testsuite/mpitests/test_get_nodes.sli
+++ b/testsuite/mpitests/test_get_nodes.sli
@@ -32,6 +32,8 @@ Description:
 Author: August 2019, Stine B. Vennemo
 */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/mpitests/test_sinusoidal_poisson_generator_5.sli
+++ b/testsuite/mpitests/test_sinusoidal_poisson_generator_5.sli
@@ -35,6 +35,8 @@ Author:  December 2012, May 2013, Plesser, based on test_poisson_generator.sli
 See also: test_sinusoidal_poisson_generator_{1,2,3,4,6}, test_sinusoidal_poisson_generator_nostat
 */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/mpitests/test_sinusoidal_poisson_generator_6.sli
+++ b/testsuite/mpitests/test_sinusoidal_poisson_generator_6.sli
@@ -35,6 +35,8 @@ Author:  December 2012, May 2013, Plesser, based on test_poisson_generator.sli
 See also: test_sinusoidal_poisson_generator_{1,2,3,4,5}, test_sinusoidal_poisson_generator_nostat
 */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/mpitests/topo_mpi_test_pairwise_bernoulli_on_source.sli
+++ b/testsuite/mpitests/topo_mpi_test_pairwise_bernoulli_on_source.sli
@@ -20,6 +20,8 @@
  *
  */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/mpitests/topo_mpi_test_pairwise_bernoulli_on_target.sli
+++ b/testsuite/mpitests/topo_mpi_test_pairwise_bernoulli_on_target.sli
@@ -20,6 +20,8 @@
  *
  */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/pytests/mpi/2/test_connect_arrays_mpi.py
+++ b/testsuite/pytests/mpi/2/test_connect_arrays_mpi.py
@@ -32,8 +32,10 @@ except ImportError:
     HAVE_MPI4PY = False
 
 HAVE_MPI = nest.ll_api.sli_func("statusdict/have_mpi ::")
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
 @unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
 class TestConnectArraysMPICase(unittest.TestCase):
     """

--- a/testsuite/pytests/mpi/2/test_connect_arrays_mpi.py
+++ b/testsuite/pytests/mpi/2/test_connect_arrays_mpi.py
@@ -35,7 +35,7 @@ HAVE_MPI = nest.ll_api.sli_func("statusdict/have_mpi ::")
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
-@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 @unittest.skipIf(not HAVE_MPI4PY, 'mpi4py is not available')
 class TestConnectArraysMPICase(unittest.TestCase):
     """

--- a/testsuite/pytests/mpi/4/test_consistent_local_vps.py
+++ b/testsuite/pytests/mpi/4/test_consistent_local_vps.py
@@ -19,9 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
+import unittest
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
 def test_consistent_local_vps():
     """
     Test local_vps field of kernel status.

--- a/testsuite/pytests/mpi/4/test_consistent_local_vps.py
+++ b/testsuite/pytests/mpi/4/test_consistent_local_vps.py
@@ -26,7 +26,7 @@ import nest
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
-@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 def test_consistent_local_vps():
     """
     Test local_vps field of kernel status.

--- a/testsuite/pytests/test_connect_all_to_all.py
+++ b/testsuite/pytests/test_connect_all_to_all.py
@@ -27,6 +27,10 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 @nest.ll_api.check_stack
 class TestAllToAll(connect_test_base.ConnectTestBase):
 

--- a/testsuite/pytests/test_connect_array_fixed_outdegree.py
+++ b/testsuite/pytests/test_connect_array_fixed_outdegree.py
@@ -29,6 +29,10 @@ import nest
 import numpy
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 @nest.ll_api.check_stack
 class ConnectArrayFixedOutdegreeTestCase(unittest.TestCase):
     """Tests of connections with fixed outdegree and parameter arrays"""

--- a/testsuite/pytests/test_connect_arrays.py
+++ b/testsuite/pytests/test_connect_arrays.py
@@ -124,6 +124,7 @@ class TestConnectArrays(unittest.TestCase):
         np.testing.assert_array_almost_equal(conns.weight, weights)
         np.testing.assert_array_almost_equal(conns.delay, delays)
 
+    @unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
     def test_connect_arrays_threaded(self):
         """Connecting NumPy arrays, threaded"""
         nest.local_num_threads = 2

--- a/testsuite/pytests/test_connect_fixed_indegree.py
+++ b/testsuite/pytests/test_connect_fixed_indegree.py
@@ -27,6 +27,11 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+@nest.ll_api.check_stack
 class TestFixedInDegree(connect_test_base.ConnectTestBase):
 
     # specify connection pattern and specific params

--- a/testsuite/pytests/test_connect_fixed_outdegree.py
+++ b/testsuite/pytests/test_connect_fixed_outdegree.py
@@ -26,6 +26,11 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+@nest.ll_api.check_stack
 class TestFixedOutDegree(connect_test_base.ConnectTestBase):
 
     # specify connection pattern and specific params

--- a/testsuite/pytests/test_connect_fixed_total_number.py
+++ b/testsuite/pytests/test_connect_fixed_total_number.py
@@ -26,6 +26,11 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+@nest.ll_api.check_stack
 class TestFixedTotalNumber(connect_test_base.ConnectTestBase):
 
     # specify connection pattern and specific params

--- a/testsuite/pytests/test_connect_one_to_one.py
+++ b/testsuite/pytests/test_connect_one_to_one.py
@@ -25,6 +25,11 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+@nest.ll_api.check_stack
 class TestOneToOne(connect_test_base.ConnectTestBase):
 
     # specify connection pattern

--- a/testsuite/pytests/test_connect_pairwise_bernoulli.py
+++ b/testsuite/pytests/test_connect_pairwise_bernoulli.py
@@ -27,6 +27,11 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+@nest.ll_api.check_stack
 class TestPairwiseBernoulli(connect_test_base.ConnectTestBase):
 
     # specify connection pattern and specific params

--- a/testsuite/pytests/test_connect_symmetric_pairwise_bernoulli.py
+++ b/testsuite/pytests/test_connect_symmetric_pairwise_bernoulli.py
@@ -28,6 +28,11 @@ import connect_test_base
 import nest
 
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
+
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
+@nest.ll_api.check_stack
 class TestSymmetricPairwiseBernoulli(connect_test_base.ConnectTestBase):
 
     # sizes of source-, target-population and connection probability for

--- a/testsuite/pytests/test_recording_backend_ascii.py
+++ b/testsuite/pytests/test_recording_backend_ascii.py
@@ -26,7 +26,7 @@ import nest
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
-@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 class TestRecordingBackendASCII(unittest.TestCase):
 
     def testAAAOverwriteFiles(self):

--- a/testsuite/pytests/test_recording_backend_ascii.py
+++ b/testsuite/pytests/test_recording_backend_ascii.py
@@ -23,7 +23,10 @@ import os
 import unittest
 import nest
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
 class TestRecordingBackendASCII(unittest.TestCase):
 
     def testAAAOverwriteFiles(self):

--- a/testsuite/pytests/test_recording_backend_memory.py
+++ b/testsuite/pytests/test_recording_backend_memory.py
@@ -25,7 +25,7 @@ import nest
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
-@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 class TestRecordingBackendMemory(unittest.TestCase):
 
     def testEventsDict(self):

--- a/testsuite/pytests/test_recording_backend_memory.py
+++ b/testsuite/pytests/test_recording_backend_memory.py
@@ -22,7 +22,10 @@
 import unittest
 import nest
 
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
+
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
 class TestRecordingBackendMemory(unittest.TestCase):
 
     def testEventsDict(self):

--- a/testsuite/pytests/test_weight_recorder.py
+++ b/testsuite/pytests/test_weight_recorder.py
@@ -31,7 +31,7 @@ HAVE_GSL = nest.ll_api.sli_func("statusdict/have_gsl ::")
 HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
-@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')
 @nest.ll_api.check_stack
 class WeightRecorderTestCase(unittest.TestCase):
     """Tests for the Weight Recorder"""

--- a/testsuite/pytests/test_weight_recorder.py
+++ b/testsuite/pytests/test_weight_recorder.py
@@ -28,8 +28,10 @@ import nest
 import numpy as np
 
 HAVE_GSL = nest.ll_api.sli_func("statusdict/have_gsl ::")
+HAVE_OPENMP = nest.ll_api.sli_func("is_threaded")
 
 
+@unittest.skipIf(not HAVE_OPENMP, 'NEST was compiled without multi-threading')            
 @nest.ll_api.check_stack
 class WeightRecorderTestCase(unittest.TestCase):
     """Tests for the Weight Recorder"""

--- a/testsuite/regressiontests/issue-1640.sli
+++ b/testsuite/regressiontests/issue-1640.sli
@@ -34,6 +34,8 @@ Author: Håkon Mørk
 FirstVersion: August 2020
 */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/regressiontests/ticket-643.sli
+++ b/testsuite/regressiontests/ticket-643.sli
@@ -33,6 +33,8 @@
 
 */
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/regressiontests/ticket-881.sli
+++ b/testsuite/regressiontests/ticket-881.sli
@@ -34,6 +34,8 @@ Author: Hans Ekkehard Plesser
 */
 
 
+skip_if_not_threaded
+
 (unittest) run
 /unittest using
 

--- a/testsuite/unittests/test_GetConnections.sli
+++ b/testsuite/unittests/test_GetConnections.sli
@@ -222,6 +222,8 @@
 
 
 % eighth test: check static synapses on four threads
+skip_if_not_threaded
+
 {
   << >> begin
     ResetKernel

--- a/testsuite/unittests/test_sinusoidal_gamma_generator.sli
+++ b/testsuite/unittests/test_sinusoidal_gamma_generator.sli
@@ -206,6 +206,8 @@ M_ERROR setverbosity
 } assert_or_die
 (passed 4b) ==
 
+skip_if_not_threaded
+
 % test 4c: two threads, one spike train for all targets
 {
   false 2 4 test4_function

--- a/testsuite/unittests/test_sinusoidal_poisson_generator.sli
+++ b/testsuite/unittests/test_sinusoidal_poisson_generator.sli
@@ -201,6 +201,8 @@ M_ERROR setverbosity
 } assert_or_die
 (passed 4b) ==
 
+skip_if_not_threaded
+
 % test 4c: two threads, one spike train for all targets
 {
   false 2 4 test4_function


### PR DESCRIPTION
Until now, setting more than one thread if NEST was built without thread support resulted only in a warning. This led to a considerable number of tests being run in a meaningless way, and potentially causing problems in MPI-based test.

This PR makes it an error to try to set more that one local thread if NEST was built without thread support. The PR also ensures that all tests requiring multiple threads are skipped.