### PR TITLE
Update version of mermaid in documentation

### DIFF
--- a/doc/htmldoc/conf.py
+++ b/doc/htmldoc/conf.py
@@ -93,7 +93,7 @@ copybutton_prompt_text = ">>> "
 copybutton_only_copy_prompt_lines = True
 
 mermaid_output_format = "raw"
-mermaid_version = "10.2.0"
+mermaid_version = "10.3.0"
 
 # disable require js - mermaid doesn't work if require.js is loaded before it
 nbsphinx_requirejs_path = ""


### PR DESCRIPTION
Read the Docs fails because a newer version of mermaid is needed.

no reviewers needed as its a single line in the documentation conf.py file