### PR TITLE
Avoid MPI deadlocks on SynapseCollection.get()/set()

### DIFF
--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -481,8 +481,7 @@ private:
   /**
    * Update delay extrema to current values.
    *
-   * Static since it only operates in static variables. This allows it to be
-   * called from const-method get_status() as well.
+   * @note This entails MPI communication.
    */
   void update_delay_extrema_();
 

--- a/testsuite/pytests/mpi/2/test_issue_3099.py
+++ b/testsuite/pytests/mpi/2/test_issue_3099.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# test_issue_3099.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import nest
+import pytest
+
+
+@pytest.fixture
+def conns():
+    nest.ResetKernel()
+    nrn = nest.Create("parrot_neuron")
+    nest.Connect(nrn, nrn)
+    return nest.GetConnections()
+
+
+def test_conn_weight(conns):
+    """Test that operation does cause MPI deadlock."""
+
+    if conns:
+        conns.weight = 2.5
+
+
+def test_set_weight(conns):
+    """Test that operation does cause MPI deadlock."""
+
+    if conns:
+        conns.set({"weight": 2.5})
+
+
+def test_set_status_weight(conns):
+    """Test that operation does cause MPI deadlock."""
+
+    if conns:
+        nest.SetStatus(conns, "weight", 2.5)

--- a/testsuite/pytests/mpi/2/test_issue_3099.py
+++ b/testsuite/pytests/mpi/2/test_issue_3099.py
@@ -33,7 +33,7 @@ def conns():
 
 
 def test_conn_weight(conns):
-    """Test that operation does cause MPI deadlock."""
+    """Test that operation does not cause MPI deadlock."""
 
     if conns:
         conns.weight = 2.5

--- a/testsuite/pytests/mpi/2/test_issue_3099.py
+++ b/testsuite/pytests/mpi/2/test_issue_3099.py
@@ -40,14 +40,14 @@ def test_conn_weight(conns):
 
 
 def test_set_weight(conns):
-    """Test that operation does cause MPI deadlock."""
+    """Test that operation does not cause MPI deadlock."""
 
     if conns:
         conns.set({"weight": 2.5})
 
 
 def test_set_status_weight(conns):
-    """Test that operation does cause MPI deadlock."""
+    """Test that operation does not cause MPI deadlock."""
 
     if conns:
         nest.SetStatus(conns, "weight", 2.5)


### PR DESCRIPTION
This fixes #3099. MPI deadlocks could occur if only some MPI ranks performed `get()` or `set()` operations on `SynapseCollection`s. These operations are local operations so while not elegant, they should work even if executed only on some ranks and not on other, e.g., when a rank has no connections.

The hang occurred because the `get()`/`set()` methods called `GetKernelStatus()` to check for the number of connections to decide whether an SC was still valid. This was misguided to begin with, since the number of connections is only known locally. This is now changed to use the network size, whose global value is locally known. For a proposed proper solution, see #3100.

A further problem then was that `GetKernelStatus()` called `ConnectionManager::update_delay_extrema_()`, which unconditionally performed MPI exchange of `min/max_delay`. This PR changes this so that delay extrema are MPI-exchanged only if their values could have changed remotely. This also eliminates the MPI communication hidden in every single `nest.<some property>` use and might thus lead to faster execution of simulation scripts.

The test simply checks that it does not time out.