### PR TITLE
Another approach to fix the data race in PerThreadBoolIndicator

### DIFF
--- a/nestkernel/event_delivery_manager.h
+++ b/nestkernel/event_delivery_manager.h
@@ -24,6 +24,7 @@
 #define EVENT_DELIVERY_MANAGER_H
 
 // C++ includes:
+#include <atomic>
 #include <cassert>
 #include <limits>
 #include <vector>
@@ -464,7 +465,7 @@ private:
    */
   BufferResizeLog send_recv_buffer_resize_log_;
 
-  PerThreadBoolIndicator gather_completed_checker_;
+  std::atomic< int > gather_completed_check_[ 2 ];
 
 #ifdef TIMER_DETAILED
   // private stop watches for benchmarking purposes


### PR DESCRIPTION
This approach avoids some of the barriers introduced by the other PR. 
But, more significantly it does not introduce the atomic counter for the instances of PerThreadPoolIndicator that don't use the collective logical operations.