### PR TITLE
Fix type check to use isinstance()

### DIFF
--- a/pynest/nest/lib/hl_api_helper.py
+++ b/pynest/nest/lib/hl_api_helper.py
@@ -538,7 +538,7 @@ def get_parameters_hierarchical_addressing(nc, params):
     # or list of strings.
     if is_literal(params[0]):
         value_list = nc.get(params[0])
-        if type(value_list) != tuple:
+        if not isinstance(value_list, tuple):
             value_list = (value_list,)
     else:
         raise TypeError("First argument must be a string, specifying path into hierarchical dictionary")


### PR DESCRIPTION
Flake8 has recently started to complain about a type check in PyNEST (https://github.com/nest/nest-simulator/actions/runs/5786174318/job/15680357178#step:5:12). This PR changes the check to use `isinstance()` as the proper way of testing the type.

I mark this PR as Critical since all CI testing will fail until it is fixed. 