### PR TITLE
Properly suppress pylint complaints about unused plt in tests

### DIFF
--- a/testsuite/pytests/test_stdp_pl_synapse_hom.py
+++ b/testsuite/pytests/test_stdp_pl_synapse_hom.py
@@ -332,6 +332,7 @@ class TestSTDPPlSynapse:
         fname_snip="",
         title_snip="",
     ):
+        # pylint: disable=E0601
         fig, ax = plt.subplots(nrows=3)
 
         n_spikes = len(pre_spikes)

--- a/testsuite/pytests/test_stdp_synapse.py
+++ b/testsuite/pytests/test_stdp_synapse.py
@@ -366,6 +366,7 @@ class TestSTDPSynapse:
         fname_snip="",
         title_snip="",
     ):
+        # pylint: disable=E0601
         fig, ax = plt.subplots(nrows=3)
 
         n_spikes = len(pre_spikes)


### PR DESCRIPTION
This is a replacement for #2970 to ensure we pass with Pylint 3. We need to allow conditional importing of matplotlib in case it is not available on test systems.

Labeled as critical since the problem blocks our CI.