### PR TITLE
Fix tutorials in documentation

### DIFF
--- a/doc/htmldoc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_1_neurons_and_simple_neural_networks.rst
@@ -165,12 +165,12 @@ called with a specific key on a NodeCollection with several elements, a list
 the size of the NodeCollection will be returned.
 
 To modify the properties in the dictionary, we use :py:meth:`~.NodeCollection.set`. In the
-following example, the background current is set to 375.0pA, a value
+following example, the background current is set to 376.0pA, a value
 causing the neuron to spike periodically.
 
 ::
 
-    neuron.set(I_e=375.0)
+    neuron.set(I_e=376.0)
 
 Note that we can set several properties at the same time by giving
 multiple comma separated key:value pairs in a dictionary. Also be
@@ -179,7 +179,7 @@ aware that NEST is type sensitive - if a particular property is of type
 
 ::
 
-    neuron.set({"I_e": 375})
+    neuron.set({"I_e": 376})
 
 will result in an error. This conveniently protects us from making
 integer division errors, which are hard to catch.
@@ -302,11 +302,11 @@ obtain and display the spikes from the spike recorder.
 
 ::
 
-    dSD = spikerecorder.get("events")
-    evs = dSD["senders"]
-    ts = dSD["times"]
+    events = spikerecorder.get("events")
+    senders = events["senders"]
+    ts = events["times"]
     plt.figure(2)
-    plt.plot(ts, evs, ".")
+    plt.plot(ts, senders, ".")
     plt.show()
 
 Here we extract the events more concisely by sending the parameter name to

--- a/doc/htmldoc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_2_populations_of_neurons.rst
@@ -171,8 +171,8 @@ populations of ten neurons each.
     pop1 = nest.Create("iaf_psc_alpha", 10)
     pop1.set({"I_e": 376.0})
     pop2 = nest.Create("iaf_psc_alpha", 10)
-    multimeter = nest.Create("multimeter", 10)
-    multimeter.set({"record_from":["V_m"]})
+    multimeters = nest.Create("multimeter", 10)
+    multimeters.set({"record_from":["V_m"]})
 
 If no connectivity pattern is specified, the populations are connected
 via the default rule, namely ``all_to_all``. Each neuron of ``pop1`` is
@@ -192,11 +192,11 @@ connections in total.
 
     nest.Connect(pop1, pop2, "one_to_one", syn_spec={"weight":20.0, "delay":1.0})
 
-Finally, the multimeters are connected using the default rule
+Finally, the multimeters are connected using the ``one_to_one`` rule
 
 ::
 
-    nest.Connect(multimeter, pop2)
+    nest.Connect(multimeters, pop2, "one_to_one")
 
 Here we have just used very simple connection schemes. Connectivity
 patterns requiring the specification of further parameters, such as

--- a/doc/htmldoc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
@@ -33,7 +33,7 @@ Parametrizing synapse models
 -----------------------------
 
 NEST provides a variety of different synapse models. You can see the
-available models by using the command ``Models(synapses)``, which picks
+available models by using the command ``synapse_models``, which picks
 only the synapse models out of the list of all available models.
 
 Synapse models can be parameterised analogously to neuron models. You

--- a/doc/htmldoc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_4_spatially_structured_networks.rst
@@ -141,7 +141,7 @@ The following snippet produces :numref:`grid`:
 
 ::
 
-    positions = nest.spatial.grid(shape=[10, 10]  # the number of rows and column in this grid ...
+    positions = nest.spatial.grid(shape=[10, 10],  # the number of rows and column in this grid ...
                                   extent=[2., 2.]  # the size of the grid in mm
                                   )
     nest.Create('iaf_psc_alpha', positions=positions)


### PR DESCRIPTION
We (intern Dorothee Germer and I) found a list of things to improve in the tutorials in the nest documentation:

Part 1:
- in Creating Nodes: I_e must be set to 376. instead of 375. for the neuron to elicit spikes.
- in Extracting and Plotting Data from Devices: changed the naming of variables for better readability. 

Part 2: 
- in Generating Populations of Neurons with Deterministic Connections: multimeters must be connected with the one_to_one rule, otherwise they all record the same 10 neurons, which is redundant.

Part 3:
- in Parameterizing Synapse Models: command nest.Models() is deprecated. Use command synapse_models instead.

Part 4:
- in Defining Spatially Distributed Nodes - On Grid: missing comma in code.

We suggest @jessica-mitchell as a reviewer.