### PR TITLE
Improve error checking in MPI IO backends

### DIFF
--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -410,7 +410,8 @@ std::string
 nest::MPIPortsFileMissing::message() const
 {
   std::ostringstream msg;
-  msg << "The node with ID " << node_id_ << " has no file that contains the MPI address.";
+  msg << "The node with ID " << node_id_ << " expects a file with the MPI address at location " << path_
+      << ". The file does not seem to exist.";
   return msg.str();
 }
 

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -31,6 +31,12 @@
 // Includes from sli:
 #include "interpret.h"
 
+// Include MPI for MPI error string
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
+
 std::string
 nest::UnknownModelName::message() const
 {
@@ -396,6 +402,31 @@ nest::MPIPortsFileUnknown::message() const
   std::ostringstream msg;
   msg << "The node with ID " << node_id_ << " requires a label,"
       << " which specifies the folder with files containing the MPI ports";
+  return msg.str();
+}
+
+
+std::string
+nest::MPIPortsFileMissing::message() const
+{
+  std::ostringstream msg;
+  msg << "The node with ID " << node_id_ << " has no file that contains the MPI address.";
+  return msg.str();
+}
+
+std::string
+nest::MPIErrorCode::message() const
+{
+
+  char errmsg[ 256 ];
+  int len;
+
+  MPI_Error_string( error_code_, errmsg, &len );
+  std::string error;
+  error.assign( errmsg, len );
+
+  std::ostringstream msg;
+  msg << "MPI Error: " << error;
   return msg.str();
 }
 #endif

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -36,7 +36,6 @@
 #include <mpi.h>
 #endif
 
-
 std::string
 nest::UnknownModelName::message() const
 {

--- a/nestkernel/exceptions.h
+++ b/nestkernel/exceptions.h
@@ -1191,6 +1191,34 @@ public:
 private:
   const size_t node_id_;
 };
+
+class MPIErrorCode : public KernelException
+{
+public:
+  explicit MPIErrorCode( const int error_code )
+    : error_code_( error_code )
+  {
+  }
+
+  std::string message() const;
+
+private:
+  int error_code_;
+};
+
+class MPIPortsFileMissing : public KernelException
+{
+public:
+  explicit MPIPortsFileMissing( const size_t node_id )
+    : node_id_( node_id )
+  {
+  }
+
+  std::string message() const;
+
+private:
+  const size_t node_id_;
+};
 #endif
 
 class UnmatchedSteps : public KernelException

--- a/nestkernel/exceptions.h
+++ b/nestkernel/exceptions.h
@@ -1209,8 +1209,9 @@ private:
 class MPIPortsFileMissing : public KernelException
 {
 public:
-  explicit MPIPortsFileMissing( const size_t node_id )
+  explicit MPIPortsFileMissing( const size_t node_id, const std::string path )
     : node_id_( node_id )
+    , path_( path )
   {
   }
 
@@ -1218,6 +1219,7 @@ public:
 
 private:
   const size_t node_id_;
+  const std::string path_;
 };
 #endif
 

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -174,11 +174,13 @@ nest::RecordingBackendMPI::prepare()
   // 2) connect the thread to the MPI process it needs to be connected to
   for ( auto& it_comm : commMap_ )
   {
-    MPI_Comm_connect( it_comm.first.data(),
-      MPI_INFO_NULL,
-      0,
-      MPI_COMM_WORLD,
-      std::get< 1 >( it_comm.second ) ); // should use the status for handle error
+    int ret =
+      MPI_Comm_connect( it_comm.first.data(), MPI_INFO_NULL, 0, MPI_COMM_WORLD, std::get< 1 >( it_comm.second ) );
+
+    if ( ret != MPI_SUCCESS )
+    {
+      throw MPIErrorCode( ret );
+    }
     std::ostringstream msg;
     msg << "Connect to " << it_comm.first.data() << "\n";
     LOG( M_INFO, "MPI Record connect", msg.str() );
@@ -383,8 +385,12 @@ nest::RecordingBackendMPI::get_port( const size_t index_node, const std::string&
   }
 
   basename << "/" << index_node << ".txt";
-  std::cout << basename.rdbuf() << std::endl;
+  std::cout << basename.str() << std::endl;
   std::ifstream file( basename.str() );
+  if ( !file.good() )
+  {
+    throw MPIPortsFileMissing( index_node );
+  }
   if ( file.is_open() )
   {
     getline( file, *port_name );

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -385,7 +385,6 @@ nest::RecordingBackendMPI::get_port( const size_t index_node, const std::string&
   }
 
   basename << "/" << index_node << ".txt";
-  std::cout << basename.str() << std::endl;
   std::ifstream file( basename.str() );
   if ( !file.good() )
   {

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -389,7 +389,7 @@ nest::RecordingBackendMPI::get_port( const size_t index_node, const std::string&
   std::ifstream file( basename.str() );
   if ( !file.good() )
   {
-    throw MPIPortsFileMissing( index_node );
+    throw MPIPortsFileMissing( index_node, basename.str() );
   }
   if ( file.is_open() )
   {

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -313,7 +313,6 @@ nest::StimulationBackendMPI::get_port( const size_t index_node, const std::strin
   }
   // add the id of the device to the path
   basename << "/" << index_node << ".txt";
-  std::cout << basename.str() << std::endl;
   std::ifstream file( basename.str() );
   if ( !file.good() )
   {

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -317,7 +317,7 @@ nest::StimulationBackendMPI::get_port( const size_t index_node, const std::strin
   std::ifstream file( basename.str() );
   if ( !file.good() )
   {
-    throw MPIPortsFileMissing( index_node );
+    throw MPIPortsFileMissing( index_node, basename.str() );
   }
 
   // read the file

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -188,11 +188,13 @@ nest::StimulationBackendMPI::prepare()
   // 2) connect the master thread to the MPI process it needs to be connected to
   for ( auto& it_comm : commMap_ )
   {
-    MPI_Comm_connect( it_comm.first.data(),
-      MPI_INFO_NULL,
-      0,
-      MPI_COMM_WORLD,
-      std::get< 0 >( it_comm.second ) ); // should use the status for handle error
+    int ret =
+      MPI_Comm_connect( it_comm.first.data(), MPI_INFO_NULL, 0, MPI_COMM_WORLD, std::get< 0 >( it_comm.second ) );
+
+    if ( ret != MPI_SUCCESS )
+    {
+      throw MPIErrorCode( ret );
+    }
     std::ostringstream msg;
     msg << "Connect to " << it_comm.first.data() << "\n";
     LOG( M_INFO, "MPI Input connect", msg.str() );
@@ -311,8 +313,12 @@ nest::StimulationBackendMPI::get_port( const size_t index_node, const std::strin
   }
   // add the id of the device to the path
   basename << "/" << index_node << ".txt";
-  std::cout << basename.rdbuf() << std::endl;
+  std::cout << basename.str() << std::endl;
   std::ifstream file( basename.str() );
+  if ( !file.good() )
+  {
+    throw MPIPortsFileMissing( index_node );
+  }
 
   // read the file
   if ( file.is_open() )


### PR DESCRIPTION
This PR improves error handling in two cases:

1. If the file that is supposed to be read via the path given in the device label does not exist, it will throw an appropriate exception.
2. Check the MPI connect call's return code to ensure the connection was successful. 
Previously, it failed silently if, e.g., a wrong MPI address was supplied. 