### PR TITLE
Set sender node id info with correct target lcid

### DIFF
--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -617,13 +617,7 @@ EventDeliveryManager::deliver_events_( const size_t tid, const std::vector< Spik
       {
         if ( spike_data.get_tid() == tid )
         {
-          const size_t syn_id = spike_data.get_syn_id();
-          const size_t lcid = spike_data.get_lcid();
-
-          // non-local sender -> receiver retrieves ID of sender Node from SourceTable based on tid, syn_id, lcid
-          // only if needed, as this is computationally costly
-          se.set_sender_node_id_info( tid, syn_id, lcid );
-          kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
+          kernel().connection_manager.send( tid, spike_data.get_syn_id(), spike_data.get_lcid(), cm, se );
         }
       }
       else
@@ -638,12 +632,7 @@ EventDeliveryManager::deliver_events_( const size_t tid, const std::vector< Spik
         {
           if ( it->get_tid() == tid )
           {
-            const size_t lcid = it->get_lcid();
-
-            // non-local sender -> receiver retrieves ID of sender Node from SourceTable based on tid, syn_id, lcid
-            // only if needed, as this is computationally costly
-            se.set_sender_node_id_info( tid, syn_id, lcid );
-            kernel().connection_manager.send( tid, syn_id, lcid, cm, se );
+            kernel().connection_manager.send( tid, syn_id, it->get_lcid(), cm, se );
           }
         }
       }


### PR DESCRIPTION
In the `event_delivery_manager` the `sender_node_id_info` is set during the event delivery using the same `lcid` for all contiguous connections with the same source instead of the actual lcid of the connection. This is not wrong per se, but prevents us from grabbing the correct lcid lateron from the `set_sender_node_id_info`. One could argue if that shouldn't be done at all, but why not. In NEST there is currently no use case in the kernel or any existing model, but it might potentially be used in NESTML or when users write their own models.  
Setting the correct lcid does not add any overhead and even reduces some redundancy in the code.