### PR TITLE
Add comment on min delay

### DIFF
--- a/pynest/examples/Potjans_2014/network.py
+++ b/pynest/examples/Potjans_2014/network.py
@@ -452,6 +452,9 @@ class Network:
                                 mean=self.net_dict['delay_matrix_mean'][i][j],
                                 std=(self.net_dict['delay_matrix_mean'][i][j] *
                                      self.net_dict['delay_rel_std'])),
+                            # resulting minimum delay is equal to resolution, see:
+                            # https://nest-simulator.readthedocs.io/en/latest/nest_behavior
+                            # /random_numbers.html#rounding-effects-when-randomizing-delays
                             min=nest.resolution - 0.5 * nest.resolution,
                             max=np.Inf)}
 
@@ -515,6 +518,9 @@ class Network:
                         mean=self.stim_dict['delay_th_mean'],
                         std=(self.stim_dict['delay_th_mean'] *
                              self.stim_dict['delay_th_rel_std'])),
+                    # resulting minimum delay is equal to resolution, see:
+                    # https://nest-simulator.readthedocs.io/en/latest/nest_behavior
+                    # /random_numbers.html#rounding-effects-when-randomizing-delays
                     min=nest.resolution - 0.5 * nest.resolution,
                     max=np.Inf)}
 


### PR DESCRIPTION
This PR is a follow-up to PR [#2504](https://github.com/nest/nest-simulator/pull/2504).
The PR adds a clarifying comment for the shift in the delay distribution in the pynest example of the microcircuit.
Created together with @jhnnsnk and @mlober. We suggest @gtrensch as a reviewer.