### PR TITLE
Fix  tests and examples to pass Pylint test R1730

### DIFF
--- a/pynest/examples/pong/pong.py
+++ b/pynest/examples/pong/pong.py
@@ -193,10 +193,7 @@ class GameOfPong(object):
         """Updates ball and paddle coordinates based on direction and velocity."""
         for paddle in [self.r_paddle, self.l_paddle]:
             paddle.y_pos += paddle.direction * paddle.velocity
-            if paddle.y_pos < 0:
-                paddle.y_pos = 0
-            if paddle.y_pos > self.y_length:
-                paddle.y_pos = self.y_length
+            paddle.y_pos = min(max(0, paddle.y_pos), self.y_length)
             paddle.update_cell()
         self.ball.y_pos += self.ball.velocity * self.ball.direction[1]
         self.ball.x_pos += self.ball.velocity * self.ball.direction[0]

--- a/testsuite/pytests/test_jonke_synapse.py
+++ b/testsuite/pytests/test_jonke_synapse.py
@@ -225,8 +225,7 @@ class TestJonkeSynapse:
             * Kplus
             * np.exp(_delta_t / self.synapse_constants["tau_plus"])
         )
-        if weight > self.synapse_constants["Wmax"]:
-            weight = self.synapse_constants["Wmax"]
+        weight = min(weight, self.synapse_constants["Wmax"])
         return weight
 
     def depress(self, _delta_t, weight, Kminus):

--- a/testsuite/pytests/test_stdp_nn_synapses.py
+++ b/testsuite/pytests/test_stdp_nn_synapses.py
@@ -260,8 +260,7 @@ class TestSTDPNNSynapses:
             * ((1 - w / self.synapse_parameters["Wmax"]) ** self.synapse_parameters["mu_plus"])
             * exp(-1 * _delta_t / self.synapse_parameters["tau_plus"])
         )
-        if w > self.synapse_parameters["Wmax"]:
-            w = self.synapse_parameters["Wmax"]
+        w = min(w, self.synapse_parameters["Wmax"])
         return w
 
     def depress(self, _delta_t, w):
@@ -273,8 +272,7 @@ class TestSTDPNNSynapses:
             * ((w / self.synapse_parameters["Wmax"]) ** self.synapse_parameters["mu_minus"])
             * exp(_delta_t / self.neuron_parameters["tau_minus"])
         )
-        if w < 0:
-            w = 0
+        w = max(0, w)
         return w
 
     def test_nn_symm_synapse(self):


### PR DESCRIPTION
The R1730 test in Pylint seems to have become active with the recent update from Pylint 3.0.3 to Pylint 3.1.0 in the Github Actions.

This PR makes our tests and examples compatible.

Labeling as critical as it blocks our CI.