### PR TITLE
Allow `NodeCollection` slicing with list of NumPy integers 

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -252,7 +252,7 @@ class NodeCollection:
                     raise IndexError("Bool index array must be the same length as NodeCollection")
                 np_key = numpy.array(key, dtype=bool)
             # Checking that elements are not instances of bool too, because bool inherits from int
-            elif all(isinstance(x, int) and not isinstance(x, bool) for x in key):
+            elif all(isinstance(x, (int, numpy.integer)) and not isinstance(x, bool) for x in key):
                 np_key = numpy.array(key, dtype=numpy.uint64)
                 if len(numpy.unique(np_key)) != len(np_key):
                     raise ValueError("All node IDs in a NodeCollection have to be unique")

--- a/testsuite/pytests/sli2py_regressions/test_issue_2637.py
+++ b/testsuite/pytests/sli2py_regressions/test_issue_2637.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# test_issue_2637.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Regression test for Issue #2637 (GitHub).
+
+This set of tests ensures that a ``NodeCollection`` can be sliced with
+a Python ``list`` of NumPy integers.
+"""
+
+import numpy as np
+import pytest
+
+import nest
+
+
+@pytest.mark.parametrize("dtype", [int, np.int32, np.int64])
+def test_nc_slice_list_of_numpy_ints(dtype):
+    """
+    Ensure that a list of NumPy integers can slice a ``NodeCollection``.
+    """
+
+    nc = nest.Create("iaf_psc_alpha", 2)
+    slice_arr = np.array([0, 1], dtype=dtype)
+    slice_lst = list(slice_arr)
+    nc_slice = nc[slice_lst]


### PR DESCRIPTION
Resolves https://github.com/nest/nest-simulator/issues/2637.