### PR TITLE
Clean up and fix clickable images in installation instructions

### DIFF
--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -1,6 +1,6 @@
 .. _docker:
 
-|macos| |linux| |windows| Docker
+Docker |macos| |linux| |windows|
 --------------------------------
 
 Docker provides an isolated container to run applications.
@@ -176,11 +176,14 @@ You can update the image with:
 For more information, you can checkout the `nest-docker repository <https://github.com/nest/nest-docker>`_
 
 .. |linux| image:: ../static/img/linux.png
+   :class: no-scaled-link
    :scale: 15%
 
 .. |macos| image:: ../static/img/macos.png
+   :class: no-scaled-link
    :scale: 15%
 
 
 .. |windows| image:: ../static/img/windows.png
+   :class: no-scaled-link
    :scale: 15%

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -26,8 +26,8 @@ We have live media (.ova) if you want to run NEST in a virtual machine.
 
 -------------
 
-|linux|  Linux
----------------
+Linux |linux|
+-------------
 
 Ubuntu
 ~~~~~~
@@ -95,9 +95,9 @@ Debian users can install NEST via the Ubuntu PPA repository.
     dpkg-genbuildinfo --build=binary
     dpkg-genchanges --build=binary >../nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.changes
 
-and note down the full package name. In the above example this would be
-`nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb`, where the number `202001311135` and potentially the
-Ubuntu version number may be different.
+   and note down the full package name. In the above example this would be
+   ``nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb``, where the number ``202001311135`` and potentially the
+   Ubuntu version number may be different.
 
 6. Install the ready Debian package after the rebuild:
 
@@ -115,7 +115,9 @@ Ubuntu version number may be different.
    python3
    import nest
 
-|macos| macOS
+-------------
+
+macOS |macos|
 -------------
 
 1. `Install Homebrew <https://brew.sh/>`_.
@@ -126,19 +128,19 @@ Ubuntu version number may be different.
 
     brew install nest
 
------
-
-
 
 
 .. |linux| image:: ../static/img/linux.png
+   :class: no-scaled-link
    :scale: 11%
 
 .. |macos| image:: ../static/img/macos.png
+   :class: no-scaled-link
    :scale: 11%
 
 
 .. |windows| image:: ../static/img/windows.png
+   :class: no-scaled-link
    :scale: 11%
 
 

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -95,9 +95,9 @@ Debian users can install NEST via the Ubuntu PPA repository.
     dpkg-genbuildinfo --build=binary
     dpkg-genchanges --build=binary >../nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.changes
 
-   and note down the full package name. In the above example this would be
-   ``nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb``, where the number ``202001311135`` and potentially the
-   Ubuntu version number may be different.
+and note down the full package name. In the above example this would be
+``nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb``, where the number ``202001311135`` and potentially the
+Ubuntu version number may be different.
 
 6. Install the ready Debian package after the rebuild:
 


### PR DESCRIPTION
Fixes my confusion in #2792 about Windows installation instructions.