### PR TITLE
Add missing links to examples in model documentation

### DIFF
--- a/models/aeif_cond_alpha_astro.h
+++ b/models/aeif_cond_alpha_astro.h
@@ -192,6 +192,11 @@ See also
 
 iaf_cond_alpha, aeif_cond_exp, astrocyte_lr_1994, sic_connection
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: aeif_cond_alpha_astro
+
 EndUserDocs */
 
 void register_aeif_cond_alpha_astro( const std::string& name );

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -158,6 +158,11 @@ Receives
 
 SpikeEvent, CurrentEvent, DataLoggingRequest
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: amat2_psc_exp
+
 EndUserDocs */
 
 void register_amat2_psc_exp( const std::string& name );

--- a/models/astrocyte_lr_1994.h
+++ b/models/astrocyte_lr_1994.h
@@ -239,6 +239,11 @@ See also
 
 aeif_cond_alpha_astro, sic_connection
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: astrocyte_lr_1994
+
 EndUserDocs */
 
 void register_astrocyte_lr_1994( const std::string& name );

--- a/models/glif_psc_double_alpha.h
+++ b/models/glif_psc_double_alpha.h
@@ -212,6 +212,11 @@ See also
 gif_psc_exp_multisynapse, gif_cond_exp, gif_cond_exp_multisynapse, gif_pop_psc_exp,
 glif_psc
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: glif_psc_double_alpha
+
 EndUserDocs */
 
 namespace nest

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -85,6 +85,11 @@ See also
 
 iaf_psc_alpha, iaf_psc_delta, iaf_psc_exp, iaf_cond_exp, iaf_psc_alpha_multisynapse
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: iaf_psc_exp_multisynapse
+
 EndUserDocs */
 
 void register_iaf_psc_exp_multisynapse( const std::string& name );

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -145,6 +145,11 @@ See also
 
 iaf_psc_exp, tsodyks_synapse, stdp_synapse, static_synapse
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: iaf_tum_2000
+
 EndUserDocs */
 // clang-format on
 

--- a/models/quantal_stp_synapse.h
+++ b/models/quantal_stp_synapse.h
@@ -99,6 +99,11 @@ See also
 
 tsodyks2_synapse, stdp_synapse, static_synapse
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: quantal_stp_synapse
+
 EndUserDocs */
 
 void register_quantal_stp_synapse( const std::string& name );

--- a/models/rate_connection_delayed.h
+++ b/models/rate_connection_delayed.h
@@ -65,6 +65,11 @@ See also
 
 rate_connection_instantaneous, rate_neuron_ipn, rate_neuron_opn
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: rate_connection_delayed
+
 EndUserDocs */
 
 /**

--- a/models/rate_neuron_opn.h
+++ b/models/rate_neuron_opn.h
@@ -104,6 +104,11 @@ See also
 
 lin_rate, tanh_rate, threshold_lin_rate
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: rate_neuron_opn
+
 EndUserDocs  */
 
 template < class TNonlinearities >

--- a/models/sic_connection.h
+++ b/models/sic_connection.h
@@ -56,6 +56,11 @@ See also
 
 astrocyte_lr_1994, aeif_cond_alpha_astro
 
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: sic_connection
+
 EndUserDocs */
 
 void register_sic_connection( const std::string& name );


### PR DESCRIPTION
This PR adds the missing ``listexamples`` directive to models that have been skipped over by accident.