### PR TITLE
Hike Python version for macOS tests to 3.12

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -758,7 +758,7 @@ jobs:
       - name: "Set up Python 3.x"
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: "Install MacOS system dependencies"
         run: |


### PR DESCRIPTION
Github recently seems to have changed the `macos-latest` runner to macOS 14.4 on arm64 systems (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#viewing-available-runners-for-a-repository), which support as earliest Python version 3.10, not 3.9 that we used so far in our tests for macOS. 

This PR hikes the Python version for `build-macos` to 3.12, so NEST can still be built on Github.

Testing under Linux still uses 3.9.

Marking this as critical because macOS tests cannot run until fixed.
