### PR TITLE
Add missing keyword to glif neuron model documentation

### DIFF
--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -42,7 +42,7 @@
 
 #include "dictdatum.h"
 
-/* BeginUserDocs: integrate-and-fire, conductance-based
+/* BeginUserDocs:  neuron, integrate-and-fire, conductance-based
 
 Short description
 +++++++++++++++++

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -32,7 +32,7 @@
 
 #include "dictdatum.h"
 
-/* BeginUserDocs: integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based
 
 Short description
 +++++++++++++++++

--- a/models/glif_psc_double_alpha.h
+++ b/models/glif_psc_double_alpha.h
@@ -32,7 +32,7 @@
 
 #include "dictdatum.h"
 
-/* BeginUserDocs: integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based
 
 Short description
 +++++++++++++++++


### PR DESCRIPTION
The glif neuron models are missing the keyword neuron, so they don't appear in the directory under that category.