### PR TITLE
Add `clang-format` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,8 @@ repos:
     hooks:
       - id: black
         language_version: python3
+
+  -   repo: https://github.com/pre-commit/mirrors-clang-format
+      rev: v13.0.0
+      hooks:
+      -   id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,13 @@ repos:
       - id: black
         language_version: python3
 
-  -   repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: v13.0.0
-      hooks:
-      -   id: clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.0
+    hooks:
+      - id: clang-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace


### PR DESCRIPTION
This PR introduces a pre-commit hook for `clang-format`. By default, the hook uses the `.clang-format` file from the root. 

The PR also adds the `end-of-file-fixer` and `trailing-whitespace` hooks. They are out-of-the-box hooks from `pre-commit`, which already is a dependency. These particular hooks might save a lot of back-and-forth with CI.