### PR TITLE
Fix minor Sphinx warnings related to broken links 

### DIFF
--- a/doc/htmldoc/connect_nest/nest_server.rst
+++ b/doc/htmldoc/connect_nest/nest_server.rst
@@ -79,9 +79,9 @@ consideration, each of the restrictions can be disabled by setting a correspondi
 * ``NEST_SERVER_DISABLE_AUTH``: By default, the NEST Server requires a NESTServerAuth tokens. Setting this variable to
   ``1`` disables this restriction. A token is automatically created and printed to the console by NEST Server upon
   start-up. If needed, a custom token can be set using the environment variable  ``NEST_SERVER_ACCESS_TOKEN``
-* ``NEST_SERVER_CORS_ORIGINS``: By default, the NEST Server only allows requests from localhost (see `CORS
-  <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_). Other hosts can be explicitly allowed by supplying them
-  in the form `http://host_or_ip:*`` to this variable (By default: http://localhost:*).
+* ``NEST_SERVER_CORS_ORIGINS``: By default, the NEST Server only allows requests from localhost (see
+  `CORS <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_). Other hosts can be explicitly allowed by supplying them
+  in the form http://host_or_ip:\* to this variable (By default: http://localhost:\*).
 * ``NEST_SERVER_ENABLE_EXEC_CALL``: By default, NEST Server only allows calls to its PyNEST-like API. If the use-case
   requires the execution of scripts via the ``/exec`` route, this variable can be set to ``1``. PLEASE BE AWARE THAT
   THIS OPENS YOUR COMPUTER TO REMOTE CODE EXECUTION.

--- a/doc/htmldoc/devices/index.rst
+++ b/doc/htmldoc/devices/index.rst
@@ -8,7 +8,7 @@ All about devices in NEST
 
     .. grid-item-card::  Stimulate the network
        :class-title: sd-d-flex-row sd-align-minor-center
-       :link: stimuate_network
+       :link: stimulate_network
        :link-type: ref
 
     .. grid-item-card:: Get data from simulation

--- a/doc/htmldoc/get-started_index.rst
+++ b/doc/htmldoc/get-started_index.rst
@@ -232,8 +232,6 @@ More topics
 .. toctree::
    :hidden:
 
-   understand_index
-
 .. |nav| image:: static/img/GPS-Settings-256_nest.svg
 .. |script| image:: static/img/script_white.svg
       :scale: 20%

--- a/doc/htmldoc/related_projects.rst
+++ b/doc/htmldoc/related_projects.rst
@@ -90,10 +90,10 @@ real-time operation.
 TheVirtualBrain (TVB)
 ---------------------
 
-:ref:`TVB <tvb:top_basic>` is a framework for the simulation of the dynamics of large-scale brain networks with
+:ref:`TVB <tvb:index>` is a framework for the simulation of the dynamics of large-scale brain networks with
 biologically realistic connectivity.
 
-* :ref:`Get started with TVB <tvb:tutorial_0_gettingstarted>`
+* :ref:`Get started with TVB <tvb:tutorial_0_GettingStarted>`
 
 ConnPlotter
 -----------

--- a/doc/htmldoc/synapses/synapse_specification.rst
+++ b/doc/htmldoc/synapses/synapse_specification.rst
@@ -65,7 +65,7 @@ Array parameters
 
 Array parameters can be used with the rules ``one_to_one``, ``all_to_all``,
 ``fixed_total_number``, ``fixed_indegree``, and ``fixed_outdegree``.
-For details on connection rules, see :ref:`connectivity_concept`.
+For details on connection rules, see :ref:`connectivity_concepts`.
 The arrays can be specified as NumPy arrays or Python
 lists. As with the scalar parameters, all parameters have to be
 specified as arrays of the correct type.

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -121,6 +121,10 @@ hyperpolarization to biophysically plausible values, set parameter
 
 
 .. note::
+
+   NEST uses exact integration [1]_, [2]_ to integrate subthreshold membrane
+   dynamics.
+
    Spikes arriving while the neuron is refractory, are discarded by
    default. If the property ``refractory_input`` is set to True, such
    spikes are added to the membrane potential at the end of the

--- a/nestkernel/recording_backend_ascii.h
+++ b/nestkernel/recording_backend_ascii.h
@@ -46,7 +46,7 @@ each MPI process. This can cause a high load on the file system in
 large simulations. This backend can become prohibitively inefficient,
 particularly on machines with distributed filesystems. In case you
 experience such scaling problems, the :doc:`recording backend for
-SIONlib <recording_backend_sionlib>` may be a possible alternative.
+SIONlib </models/recording_backend_sionlib>` may be a possible alternative.
 
 Filenames of data files are determined according to the following
 pattern:

--- a/nestkernel/recording_backend_sionlib.h
+++ b/nestkernel/recording_backend_sionlib.h
@@ -47,7 +47,7 @@ a binary container file (or to a rather small set of such files). This
 is especially useful for large-scale simulations running in a
 distributed way on many MPI processes/OpenMP threads. In such usage
 scenarios, writing to plain text files (see :doc:`recording backend
-for ASCII files <recording_backend_ascii>`) would cause a large
+for ASCII files </models/recording_backend_ascii>`) would cause a large
 overhead because of the huge number of generated files and thus be
 very inefficient.
 

--- a/pynest/examples/EI_clustered_network/README.rst
+++ b/pynest/examples/EI_clustered_network/README.rst
@@ -16,24 +16,24 @@ If you use this code, we ask you to cite the paper by Rostami et al. [1]_ and th
 File structure
 --------------
 
-* :doc:`run_simulation.py <run_simulation>`: an example script to try out the EI-clustered circuit model
-* :doc:`network.py <network>`: the main ``Network`` class with functions to build and simulate the network
-* :doc:`helper.py <helper>`: helper functions for calculation of synaptic weights and currents and plot function for raster plots
-* :doc:`network_params.py <network_params>`: network and neuron parameters
-* :doc:`stimulus_params.py <stimulus_params>`: parameters for optional external stimulation
-* :doc:`sim_params.py <sim_params>`: simulation parameters
+* :doc:`run_simulation_EI.py <run_simulation_EI>`: an example script to try out the EI-clustered circuit model
+* :doc:`network_EI.py <network_EI>`: the main ``Network`` class with functions to build and simulate the network
+* :doc:`helper_EI.py <helper_EI>`: helper functions for calculation of synaptic weights and currents and plot function for raster plots
+* :doc:`network_params_EI.py <network_params_EI>`: network and neuron parameters
+* :doc:`stimulus_params_EI.py <stimulus_params_EI>`: parameters for optional external stimulation
+* :doc:`sim_params_EI.py <sim_params_EI>`: simulation parameters
 
 Running the simulation
 ----------------------
 
 .. code-block:: bash
 
-   python run_simulation.py
+   python run_simulation_EI.py
 
 A raster plot of the network activity is saved as ``clustered_ei_raster.png``.
 
 The code can be parallelized by using multiple threads during the NEST simulation.
-This can be done by setting the parameter ``n_vp`` in the ``run_simulation.py`` script.
+This can be done by setting the parameter ``n_vp`` in the ``run_simulation_EI.py`` script.
 
 Contributions to this PyNEST model implementation
 -------------------------------------------------

--- a/pynest/examples/EI_clustered_network/helper_EI.py
+++ b/pynest/examples/EI_clustered_network/helper_EI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# helper.py
+# helper_EI.py
 #
 # This file is part of NEST.
 #

--- a/pynest/examples/EI_clustered_network/network_EI.py
+++ b/pynest/examples/EI_clustered_network/network_EI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# network.py
+# network_EI.py
 #
 # This file is part of NEST.
 #
@@ -58,8 +58,8 @@ class ClusteredNetwork:
     def __init__(self, sim_dict, net_dict, stim_dict):
         """Initialize the ClusteredNetwork object.
 
-        Parameters are given and explained in the files network_params.py,
-        sim_params.py and stimulus_params.py.
+        Parameters are given and explained in the files network_params_EI.py,
+        sim_params_EI.py and stimulus_params_EI.py.
 
         Parameters
         ----------

--- a/pynest/examples/EI_clustered_network/network_params_EI.py
+++ b/pynest/examples/EI_clustered_network/network_params_EI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# network_params.py
+# network_params_EI.py
 #
 # This file is part of NEST.
 #
@@ -20,7 +20,7 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 """PyNEST EI-clustered network: Network Parameters
-------------------------------------------------
+--------------------------------------------------
 
 A dictionary with parameters defining the network and neuron parameters.
 

--- a/pynest/examples/EI_clustered_network/run_simulation_EI.py
+++ b/pynest/examples/EI_clustered_network/run_simulation_EI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# run_simulation.py
+# run_simulation_EI.py
 #
 # This file is part of NEST.
 #

--- a/pynest/examples/EI_clustered_network/sim_params_EI.py
+++ b/pynest/examples/EI_clustered_network/sim_params_EI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# stimulus_params.py
+# sim_params_EI.py
 #
 # This file is part of NEST.
 #
@@ -19,20 +19,23 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-""" PyNEST EI-clustered network: Stimulus Parameters
------------------------------------------------
+"""PyNEST EI-clustered network: Simulation Parameters
+-----------------------------------------------------
 
-A dictionary with parameters for an optinal stimulation of clusters.
+A dictionary with parameters defining the simulation.
 
 """
 
-stim_dict = {
-    # list of clusters to be stimulated (None: no stimulation, 0-n_clusters-1)
-    "stim_clusters": [2, 3, 4],
-    # stimulus amplitude (in pA)
-    "stim_amp": 0.15,
-    # stimulus start times in ms: list (warmup time is added automatically)
-    "stim_starts": [2000, 6000],
-    # list of stimulus end times in ms (warmup time is added automatically)
-    "stim_ends": [3500, 7500],
+sim_dict = {
+    # The full simulation time is the sum of a presimulation time and the main
+    # simulation time.
+    # presimulation time (in ms)
+    "warmup": 1000.0,
+    # simulation time (in ms)
+    "simtime": 10000.0,
+    # resolution of the simulation (in ms)
+    "dt": 0.1,
+    "randseed": 55,
+    # Number of virtual processes
+    "n_vp": 4,
 }

--- a/pynest/examples/EI_clustered_network/stimulus_params_EI.py
+++ b/pynest/examples/EI_clustered_network/stimulus_params_EI.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# sim_params.py
+# stimulus_params_EI.py
 #
 # This file is part of NEST.
 #
@@ -19,23 +19,20 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-"""PyNEST EI-clustered network: Simulation Parameters
-------------------------------------------------
+""" PyNEST EI-clustered network: Stimulus Parameters
+-----------------------------------------------------
 
-A dictionary with parameters defining the simulation.
+A dictionary with parameters for an optinal stimulation of clusters.
 
 """
 
-sim_dict = {
-    # The full simulation time is the sum of a presimulation time and the main
-    # simulation time.
-    # presimulation time (in ms)
-    "warmup": 1000.0,
-    # simulation time (in ms)
-    "simtime": 10000.0,
-    # resolution of the simulation (in ms)
-    "dt": 0.1,
-    "randseed": 55,
-    # Number of virtual processes
-    "n_vp": 4,
+stim_dict = {
+    # list of clusters to be stimulated (None: no stimulation, 0-n_clusters-1)
+    "stim_clusters": [2, 3, 4],
+    # stimulus amplitude (in pA)
+    "stim_amp": 0.15,
+    # stimulus start times in ms: list (warmup time is added automatically)
+    "stim_starts": [2000, 6000],
+    # list of stimulus end times in ms (warmup time is added automatically)
+    "stim_ends": [3500, 7500],
 }


### PR DESCRIPTION
This PR fixes warnings that Sphinx emits due to links or references not being correct in some way.
Biggest change is renaming EI_clustered network Python scripts so they do not collide with the names of the scripts in microcircuit (Potjans_2014).