### PR TITLE
Require Cython >= 0.29.14 to avoid tp_print problem

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,8 @@ Image==1.5.30
 PyYAML>=4.2b1
 cmake==3.26.0
 csvkit==1.1.1
-cython==0.29.0
+# require cython version handling removal of tp_print with Python 3.9 correctly
+cython>=0.29.14
 docutils==0.19
 example==0.1.0
 ipykernel==6.22.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,6 @@ Image==1.5.30
 PyYAML>=4.2b1
 cmake==3.26.0
 csvkit==1.1.1
-# require cython version handling removal of tp_print with Python 3.9 correctly
 cython>=0.29.14
 docutils==0.19
 example==0.1.0


### PR DESCRIPTION
a4673ce1b847e815e36475f761f6db03a62feb73 broke sphinx_rtd testing. This PR fixes that.

Python 3.9 removed `tp_print` deep in the system, which requires extra care on Cython's part when handling different Python versions. This is only handled properly from 0.29.14 onwards (https://cython.readthedocs.io/en/latest/src/changes.html#id106), so this PR hikes that requirement. Otherwise, sphinx_rtd tests fail because Cython cannot be built, see, e.g., https://github.com/nest/nest-simulator/actions/runs/4831505004/jobs/8609059706?pr=2749#step:4:845

What was anyways the rationale behind fixing all packages to exact versions? When should they be updated?
