### PR TITLE
Fix path to docker compose file in documentation

### DIFF
--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -46,8 +46,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/steffengraber/nest-docker/<TAG>/docker-compose.yml
-
+    wget https://raw.githubusercontent.com/nest/nest-docker/master/docker-compose.yml
 
 You can then run ``docker-compose up`` with one of the following options:
 


### PR DESCRIPTION
This is just a minor fix to a link in the documentation. The download of the docker compose file is now possible.
