### PR TITLE
Fix MUSIC support in NEST

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -527,7 +527,7 @@ jobs:
           - "boost, optimize, warning"
           - "openmp, python, gsl, ltdl, boost, optimize, warning"
           - "mpi, python, gsl, ltdl, boost, optimize, warning"
-          - "openmp, mpi, python, gsl, ltdl, boost, hdf5, sionlib, libneurosim, optimize, warning"
+          - "openmp, mpi, python, gsl, ltdl, boost, hdf5, sionlib, libneurosim, optimize, warning, music"
 
     steps:
       - name: Harden Runner
@@ -678,6 +678,7 @@ jobs:
               -Dwith-hdf5=${{ contains(matrix.use, 'hdf5') && 'ON' || 'OFF' }} \
               -Dwith-sionlib=${{ contains(matrix.use, 'sionlib') && '$HOME/.cache/sionlib.install' || 'OFF' }} \
               -Dwith-libneurosim=${{ contains(matrix.use, 'libneurosim') && '$HOME/.cache/libneurosim.install' || 'OFF' }} \
+              -Dwith-music=${{ contains(matrix.use, 'music') && '$HOME/.cache/music.install' || 'OFF' }} \
               ..
 
       - name: "Add GCC problem matcher"
@@ -806,6 +807,7 @@ jobs:
               -Dwith-hdf5=${{ contains(matrix.use, 'hdf5') && 'ON' || 'OFF' }} \
               -Dwith-sionlib=${{ contains(matrix.use, 'sionlib') && '$HOME/.cache/sionlib.install' || 'OFF' }} \
               -Dwith-libneurosim=${{ contains(matrix.use, 'libneurosim') && '$HOME/.cache/libneurosim.install' || 'OFF' }} \
+              -Dwith-music=${{ contains(matrix.use, 'music') && '$HOME/.cache/music.install' || 'OFF' }} \
               ..
 
       - name: "Add GCC problem matcher"

--- a/models/music_cont_in_proxy.cpp
+++ b/models/music_cont_in_proxy.cpp
@@ -38,6 +38,14 @@
 
 // Includes from nestkernel:
 #include "kernel_manager.h"
+#include "nest_impl.h"
+
+void
+nest::register_music_cont_in_proxy( const std::string& name )
+{
+  register_node_model< music_cont_in_proxy >( name );
+}
+
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_cont_in_proxy.h
+++ b/models/music_cont_in_proxy.h
@@ -46,6 +46,7 @@
 
 namespace nest
 {
+void register_music_cont_in_proxy( const std::string& name );
 
 /* BeginUserDocs: device, MUSIC
 

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -32,6 +32,7 @@
 #include "event_delivery_manager_impl.h"
 #include "kernel_manager.h"
 #include "nest_datums.h"
+#include "nest_impl.h"
 
 // Includes from libnestutil:
 #include "compose.hpp"
@@ -42,6 +43,13 @@
 #include "dictutils.h"
 #include "doubledatum.h"
 #include "integerdatum.h"
+
+void
+nest::register_music_cont_out_proxy( const std::string& name )
+{
+  register_node_model< music_cont_out_proxy >( name );
+}
+
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_cont_out_proxy.h
+++ b/models/music_cont_out_proxy.h
@@ -49,6 +49,7 @@
 
 namespace nest
 {
+void register_music_cont_out_proxy( const std::string& name );
 
 /* BeginUserDocs: device, MUSIC
 

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -41,6 +41,14 @@
 // Includes from nestkernel:
 #include "event_delivery_manager_impl.h"
 #include "kernel_manager.h"
+#include "nest_impl.h"
+
+void
+nest::register_music_event_in_proxy( const std::string& name )
+{
+  register_node_model< music_event_in_proxy >( name );
+}
+
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -108,6 +108,8 @@ nest::music_event_in_proxy::music_event_in_proxy()
   , P_()
   , S_()
 {
+  // Register port for the model so it is available as default
+  kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 
 nest::music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n )
@@ -115,6 +117,7 @@ nest::music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n 
   , P_( n.P_ )
   , S_( n.S_ )
 {
+  // Register port for node instance because MusicManager manages ports via reference count
   kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -115,7 +115,7 @@ nest::music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n 
   , P_( n.P_ )
   , S_( n.S_ )
 {
-  kernel().music_manager.register_music_in_port( P_.port_name_, true );
+  kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 
 
@@ -156,8 +156,8 @@ nest::music_event_in_proxy::set_status( const DictionaryDatum& d )
   stmp.set( d, P_ ); // throws if BadProperty
 
   // if we get here, temporaries contain consistent set of properties
-  kernel().music_manager.register_music_in_port( ptmp.port_name_ );
   kernel().music_manager.unregister_music_in_port( P_.port_name_ );
+  kernel().music_manager.register_music_in_port( ptmp.port_name_ );
 
   P_ = ptmp;
   S_ = stmp;

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -39,6 +39,7 @@
 
 namespace nest
 {
+void register_music_event_in_proxy( const std::string& name );
 
 /* BeginUserDocs: device, MUSIC, spike
 

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -40,6 +40,13 @@
 
 // Includes from nestkernel:
 #include "kernel_manager.h"
+#include "nest_impl.h"
+
+void
+nest::register_music_event_out_proxy( const std::string& name )
+{
+  register_node_model< music_event_out_proxy >( name );
+}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_event_out_proxy.h
+++ b/models/music_event_out_proxy.h
@@ -42,6 +42,7 @@
 
 namespace nest
 {
+void register_music_event_out_proxy( const std::string& name );
 
 /* BeginUserDocs: device, MUSIC, spike
 

--- a/models/music_message_in_proxy.cpp
+++ b/models/music_message_in_proxy.cpp
@@ -38,6 +38,13 @@
 
 // Includes from nestkernel:
 #include "kernel_manager.h"
+#include "nest_impl.h"
+
+void
+nest::register_music_message_in_proxy( const std::string& name )
+{
+  register_node_model< music_message_in_proxy >( name );
+}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_message_in_proxy.h
+++ b/models/music_message_in_proxy.h
@@ -51,6 +51,8 @@
 
 namespace nest
 {
+void register_music_message_in_proxy( const std::string& name );
+
 /* BeginUserDocs: device, MUSIC
 
 Short description

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -114,7 +114,7 @@ nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
   , P_( n.P_ )
   , S_( n.S_ )
 {
-  kernel().music_manager.register_music_in_port( P_.port_name_, true );
+  kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 
 
@@ -157,8 +157,8 @@ nest::music_rate_in_proxy::set_status( const DictionaryDatum& d )
   stmp.set( d, P_ ); // throws if BadProperty
 
   // if we get here, temporaries contain consistent set of properties
-  kernel().music_manager.register_music_in_port( ptmp.port_name_ );
   kernel().music_manager.unregister_music_in_port( P_.port_name_ );
+  kernel().music_manager.register_music_in_port( ptmp.port_name_ );
   P_ = ptmp;
   S_ = stmp;
 }

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -107,6 +107,8 @@ nest::music_rate_in_proxy::music_rate_in_proxy()
   , P_()
   , S_()
 {
+  // Register port for the model so it is available as default
+  kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 
 nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
@@ -114,6 +116,7 @@ nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
   , P_( n.P_ )
   , S_( n.S_ )
 {
+  // Register port for node instance because MusicManager manages ports via reference count
   kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -38,6 +38,14 @@
 // Includes from nestkernel:
 #include "event_delivery_manager_impl.h"
 #include "kernel_manager.h"
+#include "nest_impl.h"
+
+void
+nest::register_music_rate_in_proxy( const std::string& name )
+{
+  register_node_model< music_rate_in_proxy >( name );
+}
+
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/music_rate_in_proxy.h
+++ b/models/music_rate_in_proxy.h
@@ -97,6 +97,8 @@ EndUserDocs*/
 
 namespace nest
 {
+void register_music_rate_in_proxy( const std::string& name );
+
 /**
  * Emit rate at times received from another application via a
  * MUSIC port.

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -40,10 +40,17 @@
 
 // Includes from nestkernel:
 #include "kernel_manager.h"
+#include "nest_impl.h"
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
+
+void
+nest::register_music_rate_out_proxy( const std::string& name )
+{
+  register_node_model< music_rate_out_proxy >( name );
+}
 
 nest::music_rate_out_proxy::Parameters_::Parameters_()
   : port_name_( "rate_out" )

--- a/models/music_rate_out_proxy.h
+++ b/models/music_rate_out_proxy.h
@@ -89,6 +89,8 @@ EndUserDocs */
 
 namespace nest
 {
+void register_music_rate_out_proxy( const std::string& name );
+
 class music_rate_out_proxy : public DeviceNode
 {
 

--- a/nestkernel/music_manager.cpp
+++ b/nestkernel/music_manager.cpp
@@ -48,18 +48,8 @@ MUSICManager::MUSICManager()
 }
 
 void
-MUSICManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+MUSICManager::initialize( const bool )
 {
-  if ( adjust_number_of_threads_or_rng_only )
-  {
-    return;
-  }
-
-#ifdef HAVE_MUSIC
-  // Reset music_in_portlist_ to its pristine state.
-  // See comment above pristine_music_in_portlist_ in the header.
-  music_in_portlist_ = pristine_music_in_portlist_;
-#endif
 }
 
 void
@@ -163,7 +153,7 @@ MUSICManager::advance_music_time()
 }
 
 void
-MUSICManager::register_music_in_port( std::string portname, bool pristine )
+MUSICManager::register_music_in_port( std::string portname )
 {
   std::map< std::string, MusicPortData >::iterator it;
   it = music_in_portlist_.find( portname );
@@ -175,17 +165,19 @@ MUSICManager::register_music_in_port( std::string portname, bool pristine )
   {
     music_in_portlist_[ portname ].n_input_proxies++;
   }
-
-  // pristine is true if we are building up the initial portlist
-  if ( pristine )
-  {
-    pristine_music_in_portlist_[ portname ] = music_in_portlist_[ portname ];
-  }
 }
 
 void
 MUSICManager::unregister_music_in_port( std::string portname )
 {
+  // Unregistering from an empty portlist is a no-op. This avoids the
+  // need to add a dummy entry at startup which is only there to be
+  // deleted on the registration of a proper port.
+  if ( music_in_portlist_.empty() )
+  {
+    return;
+  }
+
   std::map< std::string, MusicPortData >::iterator it;
   it = music_in_portlist_.find( portname );
   if ( it == music_in_portlist_.end() )

--- a/nestkernel/music_manager.cpp
+++ b/nestkernel/music_manager.cpp
@@ -170,14 +170,6 @@ MUSICManager::register_music_in_port( std::string portname )
 void
 MUSICManager::unregister_music_in_port( std::string portname )
 {
-  // Unregistering from an empty portlist is a no-op. This avoids the
-  // need to add a dummy entry at startup which is only there to be
-  // deleted on the registration of a proper port.
-  if ( music_in_portlist_.empty() )
-  {
-    return;
-  }
-
   std::map< std::string, MusicPortData >::iterator it;
   it = music_in_portlist_.find( portname );
   if ( it == music_in_portlist_.end() )

--- a/nestkernel/music_manager.h
+++ b/nestkernel/music_manager.h
@@ -88,15 +88,8 @@ public:
    *
    * This will increment the counter of the respective entry in the
    * music_in_portlist.
-   *
-   * The argument pristine should be set to true when a model
-   * registers the initial port name. This typically happens when the
-   * copy constructor of the model registers a port, as in
-   * models/music_event_in_proxy.cpp. Setting pristine = true causes
-   * the port to be also added to pristine_music_in_portlist. See
-   * also pristine_music_in_portlist_.
    */
-  void register_music_in_port( std::string portname, bool pristine = false );
+  void register_music_in_port( std::string portname );
 
   /**
    * Unregister a MUSIC input port (portname) from the port list.
@@ -157,16 +150,6 @@ public:
    * @see unregister_music_in_port()
    */
   std::map< std::string, MusicPortData > music_in_portlist_;
-
-  /**
-   * A copy of music_in_portlist_ at the pristine state.
-   *
-   * This is used to reset music_in_portlist_ to its pristine state in
-   * initialize (a default state). Pristine here refers to the
-   * initial state of music_in_portlist_ after the loading of the
-   * pristine_models_.
-   */
-  std::map< std::string, MusicPortData > pristine_music_in_portlist_;
 
   /**
    * The mapping between MUSIC input ports identified by portname

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -112,22 +112,13 @@ fi
 . "$(dirname $0)/junit_xml.sh"
 . "$(dirname $0)/run_test.sh"
 
+# Directory containing installed tests
 TEST_BASEDIR="${PREFIX}/share/nest/testsuite"
 
-# create the report directory in TEST_BASEDIR. Save and restore the old value
-# of TMPDIR.
-
-if [[ "${TMPDIR-}" ]]; then
-    OLD_TMPDIR=$TMPDIR
-fi
-
-TMPDIR=$TEST_BASEDIR
-REPORTDIR="$(mktemp -d test_report_XXX)"
-
-if [[ "${OLD_TMPDIR-}" ]]; then
-    TMPDIR=OLD_TMPDIR
-    unset OLD_TMPDIR
-fi
+# Create the report directory in the directory in which make installcheck is called (do_tests.sh is run).
+# Use absolute pathnames, this is necessary for MUSIC tests which otherwis will not find the logfiles
+# while running in temporary directories.
+REPORTDIR="${PWD}/$(mktemp -d test_report_XXX)"
 
 TEST_LOGFILE="${REPORTDIR}/installcheck.log"
 TEST_OUTFILE="${REPORTDIR}/output.log"


### PR DESCRIPTION
This PR fixes #3174. In particular, it does the following:

1. It activates MUSIC for the CI all-in Linux build.
2. In `do_tests.sh` it turns `REPORTDIR` and names generated from it into absolute paths so they can be used from MUSIC test's `runner.sh` running in any directory. `REPORTDIR` is a uniquely named directory in the directory from which `do_tests.sh` is run, i.e., where `make installcheck` is run. The PR also removes `TMPDIR` gymnastics which actually did not have any effect on `mktemp`.
3. All `music_*_proxy` models now use the new registration mechanism. Please check extra careful that the namings for each registration function are consistent. Note that the `registrer_...()` functions are called from `$BUILD_DIR/models/models.cpp`, which is auto-generated by CMake.
4. Previously, `music_{event,rate}_in_proxy` models were set up so that they registered an `event_in`/`rate_in` port as the default input port. Since we no longer have "pristine" models (which survived a `ResetKernel()`), this registration is now done in the default constructor for the model. In addition, the registration is done again in the copy constructor every time an instance of the model is created, since `MusicManager` keeps track of ports via reference counting.

The registration mentioned in 4. is inconsistently applied, since it is only done for `event` and `rate`, but not for `cont` and `message` proxies. I have created #3178 as a follow up issue to check this out.