### PR TITLE
Fix typos in spatial docs to render code

### DIFF
--- a/doc/htmldoc/networks/scripts/connections.py
+++ b/doc/htmldoc/networks/scripts/connections.py
@@ -572,7 +572,7 @@ pn_fig(fig, 111, spatial_nodes, cdict)
 
 plt.savefig('../user_manual_figures/conn6.png', bbox_inches='tight')
 
-#{ conn7 #}
+# { conn7 #}
 cdict_random_in = {'rule': 'fixed_indegree',
                    'p': nest.spatial_distributions.gaussian(nest.spatial.distance, std=0.5),
                    'mask': {'circular': {'radius': 1.0}},

--- a/doc/htmldoc/networks/scripts/layers.py
+++ b/doc/htmldoc/networks/scripts/layers.py
@@ -68,10 +68,10 @@ def beautify_layer(layer, fig=plt.gcf(), xlabel=None, ylabel=None,
 
 nest.ResetKernel()
 
-#{ layer1 #}
+# { layer1 #}
 layer = nest.Create('iaf_psc_alpha',
                     positions=nest.spatial.grid(shape=[5, 5]))
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=50)
 beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)')
@@ -90,28 +90,28 @@ for r in range(5):
 # plt.savefig('../user_manual_figures/layer1.png', bbox_inches='tight',
 #             bbox_extra_artists=tx)
 
-print("#{ layer1s.log #}")
-#{ layer1s #}
+print("# { layer1s.log #}")
+# { layer1s #}
 print(layer.spatial)
-#{ end #}
-print("#{ end.log #}")
+# { end #}
+print("# { end.log #}")
 
-print("#{ layer1p.log #}")
-#{ layer1p #}
+print("# { layer1p.log #}")
+# { layer1p #}
 nest.PrintNodes()
-#{ end #}
-print("#{ end.log #}")
+# { end #}
+print("# { end.log #}")
 
 # --------------------------------------------------
 
 nest.ResetKernel()
 
-#{ layer2 #}
+# { layer2 #}
 layer = nest.Create('iaf_psc_alpha',
                     positions=nest.spatial.grid(
                         shape=[5, 5],
                         extent=[2.0, 0.5]))
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=50)
 beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)')
@@ -134,7 +134,7 @@ plt.savefig('../user_manual_figures/layer2.png', bbox_inches='tight',
 
 nest.ResetKernel()
 
-#{ layer3 #}
+# { layer3 #}
 layer1 = nest.Create('iaf_psc_alpha',
                      positions=nest.spatial.grid(shape=[5, 5]))
 layer2 = nest.Create('iaf_psc_alpha',
@@ -145,7 +145,7 @@ layer3 = nest.Create('iaf_psc_alpha',
                      positions=nest.spatial.grid(
                          shape=[5, 5],
                          center=[1.5, 0.5]))
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer1, nodesize=50)
 nest.PlotLayer(layer2, nodesize=50, nodecolor='g', fig=fig)
@@ -161,7 +161,7 @@ plt.savefig('../user_manual_figures/layer3.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ layer3a #}
+# { layer3a #}
 nx, ny = 5, 3
 d = 0.1
 layer = nest.Create('iaf_psc_alpha',
@@ -169,7 +169,7 @@ layer = nest.Create('iaf_psc_alpha',
                         shape=[nx, ny],
                         extent=[nx * d, ny * d],
                         center=[nx * d / 2., 0.]))
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=100)
 plt.plot(0, 0, 'x', markersize=20, c='k', mew=3)
@@ -186,12 +186,12 @@ plt.savefig('../user_manual_figures/layer3a.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ layer4 #}
+# { layer4 #}
 pos = nest.spatial.free(pos=nest.random.uniform(min=-0.5, max=0.5),
                         num_dimensions=2)
 layer = nest.Create('iaf_psc_alpha', 50,
                     positions=pos)
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=50)
 beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
@@ -204,10 +204,10 @@ plt.savefig('../user_manual_figures/layer4.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ layer4b #}
+# { layer4b #}
 pos = nest.spatial.free(pos=[[-0.5, -0.5], [-0.25, -0.25], [0.75, 0.75]])
 layer = nest.Create('iaf_psc_alpha', positions=pos)
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=50)
 beautify_layer(layer, fig, xlabel='x-axis (columns)', ylabel='y-axis (rows)',
@@ -221,11 +221,11 @@ plt.savefig('../user_manual_figures/layer4b.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ layer4_3d #}
+# { layer4_3d #}
 pos = nest.spatial.free(nest.random.uniform(min=-0.5, max=0.5),
                         num_dimensions=3)
 layer = nest.Create('iaf_psc_alpha', 200, positions=pos)
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=50)
 
@@ -235,10 +235,10 @@ plt.savefig('../user_manual_figures/layer4_3d.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ layer4_3d_b #}
+# { layer4_3d_b #}
 pos = nest.spatial.grid(shape=[4, 5, 6])
 layer = nest.Create('iaf_psc_alpha', positions=pos)
-#{ end #}
+# { end #}
 
 fig = nest.PlotLayer(layer, nodesize=50)
 
@@ -248,13 +248,13 @@ plt.savefig('../user_manual_figures/layer4_3d_b.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ player #}
+# { player #}
 layer = nest.Create('iaf_psc_alpha',
                     positions=nest.spatial.grid(
                         shape=[5, 1],
                         extent=[5., 1.],
                         edge_wrap=True))
-#{ end #}
+# { end #}
 
 # fake plot with layer on line and circle
 clist = [(0, 0, 1), (0.35, 0, 1), (0.6, 0, 1), (0.8, 0, 1), (1.0, 0, 1)]
@@ -307,22 +307,22 @@ plt.savefig('../user_manual_figures/player.png', bbox_inches='tight')
 
 nest.ResetKernel()
 
-#{ layer6 #}
+# { layer6 #}
 layer1 = nest.Create('iaf_cond_alpha',
                      positions=nest.spatial.grid(shape=[2, 1]))
 layer2 = nest.Create('poisson_generator',
                      positions=nest.spatial.grid(shape=[2, 1]))
-#{ end #}
+# { end #}
 
-print("#{ layer6 #}")
+print("# { layer6 #}")
 nest.PrintNodes()
-print("#{ end #}")
+print("# { end #}")
 
 # --------------------------------------------------
 
 nest.ResetKernel()
 
-#{ vislayer #}
+# { vislayer #}
 layer = nest.Create('iaf_psc_alpha',
                     positions=nest.spatial.grid(shape=[21, 21]))
 probability_param = nest.spatial_distributions.gaussian(nest.spatial.distance, std=0.15)
@@ -337,5 +337,5 @@ nest.PlotTargets(ctr, layer, fig=fig,
                  mask=conndict['mask'], probability_parameter=probability_param,
                  src_size=250, tgt_color='red', tgt_size=20, mask_color='red',
                  probability_cmap='Greens')
-#{ end #}
+# { end #}
 plt.savefig('../user_manual_figures/vislayer.png', bbox_inches='tight')

--- a/doc/htmldoc/networks/spatially_structured_networks.rst
+++ b/doc/htmldoc/networks/spatially_structured_networks.rst
@@ -73,8 +73,8 @@ A very simple example
 We create a first, grid-based simple NodeCollection with the following command:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer1 #}
-    :end-before: #{ end #}
+    :start-after: # { layer1 #}
+    :end-before: # { end #}
 
 .. _fig_layer1:
 
@@ -142,8 +142,8 @@ different extent of a layer, i.e., its size in :math:`x`- and
 :math:`y`-direction by passing the ``extent`` argument to ``nest.spatial.grid()``:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer2 #}
-    :end-before: #{ end #}
+    :start-after: # { layer2 #}
+    :end-before: # { end #}
 
 .. _fig_layer2:
 
@@ -172,8 +172,8 @@ The following code creates layers centered about :math:`(0,0)`,
 :math:`(-1,1)`, and :math:`(1.5,0.5)`, respectively:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer3 #}
-    :end-before: #{ end #}
+    :start-after: # { layer3 #}
+    :end-before: # { end #}
 
 .. _fig_layer3:
 
@@ -218,8 +218,8 @@ are :math:`(n_x d/2, 0)`. The layer is created with the following code
 and shown in :numref:`fig_layer3a`:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer3a #}
-    :end-before: #{ end #}
+    :start-after: # { layer3a #}
+    :end-before: # { end #}
 
 .. _fig_layer3a:
 
@@ -244,8 +244,8 @@ extent :math:`1\times 1`, i.e., spanning the square
 :math:`[-0.5,0.5]\times[-0.5,0.5]`:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer4 #}
-    :end-before: #{ end #}
+    :start-after: # { layer4 #}
+    :end-before: # { end #}
 
 .. _fig_layer4:
 
@@ -281,8 +281,8 @@ Note the following points:
 To create a spatially distributed NodeCollection from a list, do the following:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer4b #}
-    :end-before: #{ end #}
+    :start-after: # { layer4b #}
+    :end-before: # { end #}
 
 .. _fig_layer4b:
 
@@ -303,8 +303,8 @@ in NEST may in fact be 3-dimensional. The example from the previous
 section may be easily extended by updating number of dimensions for the positions:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer4_3d #}
-    :end-before: #{ end #}
+    :start-after: # { layer4_3d #}
+    :end-before: # { end #}
 
 .. _fig_layer4_3d:
 
@@ -319,8 +319,8 @@ space. Another possibility is to create a 3D grid-layer, with 3 elements passed 
 the shape argument, ``shape=[nx, ny, nz]``:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer4_3d_b #}
-    :end-before: #{ end #}
+    :start-after: # { layer4_3d_b #}
+    :end-before: # { end #}
 
 .. _fig_layer4_3d_b:
 
@@ -356,8 +356,8 @@ You specify periodic boundary conditions for a NodeCollection using
 the entry ``edge_wrap``:
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ player #}
-    :end-before: #{ end #}
+    :start-after: # { player #}
+    :end-before: # { end #}
 
 .. _fig_player:
 
@@ -400,8 +400,8 @@ be of interest:
    of this guide):
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer1s #}
-    :end-before: #{ end #}
+    :start-after: # { layer1s #}
+    :end-before: # { end #}
 
 
 The ``spatial`` property is read-only; changing any value will
@@ -415,8 +415,8 @@ not change properties of the spatially distributed NodeCollection.
    only be used on NodeCollections created with spatial distribution.
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ layer1p #}
-    :end-before: #{ end #}
+    :start-after: # { layer1p #}
+    :end-before: # { end #}
 
 .. _sec_connections:
 
@@ -1382,8 +1382,8 @@ is shown in :numref:`fig_vislayer`. All elements and the targets of the
 center neuron are shown, as well as mask and connection probability.
 
 .. literalinclude:: scripts/layers.py
-    :start-after: #{ vislayer #}
-    :end-before: #{ end #}
+    :start-after: # { vislayer #}
+    :end-before: # { end #}
 
 .. _sec_custom_masks:
 

--- a/doc/htmldoc/networks/spatially_structured_networks.rst
+++ b/doc/htmldoc/networks/spatially_structured_networks.rst
@@ -532,7 +532,7 @@ Here is a simple example, cf. :numref:`fig_conn1`
 
 .. literalinclude:: scripts/connections.py
     :start-after: # { conn1 #}
-    :end-before: #{ end #}
+    :end-before: # { end #}
 
 .. _fig_conn1:
 
@@ -617,16 +617,16 @@ Rectangular
    same unit as element coordinates. Example:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2r #}
-    :end-before: #{ end #}
+    :start-after: # { conn2r #}
+    :end-before: # { end #}
 
 Circular
    All nodes within a circle are connected. The area is specified by its
    radius.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2c #}
-    :end-before: #{ end #}
+    :start-after: # { conn2c #}
+    :end-before: # { end #}
 
 Doughnut
    All nodes between an inner and outer circle are connected. Note that
@@ -634,23 +634,23 @@ Doughnut
    by the radii of the inner and outer circles.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2d #}
-    :end-before: #{ end #}
+    :start-after: # { conn2d #}
+    :end-before: # { end #}
 
 Elliptical
    All nodes within an ellipsis are connected. The area is specified by
    its major and minor axis.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2e #}
-    :end-before: #{ end #}
+    :start-after: # { conn2e #}
+    :end-before: # { end #}
 
 .. _fig_conn2_a:
 
 .. figure:: figures/conn2_a.png
    :name: fig:conn2_a
 
-   Masks for 2D layers. For all mask types, the driver node is marked by
+   Masks for 2D..  layers. For all mask types, the driver node is marked by
    a wide light-red circle, the selected pool nodes by red dots and the
    masks are red. From left to right, top to bottom: rectangular,
    circular, doughnut and elliptical masks centered about the driver
@@ -664,20 +664,20 @@ of the mask center relative to the driver node, as in the following
 examples (cf.  :numref:`fig_conn2_b`).
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2ro #}
-    :end-before: #{ end #}
+    :start-after: # { conn2ro #}
+    :end-before: # { end #}
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2co #}
-    :end-before: #{ end #}
+    :start-after: # { conn2co #}
+    :end-before: # { end #}
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2do #}
-    :end-before: #{ end #}
+    :start-after: # { conn2do #}
+    :end-before: # { end #}
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2eo #}
-    :end-before: #{ end #}
+    :start-after: # { conn2eo #}
+    :end-before: # { end #}
 
 .. _fig_conn2_b:
 
@@ -695,12 +695,12 @@ add an ``'azimuth_angle'`` entry in the specific mask dictionary. The
 from the x-axis to the y-axis.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2rr #}
-    :end-before: #{ end #}
+    :start-after: # { conn2rr #}
+    :end-before: # { end #}
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn2er #}
-    :end-before: #{ end #}
+    :start-after: # { conn2er #}
+    :end-before: # { end #}
 
 .. _fig_conn2_c:
 
@@ -724,24 +724,24 @@ Box
    as element coordinates. Example:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn_3d_a #}
-    :end-before: #{ end #}
+    :start-after: # { conn_3d_a #}
+    :end-before: # { end #}
 
 Spherical
    All nodes within a sphere are connected. The area is specified by its
    radius.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn_3d_b #}
-    :end-before: #{ end #}
+    :start-after: # { conn_3d_b #}
+    :end-before: # { end #}
 
 Ellipsoidal
    All nodes within an ellipsoid are connected. The area is specified by
    its major, minor, and polar axis.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn_3d_c #}
-    :end-before: #{ end #}
+    :start-after: # { conn_3d_c #}
+    :end-before: # { end #}
 
 As in the 2D case, you can change the location of the mask relative to
 the driver node by specifying a 3D vector in the ``'anchor'`` entry in
@@ -775,8 +775,8 @@ right corner coordinates, but give their size in x and y direction, as in
 this example:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn3 #}
-    :end-before: #{ end #}
+    :start-after: # { conn3 #}
+    :end-before: # { end #}
 
 The resulting connections are shown in :numref:`fig_conn3`. By default
 the top-left corner of a grid mask, i.e., the grid mask element with
@@ -785,14 +785,14 @@ aligned with the driver node. You can change this alignment by
 specifying an *anchor* for the mask:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn3c #}
-    :end-before: #{ end #}
+    :start-after: # { conn3c #}
+    :end-before: # { end #}
 
 You can even place the anchor outside the mask:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn3x #}
-    :end-before: #{ end #}
+    :start-after: # { conn3x #}
+    :end-before: # { end #}
 
 The resulting connection patterns are shown in  :numref:`fig_conn3`.
 
@@ -952,8 +952,8 @@ Constant
    Fixed connection probability:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn4cp #}
-    :end-before: #{ end #}
+    :start-after: # { conn4cp #}
+    :end-before: # { end #}
 
 Gaussian
    The connection probability is a Gaussian distribution based on the distance
@@ -962,8 +962,8 @@ Gaussian
    deviation" of :math:`\sigma=1`:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn4g #}
-    :end-before: #{ end #}
+    :start-after: # { conn4g #}
+    :end-before: # { end #}
 
 Cut-off Gaussian
    In this example we have a distance-dependent Gaussian distributon,
@@ -972,8 +972,8 @@ Cut-off Gaussian
 .. TODO: Reference to full Parameter table with nest.logic.conditional().
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn4cut #}
-    :end-before: #{ end #}
+    :start-after: # { conn4cut #}
+    :end-before: # { end #}
 
 2D Gaussian
    We conclude with an example using a two-dimensional Gaussian
@@ -982,8 +982,8 @@ Cut-off Gaussian
    only on distance:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn42d #}
-    :end-before: #{ end #}
+    :start-after: # { conn42d #}
+    :end-before: # { end #}
 
 Note that for pool layers with periodic boundary conditions, NEST
 always uses the shortest possible displacement vector from driver to
@@ -1013,8 +1013,8 @@ entire NodeCollection and is centered about the driver node.
 
 Linear example
   .. literalinclude:: scripts/connections.py
-      :start-after: #{ conn5lin #}
-      :end-before: #{ end #}
+      :start-after: # { conn5lin #}
+      :end-before: # { end #}
 
   Results are shown in the top panel of  :numref:`fig_conn5`. Connection
   weights and delays are shown for the leftmost neuron as driver. Weights
@@ -1027,8 +1027,8 @@ Linear example
 
 Linear example with periodic boundary conditions
   .. literalinclude:: scripts/connections.py
-      :start-after: #{ conn5linpbc #}
-      :end-before: #{ end #}
+      :start-after: # { conn5linpbc #}
+      :end-before: # { end #}
 
   Results are shown in the middle panel of  :numref:`fig_conn5`. This example
   is identical to the previous, except that the (pool) layer has periodic
@@ -1039,12 +1039,12 @@ Linear example with periodic boundary conditions
 
 Various spatially dependent distributions
   .. literalinclude:: scripts/connections.py
-      :start-after: #{ conn5exp #}
-      :end-before: #{ end #}
+      :start-after: # { conn5exp #}
+      :end-before: # { end #}
 
   .. literalinclude:: scripts/connections.py
-      :start-after: #{ conn5gauss #}
-      :end-before: #{ end #}
+      :start-after: # { conn5gauss #}
+      :end-before: # { end #}
 
   Results are shown in the bottom panel of :numref:`fig_conn5`. It shows
   linear, exponential and Gaussian distributions of the distance between
@@ -1054,8 +1054,8 @@ Various spatially dependent distributions
 
 Randomized weights and delays
   .. literalinclude:: scripts/connections.py
-      :start-after: #{ conn5uniform #}
-      :end-before: #{ end #}
+      :start-after: # { conn5uniform #}
+      :end-before: # { end #}
 
   By using the ``nest.random.uniform()`` parameter for weights or delays, one can
   obtain randomized values for weights and delays, as shown by the red
@@ -1087,14 +1087,14 @@ linear (actually affine) with respect to the displacement between the nodes, of 
 target neuron on the x and y axis, respectively. The parameter is then simply:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn_param_design #}
-    :end-before: #{ end #}
+    :start-after: # { conn_param_design #}
+    :end-before: # { end #}
 
 This can be directly plugged into the :py:func:`.Connect` function:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn_param_design_ex #}
-    :end-before: #{ end #}
+    :start-after: # { conn_param_design_ex #}
+    :end-before: # { end #}
 
 Periodic boundary conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1193,8 +1193,8 @@ The resulting distribution of distances between connected nodes is shown in
  :numref:`fig_conn6`.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn6 #}
-    :end-before: #{ end #}
+    :start-after: # { conn6 #}
+    :end-before: # { end #}
 
 .. _fig_conn6:
 
@@ -1215,8 +1215,8 @@ It is also possible to use a random parameter or spatially dependent parameter
 to set the number of incoming or outgoing connections.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn7 #}
-    :end-before: #{ end #}
+    :start-after: # { conn7 #}
+    :end-before: # { end #}
 
 Synapse models and properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1227,8 +1227,8 @@ adding a ``'synapse_model'`` entry to the synapse specification
 dictionary, as in this example:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn8 #}
-    :end-before: #{ end #}
+    :start-after: # { conn8 #}
+    :end-before: # { end #}
 
 You have to use synapse models if you want to set, e.g., the receptor
 type of connections or parameters for plastic synapse models. These can
@@ -1248,15 +1248,15 @@ center of the mask. As demonstrated in the following example,
 stimulation devices have to be connected as the source layer.
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn9 #}
-    :end-before: #{ end #}
+    :start-after: # { conn9 #}
+    :end-before: # { end #}
 
 While recording devices, on the other hand, have to be connected as
 the target layer (see also the following section):
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn10 #}
-    :end-before: #{ end #}
+    :start-after: # { conn10 #}
+    :end-before: # { end #}
 
 Spatially distributed NodeCollections and recording devices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1267,8 +1267,8 @@ create a single spike recorder and connect all neurons in the spatially
 distributed NodeCollection to that spike recorder:
 
 .. literalinclude:: scripts/connections.py
-    :start-after: #{ conn11 #}
-    :end-before: #{ end #}
+    :start-after: # { conn11 #}
+    :end-before: # { end #}
 
 Connecting a layer of neurons to a layer of recording devices as
 described in the section on :ref:`sec_dev_subregions`, is only


### PR DESCRIPTION
This PR fixes some typos that prevented the code from rendering in the spatially structured networks docs.