### PR TITLE
Update test failing due to removed scipy method

### DIFF
--- a/testsuite/pytests/sli2py_regressions/test_ticket_903.py
+++ b/testsuite/pytests/sli2py_regressions/test_ticket_903.py
@@ -24,7 +24,6 @@
 
 import nest
 import numpy as np
-import pytest
 import scipy.stats
 
 
@@ -46,4 +45,4 @@ def test_correct_rounding_distributions():
     delays = nest.GetConnections().delay
 
     assert set(delays) == {1, 2}
-    assert scipy.stats.binom_test(sum(np.array(delays) == 2.0), indegree) > significance
+    assert scipy.stats.binomtest(sum(np.array(delays) == 2.0), indegree).pvalue > significance


### PR DESCRIPTION
scipy.binom_test was removed and replaced by binomtest (with a slightly different return syntax) in 1.7.0:
https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binomtest.html