### PR TITLE
Ensure assert_valid_syn_id() is always called with correct thread id

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -207,7 +207,7 @@ nest::ConnectionManager::get_synapse_status( const size_t source_node_id,
   const synindex syn_id,
   const size_t lcid ) const
 {
-  kernel().model_manager.assert_valid_syn_id( syn_id );
+  kernel().model_manager.assert_valid_syn_id( syn_id, kernel().vp_manager.get_thread_id() );
 
   DictionaryDatum dict( new Dictionary );
   ( *dict )[ names::source ] = source_node_id;
@@ -253,7 +253,7 @@ nest::ConnectionManager::set_synapse_status( const size_t source_node_id,
   const size_t lcid,
   const DictionaryDatum& dict )
 {
-  kernel().model_manager.assert_valid_syn_id( syn_id );
+  kernel().model_manager.assert_valid_syn_id( syn_id, kernel().vp_manager.get_thread_id() );
 
   const Node* source = kernel().node_manager.get_node_or_proxy( source_node_id, tid );
   const Node* target = kernel().node_manager.get_node_or_proxy( target_node_id, tid );
@@ -504,7 +504,7 @@ nest::ConnectionManager::connect( const size_t snode_id,
   const double delay,
   const double weight )
 {
-  kernel().model_manager.assert_valid_syn_id( syn_id );
+  kernel().model_manager.assert_valid_syn_id( syn_id, kernel().vp_manager.get_thread_id() );
 
   Node* source = kernel().node_manager.get_node_or_proxy( snode_id, target_thread );
 
@@ -533,7 +533,7 @@ nest::ConnectionManager::connect( const size_t snode_id,
   const DictionaryDatum& params,
   const synindex syn_id )
 {
-  kernel().model_manager.assert_valid_syn_id( syn_id );
+  kernel().model_manager.assert_valid_syn_id( syn_id, kernel().vp_manager.get_thread_id() );
 
   const size_t tid = kernel().vp_manager.get_thread_id();
 

--- a/nestkernel/model_manager.cpp
+++ b/nestkernel/model_manager.cpp
@@ -272,7 +272,7 @@ void
 ModelManager::set_synapse_defaults_( size_t model_id, const DictionaryDatum& params )
 {
   params->clear_access_flags();
-  assert_valid_syn_id( model_id );
+  assert_valid_syn_id( model_id, kernel().vp_manager.get_thread_id() );
 
   std::vector< std::shared_ptr< WrappedThreadException > > exceptions_raised_( kernel().vp_manager.get_num_threads() );
 
@@ -337,7 +337,7 @@ ModelManager::get_synapse_model_id( std::string model_name )
 DictionaryDatum
 ModelManager::get_connector_defaults( synindex syn_id ) const
 {
-  assert_valid_syn_id( syn_id );
+  assert_valid_syn_id( syn_id, kernel().vp_manager.get_thread_id() );
 
   DictionaryDatum dict( new Dictionary() );
 

--- a/nestkernel/model_manager.h
+++ b/nestkernel/model_manager.h
@@ -163,7 +163,7 @@ public:
    * Asserts validity of synapse index, otherwise throws exception.
    * @throws UnknownSynapseType
    */
-  void assert_valid_syn_id( synindex syn_id, size_t t = 0 ) const;
+  void assert_valid_syn_id( synindex syn_id, size_t t ) const;
 
   bool are_model_defaults_modified() const;
 
@@ -300,7 +300,7 @@ ModelManager::are_model_defaults_modified() const
 inline ConnectorModel&
 ModelManager::get_connection_model( synindex syn_id, size_t thread_id )
 {
-  assert_valid_syn_id( syn_id );
+  assert_valid_syn_id( syn_id, thread_id );
   return *( connection_models_[ thread_id ][ syn_id ] );
 }
 
@@ -322,7 +322,7 @@ ModelManager::assert_valid_syn_id( synindex syn_id, size_t t ) const
 inline SecondaryEvent&
 ModelManager::get_secondary_event_prototype( const synindex syn_id, const size_t tid )
 {
-  assert_valid_syn_id( syn_id );
+  assert_valid_syn_id( syn_id, tid );
   return *get_connection_model( syn_id, tid ).get_secondary_event();
 }
 


### PR DESCRIPTION
Automated thread analysis revealed a data race because `ModelManager::get_connection_model()` calls `assert_valid_syn_id()` without thread argument

https://github.com/nest/nest-simulator/blob/d5aa3fe65e3d4e6eb368de561d407a572dc4e467/nestkernel/model_manager.h#L303

thus using the default thread number 0. This can lead to data races during parallel construction of new models during `CopyModel`.  This PR removes the default value for the thread so avoid data races.