### PR TITLE
Add GCC compiler problem matcher to CI

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -692,11 +692,19 @@ jobs:
               -Dwith-libneurosim=${{ contains(matrix.use, 'libneurosim') && '$HOME/.cache/libneurosim.install' || 'OFF' }} \
               ..
 
+      - name: "Add GCC problem matcher"
+        run: |
+          echo "::add-matcher::gcc_problem_matcher.json"
+
       - name: "Build NEST"
         run: |
           cd "$NEST_VPATH"
           env
           make VERBOSE=1
+
+      - name: "Remove GCC problem matcher"
+        run: |
+          echo "::remove-matcher owner=gcc-problem-matcher::"
 
       - name: "Install NEST"
         run: |

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -570,11 +570,19 @@ jobs:
               -Dwith-libneurosim=${{ contains(matrix.use, 'libneurosim') && '$HOME/.cache/libneurosim.install' || 'OFF' }} \
               ..
 
+      - name: "Add GCC problem matcher"
+        run: |
+          echo "::add-matcher::gcc_problem_matcher.json"
+
       - name: "Build NEST"
         run: |
           cd "$NEST_VPATH"
           env
-          make VERBOSE=1
+          gcc-problem-matcher make VERBOSE=1
+
+      - name: "Remove GCC problem matcher"
+        run: |
+          echo "::remove-matcher owner=gcc-problem-matcher::"
 
       - name: "Install NEST"
         run: |

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -578,7 +578,7 @@ jobs:
         run: |
           cd "$NEST_VPATH"
           env
-          gcc-problem-matcher make VERBOSE=1
+          make VERBOSE=1
 
       - name: "Remove GCC problem matcher"
         run: |

--- a/gcc_problem_matcher.json
+++ b/gcc_problem_matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Resolves https://github.com/nest/nest-simulator/issues/2779.

This PR introduces a GitHub Actions [problem matcher](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) which scans the GCC compiler output for a specified regex pattern and surface the information in the UI as [annotations]( https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#annotations-object-1).

The problem matcher is identical to the one used in VS Code's `cpptools`: 
https://github.com/microsoft/vscode-cpptools/blob/2cc55ea6ebe96b91c118c84784e980bdfaf20304/Extension/package.json#L303-L320.