### PR TITLE
Stop IPython from time consuming deep inspection of NodeCollection objects

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -548,9 +548,11 @@ class NodeCollection:
             raise AttributeError("Cannot get attribute of empty NodeCollection")
 
         # IPython looks up this method when doing pretty printing
-        # Without special casing this, this would go through SLI which is *slow*
+        # As long as we do not provide special methods to support IPython prettyprinting,
+        # HTML-rendering, etc, we stop IPython from time-consuming checks by raising an
+        # exception here. The exception must *not* be AttributeError.
         if attr == "_ipython_canary_method_should_not_exist_":
-            raise KeyError(attr)
+            raise NotImplementedError("_ipython_canary_method_should_not_exist_")
 
         if attr == "spatial":
             metadata = sli_func("GetMetadata", self._datum)

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -547,6 +547,11 @@ class NodeCollection:
         if not self:
             raise AttributeError("Cannot get attribute of empty NodeCollection")
 
+        # IPython looks up this method when doing pretty printing
+        # Without special casing this, this would go through SLI which is *slow*
+        if attr == "_ipython_canary_method_should_not_exist_":
+            raise KeyError(attr)
+
         if attr == "spatial":
             metadata = sli_func("GetMetadata", self._datum)
             val = metadata if metadata else None


### PR DESCRIPTION
This solution fixes #3144 and was suggested by Harold Gutch via NEST User (12 March 2024) with the following explanation

> What happens is that IPython's pretty printing calls (a bit down the line) the `IPythonDisplayFormatter()` class.  The first thing that does is test if for the given object there is an `_ipython_display_()` method — if that exists, it calls that, otherwise it falls back to a more generic method.  In your case the latter happens, it falls back to the more generic method and that is what then produces the output.
> 
> When looking up if there is an `_iython_display_()` method, the first thing IPython does is check for a method called `_ipython_canary_method_should_not_exist_()`— and it is precisely this lookup that takes so long.  You can verify this by
> 
> ```python
> getattr(n, "_ipython_canary_method_should_not_exist_")
> ```
> 
> which will also take rather long.  As the output here also contains some SLI things, one might need to dig deeper to actually speed this up.
> 
> Instead, adding a check specifically for exactly the above mentioned lookup of `_ipython_canary_method_should_not_exist_()` also does the job ... .  With that workaround, your example
> returns instantaneously — as one would expect it to.
> 

