### PR TITLE
Fix up HTML output to clean up browser warnings

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -172,6 +172,7 @@ html_theme_options = {
     "globaltoc_collapse": True,
     # If True, show hidden TOC entries
     "globaltoc_includehidden": True,
+    "version_dropdown": False,
 }
 
 html_static_path = ["static"]

--- a/doc/htmldoc/templates/layout.html
+++ b/doc/htmldoc/templates/layout.html
@@ -7,8 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="This is the documentation index for the NEST, a simulator for spiking neuronal networks.">
   <meta name="keywords" content="">
-  <link rel="stylesheet" href="_static/css/bootstrap/bootstrap.min.css">
-  <link rel="stylesheet" href="_static/css/custom.css">
   {{ super() }}
 {% endblock %}
 


### PR DESCRIPTION
This PR fixes some warnings that are output in the browser.
Removing extra stylesheet links in layout.html that aren't needed and add `version_dropdown` option to false to HTML config.