### PR TITLE
Add sphinx_copybutton dependency for doc building

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -106,9 +106,9 @@ dependencies:
     - example
     - Image
     - sphinx_autobuild
+    - sphinx_copybutton
     - sphinx_gallery
     - sphinx-tabs
     - sphinx_design
     - sphinx-material
     - sphinx-copybutton
-    - sphinx-notfound-page


### PR DESCRIPTION
With this PR, all necessary packages for building documentation are included in `environment.yml`. With it in place,

```
cmake ... -Dwith-userdoc=ON
make docs
```

works on macOS.