### PR TITLE
Allow `isort` pre-commit to make in-place changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        args: ["--profile", "black", "--thirdparty", "nest", "--diff"]
+        args: ["--profile", "black", "--thirdparty", "nest"]
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:


### PR DESCRIPTION
This PR removes the `--diff` flag from the `isort` pre-commit hook, thus allowing `isort` to make in-place changes instead of just showing the changes `isort` would make.