### PR TITLE
Add note about missing random generators for osx-arm64

### DIFF
--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -3,11 +3,17 @@
 Conda forge install
 ===================
 
-.. note:: 
-   
-   If you encounter problems installing the NEST conda package and 
-   environment, we recommend using Mamba (https://mamba.readthedocs.io). 
-   Mamba has the advantage of installing conda packages and 
+.. note::
+
+   We provide conda packages for linux-64, osx-64 and osx-arm64. Due to the
+   cross compiling of the conda NEST package for Apple silicon with ARM64
+   architecture, there only exists a limited set of random generators.
+
+.. note::
+
+   If you encounter problems installing the NEST conda package and
+   environment, we recommend using Mamba (https://mamba.readthedocs.io).
+   Mamba has the advantage of installing conda packages and
    environments more quickly and can be used as a complete drop-in replacement for conda.
 
 1. To keep your conda setup tidy, we recommend that you install NEST into

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -8,7 +8,6 @@ Conda forge install
    Due to a cross-compiling issue in the conda NEST package, some random number 
    generators are not available if you are using macOS arm64 architecture. 
    The available generators are the Mersenne Twister generators `mt19937` and `mt19937_64`.
-   cross compiling of the conda NEST package for Apple silicon with ARM64
    architecture, there only exists a limited set of random generators.
 
 .. note::

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -3,7 +3,7 @@
 Conda forge install
 ===================
 
-.. note::
+.. admonition:: osx-arm64: missing random number generators
 
    Due to a cross-compiling issue in the conda NEST package, some random number 
    generators are not available if you are using macOS arm64 architecture. 

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -5,7 +5,9 @@ Conda forge install
 
 .. note::
 
-   We provide conda packages for linux-64, osx-64 and osx-arm64. Due to the
+   Due to a cross-compiling issue in the conda NEST package, some random number 
+   generators are not available if you are using macOS arm64 architecture. 
+   The available generators are the Mersenne Twister generators `mt19937` and `mt19937_64`.
    cross compiling of the conda NEST package for Apple silicon with ARM64
    architecture, there only exists a limited set of random generators.
 

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -8,7 +8,6 @@ Conda forge install
    Due to a cross-compiling issue in the conda NEST package, some random number 
    generators are not available if you are using macOS arm64 architecture. 
    The available generators are the Mersenne Twister generators `mt19937` and `mt19937_64`.
-   architecture, there only exists a limited set of random generators.
 
 .. note::
 

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -3,6 +3,12 @@
 Randomness in NEST Simulations
 ==============================
 
+.. admonition:: osx-arm64: missing random number generators
+
+   Due to a cross-compiling issue in the conda NEST package, some random number
+   generators are not available if you are using macOS arm64 architecture.
+   The available generators are the Mersenne Twister generators `mt19937` and `mt19937_64`.
+
 Random numbers in network simulations
 -------------------------------------
 


### PR DESCRIPTION
see #2982.

We provide conda packages for linux-64, osx-64 and osx-arm64. Due to the cross compiling of the conda NEST package for Apple silicon with ARM64 architecture, there only exists a limited set of random generators.