### PR TITLE
Add warning if local_num_threads set by user disagrees with OMP_NUM_THREADS

### DIFF
--- a/nestkernel/vp_manager.cpp
+++ b/nestkernel/vp_manager.cpp
@@ -22,6 +22,9 @@
 
 #include "vp_manager.h"
 
+// C++ includes:
+#include <cstdlib>
+
 // Includes from libnestutil:
 #include "logging.h"
 
@@ -158,6 +161,19 @@ nest::VPManager::set_num_threads( size_t n_threads )
   {
     throw KernelException( "Multiple threads can not be used if structural plasticity is enabled" );
   }
+
+  char* omp_num_threads = std::getenv( "OMP_NUM_THREADS" );
+  if ( omp_num_threads and static_cast< size_t >( std::atoi( omp_num_threads ) ) != n_threads )
+  {
+    const std::string tstr = ( n_threads > 1 ) ? "threads" : "thread";
+    const int ONT = std::atoi( omp_num_threads );
+    std::string msg = "The new number of threads disagrees with the environment variable OMP_NUM_THREADS.\n";
+    msg += "NEST only respects the kernel attributes /local_num_threads or /total_num_virtual_procs\n";
+    msg += String::compose( "and will now use %1 %2 and ignore OMP_NUM_THREADS (set to %3).", n_threads, tstr, ONT );
+
+    LOG( M_WARNING, "MPIManager::init_mpi()", msg );
+  }
+
   n_threads_ = n_threads;
 
 #ifdef _OPENMP


### PR DESCRIPTION
This PR followed from an internal discussion and tries to protect users from running with an unexpected number of threads.