### PR TITLE
Update vale version and fix CI package index

### DIFF
--- a/.github/styles/nest-styles/Units.yml
+++ b/.github/styles/nest-styles/Units.yml
@@ -2,7 +2,6 @@
 extends: existence
 message: "Add a space between a numeral and a unit of measure."
 level: error
-noword: true
 tokens:
   - '\d+(?:MB|Gbit|GB|kbps|KB|kb)'
 

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -84,7 +84,7 @@ jobs:
           wget --progress=dot:mega 'https://github.com/errata-ai/vale/releases/download/v2.26.0/vale_2.26.0_Linux_64-bit.tar.gz'
           echo '956577b214ce3db8fb11483f99a183cf65673e3bd47423c6d4ebe37f085cadc7 vale_2.26.0_Linux_64-bit.tar.gz' | sha256sum -c
           tar -xzf 'vale_2.26.0_Linux_64-bit.tar.gz'
-
+          sudo apt update
 
       - name: "Run vale..."
         run: |

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -81,9 +81,10 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo apt install python3-docutils
-          wget --progress=dot:mega 'https://github.com/errata-ai/vale/releases/download/v2.15.2/vale_2.15.2_Linux_64-bit.tar.gz'
-          echo '7528175c995818bcb88b07574dd2e17c1aad13f5676880f43927bb8f673095aa  vale_2.15.2_Linux_64-bit.tar.gz' | sha256sum -c
-          tar -xzf 'vale_2.15.2_Linux_64-bit.tar.gz'
+          wget --progress=dot:mega 'https://github.com/errata-ai/vale/releases/download/v2.26.0/vale_2.26.0_Linux_64-bit.tar.gz'
+          echo '956577b214ce3db8fb11483f99a183cf65673e3bd47423c6d4ebe37f085cadc7 vale_2.26.0_Linux_64-bit.tar.gz' | sha256sum -c
+          tar -xzf 'vale_2.26.0_Linux_64-bit.tar.gz'
+
 
       - name: "Run vale..."
         run: |

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -80,11 +80,11 @@ jobs:
 
       - name: "Install dependencies"
         run: |
+          sudo apt update
           sudo apt install python3-docutils
           wget --progress=dot:mega 'https://github.com/errata-ai/vale/releases/download/v2.26.0/vale_2.26.0_Linux_64-bit.tar.gz'
           echo '956577b214ce3db8fb11483f99a183cf65673e3bd47423c6d4ebe37f085cadc7 vale_2.26.0_Linux_64-bit.tar.gz' | sha256sum -c
           tar -xzf 'vale_2.26.0_Linux_64-bit.tar.gz'
-          sudo apt update
 
       - name: "Run vale..."
         run: |


### PR DESCRIPTION
This PR fixes the vale CI job by adding an apt update and fix to a style syntax error.
It also updates the version of vale to the most recent version.