### PR TITLE
Fix unit typo

### DIFF
--- a/models/poisson_generator.cpp
+++ b/models/poisson_generator.cpp
@@ -40,7 +40,7 @@
  * ---------------------------------------------------------------- */
 
 nest::poisson_generator::Parameters_::Parameters_()
-  : rate_( 0.0 ) // pA
+  : rate_( 0.0 ) // Hz
 {
 }
 


### PR DESCRIPTION
The rate parameter should be in Hz instead of pA.

The rate parameter is indicated as Hz a few lines down with the function to convert the units of rate to fit the simulation resolution (ms).