### PR TITLE
Fix broken links in documentation

### DIFF
--- a/doc/htmldoc/connect_nest/using_nest_with_music.rst
+++ b/doc/htmldoc/connect_nest/using_nest_with_music.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 NEST supports the `MUSIC interface
-<http://software.incf.org/software/music>`__, a standard by
+<https://github.com/INCF/MUSIC>`__, a standard by
 the INCF, which allows the transmission of data between applications at
 runtime [1]_. It can be used to couple NEST with other simulators, with
 applications for stimulus generation and data analysis and visualization
@@ -28,7 +28,7 @@ Reference
 .. [1] Djurfeldt M, et al. 2010. Run-time interoperability between neuronal
  simulators based on the MUSIC framework. Neuroinformatics, 8.
  `doi:10.1007/s12021-010-9064-z*
- <http://www.springerlink.com/content/r6j425027lmv1251/>`__.
+ <https://link.springer.com/article/10.1007/s12021-010-9064-z>`_.
 
 Sending and receiving spike events
 ----------------------------------
@@ -384,4 +384,3 @@ which yields the following output:
 	Nov 23 11:33:28 SimulationManager::run [Info]:
 		Simulation finished.
 	(array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9.]),)
-

--- a/doc/htmldoc/developer_space/guidelines/coding_guidelines_check.rst
+++ b/doc/htmldoc/developer_space/guidelines/coding_guidelines_check.rst
@@ -76,7 +76,7 @@ Our ``clang-format`` configuration is specified in the
 ``clang-format`` is run automatically with ``pre-commit``.
 
 We supply the
-`build_support/format_all_c_c++_files.sh <https://github.com/nest/nest-simulator/blob/master/build_support/format_all_c_c++_files.sht>`_
+`build_support/format_all_c_c++_files.sh <https://github.com/nest/nest-simulator/blob/master/build_support/format_all_c_c++_files.sh>`_
 shell script to run ``clang-format`` manually:
 
 .. code-block:: bash

--- a/doc/htmldoc/developer_space/guidelines/coding_guidelines_cpp.rst
+++ b/doc/htmldoc/developer_space/guidelines/coding_guidelines_cpp.rst
@@ -83,7 +83,7 @@ Coding style
 
 In the following the coding style guidelines are explained by example and some
 parts are adopted from `Google C++ Style
-Guide <https://google-styleguide.googlecode.com/svn/trunk/cppguide.html>`_.
+Guide <https://google.github.io/styleguide/cppguide.html>`_.
 
 The #define guard
 ~~~~~~~~~~~~~~~~~

--- a/doc/htmldoc/developer_space/guidelines/styleguide/styleguide.rst
+++ b/doc/htmldoc/developer_space/guidelines/styleguide/styleguide.rst
@@ -267,7 +267,7 @@ Roles look like this ``:role-name:`content```.
 We will only cover a few examples here. You can find more information at the following links:
 
 
-* `reStructuredText User Documentation <https://docutils.sourceforge.io/rst.html#id24>`_
+* `reStructuredText User Documentation <https://docutils.sourceforge.io/rst.html>`_
 
 * `reStructuredText Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
 

--- a/doc/htmldoc/developer_space/workflows/development_workflow.rst
+++ b/doc/htmldoc/developer_space/workflows/development_workflow.rst
@@ -197,7 +197,7 @@ It is extremely important to work on the latest available source code. If you
 work on old code, it is possible that in the meantime, someone else has
 already made more changes to the same files that you have also edited. This
 will result in `merge conflicts
-<https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging#Basic-Merge-Conflicts>`_
+<https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_
 and resolving these is extra work for both the development team and you. It
 also muddles up the ``commit history`` of the source code.
 
@@ -326,7 +326,8 @@ Creating a pull request
 
 When you feel your work is finished, you can create a pull request (PR). GitHub
 has a nice help page that outlines the process for
-`submitting pull requests <https://help.github.com/articles/using-pull-requests/#initiating-the-pull-request>`_.
+`submitting pull requests
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#initiating-the-pull-request>`_.
 
 Please check out our :ref:`coding style guidelines <code_style_cpp>` and
 :ref:`code review guidelines <code_guidelines>` prior to submitting it.

--- a/doc/htmldoc/developer_space/workflows/documentation_workflow/user_documentation_workflow.rst
+++ b/doc/htmldoc/developer_space/workflows/documentation_workflow/user_documentation_workflow.rst
@@ -243,7 +243,7 @@ Read the Docs
 NEST documentation is hosted on Read the Docs. If you would like to view the documentation
 on Read the Docs, you can set up your own account and link it with your Github account.
 
-See `this guide <https://docs.readthedocs.io/en/stable/intro/import-guide.htmli>`_
+See `this guide <https://docs.readthedocs.io/en/stable/intro/import-guide.html>`_
 for more information.
 
 .. toctree::

--- a/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
+++ b/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
@@ -276,7 +276,7 @@ We present two ways to install the rest: MacPorts and Homebrew. For both version
 Homebrew
 ^^^^^^^^
 
-1. Follow the install instructions for Homebrew (`short <http://brew.sh/>`_) or `long <https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md#installation>`_)
+1. Follow the install instructions for Homebrew (`short <http://brew.sh/>`_) or `long <https://github.com/Homebrew/brew/blob/master/docs/Installation.md>`_)
 2. Open up the Terminal and execute the following lines:
 
    .. code-block:: sh
@@ -430,8 +430,8 @@ Setting up the CMake configuration in CLion has the following advantages:
 .. note::
 
    `CLion <https://www.jetbrains.com/clion/>`_ is a commercial product. It is *your responsibility* to ensure that you have a valid
-   license permitting you to use CLion (or any software product) for your work on the    
-   NEST Simulator. 
+   license permitting you to use CLion (or any software product) for your work on the
+   NEST Simulator.
 
 Setting up the project
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/htmldoc/faqs/faqs.rst
+++ b/doc/htmldoc/faqs/faqs.rst
@@ -11,7 +11,7 @@ Installation
    known issue in some :hxt_ref:`MPI` implementations. A solution is to add
    --with-debug="-DMPICH\_IGNORE\_CXX\_SEEK" to the configure command
    line. More details about this problem can be found
-   `here <http://www-unix.mcs.anl.gov/mpi/mpich/faq.htm#cxxseek>`__
+   `here <https://www.mpich.org/#cxxseek>`__
 
 2. **Configure warns that Makefile.in seems to ignore the --datarootdir
    setting and the installation fails because of permission errors**

--- a/doc/htmldoc/faqs/qa-precise-spike-times.rst
+++ b/doc/htmldoc/faqs/qa-precise-spike-times.rst
@@ -29,7 +29,7 @@ Questions and answers about precise neurons
    models relevant to Computational Neuroscience the dynamics of the single
    neuron is not. Examples are integrate-and-fire models with linear
    :hxt_ref:`subthreshold dynamics` and the AdEx model considered in `Hanuschkin
-   (2010) <http://dx.doi.org/10.3389/fninf.2010.00113>`__. In these cases
+   (2010) <https://doi.org/10.3389/fninf.2010.00113>`__. In these cases
    it is possible to study the accuracy of a solution of the single neuron
    dynamics.
 
@@ -61,7 +61,7 @@ Questions and answers about precise neurons
    A: Although the networks dynamics is chaotic, in some cases mesoscopic
    measures of network activity can be affected by the quality of the
    single neuron solver. For example, `Hansel et al.
-   (1998) <http://dx.doi.org/10.1162/089976698300017845>`__ showed that a
+   (1998) <https://doi.org/10.1162/089976698300017845>`__ showed that a
    measure of network synchrony exhibits a considerable error if the single
    neuron dynamics is integrated using a grid-constrained algorithm.
    Without confidence in the precision of the single neuron solver we

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -84,7 +84,7 @@ Options for Windows users |windows|
 ------------------------------------
 
 Please note that NEST does not officially support Windows. Members of our community have had success
-using NEST on Windows with the `Windows Subsystem for Linux <https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support#1-overview>`_.
+using NEST on Windows with the `Windows Subsystem for Linux <https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support>`_.
 You can also try our :ref:`docker container <docker_win>`.
 
 .. |linux| image:: ../static/img/linux.png

--- a/doc/htmldoc/model_details/HillTononiModels.ipynb
+++ b/doc/htmldoc/model_details/HillTononiModels.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -10,7 +10,7 @@
     "\n",
     "## Background\n",
     "\n",
-    "This notebook describes the neuron and synapse model proposed by Hill and Tononi in *J Neurophysiol* 93:1671-1698, 2005 ([doi:10.1152/jn.00915.2004](http://dx.doi.org/doi:10.1152/jn.00915.2004)) and their implementation in NEST. The notebook also contains some tests.\n",
+    "This notebook describes the neuron and synapse model proposed by Hill and Tononi in *J Neurophysiol* 93:1671-1698, 2005 ([doi:10.1152/jn.00915.2004](https://doi.org/doi:10.1152/jn.00915.2004)) and their implementation in NEST. The notebook also contains some tests.\n",
     "\n",
     "This description is based on the original publication and publications cited therein, an analysis of the source code of the original Synthesis implementation kindly provided by Sean Hill, and plausibility arguments.\n",
     "\n",

--- a/doc/htmldoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/htmldoc/model_details/aeif_models_implementation.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -48,12 +48,12 @@
     "\n",
     "The reference solution is implemented using the LSODAR solver which is described and compared in the following references:\n",
     "\n",
-    "* http://www.radford.edu/~thompson/RP/eventlocation.pdf (papers citing this one)\n",
-    "* http://www.sciencedirect.com/science/article/pii/S0377042712000684\n",
+    "* http://www.edu/~thompson/RP/eventlocation.pdf (papers citing this one)\n",
+    "* https://doi.org/10.1016/j.cam.2012.02.011\n",
     "* http://www.radford.edu/~thompson/RP/rootfinding.pdf\n",
     "* https://computation.llnl.gov/casc/nsde/pubs/u88007.pdf\n",
     "* http://www.cs.ucsb.edu/~cse/Files/SCE000136.pdf\n",
-    "* http://www.sciencedirect.com/science/article/pii/0377042789903348\n",
+    "* https://doi.org/10.1016/0377-0427(89)90334-8\n",
     "* http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.455.2976&rep=rep1&type=pdf\n",
     "* https://theses.lib.vt.edu/theses/available/etd-12092002-105032/unrestricted/etd.pdf"
    ]

--- a/doc/htmldoc/model_details/aeif_models_implementation.ipynb
+++ b/doc/htmldoc/model_details/aeif_models_implementation.ipynb
@@ -48,15 +48,14 @@
     "\n",
     "The reference solution is implemented using the LSODAR solver which is described and compared in the following references:\n",
     "\n",
-    "* http://www.edu/~thompson/RP/eventlocation.pdf (papers citing this one)\n",
-    "* https://doi.org/10.1016/j.cam.2012.02.011\n",
-    "* http://www.radford.edu/~thompson/RP/rootfinding.pdf\n",
-    "* https://computation.llnl.gov/casc/nsde/pubs/u88007.pdf\n",
-    "* http://www.cs.ucsb.edu/~cse/Files/SCE000136.pdf\n",
-    "* https://doi.org/10.1016/0377-0427(89)90334-8\n",
-    "* http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.455.2976&rep=rep1&type=pdf\n",
-    "* https://theses.lib.vt.edu/theses/available/etd-12092002-105032/unrestricted/etd.pdf"
-   ]
+
+    "* Shampine LF, and Thompson S. (2000). Event location for ordinary differential equations. Computers and Mathematics with Applications, 39(5–6), 43–54. https://doi.org/10.1016/S0898-1221(00)00045-6 \n",
+    "* Thompson S (1987). A collection of test problems for ordinary differential equation solvers which have provisions for rootfinding (ORNL/TM-9912, 6111421; p. ORNL/TM-9912, 6111421). https://doi.org/10.2172/6111421 \n",
+    "* Dieci L, and Lopez L (2012). A survey of numerical methods for IVPs of ODEs with discontinuous right-hand side. Journal of Computational and Applied Mathematics, 236(16), 3967–3991. https://doi.org/10.1016/j.cam.2012.02.011 \n",
+    "* Hindmarsh, AC (1983). ODEPACK, a systematized collection of ODE solvers. In R. S. Stepleman & others (Eds.), Scientific computing (Vol. 1, pp. 55–64). North-Holland. https://computing.llnl.gov/sites/default/files/u88007.pdf \n",
+    "* Petzold L. (1983). Automatic Selection of Methods for Solving Stiff and Nonstiff Systems of Ordinary Differential Equations. SIAM Journal on Scientific and Statistical Computing, 4(1), 136–148. https://doi.org/10.1137/0904010 \n",
+    "* Kahaner DK, Lawkins WF, and Thompson S. (1989). On the use of rootfinding ODE software for the solution of a common problem in nonlinear dynamical systems. Journal of Computational and Applied Mathematics, 28, 219–230. https://doi.org/10.1016/0377-0427(89)90334-8 \n"
+    ]
   },
   {
    "cell_type": "markdown",

--- a/doc/htmldoc/neurons/exact-integration.rst
+++ b/doc/htmldoc/neurons/exact-integration.rst
@@ -208,7 +208,7 @@ Every matrix entry is calculated twice. For inhibitory postsynaptic inputs (with
 
 The update is performed `here <https://github.com/nest/nest-simulator/blob/b3fc263e073f46f0732c10efb34fcc90f3b6771c/models/iaf_psc_alpha.cpp#L305-L307>`_. The first multiplication evolves the external input. The others are the multiplication of the matrix :math:`e^{Ah}` with :math:`y` (for inhibitory and excitatory inputs).
 
-If synaptic and membrane time constants become very close, :math:`\tau_m\approx \tau_{syn}`, the matrix :math:`e^{Ah}` becomes numerically unstable. NEST handles this gracefully as described in the `IAF Integration Singularity notebook <model_details/IAF_Integration_Singularity.ipynb>`_.
+If synaptic and membrane time constants become very close, :math:`\tau_m\approx \tau_{syn}`, the matrix :math:`e^{Ah}` becomes numerically unstable. NEST handles this gracefully as described in the `IAF Integration Singularity notebook <../model_details/IAF_Integration_Singularity.ipynb>`_.
 
 
 For more information see [1]_.

--- a/doc/htmldoc/neurons/simulations_with_precise_spike_times.rst
+++ b/doc/htmldoc/neurons/simulations_with_precise_spike_times.rst
@@ -15,7 +15,7 @@ neurons can propagate their state variables for an entire *h*-step
 without interruption by incoming spikes. This enables faster simulations
 of neurons with linear sub-threshold dynamics as a precomputed
 propagator matrix for a time step of fixed size *h* can be employed
-(`Rotter & Diesmann, 1999 <http://dx.doi.org/10.1007/s004220050570>`__).
+(`Rotter & Diesmann, 1999 <https://doi.org/10.1007/s004220050570>`__).
 
 Neurons buffer the incoming spikes until they become due, where spikes
 can be lumped together provided that the corresponding synapses have the
@@ -79,25 +79,24 @@ integrate-and-fire neuron model with alpha-shaped postsynaptic
 current that employ precise spike times; The grid-constrained
 counterpart is ``iaf_psc_alpha``. The neuron models have been developed
 in the context of `Morrison et al.
-(2007) <http://dx.doi.org/10.1162/neco.2007.19.1.47>`__. As the model
+(2007) <https://doi.org/10.1162/neco.2007.19.1.47>`__. As the model
 employ interpolation in order to determine the precise location of an
 outgoing spike, the achieved precision depends on the simulation
 resolution *h*. The models differ in the way they process incoming
 spikes, which also affects the attained precision (see `Morrison et al.
-(2007) <http://dx.doi.org/10.1162/neco.2007.19.1.47>`__ for details).
+(2007) <https://doi.org/10.1162/neco.2007.19.1.47>`__ for details).
 
 ``iaf_psc_exp_ps`` is an integrate-and-fire neuron model with
 exponentially shaped postsynaptic currents that employs precise spike
 times; its grid-constrained counterpart is ``iaf_psc_exp``. It has been
 developed in the context of `Hanuschkin et al.
-(2010) <http://dx.doi.org/10.3389/fninf.2010.00113>`__, which is a
+(2010) <https://doi.org/10.3389/fninf.2010.00113>`__, which is a
 continuation of the work presented in `Morrison et al.
-(2007) <http://dx.doi.org/10.1162/neco.2007.19.1.47>`__. As the neuron
+(2007) <https://doi.org/10.1162/neco.2007.19.1.47>`__. As the neuron
 model employs an iterative search in order to determine the precise
 location of an outgoing spike, the achieved precision does not depend on
 the simulation resolution h. The model can also be used through the
-`PyNN
-interface <http://neuralensemble.org/trac/PyNN/wiki/ContinuousTimeSpiking>`__.
+:doc:`PyNN interface <pynn:backends/NEST>`.
 
 Questions and answers about precise neurons
 -------------------------------------------
@@ -106,5 +105,3 @@ During the review process of the above mentioned papers, we came up with
 a list of questions and answers pertaining to the implementation and
 usage of precise spiking neurons. This list can be found
 :ref:`here <faqs_precise_neurons>`.
-
-

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -188,8 +188,7 @@ References
        in STDP – a unified model. Frontiers in Synaptic Neuroscience. 2:25
        DOI: https://doi.org/10.3389/fnsyn.2010.00025
 .. [3] Voltage-based STDP synapse (Clopath et al. 2010) on ModelDB
-       https://senselab.med.yale.edu/ModelDB/showmodel.cshtml?model=144566&file=%2f
-       modeldb_package%2fVoTriCode%2faEIF.m
+       https://modeldb.science/144566?tab=1
 
 See also
 ++++++++

--- a/models/clopath_synapse.h
+++ b/models/clopath_synapse.h
@@ -98,7 +98,7 @@ References
        in STDP – a unified model. Frontiers in Synaptic Neuroscience 2:25.
        DOI: https://doi.org/10.3389/fnsyn.2010.00025
 .. [3] Voltage-based STDP synapse (Clopath et al. 2010) on ModelDB
-       https://senselab.med.yale.edu/ModelDB/showmodel.cshtml?model=144566
+       https://modeldb.science/144566?tab=1
 
 See also
 ++++++++

--- a/models/glif_psc_double_alpha.h
+++ b/models/glif_psc_double_alpha.h
@@ -124,7 +124,7 @@ condition of
   ``tau_syn_in``, respectively, to avoid numerical instabilities.
 
   For implementation details see the
-  `IAF_neurons_singularity <../model_details/IAF_neurons_singularity.ipynb>`_ notebook.
+  `IAF Integration Singularity <../model_details/IAF_Integration_Singularity.ipynb>`_ notebook.
 
 Parameters
 ++++++++++

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -87,13 +87,12 @@ The key differences between the current model and the model in [1]_ are:
 For details on asynchronicity in spike and firing events with Hodgkin Huxley models
 see :ref:`here <hh_details>`.
 
-See also [2]_.
 
 Postsynaptic currents
 ---------------------
 
 Incoming spike events induce a postsynaptic change of conductance modelled by a
-beta function as outlined in [3]_ [4]_. The beta function is normalized such that an
+beta function as outlined in [2]_ [3]_. The beta function is normalized such that an
 event of weight 1.0 results in a peak current of 1 nS at :math:`t = \tau_{rise,xx}`
 where xx is ex or in.
 
@@ -151,11 +150,10 @@ References
 
 .. [1] Traub RD and Miles R (1991). Neuronal Networks of the Hippocampus.
        Cambridge University Press, Cambridge UK.
-.. [2] http://modeldb.yale.edu/83319
-.. [3] Rotter S and Diesmann M (1999). Exact digital simulation of
+.. [2] Rotter S and Diesmann M (1999). Exact digital simulation of
        time-invariant linear systems with applications to neuronal modeling.
        Biological Cybernetics 81:381 DOI: https://doi.org/10.1007/s004220050570
-.. [4] Roth A and van Rossum M (2010). Chapter 6: Modeling synapses.
+.. [3] Roth A and van Rossum M (2010). Chapter 6: Modeling synapses.
        in De Schutter, Computational Modeling Methods for Neuroscientists,
        MIT Press.
 

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -78,11 +78,12 @@ based on a model of hippocampal pyramidal cells by Traub and Miles [1]_.
 The key differences between the current model and the model in [1]_ are:
 
 - This model is a point neuron, not a compartmental model.
-- This model includes only ``I_Na`` and ``I_K``, with simpler ``I_K`` dynamics than
+- Following [2]_, this model includes only ``I_Na`` and ``I_K``, with simpler ``I_K`` dynamics than
   in [1]_, so it has only three instead of eight gating variables;
   in particular, all Ca dynamics have been removed.
 - Incoming spikes induce an instantaneous conductance change followed by
   exponential decay instead of activation over time.
+- The model incorporates gap junctions [3]_.
 
 For details on asynchronicity in spike and firing events with Hodgkin Huxley models
 see :ref:`here <hh_details>`.
@@ -92,9 +93,9 @@ Postsynaptic currents
 ---------------------
 
 Incoming spike events induce a postsynaptic change of conductance modelled by a
-beta function as outlined in [2]_ [3]_. The beta function is normalized such that an
+beta function as outlined in [4]_ [5]_. The beta function is normalized such that an
 event of weight 1.0 results in a peak current of 1 nS at :math:`t = \tau_{rise,xx}`
-where xx is ex or in.
+where xx is `ex` or `in`.
 
 Spike Detection
 ---------------
@@ -150,10 +151,17 @@ References
 
 .. [1] Traub RD and Miles R (1991). Neuronal Networks of the Hippocampus.
        Cambridge University Press, Cambridge UK.
-.. [2] Rotter S and Diesmann M (1999). Exact digital simulation of
+.. [2] Brette R, et al (2007). Simulation of networks of spiking neurons:
+       A review of tools and strategies. J Comput Neurosci, 23, 349–398
+       DOI: https://doi.org/10.1007/s10827-007-0038-6
+.. [3] Hahne J, Helias M, Kunkel S, Igarashi J, Bolten M, Frommer A,
+       and Diesmann M. (2015). A unified framework for spiking and gap-junction
+       interactions in distributed neuronal network simulations.
+       Frontiers in Neuroinformatics, 9. DOI: https://doi.org/10.3389/fninf.2015.00022
+.. [4] Rotter S and Diesmann M (1999). Exact digital simulation of
        time-invariant linear systems with applications to neuronal modeling.
        Biological Cybernetics 81:381 DOI: https://doi.org/10.1007/s004220050570
-.. [3] Roth A and van Rossum M (2010). Chapter 6: Modeling synapses.
+.. [5] Roth A and van Rossum M (2010). Chapter 6: Modeling synapses.
        in De Schutter, Computational Modeling Methods for Neuroscientists,
        MIT Press.
 

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -163,9 +163,7 @@ References
        DOI: https://doi.org/10.3389/fnsyn.2010.00025
 .. [6] Voltage-based STDP synapse (Clopath et al. 2010) connected to a
        Hodgkin-Huxley neuron on ModelDB:
-       https://senselab.med.yale.edu/ModelDB/showmodel.cshtml?model=144566&file
-       =%2fmodeldb_package%2fstdp_cc.mod
-
+       https://modeldb.science/144566?tab=1
 
 Sends
 +++++

--- a/models/sigmoid_rate_gg_1998.h
+++ b/models/sigmoid_rate_gg_1998.h
@@ -103,7 +103,7 @@ References
 .. [3] Hahne J, Helias M, Kunkel S, Igarashi J, Bolten M, Frommer A, Diesmann M
        (2015). A unified framework for spiking and gap-junction interactions
        in distributed neuronal network simulations. Frontiers in
-       Neuroinformatics, 9:22. DOI: https://doi/org/10.3389/fninf.2015.00022
+       Neuroinformatics, 9:22. DOI: https://doi.org/10.3389/fninf.2015.00022
 
 
 Sends

--- a/pynest/examples/Potjans_2014/README.rst
+++ b/pynest/examples/Potjans_2014/README.rst
@@ -56,7 +56,7 @@ To run the simulation, simply use:
 
 The output will be saved in the ``data`` directory.
 
-The code can be `parallelized <https://nest-simulator.readthedocs.io/en/latest/guides/parallel_computing.html>`_ using OpenMP and MPI, if NEST has been built with these features.
+The code can be :ref:`parallelized <parallel_computing>` using OpenMP and MPI, if NEST has been built with these features.
 The number of threads (per MPI process) can be chosen by adjusting ``local_num_threads`` in ``sim_params.py``.
 
 

--- a/pynest/examples/iaf_tum_2000_short_term_depression.py
+++ b/pynest/examples/iaf_tum_2000_short_term_depression.py
@@ -62,7 +62,7 @@ References
        20,RC50:1-5. URL: https://infoscience.epfl.ch/record/183402
 
 .. [2] Tsodyks M, Pawelzik K, Markram H (1998). Neural networks with dynamic synapses. Neural
-       computation, http://dx.doi.org/10.1162/089976698300017502
+       computation, https://doi.org/10.1162/089976698300017502
 
 See Also
 ~~~~~~~~

--- a/pynest/examples/intrinsic_currents_spiking.py
+++ b/pynest/examples/intrinsic_currents_spiking.py
@@ -39,7 +39,7 @@ References
 
 .. [1] Hill and Tononi (2005) Modeling sleep and wakefulness in the
        thalamocortical system. J Neurophysiol 93:1671
-       http://dx.doi.org/10.1152/jn.00915.2004.
+       https://doi.org/10.1152/jn.00915.2004
 
 See Also
 ~~~~~~~~

--- a/pynest/examples/sonata_example/sonata_network.py
+++ b/pynest/examples/sonata_example/sonata_network.py
@@ -27,8 +27,8 @@ This script builds and simulates a network of point neurons represented by
 the SONATA format [1]_. The network model consists of 300 internal nodes
 (explicitly simulated) and 100 external nodes (only provide inputs to the
 simulated system). The SONATA files can be found in the
-`pynest/examples/300_pointneurons
-<https://github.com/nest/nest-simulator/tree/master/pynest/examples/300_pointneurons>`_
+`pynest/examples/sonata_example/300_pointneurons
+<https://github.com/nest/nest-simulator/tree/master/pynest/examples/sonata_example/300_pointneurons>`_
 directory.
 
 See the :ref:`nest_sonata` for details on the NEST support of the SONATA format.


### PR DESCRIPTION
This PR fixes some links that were broken.

A few other broken links were found that I could not find a working link to point to.

Namely these in aeif implementation notebook:
- http://www.radford.edu/~thompson/RP/eventlocation.pdf (papers citing this one)
- http://www.radford.edu/~thompson/RP/rootfinding.pdf
- https://computation.llnl.gov/casc/nsde/pubs/u88007.pdf
- http://www.cs.ucsb.edu/~cse/Files/SCE000136.pdf
- http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.455.2976&rep=rep1&type=pdf
- https://theses.lib.vt.edu/theses/available/etd-12092002-105032/unrestricted/etd.pdf

There was a broken modeldb link for `models/hh_cond_beta_gap_traub.h`. 
I don't know what it was supposed to link to since there is not citation in the text. If I put in the same number to the new modeldb site, I get the following result https://modeldb.science/83319?tab=1. Does it make sense to have this link in this model?

