### PR TITLE
Fixed conductance based neuron model header files

### DIFF
--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -94,7 +94,7 @@ Postsynaptic currents
 
 Incoming spike events induce a postsynaptic change of conductance modelled by a
 beta function as outlined in [4]_ [5]_. The beta function is normalized such that an
-event of weight 1.0 results in a peak current of 1 nS at :math:`t = \tau_{rise,xx}`
+event of weight 1.0 results in a peak conductance of 1 nS at :math:`t = \tau_{rise,xx}`
 where xx is `ex` or `in`.
 
 Spike Detection

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -69,7 +69,7 @@ Description
 ``iaf_cond_alpha`` is an implementation of a spiking neuron using IAF dynamics with
 conductance-based synapses. Incoming spike events induce a postsynaptic change
 of conductance modelled by an alpha function. The alpha function
-is normalized such that an event of weight 1.0 results in a peak current of 1 nS
+is normalized such that an event of weight 1.0 results in a peak conductance of 1 nS
 at :math:`t = \tau_{syn}`.
 
 See also [1]_, [2]_, [3]_.

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -74,7 +74,7 @@ spike-frequency adaptation and relative refractory mechanisms as described in
 
 Incoming spike events induce a postsynaptic change of conductance modelled by
 an exponential function. The exponential function is normalized such that an
-event of weight 1.0 results in a peak current of 1 nS.
+event of weight 1.0 results in a peak conductance of 1 nS.
 
 Outgoing spike events induce a change of the adaptation and relative refractory
 conductances by ``q_sfa`` and ``q_rr``, respectively. Otherwise these conductances


### PR DESCRIPTION
[Similar conductance based neuron model](https://nest-simulator.readthedocs.io/en/stable/models/iaf_cond_exp.html) with conductance modulated by an exponential function states "conductance" instead of "current." By fixing the documentation, the conductance based neuron models are consistent so is the unit specified (i.e., nS) in respective documentations.