### PR TITLE
Add logger for nest-server-mpi

### DIFF
--- a/bin/nest-server-mpi
+++ b/bin/nest-server-mpi
@@ -19,9 +19,12 @@ from mpi4py import MPI
 if __name__ == "__main__":
     opt = docopt(__doc__)
 
+import logging
 import os
-import sys
 import time
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("NEST_SERVER_MPI_LOGGER_LEVEL", "INFO"))
 
 import nest
 import nest.server
@@ -35,17 +38,18 @@ rank = comm.Get_rank()
 
 def log(call_name, msg):
     msg = f"==> WORKER {rank}/{time.time():.7f} ({call_name}): {msg}"
-    print(msg, flush=True)
+    logger.debug(msg)
 
 
 if rank == 0:
-    print("==> Starting NEST Server Master on rank 0", flush=True)
+    logger.info("==> Starting NEST Server Master on rank 0")
     nest.server.set_mpi_comm(comm)
     nest.server.run_mpi_app(host=opt.get("--host", HOST), port=opt.get("--port", PORT))
 
 else:
-    print(f"==> Starting NEST Server Worker on rank {rank}", flush=True)
+    logger.info(f"==> Starting NEST Server Worker on rank {rank}")
     nest.server.set_mpi_comm(comm)
+
     while True:
         log("spinwait", "waiting for call bcast")
         call_name = comm.bcast(None, root=0)
@@ -70,7 +74,8 @@ else:
             try:
                 response = call(*args, **kwargs)
             except Exception:
+                logger.error("Failed to execute call")
                 continue
 
-        log(call_name, f"sending reponse gather, data={response}")
+        log(call_name, f"sending response gather, data={response}")
         comm.gather(nest.serializable(response), root=0)

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -41,8 +41,9 @@ from werkzeug.wrappers import Response
 
 # This ensures that the logging information shows up in the console running the server,
 # even when Flask's event loop is running.
-root = logging.getLogger()
-root.addHandler(default_handler)
+logger = logging.getLogger()
+logger.addHandler(default_handler)
+logger.setLevel(os.getenv("NEST_SERVER_MPI_LOGGER_LEVEL", "INFO"))
 
 
 def get_boolean_environ(env_key, default_value="false"):
@@ -228,7 +229,7 @@ def do_exec(args, kwargs):
 
 def log(call_name, msg):
     msg = f"==> MASTER 0/{time.time():.7f} ({call_name}): {msg}"
-    print(msg, flush=True)
+    logger.debug(msg)
 
 
 def do_call(call_name, args=[], kwargs={}):


### PR DESCRIPTION
The command `nest-server-mpi` always prints the simulation output which is inefficient.

I added logger for worker in `nest-server-mpi` file and for master in `hl_api_server.py`.

With the environment variable `NEST_SERVER_MPI_LOGGER_LEVEL=DEBUG` before running `nest-server-mpi` it will shows outputs otherwise none.

