### PR TITLE
Improve documentation on delays

### DIFF
--- a/doc/htmldoc/nest_behavior/running_simulations.rst
+++ b/doc/htmldoc/nest_behavior/running_simulations.rst
@@ -105,7 +105,7 @@ memory consumption of NEST (large *dmax*).
 
 Delays after changes in resolution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When the resolution is changed *dmin*, *dmax*, as well as the time-based model defaults (e.g. neuronal refractory times, synaptic delays) are adjusted to match the new resolution. In case the precision of these delays cannot be matched with the new resolution (e.g. *dmin=1.6*, *dmax=5.3* and *new_resolution=1.0*), *dmin* is rounded down (*dmin=1.0*), *dmax* is rounded up (*dmax=6.0*) and the time-based model defaults are rounded mathematically. When the new resolution value is larger than a time-based model default, this value is set to the new resolution.
+If you change the resolution, then *dmin*, *dmax*, as well as the time-based model defaults (e.g., neuronal refractory times, synaptic delays) are adjusted to match the new resolution. In case the precision of these delays cannot be matched with the new resolution (e.g., *dmin=1.6*, *dmax=5.3* and *new_resolution=1.0*), *dmin* is rounded down (*dmin=1.0*), *dmax* is rounded up (*dmax=6.0*), and the time-based model defaults are rounded mathematically. When the new resolution value is larger than a time-based model default, this value is set to the new resolution.
 
 .. note::
 

--- a/doc/htmldoc/nest_behavior/running_simulations.rst
+++ b/doc/htmldoc/nest_behavior/running_simulations.rst
@@ -105,9 +105,11 @@ memory consumption of NEST (large *dmax*).
 
 Delays after changes in resolution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When the resolution is changed *dmin*, *dmax*, as well as the time-based model defaults are adjusted to match the new resolution. In case the new resolution is lower than the precision of these delays, *dmin* is rounded down, *dmax* is rounded up and the time-based model defaults are rounded mathematically. When the new resolution value is larger than a time-based model default, this value is set to the new resolution.
+When the resolution is changed *dmin*, *dmax*, as well as the time-based model defaults (e.g. neuronal refractory times, synaptic delays) are adjusted to match the new resolution. In case the precision of these delays cannot be matched with the new resolution (e.g. *dmin=1.6*, *dmax=5.3* and *new_resolution=1.0*), *dmin* is rounded down (*dmin=1.0*), *dmax* is rounded up (*dmax=6.0*) and the time-based model defaults are rounded mathematically. When the new resolution value is larger than a time-based model default, this value is set to the new resolution.
 
-Note that delays cannot be smaller than the resolution. Further, the resolution cannot be changed once model defaults have been changed or connections have been created.
+.. note::
+
+    Delays cannot be smaller than the resolution. Further, the resolution cannot be changed once model defaults have been changed or connections have been created.
 
 Spike generation and precision
 ------------------------------


### PR DESCRIPTION
This PR improves the documentation on the effects of resolution change on the min/max delays and other time-based model parameters.

I suggest @jessica-mitchell as a reviewer.