### PR TITLE
Add calibration function for models, called when changing resolution, to NEST2

### DIFF
--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -60,6 +60,7 @@ public:
   bool potential_global_receiver();
   bool one_node_per_process();
   bool is_off_grid();
+  void calibrate_time( const TimeConverter& tc );
   /**
      @note The decision of whether one node can receive a certain
      event was originally in the node. But in the distributed case,
@@ -195,6 +196,13 @@ inline bool
 GenericModel< ElementT >::is_off_grid()
 {
   return proto_.is_off_grid();
+}
+
+template < typename ElementT >
+inline void
+GenericModel< ElementT >::calibrate_time( const TimeConverter& tc )
+{
+  proto_.calibrate_time( tc );
 }
 
 template < typename ElementT >

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -39,6 +39,7 @@
 
 namespace nest
 {
+class TimeConverter;
 
 /**
  * Base class for all Models.
@@ -135,6 +136,7 @@ public:
   virtual bool potential_global_receiver() = 0;
   virtual bool one_node_per_process() = 0;
   virtual bool is_off_grid() = 0;
+  virtual void calibrate_time( const TimeConverter& tc ) = 0;
 
   /**
    * Change properties of the prototype node according to the

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -517,9 +517,11 @@ ModelManager::clear_prototypes_()
 void
 ModelManager::calibrate( const TimeConverter& tc )
 {
-  for ( thread t = 0;
-        t < static_cast< thread >( kernel().vp_manager.get_num_threads() );
-        ++t )
+  for ( auto&& model : models_ )
+  {
+    model->calibrate_time( tc );
+  }
+  for ( thread t = 0; t < static_cast< thread >( kernel().vp_manager.get_num_threads() ); ++t )
   {
     for (
       std::vector< ConnectorModel* >::iterator pt = prototypes_[ t ].begin();

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -50,6 +50,7 @@ namespace nest
 class Model;
 class Subnet;
 class Archiving_Node;
+class TimeConverter;
 
 
 /**
@@ -297,6 +298,15 @@ public:
    *
    */
   virtual void calibrate() = 0;
+
+  /**
+   * Re-calculate time-based properties of the node.
+   * This function is called after a change in resolution.
+   */
+  virtual void
+  calibrate_time( const TimeConverter& tc )
+  {
+  }
 
   /**
    * Cleanup node after Run. Override this function if a node needs to


### PR DESCRIPTION
This would be nice to have for NESTML. It was added as part of the big NEST 3 pull request by @hakonsbm. This PR is only a cherry-pick of that commit (2dac11d).