### PR TITLE
Update README.md to fix link to "installation instructions" #3317

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ later.
 
 ## Installing NEST
 
-Please see the online [NEST Installation Instructions](http://www.nest-simulator.org/installation)
+Please see the online [NEST Installation Instructions](https://nest-simulator.readthedocs.io/en/latest/installation/index.html)
 to find out how to install NEST.
 
 ## Getting help


### PR DESCRIPTION
Fixed link to installation instructions to point to
[https://nest-simulator.readthedocs.io/en/latest/installation/index.html](https://nest-simulator.readthedocs.io/en/latest/installation/index.html) instead of [https://www.nest-simulator.org/installation](https://www.nest-simulator.org/installation) as referred to in Issue FIX #3317 