### PR TITLE
Fix indentation in PyNEST API

### DIFF
--- a/doc/htmldoc/static/css/custom.css
+++ b/doc/htmldoc/static/css/custom.css
@@ -113,7 +113,7 @@ rect.basic.label-container {
 	stroke-width: 1px;
 }
 
-figure, .align-default {
+figure.align-default {
 	text-align: center;
 }
 .mermaid svg {


### PR DESCRIPTION
This PR fixes the indentation of the API summary which was introduced in #2603.
The css was not properly constructed to only affect figures. 
So now the [figure should be centered](https://nest-simulator--2941.org.readthedocs.build/en/2941/developer_space/workflows/documentation_workflow/user_documentation_workflow.html): 
And the [API text should be aligned left](https://nest-simulator--2941.org.readthedocs.build/en/2941/ref_material/pynest_api/index.html).
