### PR TITLE
Add `-lnest` to the list of libraries to link extension modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ endforeach ()
 
 # libraries required to link extension modules
 set( MODULE_LINK_LIBS
+  "-lnest"
   "-lsli"
   "${OpenMP_CXX_FLAGS}"
   "${LTDL_LIBRARIES}"


### PR DESCRIPTION
The build for `nest-extension-module` fails for MacOS with a link error because the `libnest` is missing in the list of libraries to link for extension modules. Adding the `-lnest` option resolves the error.