### PR TITLE
NEST-SONATA: Enclose `pandas` import in `try` block

### DIFF
--- a/pynest/nest/lib/hl_api_sonata.py
+++ b/pynest/nest/lib/hl_api_sonata.py
@@ -25,7 +25,6 @@ import os
 from pathlib import Path, PurePath
 
 import numpy as np
-import pandas as pd
 
 from .. import pynestkernel as kernel
 from ..ll_api import sli_func, sps, sr
@@ -33,6 +32,13 @@ from .hl_api_models import GetDefaults
 from .hl_api_nodes import Create
 from .hl_api_simulation import SetKernelStatus, Simulate
 from .hl_api_types import NodeCollection
+
+try:
+    import pandas as pd
+
+    have_pandas = True
+except ImportError:
+    have_pandas = False
 
 try:
     import h5py
@@ -100,6 +106,9 @@ class SonataNetwork:
             raise kernel.NESTError(msg)
         if not have_h5py:
             msg = "SonataNetwork unavailable because h5py is not installed or could not be imported"
+            raise kernel.NESTError(msg)
+        if not have_pandas:
+            msg = "SonataNetwork unavailable because pandas is not installed or could not be imported"
             raise kernel.NESTError(msg)
 
         self._node_collections = {}


### PR DESCRIPTION
Enclosing the `pandas` import in a `try` block allows NEST to be built even if `pandas` is not installed. `pandas` is still a requirement for NEST-SONATA and an error will be raised if the `SonataNetwork` class is instantiated without `pandas` installed.