### PR TITLE
Fix minor integer type mismatches

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -400,7 +400,7 @@ nest::MPIManager::communicate_Allgather( std::vector< unsigned int >& send_buffe
   int disp = 0;
   unsigned int max_recv_count = send_buffer_size_;
   bool overflow = false;
-  for ( int pid = 0; pid < get_num_processes(); ++pid )
+  for ( size_t pid = 0; pid < get_num_processes(); ++pid )
   {
     unsigned int block_disp = pid * send_buffer_size_;
     displacements[ pid ] = disp;
@@ -470,7 +470,7 @@ nest::MPIManager::communicate_Allgather( std::vector< T >& send_buffer,
   int disp = 0;
   unsigned int max_recv_count = send_buffer_size_;
   bool overflow = false;
-  for ( int pid = 0; pid < get_num_processes(); ++pid )
+  for ( size_t pid = 0; pid < get_num_processes(); ++pid )
   {
     unsigned int block_disp = pid * send_buffer_size_;
     displacements[ pid ] = disp;
@@ -560,7 +560,7 @@ nest::MPIManager::communicate_Allgather( std::vector< OffGridSpike >& send_buffe
   int disp = 0;
   unsigned int max_recv_count = send_buffer_size_;
   bool overflow = false;
-  for ( int pid = 0; pid < get_num_processes(); ++pid )
+  for ( size_t pid = 0; pid < get_num_processes(); ++pid )
   {
     unsigned int block_disp = pid * send_buffer_size_;
     displacements[ pid ] = disp;
@@ -604,7 +604,7 @@ nest::MPIManager::communicate( std::vector< double >& send_buffer,
   communicate( n_nodes );
   // Set up displacements vector.
   displacements.resize( get_num_processes(), 0 );
-  for ( int i = 1; i < get_num_processes(); ++i )
+  for ( size_t i = 1; i < get_num_processes(); ++i )
   {
     displacements.at( i ) = displacements.at( i - 1 ) + n_nodes.at( i - 1 );
   }
@@ -864,7 +864,7 @@ nest::MPIManager::time_communicatev( int num_bytes, int samples )
   std::vector< int > n_nodes( get_num_processes(), packet_length );
   std::vector< int > displacements( get_num_processes(), 0 );
 
-  for ( int i = 1; i < get_num_processes(); ++i )
+  for ( size_t i = 1; i < get_num_processes(); ++i )
   {
     displacements.at( i ) = displacements.at( i - 1 ) + n_nodes.at( i - 1 );
   }
@@ -963,7 +963,7 @@ nest::MPIManager::time_communicate_alltoallv( int num_bytes, int samples )
   std::vector< int > n_nodes( get_num_processes(), packet_length );
   std::vector< int > displacements( get_num_processes(), 0 );
 
-  for ( int i = 1; i < get_num_processes(); ++i )
+  for ( size_t i = 1; i < get_num_processes(); ++i )
   {
     displacements.at( i ) = displacements.at( i - 1 ) + n_nodes.at( i - 1 );
   }

--- a/nestkernel/vp_manager.h
+++ b/nestkernel/vp_manager.h
@@ -203,7 +203,8 @@ inline void
 nest::VPManager::assert_thread_parallel() const
 {
 #ifdef _OPENMP
-  assert( omp_get_num_threads() == n_threads_ );
+  // omp_get_num_threads() returns int
+  assert( omp_get_num_threads() == static_cast< int >( n_threads_ ) );
 #endif
 }
 


### PR DESCRIPTION
This PR fixes some warnings by GCC 12.3 about integer type mismatches.

Note that we have a bit of a mess between `int` (e.g., `MPIManager::num_processes_`) and `size_t` (e.g., return type of `MPIManager::get_num_processes()`), but cleaning that up is for another day. 