### PR TITLE
Add support to set mpi address via device status

### DIFF
--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -287,6 +287,7 @@ const Name min( "min" );
 const Name min_delay( "min_delay" );
 const Name min_update_time( "min_update_time" );
 const Name minor_axis( "minor_axis" );
+const Name mpi_address( "mpi_address" );
 const Name model( "model" );
 const Name model_id( "model_id" );
 const Name ms_per_tic( "ms_per_tic" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -312,6 +312,7 @@ extern const Name min;
 extern const Name min_delay;
 extern const Name min_update_time;
 extern const Name minor_axis;
+extern const Name mpi_address;
 extern const Name model;
 extern const Name model_id;
 extern const Name ms_per_tic;

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -69,7 +69,7 @@ nest::RecordingBackendMPI::finalize()
 }
 
 void
-nest::RecordingBackendMPI::enroll( const RecordingDevice& device, const DictionaryDatum& datum )
+nest::RecordingBackendMPI::enroll( const RecordingDevice& device, const DictionaryDatum& params )
 {
   if ( device.get_type() == RecordingDevice::SPIKE_RECORDER )
   {
@@ -86,7 +86,7 @@ nest::RecordingBackendMPI::enroll( const RecordingDevice& device, const Dictiona
     devices_[ tid ].insert( std::make_pair( node_id, tuple ) );
     enrolled_ = true;
 
-    updateValue< std::string >( datum, names::mpi_address, mpi_address_ );
+    updateValue< std::string >( params, names::mpi_address, mpi_address_ );
   }
   else
   {
@@ -351,7 +351,7 @@ nest::RecordingBackendMPI::get_status( DictionaryDatum& ) const
 }
 
 void
-nest::RecordingBackendMPI::set_status( const DictionaryDatum& datum )
+nest::RecordingBackendMPI::set_status( const DictionaryDatum& )
 {
   // nothing to do
 }
@@ -366,7 +366,7 @@ nest::RecordingBackendMPI::get_port( const RecordingDevice* device, std::string*
   // b) the file is provided via a file: {data_path}/{data_prefix}{label}/{node_id}.txt
 
   // Case a: MPI address is given via device status, use the supplied address
-  if ( !mpi_address_.empty() )
+  if ( not mpi_address_.empty() )
   {
     *port_name = mpi_address_;
   }

--- a/nestkernel/recording_backend_mpi.h
+++ b/nestkernel/recording_backend_mpi.h
@@ -49,13 +49,11 @@ using MPI.
 
 There are two ways to set the MPI port. If both are set, option A has precedence
 
-A)
-The address is supplied via the recording backends "mpi_address" status property.
+1. The address is supplied via the recording backends "mpi_address" status property.
 
-B)
-The name of the MPI port to send data to is read from a file for each
-device configured to use this backend. The file needs to be named
-according to the following pattern:
+2. The name of the MPI port to send data to is read from a file for each
+   device configured to use this backend. The file needs to be named
+   according to the following pattern:
 
 ::
 

--- a/nestkernel/recording_backend_mpi.h
+++ b/nestkernel/recording_backend_mpi.h
@@ -47,6 +47,12 @@ Description
 The `mpi` recording backend sends collected data to a remote process
 using MPI.
 
+There are two ways to set the MPI port. If both are set, option A has precedence
+
+A)
+The address is supplied via the recording backends "mpi_address" status property.
+
+B)
 The name of the MPI port to send data to is read from a file for each
 device configured to use this backend. The file needs to be named
 according to the following pattern:
@@ -169,10 +175,14 @@ private:
   typedef std::map< std::string, std::tuple< int, MPI_Comm*, int > > comm_map;
   comm_map commMap_;
 
-  static void get_port( const RecordingDevice* device, std::string* port_name );
-  static void get_port( size_t index_node, const std::string& label, std::string* port_name );
-  static void send_data( const MPI_Comm* comm, const double data[], int size );
+
+  std::string mpi_address_;
+
+  void get_port( const RecordingDevice* device, std::string* port_name );
+  void get_port( size_t index_node, const std::string& label, std::string* port_name );
+  void send_data( const MPI_Comm* comm, const double data[], int size );
 };
+
 
 } // namespace
 

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -63,7 +63,7 @@ nest::StimulationBackendMPI::finalize()
 }
 
 void
-nest::StimulationBackendMPI::enroll( nest::StimulationDevice& device, const DictionaryDatum& datum )
+nest::StimulationBackendMPI::enroll( nest::StimulationDevice& device, const DictionaryDatum& params )
 {
   size_t tid = device.get_thread();
   size_t node_id = device.get_node_id();
@@ -81,7 +81,7 @@ nest::StimulationBackendMPI::enroll( nest::StimulationDevice& device, const Dict
   enrolled_ = true;
 
   // Try to read the mpi_address from the device status
-  updateValue< std::string >( datum, names::mpi_address, mpi_address_ );
+  updateValue< std::string >( params, names::mpi_address, mpi_address_ );
 }
 
 
@@ -292,7 +292,7 @@ nest::StimulationBackendMPI::get_port( nest::StimulationDevice* device, std::str
   // b) the file is provided via a file: {data_path}/{data_prefix}{label}/{node_id}.txt
 
   // Case a: MPI address is given via device status, use the supplied address
-  if ( !mpi_address_.empty() )
+  if ( not mpi_address_.empty() )
   {
     *port_name = mpi_address_;
   }

--- a/nestkernel/stimulation_backend_mpi.h
+++ b/nestkernel/stimulation_backend_mpi.h
@@ -156,7 +156,6 @@ private:
   typedef std::map< std::string, std::tuple< MPI_Comm*, std::vector< int >*, int* > > comm_map;
   comm_map commMap_;
 
-
   std::string mpi_address_;
   /**
    * Getting the port name for the MPI connection

--- a/nestkernel/stimulation_backend_mpi.h
+++ b/nestkernel/stimulation_backend_mpi.h
@@ -47,6 +47,12 @@ The `mpi` stimulation backend collects data from MPI channels and
 updates stimulation devices just before each run. This is useful for
 co-simulation or for receiving stimuli from external software.
 
+There are two ways to set the MPI port. If both are set, option A has precedence
+
+A)
+The address is supplied via the recording backends "mpi_address" status property.
+
+B)
 The name of the MPI port to receive data on is read from a file for
 each device configured to use this backend.  The file needs to be
 named according to the following pattern:
@@ -150,14 +156,16 @@ private:
   typedef std::map< std::string, std::tuple< MPI_Comm*, std::vector< int >*, int* > > comm_map;
   comm_map commMap_;
 
+
+  std::string mpi_address_;
   /**
    * Getting the port name for the MPI connection
    *
    * @param device : input device for finding the file with the port
    * @param port_name : result of the port name
    */
-  static void get_port( StimulationDevice* device, std::string* port_name );
-  static void get_port( size_t index_node, const std::string& label, std::string* port_name );
+  void get_port( StimulationDevice* device, std::string* port_name );
+  void get_port( size_t index_node, const std::string& label, std::string* port_name );
   /**
    * MPI communication for receiving the data before each run.
    *

--- a/nestkernel/stimulation_backend_mpi.h
+++ b/nestkernel/stimulation_backend_mpi.h
@@ -49,13 +49,11 @@ co-simulation or for receiving stimuli from external software.
 
 There are two ways to set the MPI port. If both are set, option A has precedence
 
-A)
-The address is supplied via the recording backends "mpi_address" status property.
+1. The address is supplied via the recording backends "mpi_address" status property.
 
-B)
-The name of the MPI port to receive data on is read from a file for
-each device configured to use this backend.  The file needs to be
-named according to the following pattern:
+2. The name of the MPI port to send data to is read from a file for each
+   device configured to use this backend. The file needs to be named
+   according to the following pattern:
 
 ::
 


### PR DESCRIPTION
This is the refactored approach of the MPI address discussed in #2585.

The mpi address can be set via the device status.
E.g.: 
```python
nest.SetStatus(sr,{"record_to":"mpi","mpi_address":"ADDRESS"})
```