### PR TITLE
Update clang-format version to 17.0.4 and activate `InsertBraces`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -76,6 +76,7 @@ IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertBraces: true
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -10,7 +10,7 @@ jobs:
   clang-format:
     runs-on: "ubuntu-20.04"
     env:
-      CLANG_REQUIRE_VERSION: 13
+      CLANG_REQUIRE_VERSION: 17
       CLANG_FORMAT_FILE: ".clang-format"
     steps:
       - name: "Checkout repository content"
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Instal dependencies"
+      - name: "Install dependencies"
         run: |
           python -m pip install --force-reinstall clang-format==${{ env.CLANG_REQUIRE_VERSION }}
 
@@ -290,7 +290,7 @@ jobs:
       - name: "Run pylint..."
         run: |
           pylint --jobs=$(nproc) pynest/ testsuite/pytests/*.py testsuite/regressiontests/*.py
-  
+
   isort:
     runs-on: "ubuntu-20.04"
     steps:
@@ -471,7 +471,7 @@ jobs:
           sudo apt-get install ccache
           sudo apt-get install libltdl-dev libreadline6-dev libncurses5-dev libgsl0-dev python3-all-dev jq libpcre3 libpcre3-dev
           sudo apt-get install tcl8.6 tcl8.6-dev tk8.6-dev
-          # Install MPI dependencies regardless of whether we compile NEST with or without MPI, so the installation of MPI4Py works 
+          # Install MPI dependencies regardless of whether we compile NEST with or without MPI, so the installation of MPI4Py works
           sudo apt-get install openmpi-bin libopenmpi-dev
           sudo apt-get install libboost-filesystem-dev libboost-regex-dev libboost-wave-dev libboost-python-dev libboost-program-options-dev libboost-test-dev
           sudo apt-get install pkg-config

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -10,7 +10,7 @@ jobs:
   clang-format:
     runs-on: "ubuntu-20.04"
     env:
-      CLANG_REQUIRE_VERSION: 17
+      CLANG_REQUIRE_VERSION: 17.0.4
       CLANG_FORMAT_FILE: ".clang-format"
     steps:
       - name: "Checkout repository content"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.0
+    rev: v17.0.4
     hooks:
       - id: clang-format
 

--- a/build_support/format_all_c_c++_files.sh
+++ b/build_support/format_all_c_c++_files.sh
@@ -2,9 +2,9 @@
 
 # With this script you can easily format all C/C++ files contained in
 # any (sub)directory of NEST. Internally it uses clang-format to do
-# the actual formatting. 
-# 
-# NEST C/C++ code should be formatted according to clang-format version 13.0.0.
+# the actual formatting.
+#
+# NEST C/C++ code should be formatted according to clang-format version 17.0.4.
 # If you would like to see how the code will be formatted with a different
 # clang-format version, execute e.g. `CLANG_FORMAT=clang-format-14 ./format_all_c_c++_files.sh`.
 #

--- a/doc/htmldoc/developer_space/guidelines/coding_guidelines_check.rst
+++ b/doc/htmldoc/developer_space/guidelines/coding_guidelines_check.rst
@@ -85,8 +85,8 @@ shell script to run ``clang-format`` manually:
 
 .. note::
 
-   We use ``clang-format`` version 13.0.0 in our CI. If your ``clang-format`` executable is
-   not version 13, you need to specify an executable with version 13.0.0 explicitly with
+   We use ``clang-format`` version 17.0.4 in our CI. If your ``clang-format`` executable is
+   not version 17, you need to specify an executable with version 17.0.4 explicitly with
    the `--clang-format` option to ensure consistency with the NEST CI.
 
 Local static analysis

--- a/environment.yml
+++ b/environment.yml
@@ -101,7 +101,7 @@ dependencies:
   - pip:
     # For testsuite
     - junitparser >= 2
-    - clang-format == 17.0
+    - clang-format == 17.0.4
     # For documentation
     - example
     - Image

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - pip
 
   # Building NEST -----------
-  - cmake >= 3.12
+  - cmake >= 3.19
   - cython
   - openmpi
   - boost >= 1.69
@@ -101,7 +101,7 @@ dependencies:
   - pip:
     # For testsuite
     - junitparser >= 2
-    - clang-format == 13.0
+    - clang-format == 17.0
     # For documentation
     - example
     - Image

--- a/nestkernel/position.h
+++ b/nestkernel/position.h
@@ -316,7 +316,7 @@ public:
   /**
    * Output the Position to an ostream.
    */
-  friend std::ostream& operator<<<>( std::ostream& os, const Position< D, T >& pos );
+  friend std::ostream& operator<< <>( std::ostream& os, const Position< D, T >& pos );
 
 protected:
   std::array< T, D > x_;

--- a/sli/filesystem.cc
+++ b/sli/filesystem.cc
@@ -150,7 +150,7 @@ FilesystemModule::DirectoryFunction::execute( SLIInterpreter* i ) const
     assert( path_buffer );
   }
   Token sd( new StringDatum( path_buffer ) );
-  delete[]( path_buffer );
+  delete[] ( path_buffer );
   i->OStack.push_move( sd );
   i->EStack.pop();
 }

--- a/sli/sliregexp.cc
+++ b/sli/sliregexp.cc
@@ -152,7 +152,7 @@ RegexpModule::RegerrorFunction::execute( SLIInterpreter* i ) const
   char* error_buffer = new char[ 256 ];
   regerror( id->get(), rd->get()->get(), error_buffer, 256 );
   Token sd( new StringDatum( error_buffer ) );
-  delete[]( error_buffer );
+  delete[] ( error_buffer );
 
   // The lockPTR rd gets locked when calling the get() function.
   // In order to be able to use (delete) this object we need to
@@ -208,7 +208,7 @@ RegexpModule::RegexecFunction::execute( SLIInterpreter* i ) const
     Token array_token( PushArray );
     i->OStack.push_move( array_token );
   };
-  delete[]( pm );
+  delete[] ( pm );
   i->OStack.push_move( id );
   i->EStack.pop();
 }


### PR DESCRIPTION
This PR hikes the clang-format version to 17.0.4, the current version at this point, which is available via PyPi for all relevant OS (https://pypi.org/project/clang-format/#files). It also activates automatic insertion of braces around blocks (https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces); this feature became available with clang-format 15.

Code format changes due to  the transition from 13 to 17 are minimal, see below.

Also fixes a forgotten requirements hike for cmake.

@terhorstd  @jessica-mitchell I'd appreciate it if you could review this quickly as #2867 would benefit from it.