### PR TITLE
Update the documentaton regarding Windows

### DIFF
--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -146,8 +146,8 @@ If you want to use the compose configuration for the ``dev`` NEST version, you c
 
 .. _docker_win:
 
-Run NEST on Windows
-^^^^^^^^^^^^^^^^^^^
+Run NEST on Windows |windows|
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. important::
 

--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -1,7 +1,7 @@
 .. _docker:
 
-Docker |macos| |linux| |windows|
---------------------------------
+Docker |macos| |linux|
+----------------------
 
 Docker provides an isolated container to run applications.
 
@@ -27,7 +27,7 @@ Docker provides an isolated container to run applications.
 Usage
 
 
-You can use the docker images directly out of https://hub.docker.com/r/nest/nest-simulator 
+You can use the docker images directly out of https://hub.docker.com/r/nest/nest-simulator
 like this:
 
 .. code-block:: bash
@@ -144,10 +144,12 @@ If you want to use the compose configuration for the ``dev`` NEST version, you c
     wget https://raw.githubusercontent.com/nest/nest-docker/master/docker-compose-dev.yml
     docker-compose -f docker-compose-dev.yml up nest-notebook
 
-On Windows
-^^^^^^^^^^
+.. _docker_win:
 
-.. note::
+Run NEST on Windows
+^^^^^^^^^^^^^^^^^^^
+
+.. important::
 
     The following commands should work on Windows. Please note that NEST does not officially
     support Windows!
@@ -161,8 +163,8 @@ In Powershell, '%cd%' might not work for the current directory. Then
 you should explicitly specify a folder with existing write permissions.
 
 In any case, this will download the docker image with the pre-installed
-NEST master from https://hub.docker.com/r/nest/nest-simulator and start it. 
-After booting, a URL is presented. Click on it or copy it to your browser. 
+NEST master from https://hub.docker.com/r/nest/nest-simulator and start it.
+After booting, a URL is presented. Click on it or copy it to your browser.
 Voilá! Jupyter notebook starts from the docker image.
 
 You can update the image with:

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -3,21 +3,24 @@
 User install instructions
 =========================
 
-Cross-platform |macos| |linux|
-------------------------------
+Cross-platform options
+-----------------------
 
-Docker
-~~~~~~
+
+Docker |linux| |macos| |windows|
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`See our docker installation instructions <docker>`.
 
-Conda install
-~~~~~~~~~~~~~
+
+Conda install |linux| |macos|
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can install NEST with the :ref:`Conda forge package <conda_forge_install>`.
 
-Live media
-~~~~~~~~~~
+
+Live media |linux| |macos| |windows|
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 We have live media (.ova) if you want to run NEST in a virtual machine.
 
@@ -131,8 +134,8 @@ macOS |macos|
 --------
 
 
-Options for Windows users
---------------------------
+Options for Windows users |windows|
+------------------------------------
 
 Please note that NEST does not officially support Windows. Members of our community have had success
 using NEST on Windows with the `Windows Subsystem for Linux <https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support#1-overview>`_.
@@ -140,8 +143,12 @@ You can also try our :ref:`docker container <docker_win>`.
 
 .. |linux| image:: ../static/img/linux.png
    :class: no-scaled-link
-   :scale: 11%
+   :scale: 7%
 
 .. |macos| image:: ../static/img/macos.png
    :class: no-scaled-link
-   :scale: 11%
+   :scale: 7%
+
+.. |windows| image:: ../static/img/windows.png
+   :class: no-scaled-link
+   :scale: 7%

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -3,8 +3,8 @@
 User install instructions
 =========================
 
-Cross-platform |macos| |linux| |windows|
-----------------------------------------
+Cross-platform |macos| |linux|
+------------------------------
 
 Docker
 ~~~~~~
@@ -128,7 +128,14 @@ macOS |macos|
 
     brew install nest
 
+--------
 
+
+Windows
+-------
+
+NEST does not officially support Windows. If you want to use NEST on Windows,
+we suggest trying the Windows Subsystem for Linux or the :ref:`docker container <docker_win>`.
 
 .. |linux| image:: ../static/img/linux.png
    :class: no-scaled-link
@@ -142,6 +149,3 @@ macOS |macos|
 .. |windows| image:: ../static/img/windows.png
    :class: no-scaled-link
    :scale: 11%
-
-
-

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -131,21 +131,17 @@ macOS |macos|
 --------
 
 
-Windows
--------
+Options for Windows users
+--------------------------
 
-NEST does not officially support Windows. If you want to use NEST on Windows,
-we suggest trying the Windows Subsystem for Linux or the :ref:`docker container <docker_win>`.
+Please note that NEST does not officially support Windows. Members of our community have had success
+using NEST on Windows with the `Windows Subsystem for Linux <https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support#1-overview>`_.
+You can also try our :ref:`docker container <docker_win>`.
 
 .. |linux| image:: ../static/img/linux.png
    :class: no-scaled-link
    :scale: 11%
 
 .. |macos| image:: ../static/img/macos.png
-   :class: no-scaled-link
-   :scale: 11%
-
-
-.. |windows| image:: ../static/img/windows.png
    :class: no-scaled-link
    :scale: 11%


### PR DESCRIPTION
Removing the Windows logo from the installation pages, as requested from users who deem it a bit deceiving, since no official support is available.
Added text stating to use Windows sub system for Linux (known to work) or the docker container. 