### PR TITLE
Fix misplaced `assert` statement causing a lot of warnings

### DIFF
--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -402,7 +402,8 @@ template < typename targetidentifierT >
 SecondaryEvent*
 Connection< targetidentifierT >::get_secondary_event()
 {
-  assert( false );
+  assert( false && "non-primary connections have to provide get_secondary_event()");
+  return nullptr;
 }
 
 } // namespace nest

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -402,7 +402,7 @@ template < typename targetidentifierT >
 SecondaryEvent*
 Connection< targetidentifierT >::get_secondary_event()
 {
-  assert( false && "non-primary connections have to provide get_secondary_event()");
+  assert( false and "Non-primary connections have to provide get_secondary_event()" );
   return nullptr;
 }
 


### PR DESCRIPTION
I just saw this warning quite often (in the EBRAINS spack build it gets repeated for 162 times ;) ):
```
/tmp/spack-stage/spack-stage-nest-3.6-uy4os6lc7odhv7bryyp2atuprbdl2xwn/spack-src/nestkernel/connection.h: In member function 'nest::SecondaryEvent* nest::Connection<targetidentifierT>::get_secondary_event()':
/tmp/spack-stage/spack-stage-nest-3.6-uy4os6lc7odhv7bryyp2atuprbdl2xwn/spack-src/nestkernel/connection.h:404:1: warning: no return statement in function returning non-void [-Wreturn-type]
  404 | }
      | ^
```

Also: I guess even if the `assert` is ensured to never be removed (contrary to standard `NDEBUG` behavior) it would be reasonable to clearly state the intention here (an exception might be more user-friendly, but I guess the code was intentionally avoiding an exception) by calling abort?