### PR TITLE
Fix processing of CMake option `with-mpi`

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -457,7 +457,7 @@ endfunction()
 function( NEST_PROCESS_WITH_MPI )
   # Find MPI
   set( HAVE_MPI OFF PARENT_SCOPE )
-  if ( with-mpi )
+  if ( NOT "${with-mpi}" STREQUAL "OFF" )
     find_package( MPI REQUIRED )
     if ( MPI_CXX_FOUND )
       set( HAVE_MPI ON PARENT_SCOPE )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -460,7 +460,7 @@ function( NEST_PROCESS_WITH_MPI )
   if ( NOT "${with-mpi}" STREQUAL "OFF" )
     if ( NOT ${with-mpi} STREQUAL "ON" )
       # if set, use this prefix
-      set( MPI_ROOT_DIR "${with-mpi}" )
+      set( MPI_ROOT "${with-mpi}" )
     endif ()
     find_package( MPI REQUIRED )
     if ( MPI_CXX_FOUND )

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -458,6 +458,10 @@ function( NEST_PROCESS_WITH_MPI )
   # Find MPI
   set( HAVE_MPI OFF PARENT_SCOPE )
   if ( NOT "${with-mpi}" STREQUAL "OFF" )
+    if ( NOT ${with-mpi} STREQUAL "ON" )
+      # if set, use this prefix
+      set( MPI_ROOT_DIR "${with-mpi}" )
+    endif ()
     find_package( MPI REQUIRED )
     if ( MPI_CXX_FOUND )
       set( HAVE_MPI ON PARENT_SCOPE )


### PR DESCRIPTION
Meant to address #2993, but does not.