### PR TITLE
Mention parameter `t_ref` in documentation

### DIFF
--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -92,6 +92,7 @@ The following parameters can be set in the status dictionary.
 V_m       mV      Membrane potential
 E_L       mV      Leak reversal potential
 C_m       pF      Capacity of the membrane
+t_ref     ms      Duration of refractory period
 g_L       nS      Leak conductance
 tau_ex    ms      Rise time of the excitatory synaptic alpha function
 tau_in    ms      Rise time of the inhibitory synaptic alpha function

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -103,6 +103,7 @@ u_bar_bar   mV      Low-pass filtered u_bar_minus
 -------------------------------------------------------------------------------
 E_L         mV      Leak reversal potential
 C_m         pF      Capacity of the membrane
+t_ref       ms      Duration of refractory period
 g_L         nS      Leak conductance
 tau_ex      ms      Rise time of the excitatory synaptic alpha function
 tau_in      ms      Rise time of the inhibitory synaptic alpha function

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -101,6 +101,7 @@ V_m          mV      Membrane potential
 E_L          mV      Leak reversal potential
 g_L          nS      Leak conductance
 C_m          pF      Capacity of the membrane
+t_ref        ms      Duration of refractory period
 tau_syn_ex   ms      Rise time of the excitatory synaptic alpha function
 tau_syn_in   ms      Rise time of the inhibitory synaptic alpha function
 E_Na         mV      Sodium reversal potential


### PR DESCRIPTION
Add `t_ref` in documentation.

closes #2405.