### PR TITLE
Add  to values to be set for synaptic elements

### DIFF
--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -115,6 +115,7 @@ nest::SynapticElement::set( const DictionaryDatum& d )
   updateValue< double >( d, names::tau_vacant, new_tau_vacant );
   updateValue< bool >( d, names::continuous, continuous_ );
   updateValue< double >( d, names::z, z_ );
+  updateValue< double >( d, names::z_connected, z_connected_ );
 
   if ( d->known( names::growth_curve ) )
   {

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -45,6 +45,10 @@
  *                             double value. An standard value for the growth of
  * a
  *                             synaptic element is around 0.0001 elements/ms.
+ *  z_connected      integer - Current number of connected synaptic elements. Stored
+ *                             as an integer variable. The difference between z
+ *                             and this value determines the number of vacant
+ *                             synaptic elements. Default is 0.
  *  continuous       boolean - Defines if the number of synaptic elements should
  *                             be treated as a continuous double number or as an
  *                             integer value. Default is false.


### PR DESCRIPTION
The ```z_connected``` variables in synaptic elements in used to keep track of the connected synaptic elements, in contrast to the ```z``` variable that is used to determine how many connections ought to be established or deleted.
There are use cases when one wants to set ```z_connected``` by hand (for example when creating connections with a higher level connections routine that subsequently should be subject to potential removal by structural plasticity).
This PR add ```z_connected``` to the parameters that can be set by the user. 