### PR TITLE
Fix bug in reconstruction of connection data structures after disconnect and fix small problems with examples

### DIFF
--- a/examples/run_examples.sh
+++ b/examples/run_examples.sh
@@ -93,11 +93,13 @@ for i in $EXAMPLES; do
     echo "  output_dir: '$output_dir'" >>"$metafile"
     echo "  log: '$logfile'" >>"$metafile"
 
-    export NEST_DATA_PATH=""  # $output_dir"
+    export NEST_DATA_PATH="$output_dir"
     touch .start_example
     sleep 1
     set +e
+    # The following line will not work on macOS. There, `brew install gnu-time` and use the commented-out line below.
     /usr/bin/time -f "$time_format" --quiet sh -c "'$runner' '$example' >'$logfile' 2>&1" |& tee -a "$metafile"
+    # /usr/local/bin/gtime -f "$time_format" --quiet sh -c "'$runner' '$example' >'$logfile' 2>&1" | tee -a "$metafile" 2>&1
     ret=$?
     set -e
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1583,6 +1583,10 @@ nest::ConnectionManager::remove_disabled_connections( const size_t tid )
     {
       continue;
     }
+
+    // Source table and connectors are sorted synchronously. All invalid connections have
+    // been sorted to end of source_table_. We find them there, then remove corresponding
+    // elements from connectors.
     const size_t first_disabled_index = source_table_.remove_disabled_sources( tid, syn_id );
 
     if ( first_disabled_index != invalid_index )

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -392,6 +392,7 @@ public:
 
     while ( true )
     {
+      assert( lcid + lcid_offset < C_.size() );
       ConnectionT& conn = C_[ lcid + lcid_offset ];
       const bool is_disabled = conn.is_disabled();
       const bool source_has_more_targets = conn.source_has_more_targets();

--- a/pynest/examples/evaluate_quantal_stp_synapse.py
+++ b/pynest/examples/evaluate_quantal_stp_synapse.py
@@ -84,7 +84,7 @@ seed = 12345
 
 # We define the number of trials as well as the number of release sites.
 
-n_sites = 10.0  # number of synaptic release sites
+n_sites = 10  # number of synaptic release sites
 n_trials = 500  # number of measurement trials
 
 # The pre-synaptic neuron is driven by an injected current for a part of each

--- a/pynest/examples/pong/README.rst
+++ b/pynest/examples/pong/README.rst
@@ -5,7 +5,7 @@ the classic game of Pong.
 
 Requirements
 ------------
-- NEST 3.3
+- NEST 3.3 or later
 - NumPy
 - Matplotlib
 

--- a/pynest/examples/store_restore_network.py
+++ b/pynest/examples/store_restore_network.py
@@ -304,8 +304,6 @@ class DemoPlot:
 
 
 if __name__ == "__main__":
-    plt.ion()
-
     T_sim = 1000
 
     dplot = DemoPlot()
@@ -370,6 +368,4 @@ if __name__ == "__main__":
     nest.Simulate(T_sim)
     dplot.add_to_plot(ein2, lbl="Reloaded simulation (different seed)")
 
-    dplot.fig.savefig("store_restore_network.png")
-
-    input("Press ENTER to close figure!")
+    plt.show()

--- a/testsuite/pytests/test_spike_transmission_after_disconnect.py
+++ b/testsuite/pytests/test_spike_transmission_after_disconnect.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# test_spike_transmission_after_disconnect.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+import nest
+
+
+def test_spike_transmission_after_disconnect():
+    """
+    Confirm that spikes can be transmitted after connections have been removed.
+    """
+
+    n = nest.Create("parrot_neuron", 10)
+    nest.Connect(n, n)
+
+    # Delete 1/3 of connections
+    c = nest.GetConnections()
+    c[::3].disconnect()
+
+    # Add spike generator to drive
+    g = nest.Create("spike_generator", params={"spike_times": [1]})
+    nest.Connect(g, n)
+
+    # Simulate long enough for spikes to be delivered, but not too long
+    # since we otherwise will be buried by exponential growth in number
+    # of spikes.
+    nest.Simulate(3)


### PR DESCRIPTION
This PR contains two parts:
- A critical bug fix including new test to ensure connection data structures are properly rebuilt after disconnect.
- Fixes to some examples and the example runner to ensure they work with current master.

This PR changes the order of structural plasticity and spike delivery: When using compressed spikes, we can only deliver spikes through the same connection setup in which they were gathered.

@terhorstd @jougs I label this one as critical because it must make it into 3.6.