### PR TITLE
Update unit from seconds to Siemens

### DIFF
--- a/models/aeif_cond_beta_multisynapse.h
+++ b/models/aeif_cond_beta_multisynapse.h
@@ -142,7 +142,7 @@ The following parameters can be set in the status dictionary.
 ======== ======= ==================================
 **Spike adaptation parameters**
 ---------------------------------------------------
- a       ns      Subthreshold adaptation
+ a       nS      Subthreshold adaptation
  b       pA      Spike-triggered adaptation
  tau_w   ms      Adaptation time constant
 ======== ======= ==================================


### PR DESCRIPTION
There is a typo in the header file resulting in typo in the documentation.