### PR TITLE
Add brief install instructions for the NESTML package in our ppa

### DIFF
--- a/doc/htmldoc/installation/docker.rst
+++ b/doc/htmldoc/installation/docker.rst
@@ -46,8 +46,7 @@ To use 'docker-compose' you need the definition file from the git repository. Do
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/steffengraber/nest-docker/<TAG>/docker-compose.yml
-
+    wget https://raw.githubusercontent.com/nest/nest-docker/master/docker-compose.yml
 
 You can then run ``docker-compose up`` with one of the following options:
 

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -50,7 +50,7 @@ Ubuntu users can install NEST via the PPA repository.
 
      sudo apt-get install nest
 
-   Or install NEST with `NESTML <https://nestml.readthedocs.io/en/latest/index.html>`_
+Or install NEST with `NESTML <https://nestml.readthedocs.io/en/latest/index.html>`_
 
 .. code-block:: bash
 

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -50,6 +50,19 @@ Ubuntu users can install NEST via the PPA repository.
 
      sudo apt-get install nest
 
+3. Optional: Install `NESTML <https://nestml.readthedocs.io/en/latest/index.html>`_
+
+.. code-block:: bash
+
+    sudo apt install nest python3-nestml
+    python3 -m pip install --upgrade odetoolbox pygsl antlr4-python3-runtime==4.10
+
+4. Set the environment
+
+.. code-block:: bash
+
+    source /usr/bin/nest_vars.sh
+
 Debian
 ~~~~~~
 

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -50,7 +50,7 @@ Ubuntu users can install NEST via the PPA repository.
 
      sudo apt-get install nest
 
-3. Optional: Install `NESTML <https://nestml.readthedocs.io/en/latest/index.html>`_
+   Or install NEST with `NESTML <https://nestml.readthedocs.io/en/latest/index.html>`_
 
 .. code-block:: bash
 

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -63,75 +63,8 @@ Ubuntu users can install NEST via the PPA repository.
 
     source /usr/bin/nest_vars.sh
 
-Debian
-~~~~~~
+--------
 
-Debian users can install NEST via the Ubuntu PPA repository.
-
-1. Create a new ``apt`` repository entry in ``/etc/apt/sources.list.d/nest-simulator-ubuntu-nest-XXX.list`` by:
-
-.. code-block:: bash
-
-    sudo apt install devscripts build-essential software-properties-common dpkg-dev
-    sudo add-apt-repository --enable-source ppa:nest-simulator/nest
-
-2. Disable the binary package in the repository file created under ``/etc/apt/sources.list.d/`` by commenting
-   out the ``deb`` line, while keeping the ``deb-src`` line. It should look similar to this:
-
-.. code-block:: bash
-
-    #deb http://ppa.launchpad.net/nest-simulator/nest/ubuntu focal main
-    deb-src http://ppa.launchpad.net/nest-simulator/nest/ubuntu focal main
-
-
-3. Import the PPA GPC key and rebuild the package:
-
-.. code-block:: bash
-
-   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-                    --recv-keys 0CF7539642ABD23CBCA8D487F0B8B6C5EC02D7DD
-   sudo apt update
-   sudo apt source --build nest
-
-4. Install any missing dependencies, if ``apt`` tells you so.
-   In addition, install:
-
-.. code-block:: bash
-
-    sudo apt install python3-all dh-python
-
-5. After installing the dependencies, enter ``sudo apt source --build nest`` again.
-   When the build finished, look for lines like:
-
-.. code-block:: bash
-
-    dpkg-deb: building package 'nest-dbgsym' in '../nest-dbgsym_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb'.
-    dpkg-deb: building package 'nest' in '../nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb'.
-    #dh binary
-    dpkg-genbuildinfo --build=binary
-    dpkg-genchanges --build=binary >../nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.changes
-
-and note down the full package name. In the above example this would be
-``nest_2.20.0-0~202001311135~ubuntu20.04.1_amd64.deb``, where the number ``202001311135`` and potentially the
-Ubuntu version number may be different.
-
-6. Install the ready Debian package after the rebuild:
-
-.. code-block:: bash
-
-    sudo dpkg --install nest-simulator-x.y.z~NUMBER~ubuntu20.04.1_amd64.deb
-
-    The package name is taken from the result of the previous step. `NUMBER` and potentially the Ubuntu
-    version might differ.
-
-7. Test the package:
-
-.. code-block:: bash
-
-   python3
-   import nest
-
--------------
 
 macOS |macos|
 -------------

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -57,7 +57,7 @@ Ubuntu users can install NEST via the PPA repository.
     sudo apt install nest python3-nestml
     python3 -m pip install --upgrade odetoolbox pygsl antlr4-python3-runtime==4.10
 
-4. Set the environment
+3. Set the environment
 
 .. code-block:: bash
 


### PR DESCRIPTION
We offer NESTML in our PPA, a brief install instructions is now included here.
In addition, the description for creating Debian packages has been removed, as this offers hardly any advantages over installing from sources.