### PR TITLE
Rename  to ```tau_vacant``` to ```decay_vacant```

### DIFF
--- a/nestkernel/nest_names.cpp
+++ b/nestkernel/nest_names.cpp
@@ -534,7 +534,7 @@ const Name tau_u_bar_minus( "tau_u_bar_minus" );
 const Name tau_u_bar_plus( "tau_u_bar_plus" );
 const Name tau_V_th( "tau_V_th" );
 const Name tau_v( "tau_v" );
-const Name tau_vacant( "tau_vacant" );
+const Name decay_vacant( "decay_vacant" );
 const Name tau_w( "tau_w" );
 const Name tau_x( "tau_x" );
 const Name tau_z( "tau_z" );

--- a/nestkernel/nest_names.h
+++ b/nestkernel/nest_names.h
@@ -560,7 +560,7 @@ extern const Name tau_u_bar_minus;
 extern const Name tau_u_bar_plus;
 extern const Name tau_V_th;
 extern const Name tau_v;
-extern const Name tau_vacant;
+extern const Name decay_vacant;
 extern const Name tau_w;
 extern const Name tau_x;
 extern const Name tau_z;

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -681,7 +681,7 @@ public:
    * Is used to reduce the number of synaptic elements in the node through
    * time.
    *
-   * This amount is defined by tau_vacant.
+   * This amount is defined by decay_vacant.
    * @ingroup SP_functions
    */
   virtual void decay_synaptic_elements_vacant() {};

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -128,7 +128,8 @@ nest::SynapticElement::set( const DictionaryDatum& d )
 
   if ( new_decay_vacant < 0.0 )
   {
-    throw BadProperty( "Decay constant must be strictly positive." );
+    throw BadProperty( "Decay constant must be greater than or equal to zero." );
+
   }
   decay_vacant_ = new_decay_vacant;
 }

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -40,7 +40,7 @@ nest::SynapticElement::SynapticElement()
   , z_connected_( 0 )
   , continuous_( true )
   , growth_rate_( 1.0 )
-  , tau_vacant_( 0.1 )
+  , decay_vacant_( 0.1 )
   , growth_curve_( new GrowthCurveLinear )
 {
 }
@@ -51,7 +51,7 @@ nest::SynapticElement::SynapticElement( const SynapticElement& se )
   , z_connected_( se.z_connected_ )
   , continuous_( se.continuous_ )
   , growth_rate_( se.growth_rate_ )
-  , tau_vacant_( se.tau_vacant_ )
+  , decay_vacant_( se.decay_vacant_ )
 {
   growth_curve_ = kernel().sp_manager.new_growth_curve( se.growth_curve_->get_name() );
   assert( growth_curve_ );
@@ -80,7 +80,7 @@ nest::SynapticElement::operator=( const SynapticElement& other )
     z_connected_ = other.z_connected_;
     continuous_ = other.continuous_;
     growth_rate_ = other.growth_rate_;
-    tau_vacant_ = other.tau_vacant_;
+    decay_vacant_ = other.decay_vacant_;
   }
   return *this;
 }
@@ -93,7 +93,7 @@ nest::SynapticElement::get( DictionaryDatum& d ) const
 {
   // Store current values in the dictionary
   def< double >( d, names::growth_rate, growth_rate_ );
-  def< double >( d, names::tau_vacant, tau_vacant_ );
+  def< double >( d, names::decay_vacant, decay_vacant_ );
   def< bool >( d, names::continuous, continuous_ );
   def< double >( d, names::z, z_ );
   def< int >( d, names::z_connected, z_connected_ );
@@ -108,11 +108,11 @@ nest::SynapticElement::get( DictionaryDatum& d ) const
 void
 nest::SynapticElement::set( const DictionaryDatum& d )
 {
-  double new_tau_vacant = tau_vacant_;
+  double new_decay_vacant = decay_vacant_;
 
   // Store values
   updateValue< double >( d, names::growth_rate, growth_rate_ );
-  updateValue< double >( d, names::tau_vacant, new_tau_vacant );
+  updateValue< double >( d, names::decay_vacant, new_decay_vacant );
   updateValue< bool >( d, names::continuous, continuous_ );
   updateValue< double >( d, names::z, z_ );
 
@@ -126,11 +126,11 @@ nest::SynapticElement::set( const DictionaryDatum& d )
   }
   growth_curve_->set( d );
 
-  if ( new_tau_vacant <= 0.0 )
+  if ( new_decay_vacant < 0.0 )
   {
-    throw BadProperty( "All time constants must be strictly positive." );
+    throw BadProperty( "Decay constant must be strictly positive." );
   }
-  tau_vacant_ = new_tau_vacant;
+  decay_vacant_ = new_decay_vacant;
 }
 
 

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -129,7 +129,6 @@ nest::SynapticElement::set( const DictionaryDatum& d )
   if ( new_decay_vacant < 0.0 )
   {
     throw BadProperty( "Decay constant must be greater than or equal to zero." );
-
   }
   decay_vacant_ = new_decay_vacant;
 }

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -51,7 +51,7 @@
  *  growth_rate      double  - The maximum amount by which the synaptic elements
  * will
  *                             change between time steps. In elements/ms.
- *  tau_vacant       double  - Rate at which vacant synaptic elements will decay.
+ *  decay_vacant     double  - Rate at which vacant synaptic elements will decay.
  *                             Typical is 0.1 which represents a
  *                             loss of 10% of the vacant synaptic elements each
  * time
@@ -165,12 +165,12 @@ public:
     return z_connected_;
   }
   /**
-   * Retrieves the value of tau_vacant
+   * Retrieves the value of decay_vacant
    */
   double
-  get_tau_vacant() const
+  get_decay_vacant() const
   {
-    return tau_vacant_;
+    return decay_vacant_;
   }
   /**
    * Changes the number of bound synaptic elements by n.
@@ -221,14 +221,14 @@ public:
   }
   /**
    * Reduce the amount of vacant synaptic elements by a factor
-   * of tau_vacant_
+   * of decay_vacant_
    */
   void
   decay_z_vacant()
   {
     if ( get_z_vacant() > 0 )
     {
-      z_ -= get_z_vacant() * tau_vacant_;
+      z_ -= get_z_vacant() * decay_vacant_;
     }
   }
 
@@ -252,7 +252,7 @@ private:
   // steps.
   double growth_rate_;
   // Rate at which vacant synaptic elements will decay
-  double tau_vacant_;
+  double decay_vacant_;
   // Growth curve which defines the dynamics of this synaptic element.
   GrowthCurve* growth_curve_;
 };

--- a/nestkernel/synaptic_element.h
+++ b/nestkernel/synaptic_element.h
@@ -51,7 +51,7 @@
  *  growth_rate      double  - The maximum amount by which the synaptic elements
  * will
  *                             change between time steps. In elements/ms.
- *  decay_vacant     double  - Rate at which vacant synaptic elements will decay.
+ *  decay_vacant     double  - Factor with which vacant synaptic elements will decay.
  *                             Typical is 0.1 which represents a
  *                             loss of 10% of the vacant synaptic elements each
  * time
@@ -251,7 +251,7 @@ private:
   // The maximum amount by which the synaptic elements will change between time
   // steps.
   double growth_rate_;
-  // Rate at which vacant synaptic elements will decay
+  // Factor with which vacant synaptic elements will decay
   double decay_vacant_;
   // Growth curve which defines the dynamics of this synaptic element.
   GrowthCurve* growth_curve_;


### PR DESCRIPTION
In the structural plasticity routine vacant (i.e. at a given time unused) synaptic elements decay with a "rate" (word used in the source code) ```tau_vacant```, also referred to as a "time constant" in one case.
I would argue the decay constant is neither a rate (units 1 / time unit) nor a time constant (units of time unit) , but a quantity without any unit.
Since ```tau_vacant``` insinuates a time constant I suggest renaming the decay constant in just ```decay_vacant``` (in line with the naming for this in [this](https://www.frontiersin.org/articles/10.3389/fnana.2016.00057/full) paper referring to it as a decay constant).
Also, in one case it is required that the decay constant is greater than 0.
I find this impractical and unnecessary and thus suggest to alter this to greater or equal than 0.