### PR TITLE
Add pre-commit to NEST environment.yml and limit pylint to pre-3.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -74,7 +74,7 @@ dependencies:
   - jupyter
   - jupyterlab
 
-  # Contributin to NEST -----
+  # Contributing to NEST -----
   - pre-commit
 
   # Building NEST documentation

--- a/environment.yml
+++ b/environment.yml
@@ -47,6 +47,8 @@ dependencies:
 
   # Testing NEST ------------
   - attrs
+  # Pytest currently incompatible with pylint 3, see https://github.com/pylint-dev/pylint/issues/8862
+  - pylint < 3
   - pytest
   - pytest-timeout
   - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -74,6 +74,9 @@ dependencies:
   - jupyter
   - jupyterlab
 
+  # Contributin to NEST -----
+  - pre-commit
+
   # Building NEST documentation
   - PyYAML>=4.2b1
   - breathe


### PR DESCRIPTION
This PR 

1. adds `pre-commit` to a new "Contributing to NEST" section of `environment.yml`
2. limits the `pylint` version installed to <3. This is need to run `pytest`, which invokes `pylint`, due to some recent changes in `pylint` (see https://github.com/pylint-dev/pylint/issues/8862).

Probably #2834 needs adjusting as a consequence.

Tagging as high priority as it may brake testing.