### PR TITLE
Clean doc for NEST Server and related projects

### DIFF
--- a/doc/htmldoc/connect_nest/nest_server.rst
+++ b/doc/htmldoc/connect_nest/nest_server.rst
@@ -6,30 +6,20 @@ NEST Server
 What is NEST Server?
 --------------------
 
-NEST Server enables users to interact with the NEST simulation engine
-via a RESTful API. Using this approach, you can perform the same basic
-operations as with :ref:`PyNEST <pynest_api>`, but
-instead of doing so by directly importing the ``nest`` module, all
-commands, including their arguments and result data, are channeled
-through HTTP requests and responses over a TCP/IP connection.
+NEST Server enables users to interact with the NEST simulation engine via a RESTful API. Using this approach, you can
+perform the same basic operations as with :ref:`PyNEST <pynest_api>`, but instead of doing so by directly importing the
+``nest`` module, all commands, including their arguments and result data, are channeled through HTTP requests and
+responses over a TCP/IP connection.
 
-The main advantage of using NEST in this way is that it decouples the
-*simulation backend* in the form of the NEST simulation kernel from the
-*frontend*, i.e., the code that controls the simulation. In such a
-scenario, only the backend (the *server*) depends on NEST, while the
-frontend could really be anything that can talk HTTP. Under the hood,
-NEST Server forwards the commands it receives to PyNEST, and sends
-back the result data in response packets.
+The main advantage of using NEST in this way is that it decouples the *simulation backend* in the form of the NEST
+simulation kernel from the *frontend*, i.e., the code that controls the simulation. In such a scenario, only the backend
+(the *server*) depends on NEST, while the frontend could really be anything that can talk HTTP. Under the hood, NEST
+Server forwards the commands it receives to PyNEST, and sends back the result data in response packets.
 
-NEST Server was initially developed as a backend for :doc:`NEST Desktop
-<desktop:index>`, a web-based graphical
-frontend for NEST. With growing interest in a more general server
-backend for NEST, the functionality of the original NEST Server was
-extended to accommodate for this broader range of application.
-Starting with NEST 3.0, the NEST Server was integrated into the main
-source code repository of NEST to make it available to everyone in a
-convenient way.
-
+NEST Server was initially developed as a backend for :doc:`NEST Desktop <desktop:index>`, a web-based graphical frontend
+for NEST. With growing interest in a more general server backend for NEST, the functionality of the original NEST Server
+was extended to accommodate for this broader range of application. Starting with NEST 3.0, the NEST Server was
+integrated into the main source code repository of NEST to make it available to everyone in a convenient way.
 
 Use cases for NEST Server
 -------------------------
@@ -39,98 +29,90 @@ Use cases for NEST Server
     :alt: NEST Server concept
     :width: 240px
 
-NEST Server can be considered a language independent interface to NEST
-that can be deployed either locally or on a remote machine. To give
-you a better idea of what NEST Server is good for, here are some of
-its main use cases.
+NEST Server can be considered a language independent interface to NEST that can be deployed either locally or on a
+remote machine. To give you a better idea of what NEST Server is good for, here are some of its main use cases.
 
-One scenario in which NEST Server comes in handy, is if you want to
-work on your laptop, but run your NEST simulations on a machine with
-higher performance or more memory, for instance, a big workstation or
-computer cluster at your lab. For this, you would deploy NEST Server
-on the remote machine, and use the :ref:`NEST Client <nest_client>`
-locally or write your own client using one of the recipes provided in
-the :ref:`section on advanced applications <nest_server_advanced>`.
+One scenario in which NEST Server comes in handy, is if you want to work on your laptop, but run your NEST simulations
+on a machine with higher performance or more memory, for instance, a big workstation or computer cluster at your lab.
+For this, you would deploy NEST Server on the remote machine, and use the :ref:`NEST Client <nest_client>` locally or
+write your own client using one of the recipes provided in the :ref:`section on advanced applications
+<nest_server_advanced>`.
 
-:doc:`NEST Desktop <desktop:index>`, the web-based
-graphical user interface for NEST, uses NEST Server as its simulation
-backend. It supports server instances running either locally or
-remotely. More details about how to configure and run this setup can
-be found in the documentation of NEST Desktop.
+:doc:`NEST Desktop <desktop:index>`, the web-based graphical user interface for NEST, uses NEST Server as its simulation
+backend. It supports server instances running either locally or remotely. More details about how to configure and run
+this setup can be found in the documentation of NEST Desktop.
 
-Last but not least, the latest version of the `HBP Neurorobotic
-Platform <https://neurorobotics.net/>`_ use the NEST Server to run the
-neuronal simulation as part of closed-loop robotic experiments. As it
-has rather specific requirements on the client side, it uses a custom
-client for the NEST Server instead of the generic one shipped with NEST.
+Last but not least, the latest version of the `HBP Neurorobotic Platform <https://neurorobotics.net/>`_ use the NEST
+Server to run the neuronal simulation as part of closed-loop robotic experiments. As it has rather specific requirements
+on the client side, it uses a custom client for the NEST Server instead of the generic one shipped with NEST.
 
-If you yourself have an interesting situation in which you use NEST
-Server and would like to have it listed here, feel free to `drop us a
-line <https://github.com/nest/nest-simulator/issues>`_.
+If you yourself have an interesting situation in which you use NEST Server and would like to have it listed here, feel
+free to `drop us a line <https://github.com/nest/nest-simulator/issues>`_.
 
 Install and run NEST Server
 ---------------------------
 
-NEST Server is included in all source code distributions of NEST and
-consequently, also available in derived packages, our virtual
-machine, and Docker images.
+NEST Server is included in all source code distributions of NEST and consequently, also available in derived packages,
+our virtual machine, and Docker images.
 
-For native installations, the requirements can be simply installed via
-``pip``::
+For native installations, the requirements can be simply installed via ``pip``::
 
   pip3 install Flask Flask-Cors gunicorn RestrictedPython
 
-or by installing the full NEST development environment in case you
-prefer using ``conda``::
+or by installing the full NEST development environment in case you prefer using ``conda``::
 
   cd <nest-source-dir>
   conda env create -p conda/
   conda activate conda/
 
-As an alternative to a native installation, NEST Server is available
-from the NEST Docker image. Please check out the corresponding
-:ref:`installation instructions <docker>` for more details.
+As an alternative to a native installation, NEST Server is available from the NEST Docker image. Please check out the
+corresponding :ref:`installation instructions <docker>` for more details.
 
 .. _sec_server_vars:
 
 Set environment variables for security options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-NEST Server comes with a number of access restrictions that are meant to protect your
-computer. After careful consideration, each of the restrictions can be disabled by setting
-a corresponding environment variable.
+NEST Server comes with a number of access restrictions that are meant to protect your computer. After careful
+consideration, each of the restrictions can be disabled by setting a corresponding environment variable.
 
-* ``NEST_SERVER_DISABLE_AUTH``: By default, the NEST Server requires a NESTServerAuth tokens. Setting this variable to ``1`` disables this restriction. A token is automatically created and printed to the console by NEST Server upon start-up. If needed, a custom token can be set using the environment variable  ``NEST_SERVER_ACCESS_TOKEN``
-* ``NEST_SERVER_CORS_ORIGINS``: By default, the NEST Server only allows requests from localhost (see `CORS <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_). Other hosts can be explicitly allowed by supplying them in the form `http://host_or_ip`` to this variable.
-* ``NEST_SERVER_ENABLE_EXEC_CALL``: By default, NEST Server only allows calls to its PyNEST-like API. If the use-case requires the execution of scripts via the ``/exec`` route, this variable can be set to ``1``. PLEASE BE AWARE THAT THIS OPENS YOUR COMPUTER TO REMOTE CODE EXECUTION.
-* ``NEST_SERVER_DISABLE_RESTRICTION``: By default, NEST Server runs all code passed to the ``/exec`` route through RestrictedPython to sanitize it. To disable this mechanism, this variable can be set to ``1``. For increased security, code passed in this way only allows explictly whitelisted modules to be imported. To import modules, the variable ``NEST_SERVER_MODULES`` can be set to a standard Python import line like this:
-       ``NEST_SERVER_MODULES='import nest; import scipy as sp; from numpy import random'``
+* ``NEST_SERVER_DISABLE_AUTH``: By default, the NEST Server requires a NESTServerAuth tokens. Setting this variable to
+  ``1`` disables this restriction. A token is automatically created and printed to the console by NEST Server upon
+  start-up. If needed, a custom token can be set using the environment variable  ``NEST_SERVER_ACCESS_TOKEN``
+* ``NEST_SERVER_CORS_ORIGINS``: By default, the NEST Server only allows requests from localhost (see `CORS
+  <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_). Other hosts can be explicitly allowed by supplying them
+  in the form `http://host_or_ip:*`` to this variable (By default: http://localhost:*).
+* ``NEST_SERVER_ENABLE_EXEC_CALL``: By default, NEST Server only allows calls to its PyNEST-like API. If the use-case
+  requires the execution of scripts via the ``/exec`` route, this variable can be set to ``1``. PLEASE BE AWARE THAT
+  THIS OPENS YOUR COMPUTER TO REMOTE CODE EXECUTION.
+* ``NEST_SERVER_DISABLE_RESTRICTION``: By default, NEST Server runs all code passed to the ``/exec`` route through
+  RestrictedPython to sanitize it. To disable this mechanism, this variable can be set to ``1``. For increased security,
+  code passed in this way only allows explictly whitelisted modules to be imported. To import modules, the variable
+  ``NEST_SERVER_MODULES`` can be set to a standard Python import line like this: ``NEST_SERVER_MODULES='import nest;
+  import scipy as sp; from numpy import random'``
+
 Run NEST Server
 ~~~~~~~~~~~~~~~
 
-All NEST Server operations are managed using the ``nest-server``
-command that can either be run directly:
+All NEST Server operations are managed using the ``nest-server`` command that can either be run directly:
 
 .. code-block:: text
 
    nest-server start
 
-or supplied to the execution command line for running the Docker
-container:
+or supplied to the execution command line for running the Docker container:
 
 .. code-block:: text
 
   docker run -it --rm -e LOCAL_USER_ID=`id -u $USER` -p 52425:52425 nest/nest-simulator:dev nest-server start
 
-The generic invocation command line for the ``nest-server`` command
-looks as follows:
+The generic invocation command line for the ``nest-server`` command looks as follows:
 
 .. code-block:: text
 
   nest-server <command> [-d] [-h <host>] [-o] [-p <port>]
 
-Possible commands are ``start``, ``stop``, ``status``, or ``log``. The meaning
-of the other arguments is as follows:
+Possible commands are ``start``, ``stop``, ``status``, or ``log``. The meaning of the other arguments is as follows:
 
 -d
     Run NEST Server in the background (i.e., daemonize it)
@@ -144,56 +126,43 @@ of the other arguments is as follows:
 Run with MPI
 ~~~~~~~~~~~~
 
-If NEST was compiled with support for :ref:`distributed computing via
-MPI <distributed_computing>`, it will usually execute the exact same
-simulation script on each of the :hxt_ref:`MPI` processes. With NEST Server, this
-would normally mean that one NEST Server instance would be spawned for
-each rank in a multi-process NEST simulation. To prevent this from
-happening, we provide a special version of the NEST Server command for
-use with MPI. It can be run as follows:
+If NEST was compiled with support for :ref:`distributed computing via MPI <distributed_computing>`, it will usually
+execute the exact same simulation script on each of the :hxt_ref:`MPI` processes. With NEST Server, this would normally
+mean that one NEST Server instance would be spawned for each rank in a multi-process NEST simulation. To prevent this
+from happening, we provide a special version of the NEST Server command for use with MPI. It can be run as follows:
 
 .. code-block:: text
 
     mpirun -np N nest-server-mpi [--host HOST] [--port PORT]
 
-If run like this, the RESTful API of the NEST Server will only be
-served by the :hxt_ref:`MPI` process with rank 0 (called the `master`), while all
-other N-1 ranks will start the NEST Server in `worker` mode. Upon
-receiving a request, the master relays all commands to the workers,
-which execute them, collect all result data, and send it back to the
-master. The master then receives and combines all worker responses,
-and replies to the caller of the NEST Server API.
+If run like this, the RESTful API of the NEST Server will only be served by the :hxt_ref:`MPI` process with rank 0
+(called the `master`), while all other N-1 ranks will start the NEST Server in `worker` mode. Upon receiving a request,
+the master relays all commands to the workers, which execute them, collect all result data, and send it back to the
+master. The master then receives and combines all worker responses, and replies to the caller of the NEST Server API.
 
-The response data in such a distributed scenario looks almost
-completely the same as one coming from the serial version of the NEST
-Server. The only difference may be that information pertaining to
-process-local data structures is being replaced by generic values.
+The response data in such a distributed scenario looks almost completely the same as one coming from the serial version
+of the NEST Server. The only difference may be that information pertaining to process-local data structures is being
+replaced by generic values.
 
 .. _nest_client:
 
 The NEST Client
 ---------------
 
-The easiest way to interact with the NEST Server is the `NEST Client`
-provided in `<https://github.com/nest/nest-client/>`_. It can be used
-either by directly starting a Python session in a clone of that
-repository, or by installing it by running ``python3 setup.py
-install`` therein. NEST itself does not have to be installed in order
-to use the NEST Client.
+The easiest way to interact with the NEST Server is the `NEST Client` provided in
+`<https://github.com/nest/nest-client/>`_. It can be used either by directly starting a Python session in a clone of
+that repository, or by installing it by running ``python3 setup.py install`` therein. NEST itself does not have to be
+installed in order to use the NEST Client.
 
-Using a dynamic function mapping mechanism, the NEST Client supports
-the same functions as PyNEST does. However, instead of directly
-executing calls in NEST, it forwards them together with their
-arguments to the NEST Server, which in turn executes them. To you as a
-user, everything looks much like a typical simulation code for NEST
-Simulator.
+Using a dynamic function mapping mechanism, the NEST Client supports the same functions as PyNEST does. However, instead
+of directly executing calls in NEST, it forwards them together with their arguments to the NEST Server, which in turn
+executes them. To you as a user, everything looks much like a typical simulation code for NEST Simulator.
 
 Basic usage
 ~~~~~~~~~~~
 
-To give you an idea of the usage, the following table shows a
-comparison of a typical simulation once for PyNEST and once using the
-NEST Client.
+To give you an idea of the usage, the following table shows a comparison of a typical simulation once for PyNEST and
+once using the NEST Client.
 
 .. list-table::
 
@@ -251,11 +220,9 @@ NEST Client.
 Run scripts
 ~~~~~~~~~~~
 
-The NEST Client is able to send complete simulation scripts to
-the NEST Server using the functions ``exec_script`` and ``from_file``.
-The following listing shows a Python snippet using the NEST Server
-Client to execute a simple script on the Server using the
-``exec_script`` function:
+The NEST Client is able to send complete simulation scripts to the NEST Server using the functions ``exec_script`` and
+``from_file``. The following listing shows a Python snippet using the NEST Server Client to execute a simple script on
+the Server using the ``exec_script`` function:
 
 .. code-block:: Python
 
@@ -271,10 +238,8 @@ Client to execute a simple script on the Server using the
     models = response['data']
     print(models)                      # the list of models
 
-In a more realistic scenario, you probably already have your
-simulation script stored in a file. Such scripts can be sent to the
-NEST Server for execution using the ``from_file`` function provided by
-the NEST Client.
+In a more realistic scenario, you probably already have your simulation script stored in a file. Such scripts can be
+sent to the NEST Server for execution using the ``from_file`` function provided by the NEST Client.
 
 .. code-block:: Python
 
@@ -288,10 +253,9 @@ the NEST Client.
 
 .. note::
 
-    By default, the NEST Server only imports the PyNEST module during
-    startup for security reasons. In case you require additional
-    Python modules for your simulation script, please see the section
-    on :ref:`security and modules <nest_server_security>` below.
+    By default, the NEST Server only imports the PyNEST module during startup for security reasons. In case you require
+    additional Python modules for your simulation script, please see the section on :ref:`security and modules
+    <nest_server_security>` below.
 
 
 NEST Client API
@@ -303,18 +267,17 @@ NEST Client API
 
 .. py:method:: NESTClient.<call>(*args, **kwargs)
 
-    Execute a PyNEST function ``<call>`` on the NEST Server; the
-    arguments ``args`` and ``kwargs`` will be forwarded to the function
+    Execute a PyNEST function ``<call>`` on the NEST Server; the arguments ``args`` and ``kwargs`` will be forwarded to
+    the function
 
 .. py:method:: NESTClient.exec_script(source, return_vars=None)
 
-    Execute a Python script on the NEST Server; the script has to be
-    given as a string in the ``source`` argument
+    Execute a Python script on the NEST Server; the script has to be given as a string in the ``source`` argument
 
 .. py:method:: NESTClient.from_file(filename, return_vars=None)
 
-    Execute a Python script on the NEST Server; the argument
-    ``filename`` is the name of the file in which the script is stored
+    Execute a Python script on the NEST Server; the argument ``filename`` is the name of the file in which the script is
+    stored
 
 REST API overview
 -----------------
@@ -344,9 +307,8 @@ REST API overview
 Low-level API usage
 ~~~~~~~~~~~~~~~~~~~
 
-The preferred command line tool for interacting with NEST Server using
-a terminal is ``curl``. For more information, please visit the `curl
-website <https://curl.se/>`_.
+The preferred command line tool for interacting with NEST Server using a terminal is ``curl``. For more information,
+please visit the `curl website <https://curl.se/>`_.
 
 To obtain basic information about the running server, run:
 
@@ -380,27 +342,22 @@ Send API request with function arguments in JSON format:
 
 .. note::
 
-    You can beautify the output of NEST Server by piping the output of
-    ``curl`` through the JSON processor ``jq``. A sample command line
-    to display the available functions in this way looks like this::
+    You can beautify the output of NEST Server by piping the output of ``curl`` through the JSON processor ``jq``. A
+    sample command line to display the available functions in this way looks like this::
 
       curl -s localhost:52425/api | jq -r .
 
-    For more information, check the `documentation on jq
-    <https://stedolan.github.io/jq/>`_.
+    For more information, check the `documentation on jq <https://stedolan.github.io/jq/>`_.
 
 
 API access from Python
 ~~~~~~~~~~~~~~~~~~~~~~
 
-If you prefer Python over ``curl``, you can use the ``requests`` module,
-which provides a convenient API for communicating with RESTful APIs.
-On most systems this is already installed or can be easily installed
-using ``pip``. Extensive documentation is available on the pages about
-`HTTP for Humans <https://requests.readthedocs.io/en/master/>`_.
+If you prefer Python over ``curl``, you can use the ``requests`` module, which provides a convenient API for
+communicating with RESTful APIs. On most systems this is already installed or can be easily installed using ``pip``.
+Extensive documentation is available on the pages about `HTTP for Humans <https://requests.readthedocs.io/en/master/>`_.
 
-Sending a simple request to the NEST Server using Python works as
-follows:
+Sending a simple request to the NEST Server using Python works as follows:
 
 .. code-block::
 
@@ -429,28 +386,22 @@ Create neurons in NEST and return a list of IDs for the new nodes::
 Security considerations
 -----------------------
 
-As explained above, the ``/exec`` route of the NEST Server API allows
-you to run custom Python scripts within the NEST Server context. This
-can greatly simplify your workflow in situations where you already
-have the simulation description in the form of a Python script. On the
-technical side, however, this route exposes a potential risk
-for the remote execution of malicious code.
+As explained above, the ``/exec`` route of the NEST Server API allows you to run custom Python scripts within the NEST
+Server context. This can greatly simplify your workflow in situations where you already have the simulation description
+in the form of a Python script. On the technical side, however, this route exposes a potential risk for the remote
+execution of malicious code.
 
-In order to protect the execution environment from such security
-breaches, we execute all user supplied code in a `RestrictedPython
-<https://restrictedpython.readthedocs.io/en/latest/>`_ trusted
-environment. Consequently, this environment blocks
-your scripts from importing additional Python modules, unless
-they are explicitly safelisted during the start-up of NEST Server.
+In order to protect the execution environment from such security breaches, we execute all user supplied code in a
+`RestrictedPython <https://restrictedpython.readthedocs.io/en/latest/>`_ trusted environment. Consequently, this
+environment blocks your scripts from importing additional Python modules, unless they are explicitly safelisted during
+the start-up of NEST Server.
 
-To mark modules as safe for execution within NEST Server and make them
-available to code from user supplied scripts that run through the ``/exec``
-route, a comma separated list of Python module names can be assigned
-to the environment variable ``NEST_SERVER_MODULES`` prior to starting
-the NEST Server.
+To mark modules as safe for execution within NEST Server and make them available to code from user supplied scripts that
+run through the ``/exec`` route, a comma separated list of Python module names can be assigned to the environment
+variable ``NEST_SERVER_MODULES`` prior to starting the NEST Server.
 
-For instance, if your script requires NumPy in addition to PyNEST, the
-command line for starting up the server would look like this:
+For instance, if your script requires NumPy in addition to PyNEST, the command line for starting up the server would
+look like this:
 
 .. code-block:: sh
 
@@ -468,23 +419,20 @@ After this, NumPy can be used from within scripts in the regular way:
 
 .. danger::
 
-    Each modification to the default security settings of NEST Server
-    should be carefully evaluated on a case-by-case basis.
+    Each modification to the default security settings of NEST Server should be carefully evaluated on a case-by-case
+    basis.
 
-    We are aware that some simulation code might not work (well) in a
-    RestrictedPython environment. To support such codes, the security
-    features of NEST Server can be completely disabled by starting it
-    in the following way:
+    We are aware that some simulation code might not work (well) in a RestrictedPython environment. To support such
+    codes, the security features of NEST Server can be completely disabled by starting it in the following way:
 
     .. code-block:: sh
 
         export NEST_SERVER_RESTRICTION_OFF=true
         nest-server start
 
-    Please be aware that running NEST Server like this bears a high
-    risk of arbitrary remote code execution, and this mode of operation
-    should only be used in exceptional cases. We cannot provide
-    any support for problems arising from such a use of NEST Server.
+    Please be aware that running NEST Server like this bears a high risk of arbitrary remote code execution, and this
+    mode of operation should only be used in exceptional cases. We cannot provide any support for problems arising from
+    such a use of NEST Server.
 
 .. _nest_server_advanced:
 
@@ -494,22 +442,35 @@ Advanced topics
 Run scripts in NEST Server using `curl`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As shown above, you can send custom simulation code to
-``localhost:52425/exec``. On the command line, this approach might be a
-bit more challenging in the case your script does not fit on a single
-line. For such situations, we recommend using a JSON file as input for
-``curl``:
+As shown above, you can send custom simulation code to ``localhost:52425/exec``. On the command line, this approach
+might be a bit more challenging in the case your script does not fit on a single line. For such situations, we recommend
+using a JSON file as input for ``curl``:
 
 .. code-block:: json
 
     {
-      "source": "import nest\n# Reset kernel\nnest.ResetKernel()\n# Create nodes\nparams = {'rate': 6500.}\npg = nest.Create('poisson_generator', 1, params)\nneurons = nest.Create('iaf_psc_alpha', 1000)\nsr = nest.Create('spike_recorder')\n# Connect nodes\nnest.Connect(pg, neurons, syn_spec={'weight': 10.})\nnest.Connect(neurons[::10], sr)\n# Simulate\nnest.Simulate(1000.0)\n# Get events\nn_events = nest.GetStatus(sr, 'n_events')[0]\nprint('Number of events:', n_events)\n",
+      "source": "
+        import nest\n
+        # Reset kernel\n
+        nest.ResetKernel()\n
+        # Create nodes\nparams = {'rate': 6500.}\n
+        pg = nest.Create('poisson_generator', 1, params)\n
+        neurons = nest.Create('iaf_psc_alpha', 1000)\n
+        sr = nest.Create('spike_recorder')\n
+        # Connect nodes\n
+        nest.Connect(pg, neurons, syn_spec={'weight': 10.})\n
+        nest.Connect(neurons[::10], sr)\n
+        # Simulate\n
+        nest.Simulate(1000.0)\n
+        # Get events\n
+        n_events = nest.GetStatus(sr, 'n_events')[0]\n
+        print('Number of events:', n_events)\n
+      ",
       "return": "n_events"
     }
 
-If we assume that the above JSON object is stored in a file called
-``simulation_script.json``, you can execute it using the following
-command:
+If we assume that the above JSON object is stored in a file called ``simulation_script.json``, you can execute it using
+the following command:
 
 .. code-block:: sh
 
@@ -519,12 +480,10 @@ command:
 Interact with NEST Server using JavaScript
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As the NEST Server is built on modern web technologies, it may be
-desirable to create a frontend to it in the form of a
-website. In this context, JavaScript is the natural choice for the
-client-side language as it is widely supported by all web browsers and
-provides libraries for handling HTTP requests and responses out of the
-box. Here is a small example showing the basic idea:
+As the NEST Server is built on modern web technologies, it may be desirable to create a frontend to it in the form of a
+website. In this context, JavaScript is the natural choice for the client-side language as it is widely supported by all
+web browsers and provides libraries for handling HTTP requests and responses out of the box. Here is a small example
+showing the basic idea:
 
 .. grid::
 
@@ -573,9 +532,8 @@ Using the above code, we can already send API-requests to NEST Server:
 
     getAPI('GetKernelStatus');  // the current kernel status dict
 
-Sending API calls with data requires a POST request, which can handle
-the data in JSON-format. To allow for this, we can define a function
-with a callback for POST requests:
+Sending API calls with data requires a POST request, which can handle the data in JSON-format. To allow for this, we can
+define a function with a callback for POST requests:
 
 .. code-block:: JavaScript
 
@@ -600,10 +558,9 @@ Using this function, sending an API-request to NEST Server becomes easy:
     // default values of iaf_psc_alpha
     postAPI('GetDefaults', {"model": "iaf_psc_alpha"});
 
-The third type of request we might want to make is sending a custom
-Python script to NEST Server. As outlined above, this is supported by
-the ``exec`` route. to make use of that, we define a function with
-callback for POST requests to execute a script:
+The third type of request we might want to make is sending a custom Python script to NEST Server. As outlined above,
+this is supported by the ``exec`` route. to make use of that, we define a function with callback for POST requests to
+execute a script:
 
 .. code-block:: JavaScript
 
@@ -631,10 +588,8 @@ Now, we can send a custom Python script to NEST Server:
 
 .. note::
 
-    A full HTML client for NEST Server based on the ideas outlined
-    above is available in the `nest-jsclient repository
-    <https://github.com/steffengraber/nest-jsclient>`_ on the GitHub
-    account of Steffen Graber.
+    A full HTML client for NEST Server based on the ideas outlined above is available in the `nest-jsclient repository
+    <https://github.com/steffengraber/nest-jsclient>`_ on the GitHub account of Steffen Graber.
 
 Control NEST from Bash
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/htmldoc/related_projects.rst
+++ b/doc/htmldoc/related_projects.rst
@@ -8,22 +8,19 @@ biologically realistic neural networks.
 
 Here you can find further information about some of these projects.
 
-
 NESTML
 ------
 
 :doc:`NESTML <nestml:index>` allows you to modify and create models for NEST in a simplified format.
 
-It is a domain-specific language that supports the specification of neuron and synapse
-models in a precise and concise syntax, based on the syntax of Python. Model equations can either be given as a simple
-string of mathematical notation or as an algorithm written in the built-in procedural language. The equations are
-analyzed by the associated toolchain, written in Python, to compute an exact solution if possible or use an appropriate
-numeric solver otherwise.
+It is a domain-specific language that supports the specification of neuron and synapse models in a precise and concise
+syntax, based on the syntax of Python. Model equations can either be given as a simple string of mathematical notation
+or as an algorithm written in the built-in procedural language. The equations are analyzed by the associated toolchain,
+written in Python, to compute an exact solution if possible or use an appropriate numeric solver otherwise.
 
 * :doc:`Get started with NESTML <nestml:tutorials/tutorials_list>`
 
 * :doc:`List of available models <nestml:models_library/index>`
-
 
 NEST extension module
 ---------------------
@@ -33,18 +30,19 @@ without messing with the source code of NEST itself. It makes sharing custom ext
 
 * :doc:`Get started with the extension module <extmod:extension_modules>`
 
-NEST desktop
+NEST Desktop
 ------------
 
-:doc:`NEST Desktop <desktop:index>` is a web-based GUI application for the NEST Simulator.
-The app enables the rapid construction, parametrization, and instrumentation of neuronal network models.
+:doc:`NEST Desktop <desktop:index>` is a web-based GUI application for the NEST Simulator. The app enables the rapid
+construction, parametrization, and instrumentation of neuronal network models.
 
 * :doc:`Get started with NEST desktop <desktop:user/index>`
 
 NEST GPU
 --------
 
-NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons. It can be used in Python, in C++ and in C.
+NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons. It can be used in Python, in
+C++ and in C.
 
 * :doc:`Get started with NEST GPU <gpu:index>`
 
@@ -62,8 +60,8 @@ number of neuromorphic hardware systems.
 Elephant
 --------
 
-:doc:`Elephant (Electrophysiology Analysis Toolkit) <elephant:index>` is an open-source, community-centered
-library for the analysis of electrophysiological data in the Python programming language.
+:doc:`Elephant (Electrophysiology Analysis Toolkit) <elephant:index>` is an open-source, community-centered library for
+the analysis of electrophysiological data in the Python programming language.
 
 * :doc:`Get started with Elephant <elephant:tutorials>`
 
@@ -80,10 +78,10 @@ multi-compartment, morphologically-detailed cells, from single cell models to ve
 Neuromorphic hardware
 ---------------------
 
-:doc:`SpiNNaker and BrainScaleS <neuromorph:index>` are neuromorphic computing systems, which enable
-energy-efficient, large-scale neuronal network simulations with simplified spiking neuron models.
-The BrainScaleS system is based on physical (analog) emulations of neuron models and offers highly accelerated
-operation (:math:`10^4` x real time). The SpiNNaker system is based on a digital many-core architecture and provides
+:doc:`SpiNNaker and BrainScaleS <neuromorph:index>` are neuromorphic computing systems, which enable energy-efficient,
+large-scale neuronal network simulations with simplified spiking neuron models. The BrainScaleS system is based on
+physical (analog) emulations of neuron models and offers highly accelerated operation (:math:`10^4` x real time). The
+SpiNNaker system is based on a digital many-core architecture and provides
 real-time operation.
 
 * :doc:`Get started with SpiNNaker <neuromorph:mc/mc_index>`
@@ -92,8 +90,8 @@ real-time operation.
 TheVirtualBrain (TVB)
 ---------------------
 
-:ref:`TVB <tvb:top_basic>` is a framework for the simulation of the dynamics of large-scale brain
-networks with biologically realistic connectivity.
+:ref:`TVB <tvb:top_basic>` is a framework for the simulation of the dynamics of large-scale brain networks with
+biologically realistic connectivity.
 
 * :ref:`Get started with TVB <tvb:tutorial_0_gettingstarted>`
 


### PR DESCRIPTION
This PR clean the documentation for NEST Server and related projects:

- Reformat "Set environment variables for security options"
- Use line length: 120 letters