### PR TITLE
Improve glossary references in documentation

### DIFF
--- a/doc/htmldoc/hpc/parallel_computing.rst
+++ b/doc/htmldoc/hpc/parallel_computing.rst
@@ -161,7 +161,7 @@ Spikes between neurons and devices
 Synaptic plasticity models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For synapse models supporting plasticity, synapse dynamics in the
+For synapse models supporting :hxt_ref:`plasticity`, synapse dynamics in the
 ``Connection`` object are always handled by the virtual process of the
 `target node`.
 

--- a/doc/htmldoc/synapses/synapse_specification.rst
+++ b/doc/htmldoc/synapses/synapse_specification.rst
@@ -450,7 +450,7 @@ NEST provides a number of built-in synapse models that can be used
 during connection setup. The default model is the :hxt_ref:`static_synapse`,
 whose only parameters ``weight`` and ``delay`` do not change over
 time. Other synapse models implement learning and adaptation in the
-form of long-term or short-term :hxt_ref:`plasticity`. A list of available
+form of long-term or short-term plasticity. A list of available
 synapse models is accessible via the command ``nest.synapse_models``.
 More detailed information about each of them can be found in the
 :doc:`model directory <../models/index_synapse>`.

--- a/doc/htmldoc/synapses/synapse_specification.rst
+++ b/doc/htmldoc/synapses/synapse_specification.rst
@@ -450,7 +450,7 @@ NEST provides a number of built-in synapse models that can be used
 during connection setup. The default model is the :hxt_ref:`static_synapse`,
 whose only parameters ``weight`` and ``delay`` do not change over
 time. Other synapse models implement learning and adaptation in the
-form of long-term or short-term plasticity. A list of available
+form of long-term or short-term :hxt_ref:`plasticity`. A list of available
 synapse models is accessible via the command ``nest.synapse_models``.
 More detailed information about each of them can be found in the
 :doc:`model directory <../models/index_synapse>`.

--- a/doc/htmldoc/tutorials/music_tutorial/music_tutorial_1.rst
+++ b/doc/htmldoc/tutorials/music_tutorial/music_tutorial_1.rst
@@ -56,7 +56,7 @@ A NEST network consists of three types of elements: neurons, devices,
 and connections between them.
 
 Neurons are the basic building blocks, and in NEST they are generally
-spiking point neuron models. Devices are supporting units that for
+spiking :hxt_ref:`point neuron` models. Devices are supporting units that for
 instance generate inputs to neurons or record data from them. The
 Poisson spike generator, the spike recorder recording device, and the
 MUSIC input and output proxies are all devices. Neurons and devices are

--- a/doc/htmldoc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
+++ b/doc/htmldoc/tutorials/pynest_tutorial/part_3_connecting_networks_with_synapses.rst
@@ -64,10 +64,10 @@ STDP synapses
 
 For the majority of synapses, all of their parameters are accessible via
 :py:func:`.GetDefaults` and :py:func:`.SetDefaults`. Synapse models implementing
-spike-timing dependent plasticity are an exception to this, as their
+:hxt_ref:`spike-timing dependent plasticity` are an exception to this, as their
 dynamics are driven by the postsynaptic :hxt_ref:`spike train` as well as the
 pre-synaptic one. As a consequence, the time constant of the depressing
-window of :hxt_ref:`STDP` is a parameter of the postsynaptic neuron. It can be set
+window of STDP is a parameter of the postsynaptic neuron. It can be set
 as follows:
 
 ::


### PR DESCRIPTION
- fixing broken link to STDP definition
- adding references to: 
    - point neuron in music tutorial 1
    - plasticity in synapse specification
    - plasticity in parallel computing guide