### PR TITLE
NEST-SONATA: Reset parameters after iteration over populations

### DIFF
--- a/nestkernel/sonata_connector.cpp
+++ b/nestkernel/sonata_connector.cpp
@@ -150,11 +150,11 @@ SonataConnector::connect()
       sequential_chunkwise_connector_();
 
       close_dsets_();
-      reset_params_();
 
     } // end iteration over population groups
 
-    // Close H5 objects in scope
+    // Reset and close H5 objects in scope
+    reset_params_();
     edges_top_level_grp->close();
     file->close();
 


### PR DESCRIPTION
This PR fixes a bug that occurs when SONATA edge file contains more than one edge population (HDF5 group). After opening an edge file, the edge populations within are iterated over and connected. However, the edge parameters container is reset in the first iteration such that subsequent populations will try to access an empty parameter container. This PR fixes this bug by moving the reset out of the loop iterating the edge populations.