### PR TITLE
Remove unused doxygen groups in developer documentation

### DIFF
--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -367,7 +367,6 @@ private:
   // Data members -----------------------------------------------------------
 
   /**
-   * @defgroup aeif_cond_alpha_multisynapse
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -371,7 +371,6 @@ private:
   // Data members -----------------------------------------------------------
 
   /**
-   * @defgroup aeif_cond_beta_multisynapse
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -389,7 +389,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup amat2_psc_exp_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -211,7 +211,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -394,7 +394,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -400,7 +400,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -399,7 +399,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_chs_2007.h
+++ b/models/iaf_chs_2007.h
@@ -275,7 +275,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_exp_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -383,7 +383,6 @@ private:
   // Data members -----------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_alpha_multisynapse.h
+++ b/models/iaf_psc_alpha_multisynapse.h
@@ -275,7 +275,6 @@ private:
   // Data members -----------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_multisynapse_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -449,7 +449,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -306,7 +306,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -388,7 +388,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_delta_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -382,7 +382,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_exp_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -335,7 +335,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_exp_htum_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_exp_multisynapse.h
+++ b/models/iaf_psc_exp_multisynapse.h
@@ -275,7 +275,6 @@ private:
   }; // Variables
 
   /**
-   * @defgroup iaf_psc_exp_multisynapse_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -405,7 +405,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_exp_ps_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -452,7 +452,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_exp_ps_lossless_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -371,7 +371,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_exp_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -335,7 +335,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup mat2_psc_exp_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -380,7 +380,6 @@ private:
   // ----------------------------------------------------------------
 
   /**
-   * @defgroup iaf_psc_alpha_data
    * Instances of private data structures for the different types
    * of data pertaining to the model.
    * @note The order of definitions is important for speed.

--- a/nestkernel/exceptions.h
+++ b/nestkernel/exceptions.h
@@ -47,12 +47,10 @@ class Event;
  * @defgroup KernelExceptions NEST kernel exception classes
  * Exception classes that are thrown by the NEST kernel to indicate
  * an error.
- * @ingroup Exceptions
  */
 
 /**
  * Base class for all Kernel exceptions.
- * @ingroup Exceptions
  * @ingroup KernelExceptions
  */
 class KernelException : public SLIException

--- a/nestkernel/manager_interface.h
+++ b/nestkernel/manager_interface.h
@@ -41,7 +41,6 @@ namespace nest
  * @note Each manager shall be instantiated only once. Therefore, copy
  * constructor and assignment operator are declared private and not implemented.
  *
- * @ingroup KernelManagers
  */
 class ManagerInterface
 {

--- a/nestkernel/nestmodule.h
+++ b/nestkernel/nestmodule.h
@@ -133,7 +133,7 @@ public:
   static AbstractMask* create_mask( const Name& name, const DictionaryDatum& d );
 
   /**
-   * @defgroup NestSliInterface SLI Interface functions of the NEST kernel.
+   * SLI Interface functions of the NEST kernel.
    *
    * This group contains the functions that form the SLI interface
    * of the NEST kernel.

--- a/nestkernel/node_manager.h
+++ b/nestkernel/node_manager.h
@@ -146,7 +146,6 @@ public:
    * @param node_id index of the Node
    * @param tid local thread index of the Node
    *
-   * @ingroup net_access
    */
   Node* get_node_or_proxy( size_t node_id, size_t tid );
 
@@ -173,7 +172,6 @@ public:
    *
    * @throws nest::NoThreadSiblingsAvailable Node does not have thread siblings.
    *
-   * @ingroup net_access
    */
   std::vector< Node* > get_thread_siblings( size_t n ) const;
 

--- a/nestkernel/recording_backend.h
+++ b/nestkernel/recording_backend.h
@@ -63,7 +63,6 @@ class Event;
  * device is enrolled with. Cleanup on the user level finally calls
  * the cleanup() function of all backends.
  *
- * @ingroup NESTio
  */
 
 class RecordingBackend
@@ -114,7 +113,6 @@ public:
    *
    * @see set_value_names(), disenroll(), write(),
    *
-   * @ingroup NESTio
    */
   virtual void enroll( const RecordingDevice& device, const DictionaryDatum& params ) = 0;
 
@@ -132,7 +130,6 @@ public:
    *
    * @see enroll()
    *
-   * @ingroup NESTio
    */
   virtual void disenroll( const RecordingDevice& device ) = 0;
 
@@ -153,7 +150,6 @@ public:
    *
    * @see enroll(), disenroll(), write(),
    *
-   * @ingroup NESTio
    */
   virtual void set_value_names( const RecordingDevice& device,
     const std::vector< Name >& double_value_names,
@@ -168,7 +164,6 @@ public:
    *
    * @see cleanup()
    *
-   * @ingroup NESTio
    */
   virtual void prepare() = 0;
 
@@ -181,7 +176,6 @@ public:
    *
    * @see prepare()
    *
-   * @ingroup NESTio
    */
   virtual void cleanup() = 0;
 
@@ -195,7 +189,6 @@ public:
    *
    * @see post_run_hook()
    *
-   * @ingroup NESTio
    */
   virtual void pre_run_hook() = 0;
 
@@ -209,7 +202,6 @@ public:
    *
    * @see pre_run_hook()
    *
-   * @ingroup NESTio
    */
   virtual void post_run_hook() = 0;
 
@@ -222,7 +214,6 @@ public:
    *
    * @see pre_run_hook()
    *
-   * @ingroup NESTio
    */
   virtual void post_step_hook() = 0;
 
@@ -239,7 +230,6 @@ public:
    * @param double_values vector of double valued to be written
    * @param long_values vector of long values to be written
    *
-   * @ingroup NESTio
    */
   virtual void write( const RecordingDevice& device,
     const Event& event,
@@ -254,7 +244,6 @@ public:
    *
    * @see get_status()
    *
-   * @ingroup NESTio
    */
   virtual void set_status( const DictionaryDatum& params ) = 0;
 
@@ -266,7 +255,6 @@ public:
    *
    * @see set_status()
    *
-   * @ingroup NESTio
    */
   virtual void get_status( DictionaryDatum& params ) const = 0;
 
@@ -285,7 +273,6 @@ public:
    *
    * @see get_device_defaults(), get_device_status()
    *
-   * @ingroup NESTio
    */
   virtual void check_device_status( const DictionaryDatum& params ) const = 0;
 
@@ -297,7 +284,6 @@ public:
    *
    * @see check_device_status(), get_device_status()
    *
-   * @ingroup NESTio
    */
   virtual void get_device_defaults( DictionaryDatum& params ) const = 0;
 
@@ -314,7 +300,6 @@ public:
    *
    * @see enroll(), check_device_status(), get_device_defaults()
    *
-   * @ingroup NESTio
    */
   virtual void get_device_status( const RecordingDevice& device, DictionaryDatum& params ) const = 0;
 

--- a/nestkernel/stimulation_backend.h
+++ b/nestkernel/stimulation_backend.h
@@ -66,7 +66,6 @@ namespace nest
  *
  * @author Sandra Diaz
  *
- * @ingroup NESTio
  */
 
 class StimulationBackend
@@ -108,7 +107,6 @@ public:
    *
    * @see disenroll()
    *
-   * @ingroup NESTio
    */
   virtual void enroll( StimulationDevice&, const DictionaryDatum& ) {};
 
@@ -126,7 +124,6 @@ public:
    *
    * @see enroll()
    *
-   * @ingroup NESTio
    */
   virtual void disenroll( StimulationDevice& ) {};
 
@@ -142,7 +139,6 @@ public:
    *
    * @see post_run_hook()
    *
-   * @ingroup NESTio
    */
   virtual void pre_run_hook() = 0;
 
@@ -154,7 +150,6 @@ public:
    *
    * @see pre_run_hook()
    *
-   * @ingroup NESTio
    */
   virtual void post_run_hook() = 0;
 
@@ -175,7 +170,6 @@ public:
    *
    * @see cleanup()
    *
-   * @ingroup NESTio
    */
   virtual void prepare() = 0;
 
@@ -188,7 +182,6 @@ public:
    *
    * @see prepare()
    *
-   * @ingroup NESTio
    */
   virtual void cleanup() = 0;
 


### PR DESCRIPTION
This PR removes various groups that either do not have a definition (defgroup) or they do not have any members (ingroup).
In a future PR, some groups may be re-introduced but with proper structuring.