### PR TITLE
Update readthedocs.yml to resolve build error from incompatible urllib3 version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,13 +1,14 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 sphinx:
   builder: html
-  configuration: doc/htmldoc/conf.py
+  configuration: source/conf.py
 
 python:
-   version: "3.8"
    install:
-   - requirements: doc/requirements.txt
-
-build:
-  image: latest
+   - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,8 @@ build:
 
 sphinx:
   builder: html
-  configuration: source/conf.py
+  configuration: doc/htmldoc/conf.py
 
 python:
    install:
-   - requirements: requirements.txt
+   - requirements: doc/requirements.txt


### PR DESCRIPTION
This PR resolves an error brought on by a recent external update to the urllib3 version that was incompatible with the version of Read the Docs we are using. The solution is to update the yml file to include the os build so a more recent version is used to build the docs. 

See the issue on the Read the Docs issue tracker: https://github.com/readthedocs/readthedocs.org/issues/10290 