### PR TITLE
Hike minimum required CMake version to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>
 
-# Version range from minimum required (3.12 for macOS OpenMP)
-# up to newest version tested, see https://cliutils.gitlab.io/modern-cmake/chapters/basics.html
-cmake_minimum_required( VERSION 3.12...3.16 )
+cmake_minimum_required( VERSION 3.19 )
 
 # add cmake modules: for all `include(...)` first look here
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )


### PR DESCRIPTION
#2835 took into use CMake function COMMAND_ERROR_IS_FATAL which is only available from CMake 3.19 on (https://github.com/nest/nest-simulator/blob/1a5838eb15321909ffed31de84cfa0b6e048b321/cmake/ProcessOptions.cmake#L664C10-L664C10).

This PR hikes the CMake requirement correspondingly and simplifies the requirement to just a minimum version.

This can cause problems for reproducibility runs on some supercomputers; e.g., JUSUF Stages/2020 supports only CMake 3.18, but is required for use of Python 3.8.