### PR TITLE
Add copy button for code blocks in documentation

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -58,6 +58,7 @@ extensions = [
     'sphinx_design',
     'HoverXTooltip',
     'VersionSyncRole',
+    'sphinx_copybutton',
 ]
 
 autodoc_mock_imports = ["nest.pynestkernel", "nest.ll_api"]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -22,6 +22,7 @@ scipy==1.10.1
 seaborn==0.12.2
 sphinx==6.2.1
 sphinx_autobuild==2021.3.14
+sphinx-copybutton>=0.5.2
 sphinx-design==0.4.1
 sphinx-gallery==0.13.0
 sphinx-material==0.0.35

--- a/environment.yml
+++ b/environment.yml
@@ -110,3 +110,4 @@ dependencies:
     - sphinx-tabs
     - sphinx_design
     - sphinx-material
+    - sphinx-copybutton


### PR DESCRIPTION
This PR adds an extension that allows code blocks on mouse-over to be copied with a click of a button in Sphinx.

See example here: https://nest-test.readthedocs.io/en/add-copybutton/auto_examples/one_neuron.html