### PR TITLE
Attempt cache thrashing fix for low synapse count vector access

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -131,7 +131,7 @@ nest::ConnectionManager::initialize( const bool reset_kernel )
   std::vector< DelayChecker > tmp( kernel().vp_manager.get_num_threads() );
   delay_checkers_.swap( tmp );
 
-  std::vector< std::vector< size_t > > tmp2( kernel().vp_manager.get_num_threads(), std::vector< size_t >() );
+  std::vector<aligned_vector<size_t>> tmp2( kernel().vp_manager.get_num_threads(), aligned_vector<size_t>() );
   num_connections_.swap( tmp2 );
 }
 

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -30,6 +30,11 @@
 #include "manager_interface.h"
 #include "stopwatch.h"
 
+#ifdef HAVE_BOOST
+#include <new>
+#include <boost/align/aligned_allocator.hpp>
+#endif
+
 // Includes from nestkernel:
 #include "conn_builder.h"
 #include "connection_id.h"
@@ -52,6 +57,15 @@
 
 namespace nest
 {
+
+#ifdef HAVE_BOOST
+  template <typename T>
+  using aligned_vector = std::vector< T, boost::alignment::aligned_allocator<T, std::hardware_destructive_interference_size> >;
+#else
+  template <typename T>
+  using aligned_vector = std::vector<T>;
+#endif
+
 class GenericConnBuilderFactory;
 class spikecounter;
 class Node;
@@ -633,7 +647,8 @@ private:
    * A structure to count the number of synapses of a specific
    * type. Arranged in a 2d structure: threads|synapsetypes.
    */
-  std::vector< std::vector< size_t > > num_connections_;
+
+  std::vector<aligned_vector<size_t>> num_connections_;
 
   DictionaryDatum connruledict_; //!< Dictionary for connection rules.
 


### PR DESCRIPTION
- This is an attempt to fix an observed niche issue where, on a C++ level, connection creation will be slowed down by the `num_connections_` vector accessing inner indices on the same cache line and therefore invalidating memory across threads, usually when there is only a few synapse models (e.g. when running with `-Dwith-modelset=iaf_minimal`)
- Very much experimental, this fixes the `time_construction_connect` difference in SLI tests but makes no difference on a Python level (neither did the problem occur when timing from Python to begin with. Too insignificant?) 
- This does increase memory consumption up to a certain point (the L1 cache line usually is 64 bytes), but stays below full modelset levels.
- Maybe the destructive interference constexprs can be useful for something else further down the line
- If this does get considered it should probably be amended to include `-Wno-interference-size` to suppress the compile warnings about this value varying between platforms, or be an optional CMake flag altogether 