### PR TITLE
Register only spikes actually sent with weight_recorder

### DIFF
--- a/models/bernoulli_synapse.h
+++ b/models/bernoulli_synapse.h
@@ -154,25 +154,17 @@ public:
     ConnectionBase::check_connection_( dummy_target, s, t, receptor_type );
   }
 
-  void
+  bool
   send( Event& e, size_t t, const CommonSynapseProperties& )
   {
     SpikeEvent e_spike = static_cast< SpikeEvent& >( e );
 
-    const unsigned long n_spikes_in = e_spike.get_multiplicity();
-    unsigned long n_spikes_out = 0;
+    assert( e_spike.get_multiplicity() == 1 );
 
-    for ( unsigned long n = 0; n < n_spikes_in; ++n )
-    {
-      if ( get_vp_specific_rng( t )->drand() < p_transmit_ )
-      {
-        ++n_spikes_out;
-      }
-    }
+    const bool send_spike = get_vp_specific_rng( t )->drand() < p_transmit_;
 
-    if ( n_spikes_out > 0 )
+    if ( send_spike )
     {
-      e_spike.set_multiplicity( n_spikes_out );
       e.set_weight( weight_ );
       e.set_delay_steps( get_delay_steps() );
       e.set_receiver( *get_target( t ) );
@@ -180,8 +172,7 @@ public:
       e();
     }
 
-    // Resets multiplicity for consistency
-    e_spike.set_multiplicity( n_spikes_in );
+    return send_spike;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/clopath_synapse.h
+++ b/models/clopath_synapse.h
@@ -167,7 +167,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -234,7 +234,7 @@ constexpr ConnectionModelProperties clopath_synapse< targetidentifierT >::proper
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 clopath_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   double t_spike = e.get_stamp().get_ms();
@@ -279,6 +279,8 @@ clopath_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSyna
   x_bar_ = x_bar_ * std::exp( ( t_lastspike_ - t_spike ) / tau_x_ ) + 1.0 / tau_x_;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/cont_delay_synapse.h
+++ b/models/cont_delay_synapse.h
@@ -147,7 +147,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -216,7 +216,7 @@ private:
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 cont_delay_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   e.set_receiver( *get_target( t ) );
@@ -241,6 +241,8 @@ cont_delay_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonS
   e();
   // reset offset to original value
   e.set_offset( orig_event_offset );
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/diffusion_connection.h
+++ b/models/diffusion_connection.h
@@ -140,7 +140,7 @@ public:
    * \param e The event to send
    * \param p The port under which this connection is stored in the Connector.
    */
-  void
+  bool
   send( Event& e, size_t t, const CommonSynapseProperties& )
   {
     e.set_drift_factor( drift_factor_ );
@@ -148,6 +148,8 @@ public:
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();
+
+    return true;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/gap_junction.h
+++ b/models/gap_junction.h
@@ -131,13 +131,14 @@ public:
    * \param e The event to send
    * \param p The port under which this connection is stored in the Connector.
    */
-  void
+  bool
   send( Event& e, size_t t, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();
+    return true;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/ht_synapse.h
+++ b/models/ht_synapse.h
@@ -153,7 +153,7 @@ public:
    * \param e The event to send
    * \param cp Common properties to all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -202,7 +202,7 @@ constexpr ConnectionModelProperties ht_synapse< targetidentifierT >::properties;
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 ht_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   // propagation t_lastspike -> t_spike, t_lastspike_ = 0 initially, p_ = 1
@@ -221,6 +221,8 @@ ht_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapsePr
   p_ *= ( 1 - delta_P_ );
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/jonke_synapse.h
+++ b/models/jonke_synapse.h
@@ -214,7 +214,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const JonkeCommonProperties& cp );
+  bool send( Event& e, size_t t, const JonkeCommonProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -297,7 +297,7 @@ constexpr ConnectionModelProperties jonke_synapse< targetidentifierT >::properti
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 jonke_synapse< targetidentifierT >::send( Event& e, size_t t, const JonkeCommonProperties& cp )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -347,6 +347,8 @@ jonke_synapse< targetidentifierT >::send( Event& e, size_t t, const JonkeCommonP
   Kplus_ = Kplus_ * std::exp( ( t_lastspike_ - t_spike ) / cp.tau_plus_ ) + 1.0;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/quantal_stp_synapse.h
+++ b/models/quantal_stp_synapse.h
@@ -156,7 +156,7 @@ public:
    * \param e The event to send
    * \param cp Common properties to all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -205,7 +205,7 @@ constexpr ConnectionModelProperties quantal_stp_synapse< targetidentifierT >::pr
  * \param cp Common properties object, containing the quantal_stp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 quantal_stp_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   const double t_spike = e.get_stamp().get_ms();
@@ -225,7 +225,9 @@ quantal_stp_synapse< targetidentifierT >::send( Event& e, size_t t, const Common
     }
   }
 
-  if ( n_release > 0 )
+  const bool send_spike = n_release > 0;
+
+  if ( send_spike )
   {
     e.set_receiver( *get_target( t ) );
     e.set_weight( n_release * weight_ );
@@ -248,6 +250,8 @@ quantal_stp_synapse< targetidentifierT >::send( Event& e, size_t t, const Common
   }
 
   t_lastspike_ = t_spike;
+
+  return send_spike;
 }
 
 } // namespace

--- a/models/rate_connection_delayed.h
+++ b/models/rate_connection_delayed.h
@@ -127,7 +127,7 @@ public:
    * \param e The event to send
    * \param p The port under which this connection is stored in the Connector.
    */
-  void
+  bool
   send( Event& e, size_t t, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
@@ -135,6 +135,8 @@ public:
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();
+
+    return true;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/rate_connection_instantaneous.h
+++ b/models/rate_connection_instantaneous.h
@@ -128,13 +128,14 @@ public:
    * \param e The event to send
    * \param p The port under which this connection is stored in the Connector.
    */
-  void
+  bool
   send( Event& e, size_t t, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();
+    return true;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/sic_connection.h
+++ b/models/sic_connection.h
@@ -112,7 +112,7 @@ public:
    * \param e The event to send
    * \param p The port under which this connection is stored in the Connector.
    */
-  void
+  bool
   send( Event& e, size_t t, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
@@ -120,6 +120,8 @@ public:
     e.set_receiver( *get_target( t ) );
     e.set_rport( get_rport() );
     e();
+
+    return true;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/static_synapse.h
+++ b/models/static_synapse.h
@@ -157,7 +157,7 @@ public:
     ConnectionBase::check_connection_( dummy_target, s, t, receptor_type );
   }
 
-  void
+  bool
   send( Event& e, const size_t tid, const CommonSynapseProperties& )
   {
     e.set_weight( weight_ );
@@ -165,6 +165,7 @@ public:
     e.set_receiver( *get_target( tid ) );
     e.set_rport( get_rport() );
     e();
+    return true;
   }
 
   void get_status( DictionaryDatum& d ) const;

--- a/models/static_synapse_hom_w.h
+++ b/models/static_synapse_hom_w.h
@@ -166,7 +166,7 @@ public:
    * \param tid Thread ID of the target
    * \param cp Common properties-object of the synapse
    */
-  void
+  bool
   send( Event& e, const size_t tid, const CommonPropertiesHomW& cp )
   {
     e.set_weight( cp.get_weight() );
@@ -174,6 +174,8 @@ public:
     e.set_receiver( *get_target( tid ) );
     e.set_rport( get_rport() );
     e();
+
+    return true;
   }
 
   void

--- a/models/stdp_dopamine_synapse.h
+++ b/models/stdp_dopamine_synapse.h
@@ -249,7 +249,7 @@ public:
    * Send an event to the receiver of this connection.
    * \param e The event to send
    */
-  void send( Event& e, size_t t, const STDPDopaCommonProperties& cp );
+  bool send( Event& e, size_t t, const STDPDopaCommonProperties& cp );
 
   void trigger_update_weight( size_t t,
     const std::vector< spikecounter >& dopa_spikes,
@@ -523,7 +523,7 @@ stdp_dopamine_synapse< targetidentifierT >::depress_( double kminus, const STDPD
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_dopamine_synapse< targetidentifierT >::send( Event& e, size_t t, const STDPDopaCommonProperties& cp )
 {
   Node* target = get_target( t );
@@ -572,6 +572,8 @@ stdp_dopamine_synapse< targetidentifierT >::send( Event& e, size_t t, const STDP
   Kplus_ = Kplus_ * std::exp( ( t_last_update_ - t_spike ) / cp.tau_plus_ ) + 1.0;
   t_last_update_ = t_spike;
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_facetshw_synapse_hom.h
+++ b/models/stdp_facetshw_synapse_hom.h
@@ -282,8 +282,7 @@ public:
    * Send an event to the receiver of this connection.
    * \param e The event to send
    */
-  void send( Event& e, size_t t, const STDPFACETSHWHomCommonProperties< targetidentifierT >& );
-
+  bool send( Event& e, size_t t, const STDPFACETSHWHomCommonProperties< targetidentifierT >& );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -407,7 +406,7 @@ stdp_facetshw_synapse_hom< targetidentifierT >::lookup_( unsigned int discrete_w
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_facetshw_synapse_hom< targetidentifierT >::send( Event& e,
   size_t t,
   const STDPFACETSHWHomCommonProperties< targetidentifierT >& cp )
@@ -534,6 +533,8 @@ stdp_facetshw_synapse_hom< targetidentifierT >::send( Event& e,
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 } // of namespace nest
 

--- a/models/stdp_nn_pre_centered_synapse.h
+++ b/models/stdp_nn_pre_centered_synapse.h
@@ -179,8 +179,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
-
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -249,7 +248,7 @@ constexpr ConnectionModelProperties stdp_nn_pre_centered_synapse< targetidentifi
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_nn_pre_centered_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -316,6 +315,8 @@ stdp_nn_pre_centered_synapse< targetidentifierT >::send( Event& e, size_t t, con
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/stdp_nn_restr_synapse.h
+++ b/models/stdp_nn_restr_synapse.h
@@ -174,7 +174,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -243,7 +243,7 @@ constexpr ConnectionModelProperties stdp_nn_restr_synapse< targetidentifierT >::
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_nn_restr_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -308,6 +308,8 @@ stdp_nn_restr_synapse< targetidentifierT >::send( Event& e, size_t t, const Comm
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/stdp_nn_symm_synapse.h
+++ b/models/stdp_nn_symm_synapse.h
@@ -176,7 +176,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -245,7 +245,7 @@ constexpr ConnectionModelProperties stdp_nn_symm_synapse< targetidentifierT >::p
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_nn_symm_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -298,6 +298,8 @@ stdp_nn_symm_synapse< targetidentifierT >::send( Event& e, size_t t, const Commo
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/stdp_pl_synapse_hom.h
+++ b/models/stdp_pl_synapse_hom.h
@@ -178,7 +178,7 @@ public:
    * Send an event to the receiver of this connection.
    * \param e The event to send
    */
-  void send( Event& e, size_t t, const STDPPLHomCommonProperties& );
+  bool send( Event& e, size_t t, const STDPPLHomCommonProperties& );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -255,7 +255,7 @@ constexpr ConnectionModelProperties stdp_pl_synapse_hom< targetidentifierT >::pr
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_pl_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const STDPPLHomCommonProperties& cp )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -297,6 +297,8 @@ stdp_pl_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const STDPPL
   Kplus_ = Kplus_ * std::exp( ( t_lastspike_ - t_spike ) * cp.tau_plus_inv_ ) + 1.0;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_synapse.h
+++ b/models/stdp_synapse.h
@@ -166,7 +166,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -236,7 +236,7 @@ constexpr ConnectionModelProperties stdp_synapse< targetidentifierT >::propertie
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -286,6 +286,8 @@ stdp_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapse
   Kplus_ = Kplus_ * std::exp( ( t_lastspike_ - t_spike ) / tau_plus_ ) + 1.0;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/stdp_synapse_hom.h
+++ b/models/stdp_synapse_hom.h
@@ -205,7 +205,7 @@ public:
    * Send an event to the receiver of this connection.
    * \param e The event to send
    */
-  void send( Event& e, size_t t, const STDPHomCommonProperties& );
+  bool send( Event& e, size_t t, const STDPHomCommonProperties& );
 
   void
   set_weight( double w )
@@ -292,7 +292,7 @@ stdp_synapse_hom< targetidentifierT >::stdp_synapse_hom()
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const STDPHomCommonProperties& cp )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -332,6 +332,8 @@ stdp_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const STDPHomCo
   Kplus_ = Kplus_ * std::exp( ( t_lastspike_ - t_spike ) / cp.tau_plus_ ) + 1.0;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/stdp_triplet_synapse.h
+++ b/models/stdp_triplet_synapse.h
@@ -177,7 +177,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -260,7 +260,7 @@ constexpr ConnectionModelProperties stdp_triplet_synapse< targetidentifierT >::p
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 stdp_triplet_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   double t_spike = e.get_stamp().get_ms();
@@ -308,6 +308,8 @@ stdp_triplet_synapse< targetidentifierT >::send( Event& e, size_t t, const Commo
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 // Defaults come from reference [1]_ data fitting and table 3.

--- a/models/tsodyks2_synapse.h
+++ b/models/tsodyks2_synapse.h
@@ -173,8 +173,7 @@ public:
    * \param e The event to send
    * \param cp Common properties to all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
-
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -223,7 +222,7 @@ constexpr ConnectionModelProperties tsodyks2_synapse< targetidentifierT >::prope
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 tsodyks2_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   Node* target = get_target( t );
@@ -245,6 +244,8 @@ tsodyks2_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSyn
   u_ = U_ + u_ * ( 1. - U_ ) * u_decay;      // Eq. 4 from [3]_
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/tsodyks_synapse.h
+++ b/models/tsodyks_synapse.h
@@ -193,7 +193,7 @@ public:
    * \param e The event to send
    * \param cp Common properties to all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -242,7 +242,7 @@ constexpr ConnectionModelProperties tsodyks_synapse< targetidentifierT >::proper
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 tsodyks_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   const double t_spike = e.get_stamp().get_ms();
@@ -288,6 +288,8 @@ tsodyks_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSyna
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/tsodyks_synapse_hom.h
+++ b/models/tsodyks_synapse_hom.h
@@ -226,7 +226,7 @@ public:
    * \param e The event to send
    * \param cp Common properties to all synapses (empty).
    */
-  void send( Event& e, size_t t, const TsodyksHomCommonProperties& cp );
+  bool send( Event& e, size_t t, const TsodyksHomCommonProperties& cp );
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
   {
@@ -272,7 +272,7 @@ constexpr ConnectionModelProperties tsodyks_synapse_hom< targetidentifierT >::pr
  * \param p The port under which this connection is stored in the Connector.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 tsodyks_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const TsodyksHomCommonProperties& cp )
 {
   const double t_spike = e.get_stamp().get_ms();
@@ -318,6 +318,8 @@ tsodyks_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const Tsodyk
   e();
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 template < typename targetidentifierT >

--- a/models/urbanczik_synapse.h
+++ b/models/urbanczik_synapse.h
@@ -161,7 +161,7 @@ public:
    * \param e The event to send
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -219,7 +219,7 @@ constexpr ConnectionModelProperties urbanczik_synapse< targetidentifierT >::prop
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 urbanczik_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   double t_spike = e.get_stamp().get_ms();
@@ -280,6 +280,8 @@ urbanczik_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSy
   tau_s_trace_ = tau_s_trace_ * std::exp( ( t_lastspike_ - t_spike ) / tau_s ) + 1.0;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/models/vogels_sprekeler_synapse.h
+++ b/models/vogels_sprekeler_synapse.h
@@ -144,7 +144,7 @@ public:
    * \param t_lastspike Point in time of last spike sent.
    * \param cp common properties of all synapses (empty).
    */
-  void send( Event& e, size_t t, const CommonSynapseProperties& cp );
+  bool send( Event& e, size_t t, const CommonSynapseProperties& cp );
 
 
   class ConnTestDummyNode : public ConnTestDummyNodeBase
@@ -213,7 +213,7 @@ constexpr ConnectionModelProperties vogels_sprekeler_synapse< targetidentifierT 
  * \param cp Common properties object, containing the stdp parameters.
  */
 template < typename targetidentifierT >
-inline void
+inline bool
 vogels_sprekeler_synapse< targetidentifierT >::send( Event& e, size_t t, const CommonSynapseProperties& )
 {
   // synapse STDP depressing/facilitation dynamics
@@ -264,6 +264,8 @@ vogels_sprekeler_synapse< targetidentifierT >::send( Event& e, size_t t, const C
   Kplus_ = Kplus_ * std::exp( ( t_lastspike_ - t_spike ) / tau_ ) + 1.0;
 
   t_lastspike_ = t_spike;
+
+  return true;
 }
 
 

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -399,7 +399,11 @@ public:
       if ( not conn.is_disabled() )
       {
         // Some synapses, e.g., bernoulli_synapse, may not send an event after all
-        conn.send( e, tid, cp ) and send_weight_event( tid, lcid + lcid_offset, e, cp );
+        const bool event_sent = conn.send( e, tid, cp );
+        if ( event_sent )
+        {
+          send_weight_event( tid, lcid + lcid_offset, e, cp );
+        }
       }
       if ( not conn.source_has_more_targets() )
       {

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -399,11 +399,7 @@ public:
       if ( not conn.is_disabled() )
       {
         // Some synapses, e.g., bernoulli_synapse, may not send an event after all
-        const bool event_sent = conn.send( e, tid, cp );
-        if ( event_sent )
-        {
-          send_weight_event( tid, lcid + lcid_offset, e, cp );
-        }
+        conn.send( e, tid, cp ) and send_weight_event( tid, lcid + lcid_offset, e, cp );
       }
       if ( not conn.source_has_more_targets() )
       {

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -394,16 +394,18 @@ public:
     {
       assert( lcid + lcid_offset < C_.size() );
       ConnectionT& conn = C_[ lcid + lcid_offset ];
-      const bool is_disabled = conn.is_disabled();
-      const bool source_has_more_targets = conn.source_has_more_targets();
 
       e.set_port( lcid + lcid_offset );
-      if ( not is_disabled )
+      if ( not conn.is_disabled() )
       {
-        conn.send( e, tid, cp );
-        send_weight_event( tid, lcid + lcid_offset, e, cp );
+        // Some synapses, e.g., bernoulli_synapse, may not send an event after all
+        const bool event_sent = conn.send( e, tid, cp );
+        if ( event_sent )
+        {
+          send_weight_event( tid, lcid + lcid_offset, e, cp );
+        }
       }
-      if ( not source_has_more_targets )
+      if ( not conn.source_has_more_targets() )
       {
         break;
       }

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -398,7 +398,8 @@ public:
       e.set_port( lcid + lcid_offset );
       if ( not conn.is_disabled() )
       {
-        // Some synapses, e.g., bernoulli_synapse, may not send an event after all
+        // Some synapses, e.g., bernoulli_synapse, may not send an event after all.
+        // Short circuiting will call send_weight_event() only if conn.send() actually sent the event.
         conn.send( e, tid, cp ) and send_weight_event( tid, lcid + lcid_offset, e, cp );
       }
       if ( not conn.source_has_more_targets() )

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -398,8 +398,7 @@ public:
       e.set_port( lcid + lcid_offset );
       if ( not conn.is_disabled() )
       {
-        // Some synapses, e.g., bernoulli_synapse, may not send an event after all.
-        // Short circuiting will call send_weight_event() only if conn.send() actually sent the event.
+        // Some synapses, e.g., bernoulli_synapse, may not send an event after all
         conn.send( e, tid, cp ) and send_weight_event( tid, lcid + lcid_offset, e, cp );
       }
       if ( not conn.source_has_more_targets() )

--- a/testsuite/pytests/test_weight_recorder_dropped_spikes.py
+++ b/testsuite/pytests/test_weight_recorder_dropped_spikes.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# test_weight_recorder_dropped_spikes.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test that weight recorded records correctly also for synapses which drop spikes.
+"""
+
+
+import nest
+import numpy as np
+
+
+def test_weight_recorder_with_bernoulli():
+    """
+    Confirm that dropped spikes are not recorded and all recorded spikes have individual target.
+    """
+
+    # Choose parameters that yield an astromomically small probability
+    # of n_targets spikes to be transmitted
+    n_targets = 100
+    p_bernoulli = 0.2
+
+    sg = nest.Create("spike_generator", params={"spike_times": [1.0]})
+    sender = nest.Create("parrot_neuron")
+    targets = nest.Create("parrot_neuron", n=n_targets)
+    sr = nest.Create("spike_recorder")
+    wr = nest.Create("weight_recorder")
+
+    nest.SetDefaults("bernoulli_synapse", {"p_transmit": p_bernoulli, "weight_recorder": wr})
+
+    nest.Connect(sg, sender)
+    nest.Connect(sender, targets, syn_spec={"synapse_model": "bernoulli_synapse"})
+    nest.Connect(targets, sr)
+
+    nest.Simulate(5)
+
+    # Test logic:
+    # 1. sender sends a single spike to each neuron in the targets population
+    # 2. The bernoulli_synapse transmits only some of these spikes
+    # 3. A subset of the neurons in the targets population thus emit a spike,
+    #    namely those who receive an input spike via the bernoulli_synapse
+    # 4. Each output spike from the targets population recorded by the spike recorder
+    #    (with the targets neuron as "sender") must therefore have exactly one corresponding
+    #    entry in weight_recorder data with that neuron as "target".
+
+    # Ensure we have some spikes but fewer than n_targets, otherwise test would be meaningless
+    sr_targets = sr.get("events", "senders")
+    assert 0 < len(sr_targets) < n_targets
+
+    # Weight recorder shall have picked up the same spikes as the spike recorder
+    wr_targets = wr.get("events", "targets")
+    np.testing.assert_array_equal(wr_targets, sr_targets, strict=True)


### PR DESCRIPTION
Until now, spikes would be registered with a `weight_recorder` even if the spike was not transmitted to the target, e.g., by a `bernoulli_synapse`. This PR changes all `Connection<T>::send()` methods to return `true` if they actually transmit a spike to the target node (call `e();`) and `false` otherwise.

The PR also simplifies the code in the `bernoulli_synapse`. Since this synapse model can only be used between normal nodes (not to/from devices), it will only receive events with multiplicity 1, allowing for significant simplification.

@JesusEV @terhorstd I'd appreciate if you could fast-track this PR since e-prop work depends on it.