### PR TITLE
Add note on using Mamba instead of conda

### DIFF
--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -8,7 +8,7 @@ Conda forge install
    If you encounter problems installing the NEST conda package and 
    environment, we recommend using Mamba (https://mamba.readthedocs.io). 
    Mamba has the advantage of installing conda packages and 
-   environments and can be used as a complete drop-in replacement.
+   environments more quickly and can be used as a complete drop-in replacement for conda.
 
 1. To keep your conda setup tidy, we recommend that you install NEST into
    a separate `conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -6,7 +6,7 @@ Conda forge install
 .. note:: 
    
    If you encounter problems installing the NEST conda package and 
-   environment, we recommend using mamba (https://mamba.readthedocs.io). 
+   environment, we recommend using Mamba (https://mamba.readthedocs.io). 
    Mamba provides a huge speed advantage installing conda packages and 
    environments and can be used as a complete drop-in replacement.
 

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -3,7 +3,9 @@
 Conda forge install
 ===================
 
-.. note:: If you encounter problems installing the NEST conda package and 
+.. note:: 
+   
+   If you encounter problems installing the NEST conda package and 
    environment, we recommend using mamba (https://mamba.readthedocs.io). 
    Mamba provides a huge speed advantage installing conda packages and 
    environments and can be used as a complete drop-in replacement.

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -3,6 +3,11 @@
 Conda forge install
 ===================
 
+.. note:: If you encounter problems installing the NEST conda package and 
+   environment, we recommend using mamba (https://mamba.readthedocs.io). 
+   Mamba provides a huge speed advantage installing conda packages and 
+   environments and can be used as a complete drop-in replacement.
+
 1. To keep your conda setup tidy, we recommend that you install NEST into
    a separate `conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
    together with Python packages that you will use when working with NEST;

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -7,7 +7,7 @@ Conda forge install
    
    If you encounter problems installing the NEST conda package and 
    environment, we recommend using Mamba (https://mamba.readthedocs.io). 
-   Mamba provides a huge speed advantage installing conda packages and 
+   Mamba has the advantage of installing conda packages and 
    environments and can be used as a complete drop-in replacement.
 
 1. To keep your conda setup tidy, we recommend that you install NEST into

--- a/doc/htmldoc/installation/conda_tips.rst
+++ b/doc/htmldoc/installation/conda_tips.rst
@@ -3,9 +3,13 @@
 Tips for installing NEST with conda
 ===================================
 
+.. note:: If you encounter problems installing the NEST conda package and 
+   environment, we recommend using mamba (https://mamba.readthedocs.io). 
+   Mamba provides a huge speed advantage installing conda packages and
+   environments and can be used as a complete drop-in replacement.
+
 This page provides a series of recommendations for installing pre-built NEST with
 conda or to set up conda environments for building NEST and NEST documentation.
-
 
 Basic conda setup
 -----------------

--- a/doc/htmldoc/installation/conda_tips.rst
+++ b/doc/htmldoc/installation/conda_tips.rst
@@ -3,10 +3,12 @@
 Tips for installing NEST with conda
 ===================================
 
-.. note:: If you encounter problems installing the NEST conda package and 
-   environment, we recommend using mamba (https://mamba.readthedocs.io). 
-   Mamba provides a huge speed advantage installing conda packages and
-   environments and can be used as a complete drop-in replacement.
+.. note:: 
+
+   If you encounter problems installing the NEST conda package and 
+   environment, we recommend using Mamba (https://mamba.readthedocs.io). 
+   Mamba has the advantage of installing conda packages and 
+   environments more quickly and can be used as a complete drop-in replacement for conda.
 
 This page provides a series of recommendations for installing pre-built NEST with
 conda or to set up conda environments for building NEST and NEST documentation.

--- a/doc/htmldoc/installation/condaenv_install.rst
+++ b/doc/htmldoc/installation/condaenv_install.rst
@@ -3,10 +3,12 @@
 Install from source in a conda environment
 ==========================================
 
-.. note:: If you encounter problems installing the NEST conda package and 
-   environment, we recommend using mamba (https://mamba.readthedocs.io). 
-   Mamba provides a huge speed advantage installing conda packages and 
-   environments and can be used as a complete drop-in replacement.
+.. note:: 
+
+   If you encounter problems installing the NEST conda package and 
+   environment, we recommend using Mamba (https://mamba.readthedocs.io). 
+   Mamba has the advantage of installing conda packages and 
+   environments more quickly and can be used as a complete drop-in replacement for conda.
 
 * Create a conda environment from the `environment.yml <https://github.com/nest/nest-simulator/blob/master/environment.yml>`_ file.
   We recommend specifying a dedicated location (``-p <path/to/conda/env>``) for your environment.

--- a/doc/htmldoc/installation/condaenv_install.rst
+++ b/doc/htmldoc/installation/condaenv_install.rst
@@ -3,6 +3,11 @@
 Install from source in a conda environment
 ==========================================
 
+.. note:: If you encounter problems installing the NEST conda package and 
+   environment, we recommend using mamba (https://mamba.readthedocs.io). 
+   Mamba provides a huge speed advantage installing conda packages and 
+   environments and can be used as a complete drop-in replacement.
+
 * Create a conda environment from the `environment.yml <https://github.com/nest/nest-simulator/blob/master/environment.yml>`_ file.
   We recommend specifying a dedicated location (``-p <path/to/conda/env>``) for your environment.
   See the `conda documentation <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#specifying-a-location-for-an-environment>`_


### PR DESCRIPTION
#2863 and #2896 show problems in using the NEST conda package and the conda environment file. 
With conda, the installation of NEST and the environment can be very slow, leading to crashes. Mamba (https://mamba.readthedocs.io) speeds up the installation enormously and thus improves the stability of the process. Mamba can be used as a drop-in replacement to conda.
The note draws attention to the problem and should provide a solution. 
Conda remains the standard tool for the time being.
@jessica-mitchell Would be nice if you could have a look.