### PR TITLE
Fix Pylint errors caused by new, stricter Pylint version

### DIFF
--- a/testsuite/pytests/test_stdp_pl_synapse_hom.py
+++ b/testsuite/pytests/test_stdp_pl_synapse_hom.py
@@ -21,23 +21,13 @@
 
 from math import exp
 
+import matplotlib.pyplot as plt
 import nest
 import numpy as np
-import pytest
 
 DEBUG_PLOTS = False
 
-if DEBUG_PLOTS:
-    try:
-        import matplotlib as mpl  # noqa: F401
-        import matplotlib.pyplot as plt
 
-        DEBUG_PLOTS = True
-    except Exception:
-        DEBUG_PLOTS = False
-
-
-@nest.ll_api.check_stack
 class TestSTDPPlSynapse:
     """
     Compare the STDP power-law synaptic plasticity model against a self-contained Python reference.

--- a/testsuite/pytests/test_stdp_synapse.py
+++ b/testsuite/pytests/test_stdp_synapse.py
@@ -21,27 +21,17 @@
 
 from math import exp
 
+import matplotlib.pyplot as plt
 import nest
 import numpy as np
 import pytest
 
 DEBUG_PLOTS = False
 
-if DEBUG_PLOTS:
-    try:
-        import matplotlib as mpl  # noqa: F401
-        import matplotlib.pyplot as plt
-
-        DEBUG_PLOTS = True
-    except Exception:
-        DEBUG_PLOTS = False
-
-
 # Defined here so we can use it in init_params() and in parametrization
 RESOLUTION = 0.1  # [ms]
 
 
-@nest.ll_api.check_stack
 class TestSTDPSynapse:
     """
     Compare the STDP synaptic plasticity model against a self-contained Python reference.


### PR DESCRIPTION
Currently the Pylint checker fails due to a new, stricter version. This PR fix the errors Pylint points out.