### PR TITLE
Fail gracefully when `node_id` 0 is used to access non-existent node

### DIFF
--- a/nestkernel/modelrange_manager.h
+++ b/nestkernel/modelrange_manager.h
@@ -99,7 +99,7 @@ nest::ModelRangeManager::get_status( DictionaryDatum& )
 inline bool
 nest::ModelRangeManager::is_in_range( size_t node_id ) const
 {
-  return ( node_id <= last_node_id_ and node_id >= first_node_id_ );
+  return ( node_id > 0 and node_id <= last_node_id_ and node_id >= first_node_id_ );
 }
 
 inline std::vector< modelrange >::const_iterator

--- a/testsuite/pytests/sli2py_regressions/test_issue_2636_2795.py
+++ b/testsuite/pytests/sli2py_regressions/test_issue_2636_2795.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# test_issue_2795.py
+# test_issue_2636_2795.py
 #
 # This file is part of NEST.
 #
@@ -20,16 +20,19 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Regression test for Issue #2795 (GitHub).
+Regression test for Issue #2636 and #2795 (GitHub).
 
-The issue was that the following resulted in a crash instead of an error
-message:
+This issue occurred when no nodes had been created and ``node_id=0`` was
+provided as an array-like object to ``Connect`` or to access a 
+``NodeCollection``. That is, the following cases would result in a crash
+instead of an error message:
 
 .. code-block:: python
 
    import nest
-
-   nest.Connect([0], [0])
+   
+   nest.Connect([0], [0])    # Crash case 1
+   nest.NodeCollection([0])  # Crash case 2
 
 The reason was that ``node_id=0`` passed through the consistency check of
 ``ModelRangeManager::is_in_range`` due to the default values of the expected
@@ -43,9 +46,23 @@ import nest
 
 
 @pytest.mark.parametrize("node_id", [0, 1])
-def test_connection_without_creation(node_id):
+def test_nc_access_fail_without_node_creation(node_id):
     """
-    Ensure that connecting non-existent nodes fails.
+    Ensure that accessing non-existent nodes fails (Issue #2636).
+
+    This test ensures that accessing node ids when no nodes have not been
+    created results in an ``UnknownNode`` error, including the invalid
+    ``node_id=0``.
+    """
+
+    with pytest.raises(nest.kernel.NESTErrors.UnknownNode):
+        nest.NodeCollection([node_id])
+
+
+@pytest.mark.parametrize("node_id", [0, 1])
+def test_connection_fail_without_node_creation(node_id):
+    """
+    Ensure that connecting non-existent nodes fails (Issue #2795).
 
     This test ensures that connecting node ids when no nodes have not been
     created results in an ``UnknownNode`` error, including the invalid

--- a/testsuite/pytests/sli2py_regressions/test_issue_2636_2795.py
+++ b/testsuite/pytests/sli2py_regressions/test_issue_2636_2795.py
@@ -23,14 +23,14 @@
 Regression test for Issue #2636 and #2795 (GitHub).
 
 This issue occurred when no nodes had been created and ``node_id=0`` was
-provided as an array-like object to ``Connect`` or to access a 
+provided as an array-like object to ``Connect`` or to access a
 ``NodeCollection``. That is, the following cases would result in a crash
 instead of an error message:
 
 .. code-block:: python
 
    import nest
-   
+
    nest.Connect([0], [0])    # Crash case 1
    nest.NodeCollection([0])  # Crash case 2
 

--- a/testsuite/pytests/sli2py_regressions/test_issue_2795.py
+++ b/testsuite/pytests/sli2py_regressions/test_issue_2795.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# test_issue_2795.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Regression test for Issue #2795 (GitHub).
+
+The issue was that the following resulted in a crash instead of an error
+message:
+
+.. code-block:: python
+
+   import nest
+
+   nest.Connect([0], [0])
+
+The reason was that ``node_id=0`` passed through the consistency check of
+``ModelRangeManager::is_in_range`` due to the default values of the expected
+first and last node id's also being 0 before a ``NodeCollection`` is created.
+The consistency check now addresses the edge case of ``node_id=0``.
+"""
+
+import pytest
+
+import nest
+
+
+@pytest.mark.parametrize("node_id", [0, 1])
+def test_connection_without_creation(node_id):
+    """
+    Ensure that connecting non-existent nodes fails.
+
+    This test ensures that connecting node ids when no nodes have not been
+    created results in an ``UnknownNode`` error, including the invalid
+    ``node_id=0``.
+    """
+
+    with pytest.raises(nest.kernel.NESTErrors.UnknownNode):
+        nest.Connect([node_id], [node_id])


### PR DESCRIPTION
Fixes [#2636](https://github.com/nest/nest-simulator/issues/2636), fixes https://github.com/nest/nest-simulator/issues/2795. 

This issue occurred when no nodes had been created and ``node_id=0`` was provided as an array-like object to ``Connect`` or to access a ``NodeCollection``. That is, the following cases would result in a crash instead of an error message:

```python
import nest
nest.Connect([0], [0])    # Crash case 1
nest.NodeCollection([0])  # Crash case 2
```

Providing a `node_id=0` is not really valid and will fail if a `NodeCollection` has been created. However, if no nodes have been created before trying to connect or access, `node_id=0` passes through the consistency check of `ModelRangeManager::is_in_range` because `first_node_id_` and `last_node_id_` both have 0 as default values. Instead of introducing two additional checks ( `first_node_id_ > 0` and `last_node_id_ > 0`) to account for this edge case, we can just ensure that `node_id > 0` with the same effect.

An alternative solution to this issue could be to ensure that `0` is not contained in array-like objects passed to `Connect` or `NodeCollection` on the PyNEST level. 