### PR TITLE
Add deprecation notice to `iaf_cond_alpha_mc` model documentation

### DIFF
--- a/models/iaf_cond_alpha_mc.h
+++ b/models/iaf_cond_alpha_mc.h
@@ -68,9 +68,13 @@ Short description
 
 Multi-compartment conductance-based leaky integrate-and-fire neuron model
 
-
 Description
 +++++++++++
+
+.. admonition:: Deprecated model
+
+   ``iaf_cond_alpha_mc`` is deprecated because cm_default is an improved
+    implementation of compartmental models in NEST (see :doc:`cm_default`).
 
 THIS MODEL IS A PROTOTYPE FOR ILLUSTRATION PURPOSES. IT IS NOT YET
 FULLY TESTED. USE AT YOUR OWN PERIL!

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -115,6 +115,11 @@ Two-compartment point process neuron with conductance-based synapses
 Description
 +++++++++++
 
+.. admonition:: Deprecated model
+
+   ``pp_cond_exp_mc_urbanczik`` is deprecated because cm_default is an improved
+    implementation of compartmental models in NEST (see :doc:`cm_default`).
+
 pp_cond_exp_mc_urbanczik is an implementation of a two-compartment spiking
 point process neuron with conductance-based synapses as it is used
 in [1]_. It is capable of connecting to an :doc:`Urbanczik synapse

--- a/models/pp_cond_exp_mc_urbanczik.h
+++ b/models/pp_cond_exp_mc_urbanczik.h
@@ -115,11 +115,6 @@ Two-compartment point process neuron with conductance-based synapses
 Description
 +++++++++++
 
-.. admonition:: Deprecated model
-
-   ``pp_cond_exp_mc_urbanczik`` is deprecated because cm_default is an improved
-    implementation of compartmental models in NEST (see :doc:`cm_default`).
-
 pp_cond_exp_mc_urbanczik is an implementation of a two-compartment spiking
 point process neuron with conductance-based synapses as it is used
 in [1]_. It is capable of connecting to an :doc:`Urbanczik synapse


### PR DESCRIPTION
Fixes #2461 

Adding deprecation notice to the 'mc' models since the cm_default model is an improved implementation of compartmental neurons, as discussed in issue.

Models should be removed in an upcoming release.
Info about NEAT, once that has progressed could also be added.

See Read the Docs output here: https://nest-simulator--3240.org.readthedocs.build/en/3240/models/iaf_cond_alpha_mc.html