### PR TITLE
Update models with adaptation mechanisms and change tag 'adaptive threshold' to 'adaptation'

### DIFF
--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -68,7 +68,7 @@ extern "C" int aeif_cond_alpha_dynamics( double, const double*, double*, void* )
  */
 extern "C" int aeif_cond_alpha_dynamics_DT0( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, integrate-and-fire, adaptive threshold, conductance-based
+/* BeginUserDocs: neuron, integrate-and-fire, adaptation, conductance-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_cond_alpha_astro.h
+++ b/models/aeif_cond_alpha_astro.h
@@ -68,7 +68,7 @@ extern "C" int aeif_cond_alpha_astro_dynamics( double, const double*, double*, v
  */
 extern "C" int aeif_cond_alpha_astro_dynamics_DT0( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, integrate-and-fire, adaptive threshold, conductance-based, astrocyte
+/* BeginUserDocs: neuron, integrate-and-fire, adaptation, conductance-based, astrocyte
 
 Short description
 +++++++++++++++++

--- a/models/aeif_cond_alpha_multisynapse.h
+++ b/models/aeif_cond_alpha_multisynapse.h
@@ -42,7 +42,7 @@
 #include "ring_buffer.h"
 #include "universal_data_logger.h"
 
-/* BeginUserDocs: neuron, integrate-and-fire, adaptive threshold, conductance-based
+/* BeginUserDocs: neuron, integrate-and-fire, adaptation, conductance-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -56,7 +56,7 @@ namespace nest
  */
 extern "C" int aeif_cond_beta_multisynapse_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, adaptive threshold, integrate-and-fire, conductance-based
+/* BeginUserDocs: neuron, adaptation, integrate-and-fire, conductance-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -68,7 +68,7 @@ extern "C" int aeif_cond_exp_dynamics( double, const double*, double*, void* );
  */
 extern "C" int aeif_cond_exp_dynamics_DT0( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, adaptive threshold, integrate-and-fire, conductance-based
+/* BeginUserDocs: neuron, adaptation, integrate-and-fire, conductance-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -57,7 +57,7 @@ namespace nest
  */
 extern "C" int aeif_psc_alpha_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, adaptive threshold, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, adaptation, integrate-and-fire, current-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_psc_delta.h
+++ b/models/aeif_psc_delta.h
@@ -57,7 +57,7 @@ namespace nest
  */
 extern "C" int aeif_psc_delta_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, adaptive threshold, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, adaptation, integrate-and-fire, current-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_psc_delta_clopath.h
+++ b/models/aeif_psc_delta_clopath.h
@@ -58,7 +58,7 @@ namespace nest
  */
 extern "C" int aeif_psc_delta_clopath_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, adaptive threshold, integrate-and-fire, Clopath plasticity, current-based
+/* BeginUserDocs: neuron, adaptation, integrate-and-fire, Clopath plasticity, current-based
 
 Short description
 +++++++++++++++++

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -57,7 +57,7 @@ namespace nest
  */
 extern "C" int aeif_psc_exp_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, integrate-and-fire, adaptive threshold, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, adaptation, current-based
 
 Short description
 +++++++++++++++++

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -36,7 +36,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/eprop_iaf_adapt_bsshslm_2020.h
+++ b/models/eprop_iaf_adapt_bsshslm_2020.h
@@ -35,7 +35,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, e-prop plasticity, current-based, integrate-and-fire, adaptive threshold
+/* BeginUserDocs: neuron, e-prop plasticity, current-based, integrate-and-fire, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -48,7 +48,7 @@ namespace nest
 
 extern "C" int gif_cond_exp_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, integrate-and-fire, conductance-based
+/* BeginUserDocs: neuron, integrate-and-fire, conductance-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/gif_cond_exp_multisynapse.h
+++ b/models/gif_cond_exp_multisynapse.h
@@ -46,7 +46,7 @@ namespace nest
 
 extern "C" int gif_cond_exp_multisynapse_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, integrate-and-fire, conductance-based
+/* BeginUserDocs: neuron, integrate-and-fire, conductance-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -38,7 +38,7 @@ namespace nest
 
 class Network;
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -35,7 +35,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/gif_psc_exp_multisynapse.h
+++ b/models/gif_psc_exp_multisynapse.h
@@ -35,7 +35,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -42,7 +42,7 @@
 
 #include "dictdatum.h"
 
-/* BeginUserDocs:  neuron, integrate-and-fire, conductance-based
+/* BeginUserDocs:  neuron, integrate-and-fire, conductance-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -32,7 +32,7 @@
 
 #include "dictdatum.h"
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/glif_psc_double_alpha.h
+++ b/models/glif_psc_double_alpha.h
@@ -32,7 +32,7 @@
 
 #include "dictdatum.h"
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/ht_neuron.h
+++ b/models/ht_neuron.h
@@ -63,7 +63,7 @@ namespace nest
  */
 extern "C" int ht_neuron_dynamics( double, const double*, double*, void* );
 
-/* BeginUserDocs: neuron, Hill-Tononi plasticity
+/* BeginUserDocs: neuron, Hill-Tononi plasticity, adaptation, integrate-and-fire
 
 Short description
 +++++++++++++++++
@@ -76,7 +76,7 @@ Description
 This model neuron implements a slightly modified version of the
 neuron model described in [1]_. The most important properties are:
 
-- Integrate-and-fire with threshold adaptive threshold.
+- Integrate-and-fire with adaptive threshold.
 - Repolarizing potassium current instead of hard reset.
 - AMPA, NMDA, GABA_A, and GABA_B conductance-based synapses with
   beta-function (difference of exponentials) time course.

--- a/models/izhikevich.h
+++ b/models/izhikevich.h
@@ -34,7 +34,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, integrate-and-fire
+/* BeginUserDocs: neuron, integrate-and-fire, adaptation
 
 Short description
 +++++++++++++++++
@@ -49,7 +49,7 @@ Implementation of the simple spiking neuron model introduced by Izhikevich
 
 .. math::
    &dV_m/dt = 0.04 {V_m}^2 + 5 V_m + 140 - U_m + I \\
-   &du/dt = a (b V_m - U_m) \\
+   &dU_m/dt = a (b V_m - U_m) \\
 
 .. math::
 

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -36,7 +36,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, integrate-and-fire, current-based
+/* BeginUserDocs: neuron, integrate-and-fire, current-based, adaptation
 
 Short description
 +++++++++++++++++

--- a/models/pp_psc_delta.h
+++ b/models/pp_psc_delta.h
@@ -35,7 +35,7 @@
 namespace nest
 {
 
-/* BeginUserDocs: neuron, point process, current-based
+/* BeginUserDocs: neuron, point process, current-based, adaptation
 
 Short description
 +++++++++++++++++


### PR DESCRIPTION
This PR updates the model tag for models that use an adaptation mechanism to 'adaptation' after discussions with @ddahmen 
The reason is that not all the models have the same adaptation mechanism, and the ones labeled with adaptive threshold (i.e. 'aeif' models) technically do not have an adaptive threshold. 
We were also missing tags for several models that have an adaptation mechanism but were not 'aeif' models.

See Read the Docs output here: https://nest-simulator--3241.org.readthedocs.build/en/3241/models/index.html#adaptation

@shimoura agreed to review, thanks!
