### PR TITLE
Add documentation builds to cmake options

### DIFF
--- a/doc/htmldoc/installation/cmake_options.rst
+++ b/doc/htmldoc/installation/cmake_options.rst
@@ -101,7 +101,7 @@ Build documentation
 |                              |                                                             |
 +------------------------------+-------------------------------------------------------------+
 
-If either documentation build is toggled to `on`, you can then run ``make docs`` if you want to only
+If either documentation build is toggled to `ON`, you can then run ``make docs`` if you only want to
 build the docs.
 
 See also the :ref:`documentation workflow <doc_workflow>` for user and developer docs.

--- a/doc/htmldoc/installation/cmake_options.rst
+++ b/doc/htmldoc/installation/cmake_options.rst
@@ -15,7 +15,7 @@ environment.
 
 .. note::
 
-  If you want to specify an alternative install location, use  
+  If you want to specify an alternative install location, use
   ``-DCMAKE_INSTALL_PREFIX:PATH=<nest_install_dir>``. It needs to be
   writable by the user running the install command.
 
@@ -88,6 +88,24 @@ Select parallelization scheme
 +---------------------------------------------+----------------------------------------------------------------+
 
 See also the section on :ref:`building with MPI <compile-with-mpi>` below.
+
+
+Build documentation
+~~~~~~~~~~~~~~~~~~~
+
++------------------------------+-------------------------------------------------------------+
+| ``-Dwith-devdoc=[OFF|ON]``   | Build the developer (doxygen) documentation [default=OFF]   |
+|                              |                                                             |
++------------------------------+-------------------------------------------------------------+
+| ``-Dwith-userdoc=[OFF|ON]``  | Build the user (Sphinx) documentation [default=OFF]         |
+|                              |                                                             |
++------------------------------+-------------------------------------------------------------+
+
+If either documentation build is toggled to `on`, you can then run ``make docs`` if you want to only
+build the docs.
+
+See also the :ref:`documentation workflow <doc_workflow>` for user and developer docs.
+
 
 External libraries
 ~~~~~~~~~~~~~~~~~~

--- a/doc/htmldoc/installation/developer.rst
+++ b/doc/htmldoc/installation/developer.rst
@@ -39,6 +39,11 @@ file that contains all possible packages needed for NEST development.
 
          If you want to install NEST without any environment, see the :ref:`instructions here <noenv>`.
 
+
+.. seealso::
+
+  :ref:`cmake options for NEST <cmake_options>`
+
 What gets installed where
 -------------------------
 


### PR DESCRIPTION
Resolves #2931 

This PR adds the `devdoc` and `userdoc` cmake options to the cmake_options file.
It also adds an additional link to the cmake options to make them more visible.

See here for output: https://nest-simulator--2934.org.readthedocs.build/en/2934/installation/cmake_options.html#cmake-options