### PR TITLE
Exponential lookup tables for homogenous STDP synapses

### DIFF
--- a/examples/nest/hpc_benchmark.sli
+++ b/examples/nest/hpc_benchmark.sli
@@ -144,7 +144,6 @@ def
     /V_reset 0.0  mV  % Reset Potential (mV)
     /tau_syn_ex   tau_syn % time const. postsynaptic excitatory currents (ms)
     /tau_syn_in   tau_syn % time const. postsynaptic inhibitory currents (ms)
-    /tau_minus 30.0 ms %time constant for STDP (depression)
     % V can be randomly initialized see below
     /V_m 5.7 mV % mean value of membrane potential
   >>
@@ -169,6 +168,7 @@ def
     /lambda 0.1           % STDP step size
     /mu     0.4           % STDP weight dependence exponent (potentiation)
     /tau_plus 15.0        % time constant for potentiation
+    /tau_minus 30.0      %time constant for depression
   >>
 
   /eta 1.685              % scaling of external stimulus

--- a/models/iaf_psc_alpha_hom.cpp
+++ b/models/iaf_psc_alpha_hom.cpp
@@ -1,0 +1,408 @@
+/*
+*  iaf_psc_alpha_hom.cpp
+*
+*  This file is part of NEST.
+*
+*  Copyright (C) 2004 The NEST Initiative
+*
+*  NEST is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  NEST is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#include "iaf_psc_alpha_hom.h"
+
+// C++ includes:
+#include <limits>
+
+// Includes from libnestutil:
+#include "dict_util.h"
+#include "exceptions.h"
+#include "iaf_propagator.h"
+#include "kernel_manager.h"
+#include "nest_impl.h"
+#include "numerics.h"
+#include "ring_buffer_impl.h"
+#include "universal_data_logger_impl.h"
+
+// Includes from sli:
+#include "dictutils.h"
+
+nest::RecordablesMap< nest::iaf_psc_alpha_hom > nest::iaf_psc_alpha_hom::recordablesMap_;
+
+namespace nest
+{
+void
+register_iaf_psc_alpha_hom( const std::string& name )
+{
+ register_node_model< iaf_psc_alpha_hom >( name );
+}
+
+
+/*
+* Override the create() method with one call to RecordablesMap::insert_()
+* for each quantity to be recorded.
+*/
+template <>
+void
+RecordablesMap< iaf_psc_alpha_hom >::create()
+{
+ // use standard names wherever you can for consistency!
+ insert_( names::V_m, &iaf_psc_alpha_hom::get_V_m_ );
+ insert_( names::I_syn_ex, &iaf_psc_alpha_hom::get_I_syn_ex_ );
+ insert_( names::I_syn_in, &iaf_psc_alpha_hom::get_I_syn_in_ );
+}
+
+/* ----------------------------------------------------------------
+* Default constructors defining default parameters and state
+* ---------------------------------------------------------------- */
+
+iaf_psc_alpha_hom::Parameters_::Parameters_()
+ : Tau_( 10.0 )             // ms
+ , C_( 250.0 )              // pF
+ , TauR_( 2.0 )             // ms
+ , E_L_( -70.0 )            // mV
+ , I_e_( 0.0 )              // pA
+ , V_reset_( -70.0 - E_L_ ) // mV, rel to E_L_
+ , Theta_( -55.0 - E_L_ )   // mV, rel to E_L_
+ , LowerBound_( -std::numeric_limits< double >::infinity() )
+ , tau_ex_( 2.0 ) // ms
+ , tau_in_( 2.0 ) // ms
+{
+}
+
+iaf_psc_alpha_hom::State_::State_()
+ : y0_( 0.0 )
+ , dI_ex_( 0.0 )
+ , I_ex_( 0.0 )
+ , dI_in_( 0.0 )
+ , I_in_( 0.0 )
+ , y3_( 0.0 )
+ , r_( 0 )
+{
+}
+
+/* ----------------------------------------------------------------
+* Parameter and state extractions and manipulation functions
+* ---------------------------------------------------------------- */
+
+void
+iaf_psc_alpha_hom::Parameters_::get( DictionaryDatum& d ) const
+{
+ def< double >( d, names::E_L, E_L_ ); // Resting potential
+ def< double >( d, names::I_e, I_e_ );
+ def< double >( d, names::V_th, Theta_ + E_L_ ); // threshold value
+ def< double >( d, names::V_reset, V_reset_ + E_L_ );
+ def< double >( d, names::V_min, LowerBound_ + E_L_ );
+ def< double >( d, names::C_m, C_ );
+ def< double >( d, names::tau_m, Tau_ );
+ def< double >( d, names::t_ref, TauR_ );
+ def< double >( d, names::tau_syn_ex, tau_ex_ );
+ def< double >( d, names::tau_syn_in, tau_in_ );
+}
+
+double
+iaf_psc_alpha_hom::Parameters_::set( const DictionaryDatum& d, Node* node )
+{
+ // if E_L_ is changed, we need to adjust all variables defined relative to
+ // E_L_
+ const double ELold = E_L_;
+ updateValueParam< double >( d, names::E_L, E_L_, node );
+ const double delta_EL = E_L_ - ELold;
+
+ if ( updateValueParam< double >( d, names::V_reset, V_reset_, node ) )
+ {
+   V_reset_ -= E_L_;
+ }
+ else
+ {
+   V_reset_ -= delta_EL;
+ }
+
+ if ( updateValueParam< double >( d, names::V_th, Theta_, node ) )
+ {
+   Theta_ -= E_L_;
+ }
+ else
+ {
+   Theta_ -= delta_EL;
+ }
+
+ if ( updateValueParam< double >( d, names::V_min, LowerBound_, node ) )
+ {
+   LowerBound_ -= E_L_;
+ }
+ else
+ {
+   LowerBound_ -= delta_EL;
+ }
+
+ updateValueParam< double >( d, names::I_e, I_e_, node );
+ updateValueParam< double >( d, names::C_m, C_, node );
+ updateValueParam< double >( d, names::tau_m, Tau_, node );
+ updateValueParam< double >( d, names::tau_syn_ex, tau_ex_, node );
+ updateValueParam< double >( d, names::tau_syn_in, tau_in_, node );
+ updateValueParam< double >( d, names::t_ref, TauR_, node );
+
+ if ( C_ <= 0.0 )
+ {
+   throw BadProperty( "Capacitance must be > 0." );
+ }
+
+ if ( Tau_ <= 0.0 )
+ {
+   throw BadProperty( "Membrane time constant must be > 0." );
+ }
+
+ if ( tau_ex_ <= 0.0 or tau_in_ <= 0.0 )
+ {
+   throw BadProperty( "All synaptic time constants must be > 0." );
+ }
+
+ if ( TauR_ < 0.0 )
+ {
+   throw BadProperty( "The refractory time t_ref can't be negative." );
+ }
+ if ( V_reset_ >= Theta_ )
+ {
+   throw BadProperty( "Reset potential must be smaller than threshold." );
+ }
+
+ return delta_EL;
+}
+
+void
+iaf_psc_alpha_hom::State_::get( DictionaryDatum& d, const Parameters_& p ) const
+{
+ def< double >( d, names::V_m, y3_ + p.E_L_ ); // Membrane potential
+}
+
+void
+iaf_psc_alpha_hom::State_::set( const DictionaryDatum& d, const Parameters_& p, double delta_EL, Node* node )
+{
+ if ( updateValueParam< double >( d, names::V_m, y3_, node ) )
+ {
+   y3_ -= p.E_L_;
+ }
+ else
+ {
+   y3_ -= delta_EL;
+ }
+}
+
+iaf_psc_alpha_hom::Buffers_::Buffers_( iaf_psc_alpha_hom& n )
+ : logger_( n )
+{
+}
+
+iaf_psc_alpha_hom::Buffers_::Buffers_( const Buffers_&, iaf_psc_alpha_hom& n )
+ : logger_( n )
+{
+}
+
+
+/* ----------------------------------------------------------------
+* Default and copy constructor for node
+* ---------------------------------------------------------------- */
+
+iaf_psc_alpha_hom::iaf_psc_alpha_hom()
+ : ArchivingNodeHom()
+ , P_()
+ , S_()
+ , B_( *this )
+{
+ recordablesMap_.create();
+}
+
+iaf_psc_alpha_hom::iaf_psc_alpha_hom( const iaf_psc_alpha_hom& n )
+ : ArchivingNodeHom( n )
+ , P_( n.P_ )
+ , S_( n.S_ )
+ , B_( n.B_, *this )
+{
+}
+
+/* ----------------------------------------------------------------
+* Node initialization functions
+* ---------------------------------------------------------------- */
+
+void
+iaf_psc_alpha_hom::init_buffers_()
+{
+ B_.input_buffer_.clear(); // includes resize
+
+ B_.logger_.reset();
+
+ ArchivingNodeHom::clear_history();
+}
+
+void
+iaf_psc_alpha_hom::pre_run_hook()
+{
+ // ensures initialization in case mm connected after Simulate
+ B_.logger_.init();
+
+ const double h = Time::get_resolution().get_ms();
+
+ // these P are independent
+ V_.P11_ex_ = V_.P22_ex_ = std::exp( -h / P_.tau_ex_ );
+ V_.P11_in_ = V_.P22_in_ = std::exp( -h / P_.tau_in_ );
+
+ V_.P33_ = std::exp( -h / P_.Tau_ );
+
+ V_.expm1_tau_m_ = numerics::expm1( -h / P_.Tau_ );
+
+ // these depend on the above. Please do not change the order.
+ V_.P30_ = -P_.Tau_ / P_.C_ * numerics::expm1( -h / P_.Tau_ );
+ V_.P21_ex_ = h * V_.P11_ex_;
+ V_.P21_in_ = h * V_.P11_in_;
+
+ // these are determined according to a numeric stability criterion
+ std::tie( V_.P31_ex_, V_.P32_ex_ ) = IAFPropagatorAlpha( P_.tau_ex_, P_.Tau_, P_.C_ ).evaluate( h );
+ std::tie( V_.P31_in_, V_.P32_in_ ) = IAFPropagatorAlpha( P_.tau_in_, P_.Tau_, P_.C_ ).evaluate( h );
+
+ V_.EPSCInitialValue_ = 1.0 * numerics::e / P_.tau_ex_;
+ V_.IPSCInitialValue_ = 1.0 * numerics::e / P_.tau_in_;
+
+ // TauR specifies the length of the absolute refractory period as
+ // a double in ms. The grid based iaf_psc_alpha can only handle refractory
+ // periods that are integer multiples of the computation step size (h).
+ // To ensure consistency with the overall simulation scheme such conversion
+ // should be carried out via objects of class nest::Time. The conversion
+ // requires 2 steps:
+ //     1. A time object is constructed defining representation of
+ //        TauR in tics. This representation is then converted to computation
+ //        time steps again by a strategy defined by class nest::Time.
+ //     2. The refractory time in units of steps is read out get_steps(), a
+ //        member function of class nest::Time.
+ //
+ // The definition of the refractory period of the iaf_psc_alpha is consistent
+ // the one of iaf_psc_alpha_ps.
+ //
+ // Choosing a TauR that is not an integer multiple of the computation time
+ // step h will lead to accurate (up to the resolution h) and self-consistent
+ // results. However, a neuron model capable of operating with real valued
+ // spike time may exhibit a different effective refractory time.
+
+ V_.RefractoryCounts_ = Time( Time::ms( P_.TauR_ ) ).get_steps();
+ // since t_ref_ >= 0, this can only fail in error
+ assert( V_.RefractoryCounts_ >= 0 );
+}
+
+/* ----------------------------------------------------------------
+* Update and spike handling functions
+*/
+
+void
+iaf_psc_alpha_hom::update( Time const& origin, const long from, const long to )
+{
+ for ( long lag = from; lag < to; ++lag )
+ {
+   if ( S_.r_ == 0 )
+   {
+     // neuron not refractory
+     S_.y3_ = V_.P30_ * ( S_.y0_ + P_.I_e_ ) + V_.P31_ex_ * S_.dI_ex_ + V_.P32_ex_ * S_.I_ex_ + V_.P31_in_ * S_.dI_in_
+       + V_.P32_in_ * S_.I_in_ + V_.expm1_tau_m_ * S_.y3_ + S_.y3_;
+
+     // lower bound of membrane potential
+     S_.y3_ = ( S_.y3_ < P_.LowerBound_ ? P_.LowerBound_ : S_.y3_ );
+   }
+   else
+   {
+     // neuron is absolute refractory
+     --S_.r_;
+   }
+
+   // alpha shape EPSCs
+   S_.I_ex_ = V_.P21_ex_ * S_.dI_ex_ + V_.P22_ex_ * S_.I_ex_;
+   S_.dI_ex_ *= V_.P11_ex_;
+
+   // get read access to the correct input-buffer slot
+   const size_t input_buffer_slot = kernel().event_delivery_manager.get_modulo( lag );
+   auto& input = B_.input_buffer_.get_values_all_channels( input_buffer_slot );
+
+   // Apply spikes delivered in this step; spikes arriving at T+1 have
+   // an immediate effect on the state of the neuron
+   V_.weighted_spikes_ex_ = input[ Buffers_::SYN_EX ];
+   S_.dI_ex_ += V_.EPSCInitialValue_ * V_.weighted_spikes_ex_;
+
+   // alpha shape EPSCs
+   S_.I_in_ = V_.P21_in_ * S_.dI_in_ + V_.P22_in_ * S_.I_in_;
+   S_.dI_in_ *= V_.P11_in_;
+
+   // Apply spikes delivered in this step; spikes arriving at T+1 have
+   // an immediate effect on the state of the neuron
+   V_.weighted_spikes_in_ = input[ Buffers_::SYN_IN ];
+   S_.dI_in_ += V_.IPSCInitialValue_ * V_.weighted_spikes_in_;
+
+   // threshold crossing
+   if ( S_.y3_ >= P_.Theta_ )
+   {
+     S_.r_ = V_.RefractoryCounts_;
+     S_.y3_ = P_.V_reset_;
+     // A supra-threshold membrane potential should never be observable.
+     // The reset at the time of threshold crossing enables accurate
+     // integration independent of the computation step size, see [2,3] for
+     // details.
+
+     set_spiketime( Time::step( origin.get_steps() + lag + 1 ) );
+     SpikeEvent se;
+     kernel().event_delivery_manager.send( *this, se, lag );
+   }
+
+   // set new input current
+   S_.y0_ = input[ Buffers_::I0 ];
+
+   // reset all values in the currently processed input-buffer slot
+   B_.input_buffer_.reset_values_all_channels( input_buffer_slot );
+
+   // log state data
+   B_.logger_.record_data( origin.get_steps() + lag );
+ }
+}
+
+void
+iaf_psc_alpha_hom::handle( SpikeEvent& e )
+{
+ assert( e.get_delay_steps() > 0 );
+
+ const size_t input_buffer_slot = kernel().event_delivery_manager.get_modulo(
+   e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ) );
+
+ const double s = e.get_weight() * e.get_multiplicity();
+
+ // separate buffer channels for excitatory and inhibitory inputs
+ B_.input_buffer_.add_value( input_buffer_slot, s > 0 ? Buffers_::SYN_EX : Buffers_::SYN_IN, s );
+}
+
+void
+iaf_psc_alpha_hom::handle( CurrentEvent& e )
+{
+ assert( e.get_delay_steps() > 0 );
+
+ const size_t input_buffer_slot = kernel().event_delivery_manager.get_modulo(
+   e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ) );
+
+ const double I = e.get_current();
+ const double w = e.get_weight();
+
+ B_.input_buffer_.add_value( input_buffer_slot, Buffers_::I0, w * I );
+}
+
+void
+iaf_psc_alpha_hom::handle( DataLoggingRequest& e )
+{
+ B_.logger_.handle( e );
+}
+
+} // namespace

--- a/models/iaf_psc_alpha_hom.h
+++ b/models/iaf_psc_alpha_hom.h
@@ -1,0 +1,487 @@
+/*
+*  iaf_psc_alpha_hom.h
+*
+*  This file is part of NEST.
+*
+*  Copyright (C) 2004 The NEST Initiative
+*
+*  NEST is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  NEST is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+#ifndef IAF_PSC_ALPHA_HOM_H
+#define IAF_PSC_ALPHA_HOM_H
+
+// Includes from nestkernel:
+#include "archiving_node_hom.h"
+#include "connection.h"
+#include "event.h"
+#include "nest_types.h"
+#include "recordables_map.h"
+#include "ring_buffer.h"
+#include "universal_data_logger.h"
+
+namespace nest
+{
+// Disable clang-formatting for documentation due to over-wide table.
+// clang-format off
+/* BeginUserDocs: neuron, integrate-and-fire, current-based
+
+Short description
++++++++++++++++++
+
+Leaky integrate-and-fire model with alpha-shaped input currents
+
+Description
++++++++++++
+
+``iaf_psc_alpha_hom`` is a leaky integrate-and-fire neuron model with
+
+* a hard threshold,
+* a fixed refractory period,
+* no adaptation mechanisms,
+ * exponential lookup tables for efficiency,
+* :math:`\alpha`-shaped synaptic input currents.
+
+Membrane potential evolution, spike emission, and refractoriness
+................................................................
+
+The membrane potential evolves according to
+
+.. math::
+
+  \frac{dV_\text{m}}{dt} = -\frac{V_{\text{m}} - E_\text{L}}{\tau_{\text{m}}} + \frac{I_{\text{syn}} + I_\text{e}}{C_{\text{m}}}
+
+where the synaptic input current :math:`I_{\text{syn}}(t)` is discussed below and :math:`I_\text{e}` is
+a constant input current set as a model parameter.
+
+A spike is emitted at time step :math:`t^*=t_{k+1}` if
+
+.. math::
+
+  V_\text{m}(t_k) < V_{th} \quad\text{and}\quad V_\text{m}(t_{k+1})\geq V_\text{th} \;.
+
+Subsequently,
+
+.. math::
+
+  V_\text{m}(t) = V_{\text{reset}} \quad\text{for}\quad t^* \leq t < t^* + t_{\text{ref}} \;,
+
+that is, the membrane potential is clamped to :math:`V_{\text{reset}}` during the refractory period.
+
+Synaptic input
+..............
+
+The synaptic input current has an excitatory and an inhibitory component
+
+.. math::
+
+  I_{\text{syn}}(t) = I_{\text{syn, ex}}(t) + I_{\text{syn, in}}(t)
+
+where
+
+.. math::
+
+  I_{\text{syn, X}}(t) = \sum_{j} w_j \sum_k i_{\text{syn, X}}(t-t_j^k-d_j) \;,
+
+where :math:`j` indexes either excitatory (:math:`\text{X} = \text{ex}`)
+or inhibitory (:math:`\text{X} = \text{in}`) presynaptic neurons,
+:math:`k` indexes the spike times of neuron :math:`j`, and :math:`d_j`
+is the delay from neuron :math:`j`.
+
+The individual post-synaptic currents (PSCs) are given by
+
+.. math::
+
+  i_{\text{syn, X}}(t) = \frac{e}{\tau_{\text{syn, X}}} t e^{-\frac{t}{\tau_{\text{syn, X}}}} \Theta(t)
+
+where :math:`\Theta(x)` is the Heaviside step function. The PSCs are normalized to unit maximum, that is,
+
+.. math::
+
+  i_{\text{syn, X}}(t= \tau_{\text{syn, X}}) = 1 \;.
+
+As a consequence, the total charge :math:`q` transferred by a single PSC depends
+on the synaptic time constant according to
+
+.. math::
+
+  q = \int_0^{\infty}  i_{\text{syn, X}}(t) dt = e \tau_{\text{syn, X}} \;.
+
+By default, :math:`V_\text{m}` is not bounded from below. To limit
+hyperpolarization to biophysically plausible values, set parameter
+:math:`V_{\text{min}}` as lower bound of :math:`V_\text{m}`.
+
+.. note::
+
+  NEST uses exact integration [1]_, [2]_ to integrate subthreshold membrane
+  dynamics with maximum precision; see also [3]_.
+
+  If :math:`\tau_\text{m}\approx \tau_{\text{syn, ex}}` or
+  :math:`\tau_\text{m}\approx \tau_{\text{syn, in}}`, the model will
+  numerically behave as if :math:`\tau_\text{m} = \tau_{\text{syn, ex}}` or
+  :math:`\tau_\text{m} = \tau_{\text{syn, in}}`, respectively, to avoid
+  numerical instabilities.
+
+  For implementation details see the
+  `IAF Integration Singularity notebook <../model_details/IAF_Integration_Singularity.ipynb>`_.
+
+
+Parameters
+++++++++++
+
+The following parameters can be set in the status dictionary.
+
+=============== ================== =============================== ========================================================================
+**Parameter**   **Default**        **Math equivalent**             **Description**
+=============== ================== =============================== ========================================================================
+``E_L``         -70 mV             :math:`E_\text{L}`              Resting membrane potential
+``C_m``         250 pF             :math:`C_{\text{m}}`            Capacity of the membrane
+``tau_m``       10 ms              :math:`\tau_{\text{m}}`         Membrane time constant
+``t_ref``       2 ms               :math:`t_{\text{ref}}`          Duration of refractory period
+``V_th``        -55 mV             :math:`V_{\text{th}}`           Spike threshold
+``V_reset``     -70 mV             :math:`V_{\text{reset}}`        Reset potential of the membrane
+``tau_syn_ex``  2 ms               :math:`\tau_{\text{syn, ex}}`   Rise time of the excitatory synaptic alpha function
+``tau_syn_in``  2 ms               :math:`\tau_{\text{syn, in}}`   Rise time of the inhibitory synaptic alpha function
+``I_e``         0 pA               :math:`I_\text{e}`              Constant input current
+``V_min``       :math:`-\infty` mV :math:`V_{\text{min}}`          Absolute lower value for the membrane potential
+=============== ================== =============================== ========================================================================
+
+The following state variables evolve during simulation and are available either as neuron properties or as recordables.
+
+================== ================= ========================== =================================
+**State variable** **Initial value** **Math equivalent**        **Description**
+================== ================= ========================== =================================
+``V_m``            -70 mV            :math:`V_{\text{m}}`       Membrane potential
+``I_syn_ex``       0 pA              :math:`I_{\text{syn, ex}}` Excitatory synaptic input current
+``I_syn_in``       0 pA              :math:`I_{\text{syn, in}}` Inhibitory synaptic input current
+================== ================= ========================== =================================
+
+
+References
+++++++++++
+
+.. [1] Rotter S,  Diesmann M (1999). Exact simulation of
+      time-invariant linear systems with applications to neuronal
+      modeling. Biologial Cybernetics 81:381-402.
+      DOI: https://doi.org/10.1007/s004220050570
+.. [2] Diesmann M, Gewaltig M-O, Rotter S, & Aertsen A (2001). State
+      space analysis of synchronous spiking in cortical neural
+      networks. Neurocomputing 38-40:565-571.
+      DOI: https://doi.org/10.1016/S0925-2312(01)00409-X
+.. [3] Morrison A, Straube S, Plesser H E, Diesmann M (2006). Exact
+      subthreshold integration with continuous spike times in discrete time
+      neural network simulations. Neural Computation, in press
+      DOI: https://doi.org/10.1162/neco.2007.19.1.47
+
+Sends
++++++
+
+SpikeEvent
+
+Receives
+++++++++
+
+SpikeEvent, CurrentEvent, DataLoggingRequest
+
+See also
+++++++++
+
+iaf_psc_delta, iaf_psc_exp, iaf_cond_exp
+
+
+Examples using this model
++++++++++++++++++++++++++
+
+.. listexamples:: iaf_psc_alpha_hom
+
+EndUserDocs */
+// clang-format on
+
+void register_iaf_psc_alpha_hom( const std::string& name );
+
+class iaf_psc_alpha_hom : public ArchivingNodeHom
+{
+
+public:
+ iaf_psc_alpha_hom();
+ iaf_psc_alpha_hom( const iaf_psc_alpha_hom& );
+
+ /**
+  * Import sets of overloaded virtual functions.
+  * @see Technical Issues / Virtual Functions: Overriding, Overloading, and
+  * Hiding
+  */
+ using Node::handle;
+ using Node::handles_test_event;
+
+ size_t send_test_event( Node&, size_t, synindex, bool ) override;
+
+ void handle( SpikeEvent& ) override;
+ void handle( CurrentEvent& ) override;
+ void handle( DataLoggingRequest& ) override;
+
+ size_t handles_test_event( SpikeEvent&, size_t ) override;
+ size_t handles_test_event( CurrentEvent&, size_t ) override;
+ size_t handles_test_event( DataLoggingRequest&, size_t ) override;
+
+ void get_status( DictionaryDatum& ) const override;
+ void set_status( const DictionaryDatum& ) override;
+
+private:
+ void init_buffers_() override;
+ void pre_run_hook() override;
+
+ void update( Time const&, const long, const long ) override;
+
+ // The next two classes need to be friends to access the State_ class/member
+ friend class RecordablesMap< iaf_psc_alpha_hom >;
+ friend class UniversalDataLogger< iaf_psc_alpha_hom >;
+
+ // ----------------------------------------------------------------
+
+ struct Parameters_
+ {
+   /** Membrane time constant in ms. */
+   double Tau_;
+
+   /** Membrane capacitance in pF. */
+   double C_;
+
+   /** Refractory period in ms. */
+   double TauR_;
+
+   /** Resting potential in mV. */
+   double E_L_;
+
+   /** External current in pA */
+   double I_e_;
+
+   /** Reset value of the membrane potential */
+   double V_reset_;
+
+   /** Threshold, RELATIVE TO RESTING POTENTIAL(!).
+       I.e. the real threshold is (E_L_+Theta_). */
+   double Theta_;
+
+   /** Lower bound, RELATIVE TO RESTING POTENTIAL(!).
+       I.e. the real lower bound is (LowerBound_+E_L_). */
+   double LowerBound_;
+
+   /** Time constant of excitatory synaptic current in ms. */
+   double tau_ex_;
+
+   /** Time constant of inhibitory synaptic current in ms. */
+   double tau_in_;
+
+   Parameters_(); //!< Sets default parameter values
+
+   void get( DictionaryDatum& ) const; //!< Store current values in dictionary
+
+   /** Set values from dictionary.
+    * @returns Change in reversal potential E_L, to be passed to State_::set()
+    */
+   double set( const DictionaryDatum&, Node* node );
+ };
+
+ // ----------------------------------------------------------------
+
+ struct State_
+ {
+   double y0_; //!< Constant current
+   double dI_ex_;
+   double I_ex_;
+   double dI_in_;
+   double I_in_;
+   //! This is the membrane potential RELATIVE TO RESTING POTENTIAL.
+   double y3_;
+
+   int r_; //!< Number of refractory steps remaining
+
+   State_(); //!< Default initialization
+
+   void get( DictionaryDatum&, const Parameters_& ) const;
+
+   /** Set values from dictionary.
+    * @param dictionary to take data from
+    * @param current parameters
+    * @param Change in reversal potential E_L specified by this dict
+    */
+   void set( const DictionaryDatum&, const Parameters_&, double, Node* node );
+ };
+
+ // ----------------------------------------------------------------
+
+ struct Buffers_
+ {
+
+   Buffers_( iaf_psc_alpha_hom& );
+   Buffers_( const Buffers_&, iaf_psc_alpha_hom& );
+
+   //! Indices for access to different channels of input_buffer_
+   enum
+   {
+     SYN_IN = 0,
+     SYN_EX,
+     I0,
+     NUM_INPUT_CHANNELS
+   };
+
+   /** buffers and sums up incoming spikes/currents */
+   MultiChannelInputBuffer< NUM_INPUT_CHANNELS > input_buffer_;
+
+   //! Logger for all analog data
+   UniversalDataLogger< iaf_psc_alpha_hom > logger_;
+ };
+
+ // ----------------------------------------------------------------
+
+ struct Variables_
+ {
+
+   /** Amplitude of the synaptic current.
+       This value is chosen such that a postsynaptic potential with
+       weight one has an amplitude of 1 mV.
+    */
+   double EPSCInitialValue_;
+   double IPSCInitialValue_;
+   int RefractoryCounts_;
+
+   double P11_ex_;
+   double P21_ex_;
+   double P22_ex_;
+   double P31_ex_;
+   double P32_ex_;
+   double P11_in_;
+   double P21_in_;
+   double P22_in_;
+   double P31_in_;
+   double P32_in_;
+   double P30_;
+   double P33_;
+   double expm1_tau_m_;
+
+   double weighted_spikes_ex_;
+   double weighted_spikes_in_;
+ };
+
+ // Access functions for UniversalDataLogger -------------------------------
+
+ //! Read out the real membrane potential
+ inline double
+ get_V_m_() const
+ {
+   return S_.y3_ + P_.E_L_;
+ }
+
+ inline double
+ get_I_syn_ex_() const
+ {
+   return S_.I_ex_;
+ }
+
+ inline double
+ get_I_syn_in_() const
+ {
+   return S_.I_in_;
+ }
+
+ // Data members -----------------------------------------------------------
+
+ /**
+  * Instances of private data structures for the different types
+  * of data pertaining to the model.
+  * @note The order of definitions is important for speed.
+  * @{
+  */
+ Parameters_ P_;
+ State_ S_;
+ Variables_ V_;
+ Buffers_ B_;
+ /** @} */
+
+ //! Mapping of recordables names to access functions
+ static RecordablesMap< iaf_psc_alpha_hom > recordablesMap_;
+};
+
+inline size_t
+nest::iaf_psc_alpha_hom::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+{
+ SpikeEvent e;
+ e.set_sender( *this );
+ return target.handles_test_event( e, receptor_type );
+}
+
+inline size_t
+iaf_psc_alpha_hom::handles_test_event( SpikeEvent&, size_t receptor_type )
+{
+ if ( receptor_type != 0 )
+ {
+   throw UnknownReceptorType( receptor_type, get_name() );
+ }
+ return 0;
+}
+
+inline size_t
+iaf_psc_alpha_hom::handles_test_event( CurrentEvent&, size_t receptor_type )
+{
+ if ( receptor_type != 0 )
+ {
+   throw UnknownReceptorType( receptor_type, get_name() );
+ }
+ return 0;
+}
+
+inline size_t
+iaf_psc_alpha_hom::handles_test_event( DataLoggingRequest& dlr, size_t receptor_type )
+{
+ if ( receptor_type != 0 )
+ {
+   throw UnknownReceptorType( receptor_type, get_name() );
+ }
+ return B_.logger_.connect_logging_device( dlr, recordablesMap_ );
+}
+
+inline void
+iaf_psc_alpha_hom::get_status( DictionaryDatum& d ) const
+{
+ P_.get( d );
+ S_.get( d, P_ );
+ ArchivingNodeHom::get_status( d );
+
+ ( *d )[ names::recordables ] = recordablesMap_.get_list();
+}
+
+inline void
+iaf_psc_alpha_hom::set_status( const DictionaryDatum& d )
+{
+ Parameters_ ptmp = P_;                       // temporary copy in case of errors
+ const double delta_EL = ptmp.set( d, this ); // throws if BadProperty
+ State_ stmp = S_;                            // temporary copy in case of errors
+ stmp.set( d, ptmp, delta_EL, this );         // throws if BadProperty
+
+ // We now know that (ptmp, stmp) are consistent. We do not
+ // write them back to (P_, S_) before we are also sure that
+ // the properties to be set in the parent class are internally
+ // consistent.
+ ArchivingNodeHom::set_status( d );
+
+ // if we get here, temporaries contain consistent set of properties
+ P_ = ptmp;
+ S_ = stmp;
+}
+
+} // namespace
+
+#endif /* #ifndef IAF_PSC_ALPHA_HOM_H */

--- a/models/stdp_pl_synapse_hom.cpp
+++ b/models/stdp_pl_synapse_hom.cpp
@@ -48,8 +48,6 @@ STDPPLHomCommonProperties::STDPPLHomCommonProperties()
   : CommonSynapseProperties()
   , tau_plus_( 20.0 )
   , tau_minus_( 20.0 )
-  , minus_tau_plus_inv_( -1. / tau_plus_ )
-  , minus_tau_minus_inv_( -1. / tau_minus_ )
   , lambda_( 0.1 )
   , alpha_( 1.0 )
   , mu_( 0.4 )
@@ -79,7 +77,6 @@ STDPPLHomCommonProperties::set_status( const DictionaryDatum& d, ConnectorModel&
   {
     if ( tau_plus_ > 0. )
     {
-      minus_tau_plus_inv_ = -1. / tau_plus_;
       init_exp_tau_plus();
     }
     else
@@ -92,7 +89,6 @@ STDPPLHomCommonProperties::set_status( const DictionaryDatum& d, ConnectorModel&
   {
     if ( tau_minus_ > 0. )
     {
-      minus_tau_minus_inv_ = -1. / tau_minus_;
       init_exp_tau_minus();
     }
     else
@@ -109,23 +105,30 @@ STDPPLHomCommonProperties::set_status( const DictionaryDatum& d, ConnectorModel&
 void
 STDPPLHomCommonProperties::init_exp_tau_plus()
 {
-  // TODO if resolution is changed, the look-up table needs to be recomputed
-  exp_tau_plus_.resize( 10000, 0.0 );
-  for ( unsigned long dt = 0 ; dt < exp_tau_plus_.size() ; ++dt )
+  const auto minus_tau_plus_inv_ = -1. / tau_plus_;
+  exp_tau_plus_.resize( EXP_LOOKUP_SIZE, 0.0 );
+  for ( unsigned long dt = 0; dt < exp_tau_plus_.size(); ++dt )
   {
-    exp_tau_plus_[dt] = std::exp( Time( Time::step(dt) ).get_ms() * minus_tau_plus_inv_ );
+    exp_tau_plus_[ dt ] = std::exp( Time( Time::step( dt ) ).get_ms() * minus_tau_plus_inv_ );
   }
 }
 
 void
 STDPPLHomCommonProperties::init_exp_tau_minus()
 {
-  // TODO if resolution is changed, the look-up table needs to be recomputed
-  exp_tau_minus_.resize( 10000, 0.0 );
-  for ( unsigned long dt = 0 ; dt < exp_tau_minus_.size() ; ++dt )
+  const auto minus_tau_minus_inv_ = -1. / tau_minus_;
+  exp_tau_minus_.resize( EXP_LOOKUP_SIZE, 0.0 );
+  for ( unsigned long dt = 0; dt < exp_tau_minus_.size(); ++dt )
   {
-    exp_tau_minus_[dt] = std::exp( Time( Time::step( dt ) ).get_ms() * minus_tau_minus_inv_ );
+    exp_tau_minus_[ dt ] = std::exp( Time( Time::step( dt ) ).get_ms() * minus_tau_minus_inv_ );
   }
+}
+
+void
+STDPPLHomCommonProperties::calibrate( const TimeConverter& )
+{
+  init_exp_tau_minus();
+  init_exp_tau_plus();
 }
 
 } // of namespace nest

--- a/models/stdp_pl_synapse_hom.cpp
+++ b/models/stdp_pl_synapse_hom.cpp
@@ -47,11 +47,15 @@ namespace nest
 STDPPLHomCommonProperties::STDPPLHomCommonProperties()
   : CommonSynapseProperties()
   , tau_plus_( 20.0 )
-  , tau_plus_inv_( 1. / tau_plus_ )
+  , tau_minus_( 20.0 )
+  , minus_tau_plus_inv_( -1. / tau_plus_ )
+  , minus_tau_minus_inv_( -1. / tau_minus_ )
   , lambda_( 0.1 )
   , alpha_( 1.0 )
   , mu_( 0.4 )
 {
+  init_exp_tau_plus();
+  init_exp_tau_minus();
 }
 
 void
@@ -60,6 +64,7 @@ STDPPLHomCommonProperties::get_status( DictionaryDatum& d ) const
   CommonSynapseProperties::get_status( d );
 
   def< double >( d, names::tau_plus, tau_plus_ );
+  def< double >( d, names::tau_minus, tau_minus_ );
   def< double >( d, names::lambda, lambda_ );
   def< double >( d, names::alpha, alpha_ );
   def< double >( d, names::mu, mu_ );
@@ -70,18 +75,57 @@ STDPPLHomCommonProperties::set_status( const DictionaryDatum& d, ConnectorModel&
 {
   CommonSynapseProperties::set_status( d, cm );
 
-  updateValue< double >( d, names::tau_plus, tau_plus_ );
-  if ( tau_plus_ > 0. )
+  if ( updateValue< double >( d, names::tau_plus, tau_plus_ ) )
   {
-    tau_plus_inv_ = 1. / tau_plus_;
+    if ( tau_plus_ > 0. )
+    {
+      minus_tau_plus_inv_ = -1. / tau_plus_;
+      init_exp_tau_plus();
+    }
+    else
+    {
+      throw BadProperty( "tau_plus > 0. required." );
+    }
   }
-  else
+
+  if ( updateValue< double >( d, names::tau_minus, tau_minus_ ) )
   {
-    throw BadProperty( "tau_plus > 0. required." );
+    if ( tau_minus_ > 0. )
+    {
+      minus_tau_minus_inv_ = -1. / tau_minus_;
+      init_exp_tau_minus();
+    }
+    else
+    {
+      throw BadProperty( "tau_minus > 0. required." );
+    }
   }
+
   updateValue< double >( d, names::lambda, lambda_ );
   updateValue< double >( d, names::alpha, alpha_ );
   updateValue< double >( d, names::mu, mu_ );
+}
+
+void
+STDPPLHomCommonProperties::init_exp_tau_plus()
+{
+  // TODO if resolution is changed, the look-up table needs to be recomputed
+  exp_tau_plus_.resize( 10000, 0.0 );
+  for ( unsigned long dt = 0 ; dt < exp_tau_plus_.size() ; ++dt )
+  {
+    exp_tau_plus_[dt] = std::exp( Time( Time::step(dt) ).get_ms() * minus_tau_plus_inv_ );
+  }
+}
+
+void
+STDPPLHomCommonProperties::init_exp_tau_minus()
+{
+  // TODO if resolution is changed, the look-up table needs to be recomputed
+  exp_tau_minus_.resize( 10000, 0.0 );
+  for ( unsigned long dt = 0 ; dt < exp_tau_minus_.size() ; ++dt )
+  {
+    exp_tau_minus_[dt] = std::exp( Time( Time::step( dt ) ).get_ms() * minus_tau_minus_inv_ );
+  }
 }
 
 } // of namespace nest

--- a/models/stdp_pl_synapse_hom.h
+++ b/models/stdp_pl_synapse_hom.h
@@ -98,6 +98,7 @@ EndUserDocs */
  */
 class STDPPLHomCommonProperties : public CommonSynapseProperties
 {
+  constexpr static size_t EXP_LOOKUP_SIZE = 10000;
 
 public:
   /**
@@ -122,11 +123,11 @@ public:
   double get_exp_tau_plus( const long dt_steps ) const;
   double get_exp_tau_minus( const long dt_steps ) const;
 
+  void calibrate( const TimeConverter& );
+
   // data members common to all connections
   double tau_plus_;
   double tau_minus_;
-  double minus_tau_plus_inv_;  //!< - 1 / tau_plus for efficiency
-  double minus_tau_minus_inv_; //!< - 1 / tau_minus for efficiency
   double lambda_;
   double alpha_;
   double mu_;
@@ -146,6 +147,7 @@ STDPPLHomCommonProperties::get_exp_tau_plus( const long dt_steps ) const
   }
   else
   {
+    const auto minus_tau_plus_inv_ = -1. / tau_plus_;
     return std::exp( Time( Time::step( dt_steps ) ).get_ms() * minus_tau_plus_inv_ );
   }
 }
@@ -159,6 +161,7 @@ STDPPLHomCommonProperties::get_exp_tau_minus( const long dt_steps ) const
   }
   else
   {
+    const auto minus_tau_minus_inv_ = -1. / tau_minus_;
     return std::exp( Time( Time::step( dt_steps ) ).get_ms() * minus_tau_minus_inv_ );
   }
 }

--- a/models/stdp_pl_synapse_hom.h
+++ b/models/stdp_pl_synapse_hom.h
@@ -309,8 +309,8 @@ stdp_pl_synapse_hom< targetidentifierT >::send( Event& e, size_t t, const STDPPL
   const long dendritic_delay = get_delay_steps();
 
   // get spike history in relevant range (t1, t2] from postsynaptic neuron
-  std::deque< histentry >::iterator start;
-  std::deque< histentry >::iterator finish;
+  std::deque< histentry_step >::iterator start;
+  std::deque< histentry_step >::iterator finish;
   target->get_history( t_lastspike_ - dendritic_delay, t_spike - dendritic_delay, &start, &finish );
 
   // facilitation due to postsynaptic spikes since last pre-synaptic spike

--- a/modelsets/full
+++ b/modelsets/full
@@ -54,6 +54,7 @@ iaf_cond_beta
 iaf_cond_exp
 iaf_cond_exp_sfa_rr
 iaf_psc_alpha
+iaf_psc_alpha_hom
 iaf_psc_alpha_multisynapse
 iaf_psc_alpha_ps
 iaf_psc_delta

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -21,6 +21,7 @@ set ( nestkernel_sources
       universal_data_logger_impl.h universal_data_logger.h
       recordables_map.h
       archiving_node.h archiving_node.cpp
+      archiving_node_hom.h archiving_node_hom.cpp
       clopath_archiving_node.h clopath_archiving_node.cpp
       urbanczik_archiving_node.h urbanczik_archiving_node_impl.h
       eprop_archiving_node.h eprop_archiving_node_impl.h eprop_archiving_node.cpp

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -1,24 +1,24 @@
 /*
- *  archiving_node.cpp
- *
- *  This file is part of NEST.
- *
- *  Copyright (C) 2004 The NEST Initiative
- *
- *  NEST is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  NEST is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+*  archiving_node.cpp
+*
+*  This file is part of NEST.
+*
+*  Copyright (C) 2004 The NEST Initiative
+*
+*  NEST is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  NEST is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
 
 #include "archiving_node.h"
 
@@ -34,253 +34,243 @@ namespace nest
 // member functions for ArchivingNode
 
 nest::ArchivingNode::ArchivingNode()
-  : n_incoming_( 0 )
-  , Kminus_( 0.0 )
-  , Kminus_triplet_( 0.0 )
-  , tau_minus_( 1.0 ) // TODO: signals that tau_minus_ has not been set
-  , tau_minus_inv_( 1. / tau_minus_ )
-  , tau_minus_triplet_( 110.0 )
-  , tau_minus_triplet_inv_( 1. / tau_minus_triplet_ )
-  , max_delay_( 0 )
-  , trace_( 0.0 )
-  , last_spike_( -1 )
+ : n_incoming_( 0 )
+ , Kminus_( 0.0 )
+ , Kminus_triplet_( 0.0 )
+ , tau_minus_( 20.0 )
+ , tau_minus_inv_( 1. / tau_minus_ )
+ , tau_minus_triplet_( 110.0 )
+ , tau_minus_triplet_inv_( 1. / tau_minus_triplet_ )
+ , max_delay_( 0 )
+ , trace_( 0.0 )
+ , last_spike_( -1.0 )
 {
 }
 
 nest::ArchivingNode::ArchivingNode( const ArchivingNode& n )
-  : StructuralPlasticityNode( n )
-  , n_incoming_( n.n_incoming_ )
-  , Kminus_( n.Kminus_ )
-  , Kminus_triplet_( n.Kminus_triplet_ )
-  , tau_minus_( 1.0 ) // TODO: signals that tau_minus_ has not been set
-  , tau_minus_inv_( 1. / tau_minus_ )
-  , tau_minus_triplet_( n.tau_minus_triplet_ )
-  , tau_minus_triplet_inv_( n.tau_minus_triplet_inv_ )
-  , max_delay_( n.max_delay_ )
-  , trace_( n.trace_ )
-  , last_spike_( n.last_spike_ )
+ : StructuralPlasticityNode( n )
+ , n_incoming_( n.n_incoming_ )
+ , Kminus_( n.Kminus_ )
+ , Kminus_triplet_( n.Kminus_triplet_ )
+ , tau_minus_( n.tau_minus_ )
+ , tau_minus_inv_( n.tau_minus_inv_ )
+ , tau_minus_triplet_( n.tau_minus_triplet_ )
+ , tau_minus_triplet_inv_( n.tau_minus_triplet_inv_ )
+ , max_delay_( n.max_delay_ )
+ , trace_( n.trace_ )
+ , last_spike_( n.last_spike_ )
 {
 }
 
 void
-ArchivingNode::register_stdp_connection( size_t t_first_read, size_t delay, const double tau_minus )
+ArchivingNode::register_stdp_connection( double t_first_read, double delay )
 {
-  if ( tau_minus_ > 1.0 && tau_minus_ != tau_minus )
-  {
-    throw IllegalConnection();
-  }
-  else
-  {
-    tau_minus_ = tau_minus;
-    tau_minus_inv_ = 1. / tau_minus_;
-  }
+ // Mark all entries in the deque, which we will not read in future as read by
+ // this input, so that we safely increment the incoming number of
+ // connections afterwards without leaving spikes in the history.
+ // For details see bug #218. MH 08-04-22
 
-  // Mark all entries in the deque, which we will not read in future as read by
-  // this input, so that we safely increment the incoming number of
-  // connections afterwards without leaving spikes in the history.
-  // For details see bug #218. MH 08-04-22
-  for ( std::deque< histentry >::iterator runner = history_.begin();
-        runner != history_.end() and ( t_first_read - runner->t_ >= 0 );
-        ++runner )
-  {
-    ( runner->access_counter_ )++;
-  }
+ for ( std::deque< histentry >::iterator runner = history_.begin();
+       runner != history_.end() and ( t_first_read - runner->t_ > -1.0 * kernel().connection_manager.get_stdp_eps() );
+       ++runner )
+ {
+   ( runner->access_counter_ )++;
+ }
 
-  n_incoming_++;
+ n_incoming_++;
 
-  max_delay_ = std::max( delay, max_delay_ );
+ max_delay_ = std::max( delay, max_delay_ );
 }
 
 double
-nest::ArchivingNode::get_K_value( long t, size_t& dt_steps )
+nest::ArchivingNode::get_K_value( double t )
 {
-  dt_steps = 0;
-  // case when the neuron has not yet spiked
-  if ( history_.empty() )
-  {
-    trace_ = 0.;
-    return trace_;
-  }
+ // case when the neuron has not yet spiked
+ if ( history_.empty() )
+ {
+   trace_ = 0.;
+   return trace_;
+ }
 
-  int i = history_.size() - 1;
+ // search for the latest post spike in the history buffer that came strictly
+ // before `t`
+ int i = history_.size() - 1;
+ while ( i >= 0 )
+ {
+   if ( t - history_[ i ].t_ > kernel().connection_manager.get_stdp_eps() )
+   {
+     trace_ = ( history_[ i ].Kminus_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ ) );
+     return trace_;
+   }
+   --i;
+ }
 
-  while ( i >= 0 )
-  {
-    const auto hist = history_[ i ];
-    if ( t > static_cast< long >( hist.t_ ) )
-    {
-      trace_ = hist.Kminus_;
-      dt_steps = t - hist.t_;
-
-      return trace_;
-    }
-    --i;
-  }
-
-  // this case occurs when the trace was requested at a time precisely at or
-  // before the first spike in the history
-  trace_ = 0.;
-  return trace_;
+ // this case occurs when the trace was requested at a time precisely at or
+ // before the first spike in the history
+ trace_ = 0.;
+ return trace_;
 }
 
 void
 nest::ArchivingNode::get_K_values( double t,
-  double& K_value,
-  double& nearest_neighbor_K_value,
-  double& K_triplet_value )
+ double& K_value,
+ double& nearest_neighbor_K_value,
+ double& K_triplet_value )
 {
-  // case when the neuron has not yet spiked
-  if ( history_.empty() )
-  {
-    K_triplet_value = Kminus_triplet_;
-    nearest_neighbor_K_value = Kminus_;
-    K_value = Kminus_;
-    return;
-  }
+ // case when the neuron has not yet spiked
+ if ( history_.empty() )
+ {
+   K_triplet_value = Kminus_triplet_;
+   nearest_neighbor_K_value = Kminus_;
+   K_value = Kminus_;
+   return;
+ }
 
-  // search for the latest post spike in the history buffer that came strictly
-  // before `t`
-  int i = history_.size() - 1;
-  while ( i >= 0 )
-  {
-    if ( t - history_[ i ].t_ > kernel().connection_manager.get_stdp_eps() )
-    {
-      K_triplet_value =
-        ( history_[ i ].Kminus_triplet_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_triplet_inv_ ) );
-      K_value = ( history_[ i ].Kminus_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ ) );
-      nearest_neighbor_K_value = std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ );
-      return;
-    }
-    --i;
-  }
+ // search for the latest post spike in the history buffer that came strictly
+ // before `t`
+ int i = history_.size() - 1;
+ while ( i >= 0 )
+ {
+   if ( t - history_[ i ].t_ > kernel().connection_manager.get_stdp_eps() )
+   {
+     K_triplet_value =
+       ( history_[ i ].Kminus_triplet_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_triplet_inv_ ) );
+     K_value = ( history_[ i ].Kminus_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ ) );
+     nearest_neighbor_K_value = std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ );
+     return;
+   }
+   --i;
+ }
 
-  // this case occurs when the trace was requested at a time precisely at or
-  // before the first spike in the history
-  K_triplet_value = 0.0;
-  nearest_neighbor_K_value = 0.0;
-  K_value = 0.0;
+ // this case occurs when the trace was requested at a time precisely at or
+ // before the first spike in the history
+ K_triplet_value = 0.0;
+ nearest_neighbor_K_value = 0.0;
+ K_value = 0.0;
 }
 
 void
-nest::ArchivingNode::get_history( long t1,
-  long t2,
-  std::deque< histentry >::iterator* start,
-  std::deque< histentry >::iterator* finish )
+nest::ArchivingNode::get_history( double t1,
+ double t2,
+ std::deque< histentry >::iterator* start,
+ std::deque< histentry >::iterator* finish )
 {
-  *finish = history_.end();
-  if ( history_.empty() )
-  {
-    *start = *finish;
-    return;
-  }
-  std::deque< histentry >::reverse_iterator runner = history_.rbegin();
-  while ( runner != history_.rend() and static_cast< long >( runner->t_ ) > t2 )
-  {
-    ++runner;
-  }
-
-  *finish = runner.base();
-  while ( runner != history_.rend() and static_cast< long >( runner->t_ ) > t1 )
-  {
-    runner->access_counter_++;
-    ++runner;
-  }
-  *start = runner.base();
+ *finish = history_.end();
+ if ( history_.empty() )
+ {
+   *start = *finish;
+   return;
+ }
+ std::deque< histentry >::reverse_iterator runner = history_.rbegin();
+ const double t2_lim = t2 + kernel().connection_manager.get_stdp_eps();
+ const double t1_lim = t1 + kernel().connection_manager.get_stdp_eps();
+ while ( runner != history_.rend() and runner->t_ >= t2_lim )
+ {
+   ++runner;
+ }
+ *finish = runner.base();
+ while ( runner != history_.rend() and runner->t_ >= t1_lim )
+ {
+   runner->access_counter_++;
+   ++runner;
+ }
+ *start = runner.base();
 }
 
 void
 nest::ArchivingNode::set_spiketime( Time const& t_sp, double offset )
 {
-  StructuralPlasticityNode::set_spiketime( t_sp, offset );
+ StructuralPlasticityNode::set_spiketime( t_sp, offset );
 
-  const size_t t_sp_ms = t_sp.get_steps();
+ const double t_sp_ms = t_sp.get_ms() - offset;
 
-  if ( n_incoming_ )
-  {
-    // prune all spikes from history which are no longer needed
-    // only remove a spike if:
-    // - its access counter indicates it has been read out by all connected
-    //   STDP synapses, and
-    // - there is another, later spike, that is strictly more than
-    //   (min_global_delay + max_local_delay + eps) away from the new spike (at t_sp_ms)
-    while ( history_.size() > 1 )
-    {
-      const size_t next_t_sp = history_[ 1 ].t_;
-      if ( history_.front().access_counter_ >= n_incoming_
-        and t_sp_ms - next_t_sp > max_delay_ + kernel().connection_manager.get_min_delay() )
-      {
-        history_.pop_front();
-      }
-      else
-      {
-        break;
-      }
-    }
-    // update spiking history
-    Kminus_ = Kminus_ * std::exp( ( Time( Time::step( last_spike_ - t_sp_ms ) ).get_ms() ) * tau_minus_inv_ ) + 1.0;
-    // TODO: save the triplet
-    Kminus_triplet_ = Kminus_triplet_ * std::exp( ( last_spike_ - t_sp_ms ) * tau_minus_triplet_inv_ ) + 1.0;
-    last_spike_ = t_sp_ms;
-    history_.push_back( histentry( last_spike_, Kminus_, Kminus_triplet_, 0 ) );
-  }
-  else
-  {
-    last_spike_ = t_sp_ms;
-  }
+ if ( n_incoming_ )
+ {
+   // prune all spikes from history which are no longer needed
+   // only remove a spike if:
+   // - its access counter indicates it has been read out by all connected
+   //   STDP synapses, and
+   // - there is another, later spike, that is strictly more than
+   //   (min_global_delay + max_local_delay + eps) away from the new spike (at t_sp_ms)
+   while ( history_.size() > 1 )
+   {
+     const double next_t_sp = history_[ 1 ].t_;
+     if ( history_.front().access_counter_ >= n_incoming_
+       and t_sp_ms - next_t_sp > max_delay_ + Time::delay_steps_to_ms( kernel().connection_manager.get_min_delay() )
+           + kernel().connection_manager.get_stdp_eps() )
+     {
+       history_.pop_front();
+     }
+     else
+     {
+       break;
+     }
+   }
+   // update spiking history
+   Kminus_ = Kminus_ * std::exp( ( last_spike_ - t_sp_ms ) * tau_minus_inv_ ) + 1.0;
+   Kminus_triplet_ = Kminus_triplet_ * std::exp( ( last_spike_ - t_sp_ms ) * tau_minus_triplet_inv_ ) + 1.0;
+   last_spike_ = t_sp_ms;
+   history_.push_back( histentry( last_spike_, Kminus_, Kminus_triplet_, 0 ) );
+ }
+ else
+ {
+   last_spike_ = t_sp_ms;
+ }
 }
 
 void
 nest::ArchivingNode::get_status( DictionaryDatum& d ) const
 {
-  def< double >( d, names::t_spike, get_spiketime_ms() );
-  def< double >( d, names::tau_minus, tau_minus_ );
-  def< double >( d, names::tau_minus_triplet, tau_minus_triplet_ );
-  def< double >( d, names::post_trace, trace_ );
+ def< double >( d, names::t_spike, get_spiketime_ms() );
+ def< double >( d, names::tau_minus, tau_minus_ );
+ def< double >( d, names::tau_minus_triplet, tau_minus_triplet_ );
+ def< double >( d, names::post_trace, trace_ );
 #ifdef DEBUG_ARCHIVER
-  def< int >( d, names::archiver_length, history_.size() );
+ def< int >( d, names::archiver_length, history_.size() );
 #endif
 
-  // add status dict items from the parent class
-  StructuralPlasticityNode::get_status( d );
+ // add status dict items from the parent class
+ StructuralPlasticityNode::get_status( d );
 }
 
 void
 nest::ArchivingNode::set_status( const DictionaryDatum& d )
 {
-  // We need to preserve values in case invalid values are set
-  double new_tau_minus = tau_minus_;
-  double new_tau_minus_triplet = tau_minus_triplet_;
-  updateValue< double >( d, names::tau_minus_triplet, new_tau_minus_triplet );
+ // We need to preserve values in case invalid values are set
+ double new_tau_minus = tau_minus_;
+ double new_tau_minus_triplet = tau_minus_triplet_;
+ updateValue< double >( d, names::tau_minus, new_tau_minus );
+ updateValue< double >( d, names::tau_minus_triplet, new_tau_minus_triplet );
 
-  if ( new_tau_minus <= 0.0 or new_tau_minus_triplet <= 0.0 )
-  {
-    throw BadProperty( "All time constants must be strictly positive." );
-  }
+ if ( new_tau_minus <= 0.0 or new_tau_minus_triplet <= 0.0 )
+ {
+   throw BadProperty( "All time constants must be strictly positive." );
+ }
 
-  StructuralPlasticityNode::set_status( d );
+ StructuralPlasticityNode::set_status( d );
 
-  // do the actual update
-  tau_minus_ = new_tau_minus;
-  tau_minus_triplet_ = new_tau_minus_triplet;
-  tau_minus_inv_ = 1. / tau_minus_;
-  tau_minus_triplet_inv_ = 1. / tau_minus_triplet_;
+ // do the actual update
+ tau_minus_ = new_tau_minus;
+ tau_minus_triplet_ = new_tau_minus_triplet;
+ tau_minus_inv_ = 1. / tau_minus_;
+ tau_minus_triplet_inv_ = 1. / tau_minus_triplet_;
 
-  // check, if to clear spike history and K_minus
-  bool clear = false;
-  updateValue< bool >( d, names::clear, clear );
-  if ( clear )
-  {
-    clear_history();
-  }
+ // check, if to clear spike history and K_minus
+ bool clear = false;
+ updateValue< bool >( d, names::clear, clear );
+ if ( clear )
+ {
+   clear_history();
+ }
 }
 
 void
 nest::ArchivingNode::clear_history()
 {
-  last_spike_ = -1.0;
-  Kminus_ = 0.0;
-  Kminus_triplet_ = 0.0;
-  history_.clear();
+ last_spike_ = -1.0;
+ Kminus_ = 0.0;
+ Kminus_triplet_ = 0.0;
+ history_.clear();
 }
 
 

--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -1,24 +1,24 @@
 /*
- *  archiving_node.h
- *
- *  This file is part of NEST.
- *
- *  Copyright (C) 2004 The NEST Initiative
- *
- *  NEST is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  NEST is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+*  archiving_node.h
+*
+*  This file is part of NEST.
+*
+*  Copyright (C) 2004 The NEST Initiative
+*
+*  NEST is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU General Public License as published by
+*  the Free Software Foundation, either version 2 of the License, or
+*  (at your option) any later version.
+*
+*  NEST is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License
+*  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
 
 #ifndef ARCHIVING_NODE_H
 #define ARCHIVING_NODE_H
@@ -43,111 +43,111 @@ namespace nest
 {
 
 /**
- * A node which archives spike history for the purposes of spike-timing
- * dependent plasticity (STDP)
- */
+* A node which archives spike history for the purposes of spike-timing
+* dependent plasticity (STDP)
+*/
 class ArchivingNode : public StructuralPlasticityNode
 {
 public:
-  ArchivingNode();
+ ArchivingNode();
 
-  ArchivingNode( const ArchivingNode& );
+ ArchivingNode( const ArchivingNode& );
 
-  /**
-   * Return the Kminus (synaptic trace) value at time t (given in ms).
-   *
-   * When the trace is requested at the exact same time that the neuron emits a spike,
-   * the trace value as it was just before the spike is returned.
-   */
-  double get_K_value( long t, size_t& dt_steps ) override;
+ /**
+  * Return the Kminus (synaptic trace) value at time t (given in ms).
+  *
+  * When the trace is requested at the exact same time that the neuron emits a spike,
+  * the trace value as it was just before the spike is returned.
+  */
+ double get_K_value( double t ) override;
 
-  /**
-   * Write the different STDP K values at time t (in ms) to the provided locations.
-   *
-   * @param Kminus the eligibility trace for STDP
-   * @param nearest_neighbour_Kminus eligibility trace for nearest-neighbour STDP, like Kminus,
-                                     but increased to 1, rather than by 1, when a spike occurs
-   * @param Kminus_triplet eligibility trace for triplet STDP
-   *
-   * @throws UnexpectedEvent
-   */
-  void get_K_values( double t, double& Kminus, double& nearest_neighbor_Kminus, double& Kminus_triplet ) override;
+ /**
+  * Write the different STDP K values at time t (in ms) to the provided locations.
+  *
+  * @param Kminus the eligibility trace for STDP
+  * @param nearest_neighbour_Kminus eligibility trace for nearest-neighbour STDP, like Kminus,
+                                    but increased to 1, rather than by 1, when a spike occurs
+  * @param Kminus_triplet eligibility trace for triplet STDP
+  *
+  * @throws UnexpectedEvent
+  */
+ void get_K_values( double t, double& Kminus, double& nearest_neighbor_Kminus, double& Kminus_triplet ) override;
 
-  /**
-   * Return the triplet Kminus value for the associated iterator.
-   */
-  double get_K_triplet_value( const std::deque< histentry >::iterator& iter );
+ /**
+  * Return the triplet Kminus value for the associated iterator.
+  */
+ double get_K_triplet_value( const std::deque< histentry >::iterator& iter );
 
-  /**
-   * Return the spike times (in steps) of spikes which occurred in the range [t1,t2].
-   */
-  void get_history( long t1,
-    long t2,
-    std::deque< histentry >::iterator* start,
-    std::deque< histentry >::iterator* finish ) override;
+ /**
+  * Return the spike times (in steps) of spikes which occurred in the range [t1,t2].
+  */
+ void get_history( double t1,
+   double t2,
+   std::deque< histentry >::iterator* start,
+   std::deque< histentry >::iterator* finish ) override;
 
-  /**
-   * Register a new incoming STDP connection.
-   *
-   * t_first_read: The newly registered synapse will read the history entries
-   * with t > t_first_read.
-   */
-  void register_stdp_connection( size_t t_first_read, size_t delay, const double tau_minus ) override;
+ /**
+  * Register a new incoming STDP connection.
+  *
+  * t_first_read: The newly registered synapse will read the history entries
+  * with t > t_first_read.
+  */
+ void register_stdp_connection( double t_first_read, double delay ) override;
 
-  void get_status( DictionaryDatum& d ) const override;
-  void set_status( const DictionaryDatum& d ) override;
+ void get_status( DictionaryDatum& d ) const override;
+ void set_status( const DictionaryDatum& d ) override;
 
 protected:
-  /**
-   * Record spike history
-   */
-  void set_spiketime( Time const& t_sp, double offset = 0.0 );
+ /**
+  * Record spike history
+  */
+ void set_spiketime( Time const& t_sp, double offset = 0.0 );
 
-  /**
-   * Return most recent spike time in ms
-   */
-  inline double get_spiketime_ms() const;
+ /**
+  * Return most recent spike time in ms
+  */
+ inline double get_spiketime_ms() const;
 
-  /**
-   * Clear spike history
-   */
-  void clear_history();
+ /**
+  * Clear spike history
+  */
+ void clear_history();
 
-  /**
-   * Number of incoming connections from STDP connectors.
-   *
-   * This variable is needed to determine if every incoming connection has
-   * read the spikehistory for a given point in time
-   */
-  size_t n_incoming_;
+ /**
+  * Number of incoming connections from STDP connectors.
+  *
+  * This variable is needed to determine if every incoming connection has
+  * read the spikehistory for a given point in time
+  */
+ size_t n_incoming_;
 
 private:
-  // sum exp(-(t-ti)/tau_minus)
-  double Kminus_;
+ // sum exp(-(t-ti)/tau_minus)
+ double Kminus_;
 
-  // sum exp(-(t-ti)/tau_minus_triplet)
-  double Kminus_triplet_;
+ // sum exp(-(t-ti)/tau_minus_triplet)
+ double Kminus_triplet_;
 
-  double tau_minus_;
-  double tau_minus_inv_;
+ double tau_minus_;
+ double tau_minus_inv_;
 
-  // time constant for triplet low pass filtering of "post" spike train
-  double tau_minus_triplet_;
-  double tau_minus_triplet_inv_;
+ // time constant for triplet low pass filtering of "post" spike train
+ double tau_minus_triplet_;
+ double tau_minus_triplet_inv_;
 
-  size_t max_delay_;
-  double trace_;
+ double max_delay_;
+ double trace_;
 
-  long last_spike_;
+ double last_spike_;
 
-  // spiking history needed by stdp synapses
-  std::deque< histentry > history_;
+ // spiking history needed by stdp synapses
+ std::deque< histentry > history_;
 };
 
 inline double
 ArchivingNode::get_spiketime_ms() const
 {
-  return Time(Time::step( last_spike_ )).get_ms();
+ return last_spike_;
 }
 
 } // of namespace

--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -59,7 +59,7 @@ public:
    * When the trace is requested at the exact same time that the neuron emits a spike,
    * the trace value as it was just before the spike is returned.
    */
-  double get_K_value( double t ) override;
+  double get_K_value( long t, size_t& dt_steps ) override;
 
   /**
    * Write the different STDP K values at time t (in ms) to the provided locations.
@@ -81,8 +81,8 @@ public:
   /**
    * Return the spike times (in steps) of spikes which occurred in the range [t1,t2].
    */
-  void get_history( double t1,
-    double t2,
+  void get_history( long t1,
+    long t2,
     std::deque< histentry >::iterator* start,
     std::deque< histentry >::iterator* finish ) override;
 
@@ -92,7 +92,7 @@ public:
    * t_first_read: The newly registered synapse will read the history entries
    * with t > t_first_read.
    */
-  void register_stdp_connection( double t_first_read, double delay ) override;
+  void register_stdp_connection( size_t t_first_read, size_t delay, const double tau_minus ) override;
 
   void get_status( DictionaryDatum& d ) const override;
   void set_status( const DictionaryDatum& d ) override;
@@ -135,10 +135,10 @@ private:
   double tau_minus_triplet_;
   double tau_minus_triplet_inv_;
 
-  double max_delay_;
+  size_t max_delay_;
   double trace_;
 
-  double last_spike_;
+  long last_spike_;
 
   // spiking history needed by stdp synapses
   std::deque< histentry > history_;
@@ -147,7 +147,7 @@ private:
 inline double
 ArchivingNode::get_spiketime_ms() const
 {
-  return last_spike_;
+  return Time(Time::step( last_spike_ )).get_ms();
 }
 
 } // of namespace

--- a/nestkernel/archiving_node_hom.cpp
+++ b/nestkernel/archiving_node_hom.cpp
@@ -1,0 +1,285 @@
+/*
+ *  archiving_node.cpp
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "archiving_node_hom.h"
+
+// Includes from nestkernel:
+#include "kernel_manager.h"
+
+// Includes from sli:
+#include "dictutils.h"
+
+namespace nest
+{
+
+// member functions for ArchivingNode
+
+nest::ArchivingNodeHom::ArchivingNodeHom()
+  : n_incoming_( 0 )
+  , Kminus_( 0.0 )
+  , Kminus_triplet_( 0.0 )
+  , tau_minus_( TAU_MINUS_PLACEHOLDER )
+  , tau_minus_inv_( 1. / tau_minus_ )
+  , tau_minus_triplet_( 110.0 )
+  , tau_minus_triplet_inv_( 1. / tau_minus_triplet_ )
+  , max_delay_( 0 )
+  , trace_( 0.0 )
+  , last_spike_( -1 )
+{
+}
+
+nest::ArchivingNodeHom::ArchivingNodeHom( const ArchivingNodeHom& n )
+  : StructuralPlasticityNode( n )
+  , n_incoming_( n.n_incoming_ )
+  , Kminus_( n.Kminus_ )
+  , Kminus_triplet_( n.Kminus_triplet_ )
+  , tau_minus_( TAU_MINUS_PLACEHOLDER )
+  , tau_minus_inv_( 1. / tau_minus_ )
+  , tau_minus_triplet_( n.tau_minus_triplet_ )
+  , tau_minus_triplet_inv_( n.tau_minus_triplet_inv_ )
+  , max_delay_( n.max_delay_ )
+  , trace_( n.trace_ )
+  , last_spike_( n.last_spike_ )
+{
+}
+
+void
+ArchivingNodeHom::register_stdp_connection( size_t t_first_read, size_t delay, const double tau_minus )
+{
+  if ( tau_minus_ > 1.0 && tau_minus_ != tau_minus )
+  {
+    throw IllegalConnection();
+  }
+  else
+  {
+    tau_minus_ = tau_minus;
+    tau_minus_inv_ = 1. / tau_minus_;
+  }
+
+  // Mark all entries in the deque, which we will not read in future as read by
+  // this input, so that we safely increment the incoming number of
+  // connections afterwards without leaving spikes in the history.
+  // For details see bug #218. MH 08-04-22
+  for ( std::deque< histentry_step >::iterator runner = history_.begin();
+        runner != history_.end() and ( t_first_read - runner->t_ >= 0 );
+        ++runner )
+  {
+    ( runner->access_counter_ )++;
+  }
+
+  n_incoming_++;
+
+  max_delay_ = std::max( delay, max_delay_ );
+}
+
+double
+nest::ArchivingNodeHom::get_K_value( long t, size_t& dt_steps )
+{
+  dt_steps = 0;
+  // case when the neuron has not yet spiked
+  if ( history_.empty() )
+  {
+    trace_ = 0.;
+    return trace_;
+  }
+
+  int i = history_.size() - 1;
+
+  while ( i >= 0 )
+  {
+    const auto hist = history_[ i ];
+    if ( t > static_cast< long >( hist.t_ ) )
+    {
+      trace_ = hist.Kminus_;
+      dt_steps = t - hist.t_;
+
+      return trace_;
+    }
+    --i;
+  }
+
+  // this case occurs when the trace was requested at a time precisely at or
+  // before the first spike in the history
+  trace_ = 0.;
+  return trace_;
+}
+
+void
+nest::ArchivingNodeHom::get_K_values( double t,
+  double& K_value,
+  double& nearest_neighbor_K_value,
+  double& K_triplet_value )
+{
+  // case when the neuron has not yet spiked
+  if ( history_.empty() )
+  {
+    K_triplet_value = Kminus_triplet_;
+    nearest_neighbor_K_value = Kminus_;
+    K_value = Kminus_;
+    return;
+  }
+
+  // search for the latest post spike in the history buffer that came strictly
+  // before `t`
+  int i = history_.size() - 1;
+  while ( i >= 0 )
+  {
+    if ( t - history_[ i ].t_ > kernel().connection_manager.get_stdp_eps() )
+    {
+      K_triplet_value =
+        ( history_[ i ].Kminus_triplet_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_triplet_inv_ ) );
+      K_value = ( history_[ i ].Kminus_ * std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ ) );
+      nearest_neighbor_K_value = std::exp( ( history_[ i ].t_ - t ) * tau_minus_inv_ );
+      return;
+    }
+    --i;
+  }
+
+  // this case occurs when the trace was requested at a time precisely at or
+  // before the first spike in the history
+  K_triplet_value = 0.0;
+  nearest_neighbor_K_value = 0.0;
+  K_value = 0.0;
+}
+
+void
+nest::ArchivingNodeHom::get_history( long t1,
+  long t2,
+  std::deque< histentry_step >::iterator* start,
+  std::deque< histentry_step >::iterator* finish )
+{
+  *finish = history_.end();
+  if ( history_.empty() )
+  {
+    *start = *finish;
+    return;
+  }
+  std::deque< histentry_step >::reverse_iterator runner = history_.rbegin();
+  while ( runner != history_.rend() and static_cast< long >( runner->t_ ) > t2 )
+  {
+    ++runner;
+  }
+
+  *finish = runner.base();
+  while ( runner != history_.rend() and static_cast< long >( runner->t_ ) > t1 )
+  {
+    runner->access_counter_++;
+    ++runner;
+  }
+  *start = runner.base();
+}
+
+void
+nest::ArchivingNodeHom::set_spiketime( Time const& t_sp, double offset )
+{
+  StructuralPlasticityNode::set_spiketime( t_sp, offset );
+
+  const size_t t_sp_steps = t_sp.get_steps();
+
+  if ( n_incoming_ )
+  {
+    // prune all spikes from history which are no longer needed
+    // only remove a spike if:
+    // - its access counter indicates it has been read out by all connected
+    //   STDP synapses, and
+    // - there is another, later spike, that is strictly more than
+    //   (min_global_delay + max_local_delay + eps) away from the new spike (at t_sp_ms)
+    while ( history_.size() > 1 )
+    {
+      const size_t next_t_sp = history_[ 1 ].t_;
+      if ( history_.front().access_counter_ >= n_incoming_
+        and t_sp_steps - next_t_sp > max_delay_ + kernel().connection_manager.get_min_delay() )
+      {
+        history_.pop_front();
+      }
+      else
+      {
+        break;
+      }
+    }
+    // update spiking history
+    Kminus_ = Kminus_ * std::exp( Time( Time::step( last_spike_ - t_sp_steps ) ).get_ms() * tau_minus_inv_ ) + 1.0;
+    Kminus_triplet_ =
+      Kminus_triplet_ * std::exp( Time( Time::step( last_spike_ - t_sp_steps ) ).get_ms() * tau_minus_triplet_inv_ ) + 1.0;
+    last_spike_ = t_sp_steps;
+    history_.push_back( histentry_step( last_spike_, Kminus_, Kminus_triplet_, 0 ) );
+  }
+  else
+  {
+    last_spike_ = t_sp_steps;
+  }
+}
+
+void
+nest::ArchivingNodeHom::get_status( DictionaryDatum& d ) const
+{
+  def< double >( d, names::t_spike, get_spiketime_ms() );
+  def< double >( d, names::tau_minus, tau_minus_ );
+  def< double >( d, names::tau_minus_triplet, tau_minus_triplet_ );
+  def< double >( d, names::post_trace, trace_ );
+#ifdef DEBUG_ARCHIVER
+  def< int >( d, names::archiver_length, history_.size() );
+#endif
+
+  // add status dict items from the parent class
+  StructuralPlasticityNode::get_status( d );
+}
+
+void
+nest::ArchivingNodeHom::set_status( const DictionaryDatum& d )
+{
+  // We need to preserve values in case invalid values are set
+  double new_tau_minus_triplet = tau_minus_triplet_;
+
+  updateValue< double >( d, names::tau_minus_triplet, new_tau_minus_triplet );
+
+  if ( new_tau_minus_triplet <= 0.0 )
+  {
+    throw BadProperty( "All time constants must be strictly positive." );
+  }
+
+  StructuralPlasticityNode::set_status( d );
+
+  // do the actual update
+  tau_minus_triplet_ = new_tau_minus_triplet;
+  tau_minus_triplet_inv_ = 1. / tau_minus_triplet_;
+
+  // check, if to clear spike history and K_minus
+  bool clear = false;
+  updateValue< bool >( d, names::clear, clear );
+  if ( clear )
+  {
+    clear_history();
+  }
+}
+
+void
+nest::ArchivingNodeHom::clear_history()
+{
+  last_spike_ = -1.0;
+  Kminus_ = 0.0;
+  Kminus_triplet_ = 0.0;
+  history_.clear();
+}
+
+
+} // of namespace nest

--- a/nestkernel/archiving_node_hom.h
+++ b/nestkernel/archiving_node_hom.h
@@ -1,0 +1,156 @@
+/*
+ *  archiving_node_hom.h
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef ARCHIVING_NODE_HOM_H
+#define ARCHIVING_NODE_HOM_H
+
+// C++ includes:
+#include <algorithm>
+#include <deque>
+
+// Includes from nestkernel:
+#include "histentry.h"
+#include "nest_time.h"
+#include "nest_types.h"
+#include "node.h"
+#include "structural_plasticity_node.h"
+
+// Includes from sli:
+#include "dictdatum.h"
+
+#define DEBUG_ARCHIVER 1
+
+namespace nest
+{
+
+constexpr double TAU_MINUS_PLACEHOLDER = 1.0; // indicate that tau minus has not been set yet
+
+/**
+ * A node which archives spike history for the purposes of spike-timing
+ * dependent plasticity (STDP), exclusive to and optimized for homogenous synapses.
+ */
+class ArchivingNodeHom : public StructuralPlasticityNode
+{
+public:
+  ArchivingNodeHom();
+
+  ArchivingNodeHom( const ArchivingNodeHom& );
+
+  /**
+   * Return the Kminus (synaptic trace) value at time t (given in ms).
+   *
+   * When the trace is requested at the exact same time that the neuron emits a spike,
+   * the trace value as it was just before the spike is returned.
+   */
+  double get_K_value( long t, size_t& dt_steps ) override;
+
+  /**
+   * Write the different STDP K values at time t (in ms) to the provided locations.
+   *
+   * @param Kminus the eligibility trace for STDP
+   * @param nearest_neighbour_Kminus eligibility trace for nearest-neighbour STDP, like Kminus,
+                                     but increased to 1, rather than by 1, when a spike occurs
+   * @param Kminus_triplet eligibility trace for triplet STDP
+   *
+   * @throws UnexpectedEvent
+   */
+  void get_K_values( double t, double& Kminus, double& nearest_neighbor_Kminus, double& Kminus_triplet ) override;
+
+  /**
+   * Return the triplet Kminus value for the associated iterator.
+   */
+  double get_K_triplet_value( const std::deque< histentry_step >::iterator& iter );
+
+  /**
+   * Return the spike times (in steps) of spikes which occurred in the range [t1,t2].
+   */
+  void get_history( long t1,
+    long t2,
+    std::deque< histentry_step >::iterator* start,
+    std::deque< histentry_step >::iterator* finish ) override;
+
+  /**
+   * Register a new incoming STDP connection.
+   *
+   * t_first_read: The newly registered synapse will read the history entries
+   * with t > t_first_read.
+   */
+  void register_stdp_connection( size_t t_first_read, size_t delay, const double tau_minus ) override;
+
+  void get_status( DictionaryDatum& d ) const override;
+  void set_status( const DictionaryDatum& d ) override;
+
+protected:
+  /**
+   * Record spike history
+   */
+  void set_spiketime( Time const& t_sp, double offset = 0.0 );
+
+  /**
+   * Return most recent spike time in ms
+   */
+  inline double get_spiketime_ms() const;
+
+  /**
+   * Clear spike history
+   */
+  void clear_history();
+
+  /**
+   * Number of incoming connections from STDP connectors.
+   *
+   * This variable is needed to determine if every incoming connection has
+   * read the spikehistory for a given point in time
+   */
+  size_t n_incoming_;
+
+private:
+  // sum exp(-(t-ti)/tau_minus)
+  double Kminus_;
+
+  // sum exp(-(t-ti)/tau_minus_triplet)
+  double Kminus_triplet_;
+
+  double tau_minus_;
+  double tau_minus_inv_;
+
+  // time constant for triplet low pass filtering of "post" spike train
+  double tau_minus_triplet_;
+  double tau_minus_triplet_inv_;
+
+  size_t max_delay_;
+  double trace_;
+
+  long last_spike_;
+
+  // spiking history needed by stdp synapses
+  std::deque< histentry_step > history_;
+};
+
+inline double
+ArchivingNodeHom::get_spiketime_ms() const
+{
+  return Time( Time::step( last_spike_ ) ).get_ms();
+}
+
+} // of namespace
+#endif

--- a/nestkernel/histentry.cpp
+++ b/nestkernel/histentry.cpp
@@ -22,7 +22,7 @@
 
 #include "histentry.h"
 
-nest::histentry::histentry( double t, double Kminus, double Kminus_triplet, size_t access_counter )
+nest::histentry::histentry( size_t t, double Kminus, double Kminus_triplet, size_t access_counter )
   : t_( t )
   , Kminus_( Kminus )
   , Kminus_triplet_( Kminus_triplet )

--- a/nestkernel/histentry.cpp
+++ b/nestkernel/histentry.cpp
@@ -22,7 +22,15 @@
 
 #include "histentry.h"
 
-nest::histentry::histentry( size_t t, double Kminus, double Kminus_triplet, size_t access_counter )
+nest::histentry::histentry( double t, double Kminus, double Kminus_triplet, size_t access_counter )
+  : t_( t )
+  , Kminus_( Kminus )
+  , Kminus_triplet_( Kminus_triplet )
+  , access_counter_( access_counter )
+{
+}
+
+nest::histentry_step::histentry_step( size_t t, double Kminus, double Kminus_triplet, size_t access_counter )
   : t_( t )
   , Kminus_( Kminus )
   , Kminus_triplet_( Kminus_triplet )

--- a/nestkernel/histentry.h
+++ b/nestkernel/histentry.h
@@ -35,9 +35,9 @@ namespace nest
 class histentry
 {
 public:
-  histentry( double t, double Kminus, double Kminus_triplet, size_t access_counter );
+  histentry( size_t t, double Kminus, double Kminus_triplet, size_t access_counter );
 
-  double t_;              //!< point in time when spike occurred (in ms)
+  size_t t_;              //!< point in time when spike occurred (in ms)
   double Kminus_;         //!< value of Kminus at that time
   double Kminus_triplet_; //!< value of triplet STDP Kminus at that time
   size_t access_counter_; //!< access counter to enable removal of the entry, once all neurons read it

--- a/nestkernel/histentry.h
+++ b/nestkernel/histentry.h
@@ -35,13 +35,25 @@ namespace nest
 class histentry
 {
 public:
-  histentry( size_t t, double Kminus, double Kminus_triplet, size_t access_counter );
+  histentry( double t, double Kminus, double Kminus_triplet, size_t access_counter );
 
-  size_t t_;              //!< point in time when spike occurred (in ms)
+  double t_;              //!< point in time when spike occurred (in ms)
   double Kminus_;         //!< value of Kminus at that time
   double Kminus_triplet_; //!< value of triplet STDP Kminus at that time
   size_t access_counter_; //!< access counter to enable removal of the entry, once all neurons read it
 };
+
+class histentry_step
+{
+public:
+  histentry_step( size_t t, double Kminus, double Kminus_triplet, size_t access_counter );
+
+  size_t t_;              //!< point in time when spike occurred (in steps)
+  double Kminus_;         //!< value of Kminus at that time
+  double Kminus_triplet_; //!< value of triplet STDP Kminus at that time
+  size_t access_counter_; //!< access counter to enable removal of the entry, once all neurons read it
+};
+
 
 // entry in the history of plasticity rules which consider additional factors
 class histentry_extended

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -213,13 +213,13 @@ Node::send_test_event( Node&, size_t, synindex, bool )
 void
 Node::register_stdp_connection( size_t, size_t, const double )
 {
-  throw IllegalConnection( "The target node does not support STDP synapses." );
+  throw IllegalConnection( "The target node does not support homogenous STDP synapses." );
 }
 
 void
 Node::register_stdp_connection( double, double )
 {
-  throw IllegalConnection( "The target node does not support non-STDP synapses." );
+  throw IllegalConnection( "The target node does not support STDP synapses." );
 }
 
 void
@@ -492,7 +492,7 @@ Node::get_K_values( double, double&, double&, double& )
 }
 
 void
-nest::Node::get_history( long, long, std::deque< histentry >::iterator*, std::deque< histentry >::iterator* )
+nest::Node::get_history( long, long, std::deque< histentry_step >::iterator*, std::deque< histentry_step >::iterator* )
 {
   throw UnexpectedEvent();
 }

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -211,9 +211,15 @@ Node::send_test_event( Node&, size_t, synindex, bool )
  * throws IllegalConnection
  */
 void
-Node::register_stdp_connection( double, double )
+Node::register_stdp_connection( size_t, size_t, const double )
 {
   throw IllegalConnection( "The target node does not support STDP synapses." );
+}
+
+void
+Node::register_stdp_connection( double, double )
+{
+  throw IllegalConnection( "The target node does not support non-STDP synapses." );
 }
 
 void
@@ -468,14 +474,25 @@ Node::get_LTD_value( double )
 }
 
 double
+Node::get_K_value( long, size_t& )
+{
+  throw UnexpectedEvent();
+}
+
+double
 Node::get_K_value( double )
 {
   throw UnexpectedEvent();
 }
 
-
 void
 Node::get_K_values( double, double&, double&, double& )
+{
+  throw UnexpectedEvent();
+}
+
+void
+nest::Node::get_history( long, long, std::deque< histentry >::iterator*, std::deque< histentry >::iterator* )
 {
   throw UnexpectedEvent();
 }

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -479,6 +479,8 @@ public:
    * @throws IllegalConnection
    *
    */
+  virtual void register_stdp_connection( size_t, size_t, const double tau_minus );
+
   virtual void register_stdp_connection( double, double );
 
   /**
@@ -761,7 +763,9 @@ public:
    * return the Kminus value at t (in ms).
    * @throws UnexpectedEvent
    */
-  virtual double get_K_value( double t );
+  virtual double get_K_value( long t, size_t& dt_steps );
+
+  virtual double get_K_value (double );
 
   virtual double get_LTD_value( double t );
 
@@ -777,6 +781,11 @@ public:
    * return the spike history for (t1,t2].
    * @throws UnexpectedEvent
    */
+  virtual void get_history( long t1,
+    long t2,
+    std::deque< histentry >::iterator* start,
+    std::deque< histentry >::iterator* finish );
+
   virtual void get_history( double t1,
     double t2,
     std::deque< histentry >::iterator* start,

--- a/nestkernel/node.h
+++ b/nestkernel/node.h
@@ -783,8 +783,8 @@ public:
    */
   virtual void get_history( long t1,
     long t2,
-    std::deque< histentry >::iterator* start,
-    std::deque< histentry >::iterator* finish );
+    std::deque< histentry_step >::iterator* start,
+    std::deque< histentry_step >::iterator* finish );
 
   virtual void get_history( double t1,
     double t2,

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -160,7 +160,7 @@ brunel_params = {
     "NE": int(9000 * params["scale"]),  # number of excitatory neurons
     "NI": int(2250 * params["scale"]),  # number of inhibitory neurons
     "Nrec": 1000,  # number of neurons to record spikes from
-    "model_params": {  # Set variables for iaf_psc_alpha
+    "model_params": {  # Set variables for iaf_psc_alpha_hom
         "E_L": 0.0,  # Resting membrane potential(mV)
         "C_m": 250.0,  # Capacity of the membrane(pF)
         "tau_m": 10.0,  # Membrane time constant(ms)
@@ -224,10 +224,10 @@ def build_network(logger):
     nest.overwrite_files = True
 
     nest.message(M_INFO, "build_network", "Creating excitatory population.")
-    E_neurons = nest.Create("iaf_psc_alpha", NE, params=model_params)
+    E_neurons = nest.Create("iaf_psc_alpha_hom", NE, params=model_params)
 
     nest.message(M_INFO, "build_network", "Creating inhibitory population.")
-    I_neurons = nest.Create("iaf_psc_alpha", NI, params=model_params)
+    I_neurons = nest.Create("iaf_psc_alpha_hom", NI, params=model_params)
 
     if brunel_params["randomize_Vm"]:
         nest.message(M_INFO, "build_network", "Randomizing membrane potentials.")

--- a/pynest/examples/hpc_benchmark.py
+++ b/pynest/examples/hpc_benchmark.py
@@ -171,7 +171,6 @@ brunel_params = {
         "tau_syn_ex": tau_syn,
         # time const. postsynaptic inhibitory currents(ms)
         "tau_syn_in": tau_syn,
-        "tau_minus": 30.0,  # time constant for STDP(depression)
         # V can be randomly initialized see below
         "V_m": 5.7,  # mean value of membrane potential
     },
@@ -193,6 +192,7 @@ brunel_params = {
         "lambda": 0.1,  # STDP step size
         "mu": 0.4,  # STDP weight dependence exponent(potentiation)
         "tau_plus": 15.0,  # time constant for potentiation
+        "tau_minus": 30.0,  # time constant for STDP(depression)
     },
     "eta": 1.685,  # scaling of external stimulus
     "filestem": params["path_name"],

--- a/testsuite/pytests/sli2py_connect/test_common_properties_setting.py
+++ b/testsuite/pytests/sli2py_connect/test_common_properties_setting.py
@@ -58,7 +58,7 @@ common_prop_models = {
         "neuron": "iaf_psc_alpha",
     },
     "stdp_facetshw_synapse_hom": {"parameter": "tau_plus", "value": 10, "setup": None, "neuron": "iaf_psc_alpha"},
-    "stdp_pl_synapse_hom": {"parameter": "tau_plus", "value": 10, "setup": None, "neuron": "iaf_psc_alpha"},
+    "stdp_pl_synapse_hom": {"parameter": "tau_plus", "value": 10, "setup": None, "neuron": "iaf_psc_alpha_hom"},
     "stdp_synapse_hom": {"parameter": "tau_plus", "value": 10, "setup": None, "neuron": "iaf_psc_alpha"},
     "static_synapse_hom_w": {"parameter": "weight", "value": 10, "setup": None, "neuron": "iaf_psc_alpha"},
     "tsodyks_synapse_hom": {"parameter": "tau_psc", "value": 10, "setup": None, "neuron": "iaf_psc_alpha"},

--- a/testsuite/pytests/test_stdp_pl_synapse_hom.py
+++ b/testsuite/pytests/test_stdp_pl_synapse_hom.py
@@ -60,9 +60,11 @@ class TestSTDPPlSynapse:
             "alpha": 1.0,
             "mu": 0.4,
             "tau_plus": self.tau_pre,
+            "tau_minus": self.tau_post
         }
-        self.synapse_parameters = {"synapse_model": self.synapse_model, "receptor_type": 0, "weight": self.init_weight}
-        self.neuron_parameters = {"tau_minus": self.tau_post}
+        self.synapse_parameters = {"synapse_model": self.synapse_model, "receptor_type": 0,
+                                   "weight": self.init_weight, }
+        self.neuron_parameters = {}
 
         # While the random sequences, fairly long, would supposedly reveal small differences in the weight change
         # between NEST and ours, some low-probability events (say, coinciding spikes) can well not have occurred. To
@@ -334,7 +336,6 @@ class TestSTDPPlSynapse:
     ):
         if not DEBUG_PLOTS:  # make pylint happy if no matplotlib
             return
-
         # pylint: disable=E0601
         fig, ax = plt.subplots(nrows=3)
 

--- a/testsuite/pytests/test_stdp_pl_synapse_hom.py
+++ b/testsuite/pytests/test_stdp_pl_synapse_hom.py
@@ -403,3 +403,5 @@ class TestSTDPPlSynapse(unittest.TestCase):
         with self.assertRaises(NESTErrors.DictError):
             nest.SetStatus(node_hom, {"tau_minus": 16.0})
         nest.GetStatus(node_hom, "tau_minus")
+
+# todo: add res change test

--- a/testsuite/regressiontests/ticket-686-positive-parameters.sli
+++ b/testsuite/regressiontests/ticket-686-positive-parameters.sli
@@ -53,6 +53,7 @@ M_ERROR setverbosity
     /correlomatrix_detector
     /correlospinmatrix_detector
     /iaf_tum_2000   % tau_fac == 0 is permitted
+    /iaf_psc_alpha_hom % tau_minus is set on common syn properties, read-only on neuron
     /siegert_neuron ]
 def
 

--- a/testsuite/regressiontests/ticket-689.sli
+++ b/testsuite/regressiontests/ticket-689.sli
@@ -42,8 +42,8 @@ M_ERROR setverbosity
   /total_num_virtual_procs 1
 >> SetKernelStatus
 
-/iaf_psc_alpha Create /n1 Set
-/iaf_psc_alpha Create /n2 Set
+/iaf_psc_alpha_hom Create /n1 Set
+/iaf_psc_alpha_hom Create /n2 Set
 n1 n2 /all_to_all /stdp_pl_synapse_hom_hpc Connect
 
 {

--- a/testsuite/unittests/test_stdp_pl_synapse_hom.sli
+++ b/testsuite/unittests/test_stdp_pl_synapse_hom.sli
@@ -28,7 +28,7 @@ Synopsis: (test_stdp_pl_synapse_hom) run
 
 Description:
   A parrot_neuron that repeats the spikes from a poisson generator is
-  connected to an iaf_psc_alpha that is driven by inh. and exc. poisson input.
+  connected to an iaf_psc_alpha_hom that is driven by inh. and exc. poisson input.
   The synapse is an stdp_pl_synapse_hom. After the simulation, we go through
   the pre- and postsyn. spike-trains spike by spike and try to reproduce the STDP
   results. The final weight obtained after simulation is compared to the final
@@ -40,11 +40,11 @@ Author: Kunkel, Dec 2017
 
 (unittest) run
 /unittest using
- 
+
 ResetKernel
- 
+
 /resolution 0.1 def %1.0 def %2.0 -4 pow def  % simulation step size
-0 << /resolution resolution >> SetStatus %/tics_per_ms 10000.0 >> SetStatus
+0 << /resolution resolution >> SetKernelStatus %/tics_per_ms 10000.0 >> SetStatus
 
 
 %%% input parameters %%%
@@ -82,15 +82,14 @@ ResetKernel
 /pg_pre /poisson_generator << /rate nu >> Create def
 
 /parrot /parrot_neuron Create def
-/neuron /iaf_psc_alpha Create def
+/neuron /iaf_psc_alpha_hom Create def
 
-/spike_detector << /to_file       false
-                   /to_memory     true
+/spike_recorder << /to_file       false
 		   %/precision 15
 		   /time_in_steps true
                 >> SetDefaults
-/sd_pre  /spike_detector Create def
-/sd_post /spike_detector Create def
+/sd_pre  /spike_recorder Create def
+/sd_post /spike_recorder Create def
 
 
 %%% connect %%%
@@ -116,12 +115,13 @@ neuron sd_post Connect
 
 10000.0 Simulate
 
-/pre_spikes  sd_pre  GetStatus /events get /times get cva { axonal_delay add } Map def
-/post_spikes sd_post GetStatus /events get /times get cva { backpr_delay add } Map def
+/pre_spikes sd_pre /events get /times get cva { axonal_delay add } Map def
+/post_spikes sd_post /events get /times get cva { backpr_delay add } Map def
 
-/final_weight << /source [parrot] /target [neuron] >> GetConnections 0 get /weight get def
+% TODO: HOW TO FIX THIS
+/final_weight << /source [parrot] /target [neuron] >> GetConnections 0 get GetStatus /weight get def
 
-
+== cta goes meow
 %%% check final weight %%%
 
 cout 15 setprecision
@@ -157,7 +157,7 @@ def
 {
   j 1 add /j Set
   pre_spike /last_pre Set
-  pre_spikes j get /pre_spike Set  
+  pre_spikes j get /pre_spike Set
 }
 def
 
@@ -206,7 +206,7 @@ def
         if
       }
       {
-        exit  
+        exit
       }
       ifelse
     }

--- a/testsuite/unittests/test_stdp_pl_synapse_hom.sli
+++ b/testsuite/unittests/test_stdp_pl_synapse_hom.sli
@@ -1,0 +1,254 @@
+/*
+ *  test_stdp_pl_synapse_hom.sli
+ *
+ *  This file is part of NEST.
+ *
+ *  Copyright (C) 2004 The NEST Initiative
+ *
+ *  NEST is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  NEST is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/* BeginDocumentation
+Name: testsuite::test_stdp_pl_synapse_hom - basic test of stdp_pl_synapse_hom
+
+Synopsis: (test_stdp_pl_synapse_hom) run
+
+Description:
+  A parrot_neuron that repeats the spikes from a poisson generator is
+  connected to an iaf_psc_alpha that is driven by inh. and exc. poisson input.
+  The synapse is an stdp_pl_synapse_hom. After the simulation, we go through
+  the pre- and postsyn. spike-trains spike by spike and try to reproduce the STDP
+  results. The final weight obtained after simulation is compared to the final
+  weight obtained from the test.
+
+Author: Kunkel, Dec 2017
+*/
+
+
+(unittest) run
+/unittest using
+ 
+ResetKernel
+ 
+/resolution 0.1 def %1.0 def %2.0 -4 pow def  % simulation step size
+0 << /resolution resolution >> SetStatus %/tics_per_ms 10000.0 >> SetStatus
+
+
+%%% input parameters %%%
+
+/K_exc         8000.0 def  % number of exc. inputs
+/K_inh         2000.0 def  % number of inh. inputs
+/nu              10.0 def  % equil. firing rate
+/nu_x             1.7 def  % external rate
+/w_exc           45.0 def  % strength of exc. connections
+/w_inh w_exc -5.0 mul def  % strength of inh. connections
+
+/delay       1.0                      def  % synaptic transmission delay
+/delay_steps delay resolution div cvi def  % synaptic transmission delay in steps
+
+/axonal_delay 0                            def
+/backpr_delay delay_steps axonal_delay sub def
+%/axonal_delay 0.0 def
+%/backpr_delay delay axonal_delay sub def
+
+
+%%% STDP parameters %%%
+
+/alpha      0.0513 def
+/lambda     0.1    def
+/tau_plus  15.0    def
+/tau_minus 30.0    def
+/mu         0.4    def
+
+
+%%% create poisson generators, neurons and spike detector %%%
+
+/pg_exc /poisson_generator << /rate K_exc nu nu_x add mul >> Create def
+/pg_inh /poisson_generator << /rate K_inh nu mul          >> Create def
+
+/pg_pre /poisson_generator << /rate nu >> Create def
+
+/parrot /parrot_neuron Create def
+/neuron /iaf_psc_alpha Create def
+
+/spike_detector << /to_file       false
+                   /to_memory     true
+		   %/precision 15
+		   /time_in_steps true
+                >> SetDefaults
+/sd_pre  /spike_detector Create def
+/sd_post /spike_detector Create def
+
+
+%%% connect %%%
+
+/stdp_pl_synapse_hom << /alpha     alpha
+                        /lambda    lambda
+		        /tau_plus  tau_plus
+		        /tau_minus tau_minus
+		        /mu        mu
+                     >> SetDefaults
+
+pg_exc neuron w_exc delay Connect
+pg_inh neuron w_inh delay Connect
+pg_pre parrot w_exc delay Connect
+
+parrot neuron w_exc delay /stdp_pl_synapse_hom Connect
+
+parrot sd_pre  Connect
+neuron sd_post Connect
+
+
+%%% simulate and get data %%%
+
+10000.0 Simulate
+
+/pre_spikes  sd_pre  GetStatus /events get /times get cva { axonal_delay add } Map def
+/post_spikes sd_post GetStatus /events get /times get cva { backpr_delay add } Map def
+
+/final_weight << /source [parrot] /target [neuron] >> GetConnections 0 get /weight get def
+
+
+%%% check final weight %%%
+
+cout 15 setprecision
+
+/K_plus    0.0 def
+/K_minus   0.0 def
+/last_pre  0   def
+/last_post 0   def
+/j         0   def
+/i         0   def
+
+/post_spike post_spikes i get def
+/pre_spike  pre_spikes  j get def
+/w          w_exc             def
+
+/update_K_plus
+{
+  last_pre pre_spike sub resolution mul tau_plus div exp K_plus mul 1.0 add /K_plus Set
+  %last_pre pre_spike sub tau_plus div exp K_plus mul 1.0 add /K_plus Set
+  %(K_plus = ) =only K_plus =
+}
+def
+
+/update_K_minus
+{
+  last_post post_spike sub resolution mul tau_minus div exp K_minus mul 1.0 add /K_minus Set
+  %last_post post_spike sub tau_minus div exp K_minus mul 1.0 add /K_minus Set
+  %(K_minus = ) =only K_minus =
+}
+def
+
+/next_pre_spike
+{
+  j 1 add /j Set
+  pre_spike /last_pre Set
+  pre_spikes j get /pre_spike Set  
+}
+def
+
+/next_post_spike
+{
+  i 1 add /i Set
+  post_spike /last_post Set
+  post_spikes i get /post_spike Set
+}
+def
+
+/facilitate
+{
+  ( w + lambda * w**mu * K_plus * exp( ( last_pre - post_spike ) * resolution / tau_plus ) ) ExecMath /w Set
+  %( w + lambda * w**mu * K_plus * exp( ( last_pre - post_spike ) / tau_plus ) ) ExecMath /w Set
+  %(facilitation) =only (\t) =only last_pre =only (\t) =only post_spike =only (\t) =only w =
+}
+def
+
+/depress
+{
+  ( w - lambda * alpha * w * K_minus * exp( ( last_post - pre_spike ) * resolution / tau_minus ) ) ExecMath
+  %( w - lambda * alpha * w * K_minus * exp( ( last_post - pre_spike ) / tau_minus ) ) ExecMath
+  dup 0.0 gt { /w Set } { pop 0.0 /w Set } ifelse
+  %(depression) =only (\t) =only last_post =only (\t) =only pre_spike =only (\t) =only w =
+}
+def
+
+
+{
+  {
+    pre_spike post_spike eq
+    { % pre- and post-syn. spike at the same time
+      last_post post_spike neq { facilitate } if
+      last_pre pre_spike neq { depress } if
+      %(pre == post) =only (\t) =only pre_spike =only (\t) =only post_spike =only (\t) =only w =
+      j 1 add pre_spikes length lt
+      {
+        update_K_plus
+        next_pre_spike
+        i 1 add post_spikes length lt
+        {
+          update_K_minus
+  	next_post_spike
+        }
+        if
+      }
+      {
+        exit  
+      }
+      ifelse
+    }
+    {
+      pre_spike post_spike lt
+      { % next spike is a pre-syn. spike
+        depress
+        update_K_plus
+        j 1 add pre_spikes length lt
+        {
+          next_pre_spike
+        }
+        {
+          %(last presyn spike) =
+          % we don't consider the post-syn. spikes after the last pre-syn. spike
+          exit
+        }
+        ifelse
+      }
+      { % next spike is a post-syn. spike
+        facilitate
+        update_K_minus
+        i 1 add post_spikes length lt
+        {
+          next_post_spike
+        }
+        {
+          %(last postsyn spike) =
+          % we DO consider the pre-syn. spikes after the last post-syn. spike
+          post_spike /last_post Set
+          pre_spikes dup length 1 sub get 1 add /post_spike Set  % to make sure we don't come here again
+          %pre_spikes dup length 1 sub get resolution add /post_spike Set  % to make sure we don't come here again
+        }
+        ifelse
+      }
+      ifelse
+    }
+    ifelse
+  }
+  loop
+
+  %w ==
+  %final_weight ==
+  w 13 ToUnitTestPrecision final_weight 13 ToUnitTestPrecision eq
+} assert_or_die


### PR DESCRIPTION
Updated implementation of lookup tables for exponential computations in homogenous STDP synapses (original commits by @suku248 @jarsi), for now just applied to `stdp_pl_synapse_hom`. There are a few potential concerns:

- Ideally we'd be able to keep `ArchivingNode` as a common base class and support both (potentially) precise spike times as well as `size_t`-implemented grid steps, but due to the way history is stored this is impossible without costly conversion on multiple occasions. A dynamic polymorphism approach + conversions was implemented, but did considerably worse in benchmarks (albeit still better than the baseline, see figures below)

- Since we now require a separate archiving node (could be a static template impl but that also has minor overhead), we also need to duplicate the nodes that support homogenous STDP synapses; we introduced `iaf_psc_alpha_hom`. A better solution would probably require a restructuring for the way archivers are implemented, e.g. as pointers.

In the figures below, "plain" is an implementation that just replaced existing structures for testing purposes while "separate" is the current version with duplicated classes, they are both listed as a sanity check and performance should be the same. "Converted" uses a templated histentry and conversion approach in archiving node. Std and mean values taken over 3 rng seeds.
![exp_tables](https://github.com/nest/nest-simulator/assets/17948365/6c4fa44f-3f2f-4b24-ae26-9664caa7bfc6)
![exp_tables_2](https://github.com/nest/nest-simulator/assets/17948365/3b0e6ac0-ab95-4056-884a-81181c08d884)
