### PR TITLE
Remove `get_type` func from RecordingDevice

### DIFF
--- a/models/multimeter.cpp
+++ b/models/multimeter.cpp
@@ -224,12 +224,6 @@ multimeter::handle( DataLoggingReply& reply )
   }
 }
 
-RecordingDevice::Type
-multimeter::get_type() const
-{
-  return RecordingDevice::MULTIMETER;
-}
-
 voltmeter::voltmeter()
   : multimeter()
 {

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -167,7 +167,6 @@ public:
 
   SignalType sends_signal() const override;
 
-  Type get_type() const override;
   void get_status( DictionaryDatum& ) const override;
   void set_status( const DictionaryDatum& ) override;
 

--- a/models/spike_recorder.cpp
+++ b/models/spike_recorder.cpp
@@ -56,11 +56,6 @@ nest::spike_recorder::update( Time const&, const long, const long )
   // Nothing to do. Writing to the backend happens in handle().
 }
 
-nest::RecordingDevice::Type
-nest::spike_recorder::get_type() const
-{
-  return RecordingDevice::SPIKE_RECORDER;
-}
 
 void
 nest::spike_recorder::get_status( DictionaryDatum& d ) const

--- a/models/spike_recorder.h
+++ b/models/spike_recorder.h
@@ -103,6 +103,12 @@ public:
     return names::recorder;
   }
 
+  bool
+  is_recording_spikes() const override
+  {
+    return true;
+  }
+
   /**
    * Import sets of overloaded virtual functions.
    * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
@@ -116,7 +122,6 @@ public:
 
   port handles_test_event( SpikeEvent&, rport ) override;
 
-  Type get_type() const override;
   SignalType receives_signal() const override;
 
   void get_status( DictionaryDatum& ) const override;

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -68,11 +68,6 @@ nest::spin_detector::update( Time const&, const long, const long )
   }
 }
 
-nest::RecordingDevice::Type
-nest::spin_detector::get_type() const
-{
-  return RecordingDevice::SPIN_DETECTOR;
-}
 
 void
 nest::spin_detector::get_status( DictionaryDatum& d ) const

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -129,7 +129,6 @@ public:
 
   port handles_test_event( SpikeEvent&, rport ) override;
 
-  Type get_type() const override;
   SignalType receives_signal() const override;
 
   void get_status( DictionaryDatum& ) const override;

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -139,11 +139,6 @@ nest::weight_recorder::update( Time const&, const long, const long )
 {
 }
 
-nest::RecordingDevice::Type
-nest::weight_recorder::get_type() const
-{
-  return RecordingDevice::WEIGHT_RECORDER;
-}
 
 void
 nest::weight_recorder::get_status( DictionaryDatum& d ) const

--- a/models/weight_recorder.h
+++ b/models/weight_recorder.h
@@ -119,7 +119,6 @@ public:
 
   port handles_test_event( WeightRecorderEvent&, rport ) override;
 
-  Type get_type() const override;
   SignalType receives_signal() const override;
 
   void get_status( DictionaryDatum& ) const override;

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -71,7 +71,7 @@ nest::RecordingBackendMPI::finalize()
 void
 nest::RecordingBackendMPI::enroll( const RecordingDevice& device, const DictionaryDatum& )
 {
-  if ( device.get_type() == RecordingDevice::SPIKE_RECORDER )
+  if ( device.is_recording_spikes() )
   {
     thread tid = device.get_thread();
     index node_id = device.get_node_id();

--- a/nestkernel/recording_backend_sionlib.cpp
+++ b/nestkernel/recording_backend_sionlib.cpp
@@ -83,7 +83,6 @@ nest::RecordingBackendSIONlib::enroll( const RecordingDevice& device, const Dict
     DeviceInfo& info = entry.info;
 
     info.node_id = node_id;
-    info.type = static_cast< unsigned int >( device.get_type() );
     info.name = device.get_name();
     info.label = device.get_label();
 
@@ -350,7 +349,6 @@ nest::RecordingBackendSIONlib::close_files_()
       sion_fwrite( &n_dev, sizeof( sion_uint64 ), 1, file.sid );
 
       sion_uint64 node_id;
-      sion_uint32 type;
       sion_int64 origin;
       sion_int64 t_start;
       sion_int64 t_stop;
@@ -364,10 +362,9 @@ nest::RecordingBackendSIONlib::close_files_()
         DeviceInfo& dev_info = it->second.info;
 
         node_id = static_cast< sion_uint64 >( dev_info.node_id );
-        type = static_cast< sion_uint32 >( dev_info.type );
+        
 
         sion_fwrite( &node_id, sizeof( sion_uint64 ), 1, file.sid );
-        sion_fwrite( &type, sizeof( sion_uint32 ), 1, file.sid );
 
         char name[ DEV_NAME_BUFFERSIZE ];
         strncpy( name, dev_info.name.c_str(), DEV_NAME_BUFFERSIZE - 1 );

--- a/nestkernel/recording_backend_sionlib.cpp
+++ b/nestkernel/recording_backend_sionlib.cpp
@@ -362,7 +362,6 @@ nest::RecordingBackendSIONlib::close_files_()
         DeviceInfo& dev_info = it->second.info;
 
         node_id = static_cast< sion_uint64 >( dev_info.node_id );
-        
 
         sion_fwrite( &node_id, sizeof( sion_uint64 ), 1, file.sid );
 

--- a/nestkernel/recording_backend_sionlib.h
+++ b/nestkernel/recording_backend_sionlib.h
@@ -303,7 +303,6 @@ private:
     }
 
     index node_id;
-    unsigned int type;
     std::string name;
     std::string label;
 

--- a/nestkernel/recording_device.h
+++ b/nestkernel/recording_device.h
@@ -138,16 +138,11 @@ public:
 
   bool is_active( Time const& T ) const override;
 
-  enum Type
+  virtual bool
+  is_recording_spikes() const
   {
-    MULTIMETER,
-    SPIKE_RECORDER,
-    SPIN_DETECTOR,
-    WEIGHT_RECORDER
-  };
-
-  virtual Type get_type() const = 0;
-
+    return false;
+  }
   const std::string& get_label() const;
 
   void set_status( const DictionaryDatum& ) override;


### PR DESCRIPTION
Remove the `get_type` function from the `RecordingDevice` class. The function is only required when using a `RecordingBackEndMPI` with a device different from a `spike_recoder`.

The function is also being used in `RecordingBackEndSionLib` to store information about the device, but the information itself is useless to the user reading data from the `binary` file created by `RecordingBackEndSionLib`.

