### PR TITLE
Fix setting min and max delay after resolution change

### DIFF
--- a/doc/htmldoc/nest_behavior/running_simulations.rst
+++ b/doc/htmldoc/nest_behavior/running_simulations.rst
@@ -103,6 +103,12 @@ extrema too wide without need leads to decreased performance due to more
 update calls and communication cycles (small *dmin*), or increased
 memory consumption of NEST (large *dmax*).
 
+Delays after changes in resolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When the resolution is changed *dmin*, *dmax*, as well as the time-based model defaults are adjusted to match the new resolution. In case the new resolution is lower than the precision of these delays, *dmin* is rounded down, *dmax* is rounded up and the time-based model defaults are rounded mathematically. When the new resolution value is larger than a time-based model default, this value is set to the new resolution.
+
+Note that delays cannot be smaller than the resolution. Further, the resolution cannot be changed once model defaults have been changed or connections have been created.
+
 Spike generation and precision
 ------------------------------
 

--- a/nestkernel/delay_checker.cpp
+++ b/nestkernel/delay_checker.cpp
@@ -54,9 +54,9 @@ nest::DelayChecker::calibrate( const TimeConverter& tc )
   // Calibrate will be called after a change in resolution, when there are no
   // network elements present.
 
-  if (min_delay_ == Time::pos_inf() or max_delay_ == Time::neg_inf())
+  if ( min_delay_ == Time::pos_inf() or max_delay_ == Time::neg_inf() )
   {
-    min_delay_ = tc.from_old_tics( min_delay_.get_tics() ); 
+    min_delay_ = tc.from_old_tics( min_delay_.get_tics() );
     max_delay_ = tc.from_old_tics( max_delay_.get_tics() );
   }
   else
@@ -68,7 +68,7 @@ nest::DelayChecker::calibrate( const TimeConverter& tc )
   }
 }
 
-void 
+void
 nest::DelayChecker::set_min_max_delay_( const double min_d, const double max_d )
 {
   // For the minimum delay, we always round down. The easiest way to do this,
@@ -101,10 +101,8 @@ nest::DelayChecker::set_min_max_delay_( const double min_d, const double max_d )
     min_delay_ = new_min_delay;
     max_delay_ = new_max_delay;
 
-    std::string msg =
-          String::compose( "Minimum and maximum delays were changed to %1 ms and %2 ms.",
-            min_delay_.get_ms(),
-            max_delay_.get_ms() );
+    std::string msg = String::compose(
+      "Minimum and maximum delays were changed to %1 ms and %2 ms.", min_delay_.get_ms(), max_delay_.get_ms() );
     LOG( M_INFO, "DelayChecker::set_min_max_delay_", msg );
   }
 }
@@ -121,7 +119,7 @@ nest::DelayChecker::set_status( const DictionaryDatum& d )
 {
   double min_d_tmp = 0.0;
   bool min_delay_updated = updateValue< double >( d, names::min_delay, min_d_tmp );
-  
+
   double max_d_tmp = 0.0;
   bool max_delay_updated = updateValue< double >( d, names::max_delay, max_d_tmp );
 
@@ -138,8 +136,7 @@ nest::DelayChecker::set_status( const DictionaryDatum& d )
     }
     else
     {
-      std::cout<<"in set status. min_d = "<<min_d_tmp<<" , max_d = "<< max_d_tmp<<std::endl;
-      DelayChecker::set_min_max_delay_(min_d_tmp, max_d_tmp);
+      DelayChecker::set_min_max_delay_( min_d_tmp, max_d_tmp );
       user_set_delay_extrema_ = true;
     }
   }

--- a/nestkernel/delay_checker.cpp
+++ b/nestkernel/delay_checker.cpp
@@ -53,8 +53,60 @@ nest::DelayChecker::calibrate( const TimeConverter& tc )
 {
   // Calibrate will be called after a change in resolution, when there are no
   // network elements present.
-  min_delay_ = tc.from_old_tics( min_delay_.get_tics() );
-  max_delay_ = tc.from_old_tics( max_delay_.get_tics() );
+
+  if (min_delay_ == Time::pos_inf() or max_delay_ == Time::neg_inf())
+  {
+    min_delay_ = tc.from_old_tics( min_delay_.get_tics() ); 
+    max_delay_ = tc.from_old_tics( max_delay_.get_tics() );
+  }
+  else
+  {
+    double min_d = min_delay_.get_ms();
+    double max_d = max_delay_.get_ms();
+
+    DelayChecker::set_min_max_delay_( min_d, max_d );
+  }
+}
+
+void 
+nest::DelayChecker::set_min_max_delay_( const double min_d, const double max_d )
+{
+  // For the minimum delay, we always round down. The easiest way to do this,
+  // is to round up and then subtract one step. The only remaining edge case
+  // is that the min delay is exactly at a step, in which case one would get
+  // a min delay that is one step too small. We can detect this by an
+  // additional test.
+
+  Time new_min_delay;
+  delay new_min_delay_steps = Time( Time::ms_stamp( min_d ) ).get_steps();
+  if ( Time( Time::step( new_min_delay_steps ) ).get_ms() > min_d )
+  {
+    new_min_delay_steps -= 1;
+  }
+  new_min_delay = Time( Time::step( new_min_delay_steps ) );
+
+  // For the maximum delay, we always round up, using ms_stamp
+  Time new_max_delay = Time( Time::ms_stamp( max_d ) );
+
+  if ( new_min_delay < Time::get_resolution() )
+  {
+    throw BadDelay( new_min_delay.get_ms(), "min_delay must be greater than or equal to resolution." );
+  }
+  else if ( new_max_delay < new_min_delay )
+  {
+    throw BadDelay( new_min_delay.get_ms(), "min_delay must be smaller than or equal to max_delay." );
+  }
+  else
+  {
+    min_delay_ = new_min_delay;
+    max_delay_ = new_max_delay;
+
+    std::string msg =
+          String::compose( "Minimum and maximum delays were changed to %1 ms and %2 ms.",
+            min_delay_.get_ms(),
+            max_delay_.get_ms() );
+    LOG( M_INFO, "DelayChecker::set_min_max_delay_", msg );
+  }
 }
 
 void
@@ -67,27 +119,11 @@ nest::DelayChecker::get_status( DictionaryDatum& d ) const
 void
 nest::DelayChecker::set_status( const DictionaryDatum& d )
 {
-  // For the minimum delay, we always round down. The easiest way to do this,
-  // is to round up and then subtract one step. The only remaining edge case
-  // is that the min delay is exactly at a step, in which case one would get
-  // a min delay that is one step too small. We can detect this by an
-  // additional test.
-  double delay_tmp = 0.0;
-  bool min_delay_updated = updateValue< double >( d, names::min_delay, delay_tmp );
-  Time new_min_delay;
-  if ( min_delay_updated )
-  {
-    delay new_min_delay_steps = Time( Time::ms_stamp( delay_tmp ) ).get_steps();
-    if ( Time( Time::step( new_min_delay_steps ) ).get_ms() > delay_tmp )
-    {
-      new_min_delay_steps -= 1;
-    }
-    new_min_delay = Time( Time::step( new_min_delay_steps ) );
-  }
-
-  // For the maximum delay, we always round up, using ms_stamp
-  bool max_delay_updated = updateValue< double >( d, names::max_delay, delay_tmp );
-  Time new_max_delay = Time( Time::ms_stamp( delay_tmp ) );
+  double min_d_tmp = 0.0;
+  bool min_delay_updated = updateValue< double >( d, names::min_delay, min_d_tmp );
+  
+  double max_d_tmp = 0.0;
+  bool max_delay_updated = updateValue< double >( d, names::max_delay, max_d_tmp );
 
   if ( min_delay_updated xor max_delay_updated )
   {
@@ -100,18 +136,10 @@ nest::DelayChecker::set_status( const DictionaryDatum& d )
     {
       throw BadProperty( "Connections already exist. Please call ResetKernel first" );
     }
-    else if ( new_min_delay < Time::get_resolution() )
-    {
-      throw BadDelay( new_min_delay.get_ms(), "min_delay must be greater than or equal to resolution." );
-    }
-    else if ( new_max_delay < new_min_delay )
-    {
-      throw BadDelay( new_min_delay.get_ms(), "min_delay must be smaller than or equal to max_delay." );
-    }
     else
     {
-      min_delay_ = new_min_delay;
-      max_delay_ = new_max_delay;
+      std::cout<<"in set status. min_d = "<<min_d_tmp<<" , max_d = "<< max_d_tmp<<std::endl;
+      DelayChecker::set_min_max_delay_(min_d_tmp, max_d_tmp);
       user_set_delay_extrema_ = true;
     }
   }

--- a/nestkernel/delay_checker.h
+++ b/nestkernel/delay_checker.h
@@ -91,6 +91,8 @@ private:
   bool user_set_delay_extrema_; //!< Flag indicating if the user set the delay
                                 //!< extrema.
   bool freeze_delay_update_;
+
+  void set_min_max_delay_( const double, const double );
 };
 
 inline const Time&


### PR DESCRIPTION
This PR fixes a bug in adjusting the minimum and maximum delay after a change in resolution. 

When the new resolution exceeds the precision of the minimum and maximum delay, the minimum delay should be rounded down, while the maximum delay should be rounded up. 

However, in the case of changing the resolution after setting the minimum and maximum delays in a separate call, the minimum delay was always rounded up instead of down. This is now fixed.

Since I added information about the rounding procedure in the case of a resolution change to the documentation, I suggest @jessica-mitchell as one of the reviewers.