### PR TITLE
Fix incorrect name in model docs

### DIFF
--- a/models/step_current_generator.h
+++ b/models/step_current_generator.h
@@ -49,7 +49,7 @@ Provide a piecewise constant DC input current
 Description
 +++++++++++
 
-The ``dc_generator`` provides a piecewise constant DC input to the
+The ``step_current_generator`` provides a piecewise constant DC input to the
 connected node(s).  The amplitude of the current is changed at the
 specified times. The unit of the current is pA.
 


### PR DESCRIPTION
Replace`dc_generator` with   `step_current_generator`. Not sure if the rest of sentence is correct for this model or if it needs further changes.