### PR TITLE
Fix broken links in documentation

### DIFF
--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -51,7 +51,7 @@ plasticity and exponential shaped postsynaptic currents (PSCs). In particular,
 ``iaf_tum_2000`` implements short-term depression and short-term facilitation
 according to [1]_ by solving Eqs. (3) and (4) from that paper in an exact manner.
 
-``iaf_tum_2000`` differs from `iaf_psc_exp <../models/iaf_psc_exp>` by the addition
+``iaf_tum_2000`` differs from :doc:`iaf_psc_exp <../models/iaf_psc_exp>` by the addition
 of synaptic state variables :math:`x`, :math:`z` and :math:`u`, which together
 with the membrane potential :math:`V_\text{m}` and synaptic current :math:`I_\text{syn}`
 obey the following dynamics:
@@ -77,7 +77,7 @@ where :math:`\Gamma_X` is an index set over either excitatory (:math:`\text{X} =
 :math:`k` indexes the spike times of neuron :math:`j`, and :math:`d_j`
 is the delay from neuron :math:`j`.
 
-``iaf_tum_2000`` incorporates the `tsodyks_synapse <../models/tsodyks_synapse>`
+``iaf_tum_2000`` incorporates the :doc:`tsodyks_synapse </models/tsodyks_synapse>`
 computations directly in the presynaptic neuron, that is, the  synaptic state
 variables :math:`x,y,z,u` are integrated in the presynaptic neuron instead of
 the synapse model. For a presynaptic neuron with :math:`K` outgoing connections

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -51,7 +51,7 @@ plasticity and exponential shaped postsynaptic currents (PSCs). In particular,
 ``iaf_tum_2000`` implements short-term depression and short-term facilitation
 according to [1]_ by solving Eqs. (3) and (4) from that paper in an exact manner.
 
-``iaf_tum_2000`` differs from :doc:`iaf_psc_exp <../models/iaf_psc_exp>` by the addition
+``iaf_tum_2000`` differs from :doc:`iaf_psc_exp </models/iaf_psc_exp>` by the addition
 of synaptic state variables :math:`x`, :math:`z` and :math:`u`, which together
 with the membrane potential :math:`V_\text{m}` and synaptic current :math:`I_\text{syn}`
 obey the following dynamics:

--- a/pynest/examples/iaf_tum_2000_short_term_depression.py
+++ b/pynest/examples/iaf_tum_2000_short_term_depression.py
@@ -23,7 +23,7 @@ r"""
 Short-term depression example
 -----------------------------
 
-The `iaf_tum_2000 <../models/iaf_tum_2000>` neuron [1]_ is a model with
+The :doc:`iaf_tum_2000 </models/iaf_tum_2000>` neuron [1]_ is a model with
 *short-term synaptic plasticity*. Short-term plasticity can either strengthen
 or weaken a synapse and acts on a timescale of milliseconds to seconds. This
 example illustrates *short-term depression*, which is caused by depletion of
@@ -48,11 +48,11 @@ For an example on *short-term facilitation*, see
 
 .. note::
 
-    The `iaf_tum_2000 <../models/iaf_tum_2000>` neuron model combined with
-    `static_synapse <../models/static_synapse>` provides a more efficient
+    The :doc:`iaf_tum_2000 </models/iaf_tum_2000>` neuron model combined with
+    :doc:`static_synapse </models/static_synapse>` provides a more efficient
     implementation of the model studied in [1]_ and [2]_ than the combination
-    of `iaf_psc_exp <../models/iaf_psc_exp>` with
-    `tsodyks_synapse <../models/tsodyks_synapse>`.
+    of :doc:`iaf_psc_exp </models/iaf_psc_exp>` with
+    :doc:`tsodyks_synapse </models/tsodyks_synapse>`.
 
 References
 ~~~~~~~~~~

--- a/pynest/examples/iaf_tum_2000_short_term_facilitation.py
+++ b/pynest/examples/iaf_tum_2000_short_term_facilitation.py
@@ -23,7 +23,7 @@ r"""
 Short-term facilitation example
 -------------------------------
 
-The `iaf_tum_2000 <../models/iaf_tum_2000>` neuron [1]_ is a model with
+The :doc:`iaf_tum_2000 </models/iaf_tum_2000>` neuron [1]_ is a model with
 *short-term synaptic plasticity*. Short-term plasticity can either strengthen
 or weaken a synapse and acts on a timescale of milliseconds to seconds. This
 example illustrates *short-term facilitation*, which is a transient increase
@@ -50,11 +50,11 @@ For an example on *short-term depression*, see
 
 .. note::
 
-    The `iaf_tum_2000 <../models/iaf_tum_2000>` neuron model combined with
-    `static_synapse <../models/static_synapse>` provides a more efficient
+    The :doc:`iaf_tum_2000 </models/iaf_tum_2000>` neuron model combined with
+    :doc:`static_synapse </models/static_synapse>` provides a more efficient
     implementation of the model studied in [1]_ and [2]_ than the combination
-    of `iaf_psc_exp <../models/iaf_psc_exp>` with
-    `tsodyks_synapse <../models/tsodyks_synapse>`.
+    of :doc:`iaf_psc_exp </models/iaf_psc_exp>` with
+    :doc:`tsodyks_synapse </models/tsodyks_synapse>`.
 
 References
 ~~~~~~~~~~
@@ -69,7 +69,7 @@ References
 See Also
 ~~~~~~~~
 
-:doc:`../models/iaf_tum_2000`, :doc:`iaf_tum_2000_short_term_depression`
+:doc:`/models/iaf_tum_2000`, :doc:`iaf_tum_2000_short_term_depression`
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This PR fixes some links in examples and model relating to `iaf_tum_2000` that were broken.