### PR TITLE
Add documentation about deadlock in mpi processes 

### DIFF
--- a/doc/htmldoc/hpc/parallel_computing.rst
+++ b/doc/htmldoc/hpc/parallel_computing.rst
@@ -241,6 +241,31 @@ command should look like this
 Please refer to the documentation of your MPI implementation to learn
 more about the usage of ``mpirun``.
 
+
+.. important::
+
+    One should never call any ``nest.*`` function inside a block that will only be executed on a subset of MPI ranks.
+
+    Trying to access kernel information with a subset of MPI processes causes a deadlock.
+
+    For example:
+
+    **Don't do this**
+
+    .. code-block::
+
+      if nest.Rank() == 0:
+            print('RNG seed: {}'.format(
+                nest.rng_seed))
+
+
+    **Do this**
+
+    .. code-block::
+
+     if nest.Rank() == 0:
+        print('RNG seed: {}'.format(rng_seed))
+
 MPI related commands
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/htmldoc/hpc/parallel_computing.rst
+++ b/doc/htmldoc/hpc/parallel_computing.rst
@@ -228,7 +228,7 @@ Run distributed simulations
 
 Distributed simulations **cannot be run interactively**, which means that
 the simulation has to be provided as a script. However, the script can be the same
-as a script for any simulation. No changes are necessary for distibuted simulation scripts:
+as a script for any simulation. No changes are necessary for distributed simulation scripts:
 inter-process communication and node distribution is managed transparently inside of NEST.
 
 To distribute a simulation onto 128 processes of a computer cluster, the
@@ -241,6 +241,30 @@ command should look like this
 Please refer to the documentation of your MPI implementation to learn
 more about the usage of ``mpirun``.
 
+
+MPI related commands
+~~~~~~~~~~~~~~~~~~~~
+
+Although we generally advise strongly against writing process-aware code
+in simulation scripts (e.g., creating a neuron or device only on one
+process and such), in special cases it may be necessary to obtain
+information about the MPI application. One example would opening the
+right stimulus file for a specific rank. Therefore, some MPI specific
+commands are available:
+
+.. glossary::
+
+ :py:func:`.NumProcesses`
+     The number of MPI processes in the simulation
+
+ ``ProcessorName``
+     The name of the machine. The result might differ on each process.
+
+ :py:func:`.Rank`
+     The rank of the MPI process. The result differs on each process.
+
+ :py:func:`.SyncProcesses`
+      Synchronize all MPI processes.
 
 .. important::
 
@@ -266,29 +290,6 @@ more about the usage of ``mpirun``.
      if nest.Rank() == 0:
         print('RNG seed: {}'.format(rng_seed))
 
-MPI related commands
-~~~~~~~~~~~~~~~~~~~~
-
-Although we generally advise strongly against writing process-aware code
-in simulation scripts (e.g., creating a neuron or device only on one
-process and such), in special cases it may be necessary to obtain
-information about the MPI application. One example would opening the
-right stimulus file for a specific rank. Therefore, some MPI specific
-commands are available:
-
-.. glossary::
-
- :py:func:`.NumProcesses`
-     The number of MPI processes in the simulation
-
- ``ProcessorName``
-     The name of the machine. The result might differ on each process.
-
- :py:func:`.Rank`
-     The rank of the MPI process. The result differs on each process.
-
- :py:func:`.SyncProcesses`
-      Synchronize all MPI processes.
 
 
 Reproducibility


### PR DESCRIPTION
This PR add a note in the documentation in the distributed computing section of the parallel computing page, regarding the issue resolved in  #2749.

See output [here](https://nest-test.readthedocs.io/en/docs-mpi-update/hpc/parallel_computing.html#using-distributed-computing) 
