### PR TITLE
Fix uninitialized variable

### DIFF
--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -83,6 +83,7 @@ nest::iaf_psc_exp::Parameters_::Parameters_()
 
 nest::iaf_psc_exp::State_::State_()
   : i_0_( 0.0 )
+  , i_1_( 0.0 )
   , i_syn_ex_( 0.0 )
   , i_syn_in_( 0.0 )
   , V_m_( 0.0 )


### PR DESCRIPTION
Hey,
I think this PR of Jakob's - the reason for having 2.14.2 - had not been cherry-picked yet.
Anyway, I added it here.