### PR TITLE
Add new dockerhub repository to the docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Fedora package](https://img.shields.io/fedora/v/nest?logo=fedora)](https://src.fedoraproject.org/rpms/nest)
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/nest-simulator.svg?logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/nest-simulator)
 [![Homebrew version](https://img.shields.io/homebrew/v/nest.svg?logo=apple)](https://formulae.brew.sh/formula/nest)
-[![Docker Image Version](https://img.shields.io/docker/v/nestsim/nest?color=blue&label=docker&logo=docker&logoColor=white&sort=semver)](https://hub.docker.com/r/nestsim/nest)
+[![Docker Image Version](https://img.shields.io/docker/v/nest/nest-simulator?color=blue&label=docker&logo=docker&logoColor=white&sort=semver)](https://hub.docker.com/r/nest/nest-simulator)
 [![Virtual applicance](https://img.shields.io/badge/VM-v3.4-blue?logo=CodeSandbox)](https://nest-simulator.readthedocs.io/en/latest/installation/livemedia.html#live-media)
 
 [![YouTube Video Views](https://img.shields.io/youtube/views/K7KXmIv6ROY?style=social)](https://www.youtube.com/results?search_query=nest-simulator+neurons)

--- a/doc/htmldoc/connect_nest/nest_server.rst
+++ b/doc/htmldoc/connect_nest/nest_server.rst
@@ -106,7 +106,7 @@ container:
 
 .. code-block:: text
 
-  docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 52425:52425 nestsim/nest:latest nest-server start
+  docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 52425:52425 nest/nest-simulator:dev nest-server start
 
 The generic invocation command line for the ``nest-server`` command
 looks as follows:

--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -124,7 +124,6 @@ Copy and paste the URL into your browser.
 
 To stop and delete running containers use `docker-compose down`.
 
-
 To run NEST 2.20.2
 ^^^^^^^^^^^^^^^^^^
 
@@ -133,13 +132,6 @@ Jupyter notebook with NEST 2.20.2:
 .. code-block:: bash
 
     docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=notebook \
-               -p 8080:8080 nest/nest-simulator:2.20.2
-
-Jupyter lab with NEST 2.20.2
-
-.. code-block:: bash
-
-    docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=jupyterlab \
                -p 8080:8080 nest/nest-simulator:2.20.2
 
 NEST dev

--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -27,13 +27,14 @@ Docker provides an isolated container to run applications.
 Usage
 
 
-You can use the docker images directly out of docker-registry.ebrains.eu like this:
+You can use the docker images directly out of https://hub.docker.com/r/nest/nest-simulator 
+like this:
 
 .. code-block:: bash
 
-    docker pull docker-registry.ebrains.eu/nest/nest-simulator:TAG
+    docker pull nest/nest-simulator:<TAG>
 
-``TAG`` can be a version of NEST ``2.20.2`` or later. Alternatively, you can use ``dev`` for the
+``<TAG>`` can be a version of NEST ``2.20.2`` or later. Alternatively, you can use ``dev`` for the
 development branch (master).
 
 NEST 3.2 and later
@@ -45,7 +46,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/steffengraber/nest-docker/master/docker-compose.yml
+    wget https://raw.githubusercontent.com/steffengraber/nest-docker/<TAG>/docker-compose.yml
 
 
 You can then run ``docker-compose up`` with one of the following options:
@@ -60,8 +61,8 @@ or
 
 .. code-block:: bash
 
-      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 /
-           docker-registry.ebrains.eu/nest/nest-simulator:<version>
+      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 \
+           nest/nest-simulator:<TAG>
 
 Starts the NEST API server container and opens the corresponding port 52425. Test it with `curl localhost:52425/api`.
 See the :ref:`nest_server` documentation for more details.
@@ -76,10 +77,10 @@ or
 
 .. code-block:: bash
 
-      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 /
-          docker-registry.ebrains.eu/nest/nest-simulator:<version>
-      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 8000:8000  /
-          -e NEST_CONTAINER_MODE=nest-desktop docker-registry.ebrains.eu/nest/nest-simulator:<version>
+      docker run -it --rm -e NEST_CONTAINER_MODE=nest-server -p 52425:52425 \
+          nest/nest-simulator:<TAG>
+      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 8000:8000  \
+          -e NEST_CONTAINER_MODE=nest-desktop nest/nest-simulator:<TAG>
 
 Starts the NEST server and the NEST desktop web interface. Port 8000 is also made available.
 Open NEST Desktop in the web browser using the following http link: `http://localhost:8000`
@@ -96,8 +97,8 @@ or
 
 .. code-block:: bash
 
-      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=notebook /
-          -p 8080:8080 docker-registry.ebrains.eu/nest/nest-simulator:<version>
+      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=notebook \
+          -p 8080:8080 nest/nest-simulator:<TAG>
 
 Starts a notebook server with pre-installed NEST. The corresponding URL is displayed in the console. You can copy an
 d paste into your browser.
@@ -113,8 +114,8 @@ or
 
 .. code-block:: bash
 
-      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=jupyterlab /
-          -p 8080:8080 docker-registry.ebrains.eu/nest/nest-simulator:<version>)
+      docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=jupyterlab \
+          -p 8080:8080 nest/nest-simulator:<TAG>
 
 Starts a Jupyter lab server with pre-installed NEST. The corresponding URL is displayed in the console.
 Copy and paste the URL into your browser.
@@ -131,15 +132,15 @@ Jupyter notebook with NEST 2.20.2:
 
 .. code-block:: bash
 
-    docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=notebook /
-               -p 8080:8080 docker-registry.ebrains.eu/nest/nest-simulator:2.20.2
+    docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=notebook \
+               -p 8080:8080 nest/nest-simulator:2.20.2
 
 Jupyter lab with NEST 2.20.2
 
 .. code-block:: bash
 
-    docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=jupyterlab /
-               -p 8080:8080 docker-registry.ebrains.eu/nest/nest-simulator:2.20.2
+    docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -e NEST_CONTAINER_MODE=jupyterlab \
+               -p 8080:8080 nest/nest-simulator:2.20.2
 
 NEST dev
 ^^^^^^^^
@@ -148,7 +149,7 @@ If you want to use the compose configuration for the ``dev`` NEST version, you c
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/steffengraber/nest-docker/master/docker-compose.yml
+    wget https://raw.githubusercontent.com/nest/nest-docker/master/docker-compose.yml
     docker-compose -f docker-compose-dev.yml up nest-notebook
 
 On Windows
@@ -161,22 +162,22 @@ On Windows
 
 .. code-block:: bash
 
-    docker run -it --rm -v %cd%:/opt/data -p 8080:8080 -e NEST_CONTAINER_MODE=<args> /
-        docker-registry.ebrains.eu/nest/nest-simulator:<version>
+    docker run -it --rm -v %cd%:/opt/data -p 8080:8080 -e NEST_CONTAINER_MODE=<args> \
+        nest/nest-simulator:<TAG>
 
 In Powershell, '%cd%' might not work for the current directory. Then
 you should explicitly specify a folder with existing write permissions.
 
 In any case, this will download the docker image with the pre-installed
-NEST master from docker-registry.ebrains.eu and start it. After booting an URL is presented.
-Click on it or copy it to your browser. Voilá Jupyter notebook starts from
-the docker image.
+NEST master from https://hub.docker.com/r/nest/nest-simulator and start it. 
+After booting an URL is presented. Click on it or copy it to your browser. 
+Voilá Jupyter notebook starts from the docker image.
 
 You can update the image with:
 
 .. code-block:: bash
 
-    docker pull docker-registry.ebrains.eu/nest/nest-simulator:<version>
+    docker pull nest/nest-simulator:<TAG>
 
 
 

--- a/doc/htmldoc/troubleshooting.rst
+++ b/doc/htmldoc/troubleshooting.rst
@@ -203,7 +203,7 @@ If your Python version is correct and you still have the same error, then try on
 
     .. code-block:: bash
 
-        docker pull nestsim/nest:<version>
+        docker pull nest/nest-simulator:<version>
 
     replacing ``<version>`` with the actual version you want to use.
 
@@ -211,7 +211,7 @@ If your Python version is correct and you still have the same error, then try on
 
     .. code-block:: bash
 
-       docker run --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -p 8080:8080 nestsim/nest:<version> notebook
+       docker run --rm -e LOCAL_USER_ID=`id -u $USER` -v $(pwd):/opt/data -p 8080:8080 nest/nest-simulator:<version> notebook
 
 Can't find an answer to your question?
 --------------------------------------


### PR DESCRIPTION
We have a new docker repository for the NEST docker images:
    
    https://hub.docker.com/r/nest/nest-simulator

In this PR the installation instructions are adjusted and some mentions elsewhere are fixed.

@jessica-mitchell Could you review it?