### PR TITLE
Fix OpenMP issues on CI under macOS and re-activate testing with threads for macOS

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -226,7 +226,6 @@ jobs:
       - name: "Install MacOS system dependencies"
         run: |
           brew install coreutils gsl open-mpi libomp automake autoconf libtool boost
-          brew info python
 
       - name: "Restore pip cache"
         env:

--- a/build_support/ci_build.sh
+++ b/build_support/ci_build.sh
@@ -178,7 +178,7 @@ if [ "$xNEST_BUILD_TYPE" = "FULL_MACOS" ]; then
     xLTDL=1
     xMPI=1
     xMUSIC=0
-    xOPENMP=0
+    xOPENMP=1
     xPYTHON=1
     xREADLINE=1
     xSIONLIB=0
@@ -196,6 +196,9 @@ echo "MSGBLD0232: Setting configuration variables."
 
 if [ "$xOPENMP" = "1" ] ; then
     CONFIGURE_OPENMP="-Dwith-openmp=ON"
+    if [ "$xNEST_BUILD_TYPE" = "FULL_MACOS" ]; then
+	CONFIGURE_OPENMP="${CONFIGURE_OPENMP} -DOpenMP_ROOT=`brew --prefix libomp`"
+    fi
 else
     CONFIGURE_OPENMP="-Dwith-openmp=OFF"
 fi
@@ -303,6 +306,7 @@ cmake \
     -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
     -Dwith-optimize=ON \
     -Dwith-warning=ON \
+    -Dwith-userdoc=OFF \
     $CONFIGURE_BOOST \
     $CONFIGURE_OPENMP \
     $CONFIGURE_MPI \


### PR DESCRIPTION
This PR fixes the CI build of NEST under macOS by providing the location of the OpenMP lib through a `brew --prefix` query. It also re-activates testing with threads under macOS. A meaningless `brew info` line is removed—it only printed canned package information.

This fixes #2515.

PR developed in collaboration with @nicolossus.