### PR TITLE
Copy documentation to CI artifacts

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -375,7 +375,7 @@ jobs:
           name: "sphinx-rtd output"
           path: |
             build/sphinx-output.log
-            build/userdoc/html/
+            build/doc/_build/html/
 
   sphinx-conda:
     # as close as possible to the suggested user docs build in the documentation
@@ -414,7 +414,7 @@ jobs:
         with:
           path: |
             build/sphinx-output.log
-            build/userdoc/html/
+            build/doc/_build/html/
 
   build_linux:
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}


### PR DESCRIPTION
In the CI test build of the documentation, an incorrect path to the generated html files is specified. This means that the files are not present in the artifacts file. This small fix corrects that.