### PR TITLE
Improve the look of link to EBRAINS Jupyter Hub in documentation

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -234,7 +234,7 @@ def add_button_to_examples(app, env, docnames):
     :margin: 2
     :text-align: center
     :link: https://lab.ebrains.eu/hub/user-redirect/\
-git-pull?repo=https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples\&urlpath=lab\
+git-pull?repo=https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples&urlpath=lab\
 %2Ftree%2Fnest-simulator-examples%2Fnotebooks%2Fnotebooks%2Ffilepath.ipynb&branch=main
     :link-alt: JupyterHub service
 

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -225,19 +225,35 @@ def add_button_to_examples(app, env, docnames):
     example_prolog = """
 .. only:: html
 
-  .. card:: Run this example as a Jupyter notebook
-    :margin: auto
-    :width: 50%
+----
+
+ Run this example as a Jupyter notebook:
+
+  .. card::
+    :width: 25%
+    :margin: 2
     :text-align: center
+    :link: https://lab.ebrains.eu/hub/user-redirect/\
+git-pull?repo=https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples\&urlpath=lab\
+%2Ftree%2Fnest-simulator-examples%2Fnotebooks%2Fnotebooks%2Ffilepath.ipynb&branch=main
+    :link-alt: JupyterHub service
 
     .. image:: https://nest-simulator.org/TryItOnEBRAINS.png
-         :target: https://lab.ebrains.eu/hub/user-redirect/git-pull?repo=\
-https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples\
-&urlpath=lab%2Ftree%2Fnest-simulator-examples%2Fnotebooks%2F\
-notebooks%2Ffilepath.ipynb&branch=main
 
-    For details and troubleshooting see :ref:`run_jupyter`."""
 
+.. grid:: 1 1 1 1
+   :padding: 0 0 2 0
+
+   .. grid-item::
+     :class: sd-text-muted
+     :margin: 0 0 3 0
+     :padding: 0 0 3 0
+     :columns: 4
+
+     See :ref:`our guide <run_jupyter>` for more information and troubleshooting.
+
+----
+"""
     # Find all relevant files
     # Inject prolog into Python example
     files = list(Path("auto_examples/").rglob("*.rst"))
@@ -280,13 +296,12 @@ def toc_customizer(app, docname, source):
 
 
 def setup(app):
+    # for events see
+    # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx-core-events
     app.connect("source-read", toc_customizer)
     app.add_css_file('css/custom.css')
     app.add_css_file('css/pygments.css')
     app.add_js_file("js/custom.js")
-
-    # for events see
-    # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx-core-events
     app.connect('env-before-read-docs', add_button_to_examples)
     app.connect('config-inited', config_inited_handler)
 

--- a/doc/htmldoc/static/css/custom.css
+++ b/doc/htmldoc/static/css/custom.css
@@ -20,9 +20,10 @@
     --nest-green: #36B34F;
     --sd-color-primary: var(--nest-orange);
     --sd-color-primary-highlight: #e05a2d;
+    --sd-color-muted: #adadad;
     --sd-color-info: var(--nest-blue);
     --sd-color-success: var(--nest-green);
-    --sd-color-card-border-hover: var(--nest-blue);
+    --sd-color-card-border-hover: var(--nest-orange);
 }
 /* Define base font color and style */
 body{
@@ -84,6 +85,7 @@ section#kernel-attributes dl.py.class dd dl.py.attribute dd dl.field-list.simple
 .sphx-glr-download-jupyter {
   display: none;
 }
+
 /**************************************************************************************
  Settings for overriding material design theme 
  Setting nest colors to override sphinx material "orange" and other default colors


### PR DESCRIPTION
This PR modifies the overall look and format of the button link that links the PyNEST example to the Jupyter Hub service in EBRAINS.

See here for example: https://nest-test.readthedocs.io/en/jupyter-button/auto_examples/twoneurons.html