### PR TITLE
Fix malformed table in models documentation

### DIFF
--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -97,7 +97,7 @@ Parameters
  b                   real          Dopaminergic baseline concentration
  Wmin                real          Minimal synaptic weight
  Wmax                real          Maximal synaptic weight
-==================== ============= ======================================================
+=================== ============== ======================================================
 
 The common properties can only be set by :py:func:`.SetDefaults` and apply
 to all instances of the synapse model.


### PR DESCRIPTION
This PR fixes a malformed table in `stdp_dopamine_synapse`

https://nest-simulator--2887.org.readthedocs.build/en/2887/