### PR TITLE
Update extension for API extractor

### DIFF
--- a/doc/htmldoc/_ext/extract_api_functions.py
+++ b/doc/htmldoc/_ext/extract_api_functions.py
@@ -20,9 +20,10 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 import ast
 import glob
-import json
 import os
 import re
+from sphinx.application import Sphinx
+
 
 """
 Generate a JSON dictionary that stores the module name as key and corresponding
@@ -107,20 +108,18 @@ def process_directory(directory):
 
 def get_pynest_list(app, env, docname):
     directory = "../../pynest/nest/"
-    all_variables_dict = process_directory(directory)
 
-    with open("api_function_list.json", "w") as outfile:
-        json.dump(all_variables_dict, outfile, indent=4)
+    if not hasattr(env, "pynest_dict"):
+        env.pynest_dict = {}
 
-        env.env_attribute.append(all_variables_dict)
+    env.pynest_dict = process_directory(directory)
 
 
 def api_customizer(app, docname, source):
     env = app.builder.env
     if docname == "ref_material/pynest_api/index":
-        # list_apis = env.env_attribute
-        list_apis = json.load(open("api_function_list.json"))
-        html_context = {"api_dict": list_apis}
+        get_apis = env.pynest_dict
+        html_context = {"api_dict": get_apis}
         api_source = source[0]
         rendered = app.builder.templates.render_string(api_source, html_context)
         source[0] = rendered
@@ -129,3 +128,9 @@ def api_customizer(app, docname, source):
 def setup(app):
     app.connect("env-before-read-docs", get_pynest_list)
     app.connect("source-read", api_customizer)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/htmldoc/_ext/extract_api_functions.py
+++ b/doc/htmldoc/_ext/extract_api_functions.py
@@ -105,13 +105,27 @@ def process_directory(directory):
     return api_dict
 
 
-def ExtractPyNESTAPIS():
+def get_pynest_list(app, env, docname):
     directory = "../../pynest/nest/"
     all_variables_dict = process_directory(directory)
 
     with open("api_function_list.json", "w") as outfile:
         json.dump(all_variables_dict, outfile, indent=4)
 
+        env.env_attribute.append(all_variables_dict)
 
-if __name__ == "__main__":
-    ExtractPyNESTAPIS()
+
+def api_customizer(app, docname, source):
+    env = app.builder.env
+    if docname == "ref_material/pynest_api/index":
+        # list_apis = env.env_attribute
+        list_apis = json.load(open("api_function_list.json"))
+        html_context = {"api_dict": list_apis}
+        api_source = source[0]
+        rendered = app.builder.templates.render_string(api_source, html_context)
+        source[0] = rendered
+
+
+def setup(app):
+    app.connect("env-before-read-docs", get_pynest_list)
+    app.connect("source-read", api_customizer)

--- a/doc/htmldoc/_ext/extract_api_functions.py
+++ b/doc/htmldoc/_ext/extract_api_functions.py
@@ -22,8 +22,8 @@ import ast
 import glob
 import os
 import re
-from sphinx.application import Sphinx
 
+from sphinx.application import Sphinx
 
 """
 Generate a JSON dictionary that stores the module name as key and corresponding

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -32,7 +32,6 @@ from urllib.request import urlretrieve
 extension_module_dir = os.path.abspath("./_ext")
 sys.path.append(extension_module_dir)
 
-from extract_api_functions import ExtractPyNESTAPIS  # noqa
 from extractor_userdocs import ExtractUserDocs, relative_glob  # noqa
 
 repo_root_dir = os.path.abspath("../..")
@@ -215,10 +214,6 @@ def config_inited_handler(app, config):
     )
 
 
-def get_pynest_list(app, env, docname):
-    ExtractPyNESTAPIS()
-
-
 def toc_customizer(app, docname, source):
     if docname == "models/models-toc":
         models_toc = json.load(open("models/toc-tree.json"))
@@ -235,7 +230,6 @@ def setup(app):
     app.add_css_file("css/custom.css")
     app.add_css_file("css/pygments.css")
     app.add_js_file("js/custom.js")
-    app.connect("env-before-read-docs", get_pynest_list)
     app.connect("config-inited", config_inited_handler)
 
 

--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "add_button_notebook",
     "IPython.sphinxext.ipython_console_highlighting",
     "nbsphinx",
+    "extract_api_functions",
     "sphinx_design",
     "HoverXTooltip",
     "VersionSyncRole",
@@ -218,15 +219,6 @@ def get_pynest_list(app, env, docname):
     ExtractPyNESTAPIS()
 
 
-def api_customizer(app, docname, source):
-    if docname == "ref_material/pynest_api/index":
-        list_apis = json.load(open("api_function_list.json"))
-        html_context = {"api_dict": list_apis}
-        api_source = source[0]
-        rendered = app.builder.templates.render_string(api_source, html_context)
-        source[0] = rendered
-
-
 def toc_customizer(app, docname, source):
     if docname == "models/models-toc":
         models_toc = json.load(open("models/toc-tree.json"))
@@ -240,7 +232,6 @@ def setup(app):
     # for events see
     # https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx-core-events
     app.connect("source-read", toc_customizer)
-    app.connect("source-read", api_customizer)
     app.add_css_file("css/custom.css")
     app.add_css_file("css/pygments.css")
     app.add_js_file("js/custom.js")


### PR DESCRIPTION
This PR modifies the `extract_api_functions.py` script so it no longer outputs an unneeded JSON file, and moves the parts of the script that were in conf.py into one file in `_ext`.

Here is [output](https://nest-simulator--2965.org.readthedocs.build/en/2965/ref_material/pynest_api/index.html) (no change should have occurred)