### PR TITLE
Loosen pylint threshold

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,3 +12,4 @@ const-naming-style = snake_case
 method-naming-style = PascalCase
 
 max-line-length = 120
+fail-under = 9.98


### PR DESCRIPTION
This PR loosens the seemingly changed settings for `too-many-positional-arguments`. Instead of ignoring or refactoring this at this point, we loosen the threshold.
:construction:  A follow-up needs to be created to fix those bad spots in the code by appropriate refactoring.