### PR TITLE
Update documentation of video tutorial to clarify version

### DIFF
--- a/doc/htmldoc/tutorials/videos/one_neuron.rst
+++ b/doc/htmldoc/tutorials/videos/one_neuron.rst
@@ -1,8 +1,13 @@
 .. _video_one_neuron:
 
-Introduction to NEST: Simulating a single neuron
-==================================================
+Introduction to NEST: Simulating a single neuron (NEST version 2.12)
+=====================================================================
 
+.. admonition::  NEST 3.X incompatibility
+
+  The syntax used in NEST has changed in 3.X compared to what is seen in the video. Please
+  see our :doc:`one neuron example </auto_examples/one_neuron/>` for a simple
+  example with updated syntax.
 
 .. raw:: html
 


### PR DESCRIPTION
The video tutorial is old and uses 2.12, and also does not work with the newer syntax.
Until a  new video is created, I added the version of NEST that is in the video and a note to 3.x users that there is incompatibility.