### PR TITLE
Update the package index files on all CI runners

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
+          sudo apt-get update
           sudo apt install python3-docutils
           wget --progress=dot:mega 'https://github.com/errata-ai/vale/releases/download/v2.15.2/vale_2.15.2_Linux_64-bit.tar.gz'
           echo '7528175c995818bcb88b07574dd2e17c1aad13f5676880f43927bb8f673095aa  vale_2.15.2_Linux_64-bit.tar.gz' | sha256sum -c

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -341,6 +341,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
+          sudo apt-get update
           pip install -r doc/requirements.txt
           # The pandoc executable, which is required, cannot be installed via pip see: https://stackoverflow.com/a/71585691
           sudo apt install pandoc


### PR DESCRIPTION
According to the [GitHub Actions documentation](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners), one should always run `sudo apt-get update` before installing a package. This PR adds the command to all runners. This seems to fix the installation of Vale, which has been failing recently. 