### PR TITLE
Set copybutton to only copy input lines in docs

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -81,6 +81,9 @@ project = "NEST Simulator user documentation"
 copyright = "2004, nest-simulator"
 author = "nest-simulator"
 
+copybutton_prompt_text = ">>> "
+# The output lines will not be copied if set to True
+copybutton_only_copy_prompt_lines = True
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This PR modify the copy button behaviour so it won't copy the '>>>' in input lines, it's also set to not copy the output. But this can be changed if the desired state is that the input and output should be copied with the button.

so if code looks like this:
```
>>> len(syn_spec)
2
```
The copybutton will paste 
` len(syn_spec)`