### PR TITLE
Modify doc extensions to check for correct files

### DIFF
--- a/doc/htmldoc/_ext/add_button_notebook.py
+++ b/doc/htmldoc/_ext/add_button_notebook.py
@@ -81,7 +81,6 @@ git-pull?repo=https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples&urlpath=
     # Find all relevant files
     # Inject prolog into Python example
     files = list(Path("auto_examples/").rglob("*.rst"))
-    # Filter ".rst" files with corresponding ".py" files
     for file in files:
         # Skip index files and benchmark file. These files do not have notebooks that can run
         # on the service.

--- a/doc/htmldoc/_ext/add_button_notebook.py
+++ b/doc/htmldoc/_ext/add_button_notebook.py
@@ -81,6 +81,7 @@ git-pull?repo=https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples&urlpath=
     # Find all relevant files
     # Inject prolog into Python example
     files = list(Path("auto_examples/").rglob("*.rst"))
+    # Filter ".rst" files with corresponding ".py" files
     for file in files:
         # Skip index files and benchmark file. These files do not have notebooks that can run
         # on the service.
@@ -96,17 +97,22 @@ git-pull?repo=https%3A%2F%2Fgithub.com%2Fnest%2Fnest-simulator-examples&urlpath=
 
             lines = f.readlines()
 
-        # find the first heading of the file.
-        for i, item in enumerate(lines):
-            if item.startswith("-----"):
-                break
+        # make sure rst file is auto generated Python file
+        check_line = lines[1]
+        if check_line.startswith(".."):
+            # find the first heading of the file.
+            for i, item in enumerate(lines):
+                if item.startswith("-----"):
+                    break
 
-        # insert prolog into rst file after heading
-        lines.insert(i + 1, prolog + "\n")
+            # insert prolog into rst file after heading
+            lines.insert(i + 1, prolog + "\n")
 
-        with open(file, "w") as f:
-            lines = "".join(lines)
-            f.write(lines)
+            with open(file, "w") as f:
+                lines = "".join(lines)
+                f.write(lines)
+        else:
+            continue
 
 
 def setup(app):

--- a/doc/htmldoc/_ext/list_examples.py
+++ b/doc/htmldoc/_ext/list_examples.py
@@ -103,10 +103,12 @@ def ModelMatchExamples():
             continue
         with open(filename, "r", errors="ignore") as file:
             content = file.read()
-            for model_file in model_files:
-                if model_file in content:
-                    matches.setdefault(model_file, []).append(filename)
-
+            if "AUTOMATICALLY GENERATED" in content:
+                for model_file in model_files:
+                    if model_file in content:
+                        matches.setdefault(model_file, []).append(filename)
+            else:
+                continue
     return matches
 
 


### PR DESCRIPTION
This PR modifies two extension scripts so they only use the autogenerated files created from sphinx-gallery rather than all rst files in the pynest/examples directory. This means any rst files that are added manually will be skipped by the extensions.
