### PR TITLE
Update instances of conda with mamba in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Ubuntu version](https://img.shields.io/badge/ubuntu-(PPA)-blue?logo=debian)](https://nest-simulator.readthedocs.io/en/latest/installation/)
 [![Fedora package](https://img.shields.io/fedora/v/nest?logo=fedora)](https://src.fedoraproject.org/rpms/nest)
-[![Conda version](https://img.shields.io/conda/vn/conda-forge/nest-simulator.svg?logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/nest-simulator)
+[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/nest-simulator.svg?logo=conda-forge&logoColor=white)](https://anaconda.org/conda-forge/nest-simulator)
 [![Homebrew version](https://img.shields.io/homebrew/v/nest.svg?logo=apple)](https://formulae.brew.sh/formula/nest)
 [![Docker Image Version](https://img.shields.io/docker/v/nest/nest-simulator?color=blue&label=docker&logo=docker&logoColor=white&sort=semver)](https://hub.docker.com/r/nest/nest-simulator)
 [![Virtual applicance](https://img.shields.io/badge/VM-v3.7-blue?logo=CodeSandbox)](https://nest-simulator.readthedocs.io/en/latest/installation/livemedia.html#live-media)
@@ -127,5 +127,3 @@ to find out how to install NEST.
 Please cite NEST if you use it in your work.
 
 - You can find all the information for [citing NEST here](https://nest-simulator.readthedocs.io/en/latest/citing-nest.html)
-
-

--- a/doc/htmldoc/connect_nest/nest_server.rst
+++ b/doc/htmldoc/connect_nest/nest_server.rst
@@ -59,11 +59,11 @@ For native installations, the requirements can be simply installed via ``pip``::
 
   pip3 install Flask Flask-Cors gunicorn RestrictedPython
 
-or by installing the full NEST development environment in case you prefer using ``conda``::
+or by installing the full NEST development environment in case you prefer using ``mamba``::
 
   cd <nest-source-dir>
-  conda env create -p conda/
-  conda activate conda/
+  mamba env create -p mamba/
+  mamba activate mamba/
 
 As an alternative to a native installation, NEST Server is available from the NEST Docker image. Please check out the
 corresponding :ref:`installation instructions <docker>` for more details.

--- a/doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst
+++ b/doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst
@@ -30,7 +30,7 @@ please follow the guidelines below:
 
       * the steps you took that lead to the problem.
       * the specific error messages you get.
-      * relevant system and version information (e.g.,  Ubuntu 22.04/ NEST 3.5 installed using the conda-forge package).
+      * relevant system and version information (e.g.,  Ubuntu 22.04/ NEST 3.8 installed using the conda-forge package).
 
 #. Keep topics separate.
 

--- a/doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst
+++ b/doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst
@@ -30,7 +30,7 @@ please follow the guidelines below:
 
       * the steps you took that lead to the problem.
       * the specific error messages you get.
-      * relevant system and version information (e.g.,  Ubuntu 22.04/ NEST 3.5 installed using the Conda package).
+      * relevant system and version information (e.g.,  Ubuntu 22.04/ NEST 3.5 installed using the conda-forge package).
 
 #. Keep topics separate.
 

--- a/doc/htmldoc/developer_space/workflows/documentation_workflow/user_documentation_workflow.rst
+++ b/doc/htmldoc/developer_space/workflows/documentation_workflow/user_documentation_workflow.rst
@@ -84,29 +84,37 @@ If you have not done so alrealdy first
 Set up your environment
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Using the Conda package (includes everything to build NEST, including documentation)
-````````````````````````````````````````````````````````````````````````````````````
+Using the conda-forge package (includes everything to build NEST, including documentation)
+```````````````````````````````````````````````````````````````````````````````````````````
 
-For details on Conda, see :ref:`conda_tips`
+For details on installation see :ref:`conda_forge_install`
 
 .. code-block:: bash
 
     cd <nest_source_dir>/
-    conda env create -p conda/
-    conda activate conda/
+    mamba env create -p mamba/
+    mamba activate mamba/
 
 If you later on want to deactivate or delete the build environment:
 
 .. code-block:: bash
 
-   conda deactivate
-   rm -rf conda/
+   mamba deactivate
+   rm -rf mamba/
 
 Using pip (includes packages for documentation only)
 ````````````````````````````````````````````````````
 
 If you want to install only a minimal set of packages for building the
 documentation and avoid using Conda, you can use pip:
+
+Create and activate  a Python virtual environment:
+
+.. code-block:: bash
+
+   python -m venv <myvenv>
+
+   source <myvenv>/bin/activate
 
 .. code-block:: bash
 

--- a/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
+++ b/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
@@ -25,7 +25,7 @@ Requirements and limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Focus on single build configuration
-* Assumes all dependencies (OpenMPI, GSL, etc) installed in a Conda environment
+* Assumes all dependencies (OpenMPI, GSL, etc) installed in a Mamba environment
 * Does not support debugging on macOS (because Eclipse does not support lldb)
 * Does not read the NEST `.clang-format` file, so code formatting may
   be incorrect
@@ -62,10 +62,10 @@ Setting up the project
 #. Right click the project and choose ``Properties`` from the context
    menu
 
-   a. Under ``C/C++ Build/Build Variables``, define ``BUILD_DIR`` and ``CONDA_ENV``,
+   a. Under ``C/C++ Build/Build Variables``, define ``BUILD_DIR`` and ``MAMBA_ENV``,
       both of type ``Path``. The first should contain the full path to the build
-      directory you created above, the second the full path to your conda
-      environment, usually something like ``.../miniconda3/envs/nest-dev``.
+      directory you created above, the second the full path to your mamba
+      environment, usually something like ``.../mamba/envs/nest-dev``.
    #. Under ``C/C++ Build – [Tab] Builder Settings``,
 
       #. uncheck ``Use default build command``
@@ -73,14 +73,14 @@ Setting up the project
 	 number of processes to your situation)
       #. set ``Build Directory`` to ``${BUILD_DIR}``
    #. Under ``C/C++ Build > Environment``, prepend
-      ``${CONDA_ENV}/bin`` to ``PATH``
+      ``${MAMBA_ENV}/bin`` to ``PATH``
    #. Under ``C/C++ General > Paths and Symbols – [Tab] Includes``, add the
       following two direcories
 
       * ``${BUILD_DIR}/libnestutil`` (contains ``config.h``)
-      * ``${CONDA_ENV}/include`` (all headers from packages provided in conda environment)
+      * ``${mamba_env}/include`` (all headers from packages provided in Mamba environment)
    #. Under ``PyDev - Interpreter/Grammar``, choose the interpreter from
-      your Conda environment (you may need to add it by following the
+      your Mamba environment (you may need to add it by following the
       ``Click here to configure an interpreter not listed`` link and
       then ``Browse for python/pypy exe`` (this temporarily takes you
       to the global Eclipse preferences in a separate window).
@@ -261,7 +261,7 @@ We need several packages installed, before we can become productive with NEST:
 * gsl
 * cmake
 * libtool
-* ipython, python, cython, ... The best way to install all the python requirements is to use `Anaconda <https://store.continuum.io/cshop/anaconda/>`_.
+* ipython, python, cython, ... The best way to install all the python requirements is to use `Mamba <https://mamba.readthedocs.io/en/latest/index.html/>`_.
 
 We present two ways to install the rest: MacPorts and Homebrew. For both versions you need to have Xcode and Xcode command line tools installed:
 

--- a/doc/htmldoc/installation/conda_forge.rst
+++ b/doc/htmldoc/installation/conda_forge.rst
@@ -1,23 +1,22 @@
 .. _conda_forge_install:
 
-Conda forge install
+conda-forge install
 ===================
 
 .. admonition:: osx-arm64: missing random number generators
 
-   Due to a cross-compiling issue in the conda NEST package, some random number 
-   generators are not available if you are using macOS arm64 architecture. 
+   Due to a cross-compiling issue in the conda-forge NEST package, some random number
+   generators are not available if you are using macOS arm64 architecture.
    The available generators are the Mersenne Twister generators `mt19937` and `mt19937_64`.
 
 .. note::
 
-   If you encounter problems installing the NEST conda package and
-   environment, we recommend using Mamba (https://mamba.readthedocs.io).
+   We recommend using Mamba (https://mamba.readthedocs.io).
    Mamba has the advantage of installing conda packages and
    environments more quickly and can be used as a complete drop-in replacement for conda.
 
-1. To keep your conda setup tidy, we recommend that you install NEST into
-   a separate `conda environment <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
+1. To keep your mamba setup tidy, we recommend that you install NEST into
+   a separate environment
    together with Python packages that you will use when working with NEST;
    see also our :ref:`conda_tips`.
 
@@ -25,27 +24,25 @@ Conda forge install
 
    .. code-block:: sh
 
-      conda create --name ENVNAME -c conda-forge nest-simulator
+      mamba create --name ENVNAME -c conda-forge nest-simulator
 
    To install additional packages into the environment, just list them together with ``nest-simulator``.
 
    .. code-block:: sh
 
-      conda create --name ENVNAME -c conda-forge nest-simulator jupyterlab seaborn
+      mamba create --name ENVNAME -c conda-forge nest-simulator jupyterlab seaborn
 
 #. To see all NEST versions available via conda, either run
 
    .. code-block:: sh
 
-      conda search -c conda-forge nest-simulator
+      mamba search -c conda-forge nest-simulator
 
-   or browse the `conda forge file list
-   <https://anaconda.org/conda-forge/nest-simulator/files>`_ (note
-   there are multiple pages). To install, e.g., NEST 2.18.0, run
+    To install a specific version  e.g., NEST 2.18.0, run
 
    .. code-block:: sh
 
-      conda create --name nest_2_18_0 -c conda-forge nest-simulator=2.18.0=*
+      mamba create --name nest_2_18_0 -c conda-forge nest-simulator=2.18.0=*
 
    The syntax for this install follows the pattern: ``nest-simulator=<version>=<build_string>``.
 
@@ -53,9 +50,9 @@ Conda forge install
 
    .. code-block:: sh
 
-      conda activate ENVNAME
+      mamba activate ENVNAME
 
 #. Note the following:
 
-   - We currently provide NEST with thread-based parallelization on conda. This should suffice for most
+   - We currently provide NEST with thread-based parallelization on conda-forge. This should suffice for most
      uses on personal computers.

--- a/doc/htmldoc/installation/conda_tips.rst
+++ b/doc/htmldoc/installation/conda_tips.rst
@@ -1,35 +1,27 @@
 .. _conda_tips:
 
-Tips for installing NEST with conda
+Tips for installing NEST with Mamba
 ===================================
 
-.. note:: 
+.. note::
 
-   If you encounter problems installing the NEST conda package and 
-   environment, we recommend using Mamba (https://mamba.readthedocs.io). 
-   Mamba has the advantage of installing conda packages and 
+   We recommend using Mamba (https://mamba.readthedocs.io).
+   Mamba has the advantage of installing conda packages and
    environments more quickly and can be used as a complete drop-in replacement for conda.
 
 This page provides a series of recommendations for installing pre-built NEST with
 conda or to set up conda environments for building NEST and NEST documentation.
 
-Basic conda setup
+Basic mamba setup
 -----------------
 
-Choice of conda base installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Apple systems
+~~~~~~~~~~~~~
 
-We test NEST in conda environments using Miniconda installations and thus recommend
-that you do the same. The recommendations that we provide here will also likely work with a
-full-sized Anaconda installation, but we can only provide limited support for this.
 
-You can either install
-
-- Miniconda from `<https://docs.conda.io/en/latest/miniconda.html>`_
-- Miniforge from `<https://github.com/conda-forge/miniforge>`_
-
-For Apple systems with an M1 chip, you must at present use Miniforge and
-select the ``arm64 (Apple Silicon)`` installer to create a conda environment
+For Apple systems with an M1 chip, you must at present use `Miniforge
+<https://github.com/conda-forge/miniforge>`_  and
+select the ``arm64 (Apple Silicon)`` installer to create a mamba environment
 that will support native builds of NEST.
 
 
@@ -38,32 +30,29 @@ Keep your base environment empty
 
 Your base environment should be as empty as possible in order to avoid
 conflicts with other environments. Always install packages only in the new
-environments (don't worry about duplicates, conda will link the packages
+environments (don't worry about duplicates, mamba will link the packages
 if they are used in multiple environments, and not produce disk eating copies).
 
 
-Get familiar with conda environments
+Get familiar with mamba environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Conda environments are a powerful tool. See the `Conda documentation on Managing Environments
-<https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
-for more information.
 
 To see which environments are installed on your system, use
 
 .. code:: sh
 
-   conda info --envs
+   mamba info --envs
 
 
-Installing NEST with Conda
---------------------------
+Installing NEST with conda-forge
+--------------------------------
 
-We provide pre-built versions of NEST on `Conda Forge <https://anaconda.org/conda-forge/nest-simulator/files>`_.
-Follow :ref:`these instructions to install NEST from Conda Forge <conda_forge_install>`.
+We provide pre-built versions of NEST on `conda-forge <https://conda-forge.org/docs/>`_.
+Follow :ref:`these instructions to install NEST from conda-forge <conda_forge_install>`.
 
 
-Creating a Conda environment for running and building NEST
+Creating a mamba environment for running and building NEST
 ----------------------------------------------------------
 
 If you want to compile NEST yourself, you can create an environment containing all necessary
@@ -72,15 +61,15 @@ software for running and building NEST by executing the following command from t
 .. code:: sh
 
    cd <nest-source-dir>
-   conda env create -p conda
+   mamba env create -p mamba
 
-This will create an environment in the folder ``conda/``. If you would like to activate the environment, use
+This will create an environment in the folder ``mamba/``. If you would like to activate the environment, use
 
 .. code:: sh
 
-   conda activate conda/
+   mamba activate mamba/
 
-Note that the trailing slash is required for conda not to confuse the path with a named environment (for example when
+Note that the trailing slash is required for mamba not to confuse the path with a named environment (for example when
 using ``--name``).
 
 
@@ -88,15 +77,10 @@ Get a good overview
 -------------------
 
 Obtain a good overview of which packages are installed where. You can use
-``conda env export -n base`` and ``conda env export -n yournestenv``
+``mamba env export -n base`` and ``mamba env export -n yournestenv``
 (replacing the ``yournestenv`` name with whatever you chose). Make
-sure each environment contains all dependencies. One way to make
-this obvious would be to reduce conda stack to ``0`` (see conda documentation on
-`nested activation <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#nested-activation>`_),
-and/or to a certain degree by not auto-activating the base environment (see conda documentation on
-`conda init <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#conda-init>`_).
-Then packages from base do not 'leak' into your new environments.
+sure each environment contains all dependencies.
 
 .. note::
-   Packages from your system will usually also be available in your conda
+   Packages from your system will usually also be available in your mamba
    environment and may cause similar conflicts.

--- a/doc/htmldoc/installation/condaenv_install.rst
+++ b/doc/htmldoc/installation/condaenv_install.rst
@@ -29,12 +29,12 @@ Install from source in a mamba environment
 
     cd build_dir
 
-* Configure NEST. Add the cmake option ``-CDMAKE_INSTALL_PREFIX:PATH=$MAMBA_PREFIX`` to link nest to your active mamba environment.
+* Configure NEST. Add the cmake option ``-CDMAKE_INSTALL_PREFIX:PATH=$CONDA_PREFIX`` to link nest to your active mamba environment.
   You may need additional ``cmake`` options (see :ref:`cmake_options`).
 
 .. code-block:: sh
 
-   cmake -DCMAKE_INSTALL_PREFIX:PATH=$MAMBA_PREFIX </path/to/NEST/src>
+   cmake -DCMAKE_INSTALL_PREFIX:PATH=$CONDA_PREFIX </path/to/NEST/src>
 
 * Compile and install NEST:
 

--- a/doc/htmldoc/installation/condaenv_install.rst
+++ b/doc/htmldoc/installation/condaenv_install.rst
@@ -1,24 +1,21 @@
 .. _condaenv:
 
-Install from source in a conda environment
+Install from source in a mamba environment
 ==========================================
 
-.. note:: 
+.. note::
 
-   If you encounter problems installing the NEST conda package and 
-   environment, we recommend using Mamba (https://mamba.readthedocs.io). 
-   Mamba has the advantage of installing conda packages and 
+   We recommend using Mamba (https://mamba.readthedocs.io).
+   Mamba has the advantage of installing conda packages and
    environments more quickly and can be used as a complete drop-in replacement for conda.
 
-* Create a conda environment from the `environment.yml <https://github.com/nest/nest-simulator/blob/master/environment.yml>`_ file.
-  We recommend specifying a dedicated location (``-p <path/to/conda/env>``) for your environment.
-  See the `conda documentation <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#specifying-a-location-for-an-environment>`_
-  on using a custom location rather than the default envs folder.
+* Create a mamba environment from the `environment.yml <https://github.com/nest/nest-simulator/blob/master/environment.yml>`_ file.
+  We recommend specifying a dedicated location (``-p <path/to/mamba/env>``) for your environment.
 
 .. code-block:: sh
 
-    conda env create -f nest-simulator/environment.yml --p <path/to/conda/env>
-    conda activate <path/to/conda/env>
+    mamba env create -f nest-simulator/environment.yml --p <path/to/mamba/env>
+    mamba activate <path/to/mamba/env>
 
 * Create a build directory:
 
@@ -32,12 +29,12 @@ Install from source in a conda environment
 
     cd build_dir
 
-* Configure NEST. Add the cmake option ``-CDMAKE_INSTALL_PREFIX:PATH=$CONDA_PREFIX`` to link nest to your active conda environment.
+* Configure NEST. Add the cmake option ``-CDMAKE_INSTALL_PREFIX:PATH=$MAMBA_PREFIX`` to link nest to your active mamba environment.
   You may need additional ``cmake`` options (see :ref:`cmake_options`).
 
 .. code-block:: sh
 
-   cmake -DCMAKE_INSTALL_PREFIX:PATH=$CONDA_PREFIX </path/to/NEST/src>
+   cmake -DCMAKE_INSTALL_PREFIX:PATH=$MAMBA_PREFIX </path/to/NEST/src>
 
 * Compile and install NEST:
 
@@ -60,5 +57,3 @@ sourcing the script:
 .. note::
 
    To build the developer or user documentation see :ref:`doc_workflow`
-
-

--- a/doc/htmldoc/installation/developer.rst
+++ b/doc/htmldoc/installation/developer.rst
@@ -31,9 +31,9 @@ file that contains all possible packages needed for NEST development.
 
 .. grid:: 2
 
-   .. grid-item-card:: Install NEST with conda
+   .. grid-item-card:: Install NEST with mamba
 
-         See our instructions for installing NEST from source in a :ref:`conda environment <condaenv>`
+         See our instructions for installing NEST from source in a :ref:`mamba environment <mambenva>`
 
    .. grid-item-card:: Install NEST without environment
 
@@ -60,5 +60,3 @@ By default, everything will be installed to the subdirectories ``<nest_install_d
 
 If you want to run the ``nest`` executable or use the ``nest`` Python module without providing explicit paths, you
 have to add the installation directory to your search paths.
-
-

--- a/doc/htmldoc/installation/mac_install.rst
+++ b/doc/htmldoc/installation/mac_install.rst
@@ -4,13 +4,13 @@ Building NEST on macOS
 ======================
 
 Building NEST on macOS requires some developer tools. There are several sources from
-which you can install them, e.g., Conda, Homebrew, or MacPorts. The most important
+which you can install them, e.g., Conda-forge, Homebrew, or MacPorts. The most important
 recommendation for an easy and stable build is *not to mix tools from different sources*.
-This includes your Python installation: Taking Python from Conda and all else from Homebrew
+This includes your Python installation: Taking Python from conda-forge and all else from Homebrew
 may work, but can also lead to various complications.
 
-This guide shows how to build NEST with a development environment created with Conda. The main
-advantage of Conda is that you can fully insulate the entire environment in a Conda environment.
+This guide shows how to build NEST with a development environment created with mamba. The main
+advantage of mamba is that you can fully insulate the entire environment in a mamba environment.
 If you want to base your setup on Homebrew or MacPorts, you can still use the
 ``environment.yml`` file as a guide to necessary packages.
 
@@ -24,12 +24,12 @@ Preparations
 
       xcode-select --install
 
-#. Create a conda environment with necessary tools (see also :ref:`conda_tips`)
+#. Create a mamba environment with necessary tools
 
    .. code:: sh
 
       cd <nest_source_dir>
-      conda env create -p conda/
+      mamba env create -p mamba/
 
    .. note::
 
@@ -40,10 +40,10 @@ Preparations
 
    .. code:: sh
 
-      conda activate conda/
+      mamba activate mamba/
 
-   This assumes that you have created the environment in the folder ``conda/`` as given above. Note that the trailing
-   slash is necessary for conda to distinguish it from a named environment.
+   This assumes that you have created the environment in the folder ``mamba/`` as given above. Note that the trailing
+   slash is necessary for mamba to distinguish it from a named environment.
 
 #. If you want to build NEST with MPI, you must digitally sign the ``orterun`` and ``orted`` binaries
 
@@ -57,7 +57,7 @@ Preparations
          codesign -f -s "gdb-cert" `which orted`
          codesign -f -s "gdb-cert" `which orterun`
 
-      Instead of the ``which`` command you can also give the full path to the binary inside your conda
+      Instead of the ``which`` command you can also give the full path to the binary inside your mamba
       environment.
 
       .. note::
@@ -80,17 +80,17 @@ Building NEST
 
       cmake <nest_source_dir>
 
-   If you have libraries required by NEST such as GSL installed with Homebrew and Conda, this
+   If you have libraries required by NEST such as GSL installed with Homebrew and mamba, this
    can lead to library conflicts (error messages like ``Initializing libomp.dylib, but found
-   libomp.dylib already initialized.``). To ensure that libraries are found first in your conda
+   libomp.dylib already initialized.``). To ensure that libraries are found first in your mamba
    environment, invoke ``cmake`` like this
 
    .. code-block:: sh
 
-      CMAKE_PREFIX_PATH=<conda_env_dir> cmake <nest_source_dir>
+      CMAKE_PREFIX_PATH=<mamba_env_dir> cmake <nest_source_dir>
 
-   You can find the ``<conda_env_dir>`` for the currently active conda environment by running
-   ``conda info`` and looking for the "active env location" entry in the output.
+   You can find the ``<mamba_env_dir>`` for the currently active mamba environment by running
+   ``mamba info`` and looking for the "active env location" entry in the output.
 
    To compile NEST with :ref:`MPI support <distributed_computing>`, add ``-Dwith-mpi=ON`` as ``cmake`` option.
    For further CMake options, see :ref:`cmake_options`.
@@ -119,14 +119,13 @@ module is impossible, and environment variables must be set before NEST can be u
 Troubleshooting
 ---------------
 
-Conda with Intel MKL
+Mamba with Intel MKL
 ~~~~~~~~~~~~~~~~~~~~
 
-A default installation of Anaconda or Miniconda will install a version of NumPy
-built on the Intel Math Kernel Library (MKL). This library uses a different OpenMP
+The Intel Math Kernel Library (MKL) uses a different OpenMP
 library to support threading than what's included with Apple Clang or GCC. This will lead
 to conflicts if NEST is built with support for threading, which is the default and
 usually desirable. One way to avoid this is to follow the instructions above. An
-alternative is to create a conda environment in which you install ``nomkl`` as *the
-very first package*. This will tell conda to install MKL-free versions of NumPy and
+alternative is to create a mamba environment in which you install ``nomkl`` as *the
+very first package*. This will tell mamba to install MKL-free versions of NumPy and
 other linear-algebra intensive packages.

--- a/doc/htmldoc/installation/mac_install.rst
+++ b/doc/htmldoc/installation/mac_install.rst
@@ -4,7 +4,7 @@ Building NEST on macOS
 ======================
 
 Building NEST on macOS requires some developer tools. There are several sources from
-which you can install them, e.g., Conda-forge, Homebrew, or MacPorts. The most important
+which you can install them, e.g., conda-forge, Homebrew, or MacPorts. The most important
 recommendation for an easy and stable build is *not to mix tools from different sources*.
 This includes your Python installation: Taking Python from conda-forge and all else from Homebrew
 may work, but can also lead to various complications.

--- a/doc/htmldoc/installation/user.rst
+++ b/doc/htmldoc/installation/user.rst
@@ -13,8 +13,8 @@ Docker |linux| |macos| |windows|
 :ref:`See our docker installation instructions <docker>`.
 
 
-Conda install |linux| |macos|
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+conda-forge install |linux| |macos|
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can install NEST with the :ref:`Conda forge package <conda_forge_install>`.
 

--- a/doc/htmldoc/nest_behavior/random_numbers.rst
+++ b/doc/htmldoc/nest_behavior/random_numbers.rst
@@ -5,7 +5,7 @@ Randomness in NEST Simulations
 
 .. admonition:: osx-arm64: missing random number generators
 
-   Due to a cross-compiling issue in the conda NEST package, some random number
+   Due to a cross-compiling issue in the conda-forge NEST package, some random number
    generators are not available if you are using macOS arm64 architecture.
    The available generators are the Mersenne Twister generators `mt19937` and `mt19937_64`.
 

--- a/doc/htmldoc/troubleshooting.rst
+++ b/doc/htmldoc/troubleshooting.rst
@@ -150,7 +150,7 @@ If your Python version is correct and you still have the same error, then try on
 
         .. code-block:: bash
 
-            conda info -e
+            mamba info -e
 
     An asterisk (\*) indicates the active environment.
 
@@ -158,7 +158,7 @@ If your Python version is correct and you still have the same error, then try on
 
         .. code-block:: bash
 
-            conda activate ENVNAME
+            mamba activate ENVNAME
 
     Try to ``import nest`` in Python.
 
@@ -175,22 +175,22 @@ If your Python version is correct and you still have the same error, then try on
 
          .. code-block:: bash
 
-             /path/to/conda/envs/ENVNAME/bin/python3
-             /path/to/conda/envs/ENVNAME/bin/nest
+             /path/to/mamba/envs/ENVNAME/bin/python3
+             /path/to/mamba/envs/ENVNAME/bin/nest
 
 
     You can also view the list of packages in the active environment, by running:
 
         .. code-block:: bash
 
-            conda list
+            mamba list
 
     If the package is not in your environment, then it needs to be installed.
 
-    If something is missing, you can try to  ``conda install <package>`` BUT be aware that this **may break pre-installed packages**!
+    If something is missing, you can try to  ``mamba install <package>`` BUT be aware that this **may break pre-installed packages**!
 
-    You may be better off creating a new Conda environment and install NEST with all needed packages at one time!
-    See the section on :ref:`installation for Conda <install_nest>`.
+    You may be better off creating a new mamba environment and install NEST with all needed packages at one time!
+    See the section on :ref:`installation for NEST with conda-forge <install_nest>`.
 
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
-# Conda environment specification for NEST Simulator.
+# Mamba environment specification for NEST Simulator.
 #
-# This file specifies a conda environment for those who would
+# This file specifies a mamba environment for those who would
 # like to compile NEST or build NEST documentation themselves.
 # If you just want to execute NEST, you should install NEST
 # directly as described in https://www.nest-simulator.org/installation.
@@ -19,7 +19,7 @@
 #
 # To create an environment from this file, run
 #
-#     conda env create --name <my_env_name> --file environment.yml
+#     mamba env create --name <my_env_name> --file environment.yml
 #
 # where <my_env_name> is a name of your choice.
 
@@ -42,11 +42,11 @@ dependencies:
   - doxygen
   - graphviz
 
-  # mpi4py must be installed by conda in order to automatically find the path
-  # to OpenMPI installed by conda. Note that mpi4py also is included in
+  # mpi4py must be installed by mamba in order to automatically find the path
+  # to OpenMPI installed by mamba. Note that mpi4py also is included in
   # requirements_pynest.txt in case someone wants to build an environment
-  # without conda. When this conda environment is built, the pip installation
-  # of mpi4py will be skipped since it is already installed by conda.
+  # without mamba. When this mamba environment is built, the pip installation
+  # of mpi4py will be skipped since it is already installed by mamba.
   - mpi4py
 
   - pip:

--- a/nestkernel/CMakeLists.txt
+++ b/nestkernel/CMakeLists.txt
@@ -135,7 +135,7 @@ if ( HAVE_MPI )
 endif ()
 
 
-# Prevent problems with Conda path substitution (see #2348)
+# Prevent problems with Mamba path substitution (see #2348)
 set_source_files_properties( dynamicloader.cpp PROPERTIES COMPILE_OPTIONS "-O0" )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@
 # If you just want to execute NEST, you should install NEST
 # directly as described in https://www.nest-simulator.org/installation.
 #
-# Note that this file only specifies the required Python packages and 
+# Note that this file only specifies the required Python packages and
 # not the entire software stack needed to build and work with NEST Simulator.
-# To create a conda environment with the entire software stack for NEST
+# To create a mamba environment with the entire software stack for NEST
 # Simulator, use the the environment yaml file.
 #
 # The requirements from this file can be installed by
 #
 #     pip install -r requirements.txt
- 
+
 
 # To build and work with PyNEST
 -r requirements_pynest.txt

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -6,9 +6,9 @@
 # NEST, you should install NEST directly as described in
 # https://www.nest-simulator.org/installation.
 #
-# The listed requirements are used to build the conda environment defined
+# The listed requirements are used to build the mamba environment defined
 # in the environment yaml file. If you want to build an environment
-# yourself, e.g., independent of conda, the requirements from this file
+# yourself, e.g., independent of mamba, the requirements from this file
 # can be installed by
 #
 #     pip install -r requirements_docs.txt

--- a/requirements_nest_server.txt
+++ b/requirements_nest_server.txt
@@ -1,14 +1,14 @@
 # Required Python packages to run NEST Server.
 #
 # This file specifies the required Python packages to run NEST Server.
-# It is meant for those who would like to compile NEST or build NEST 
-# documentation themselves. If you just want to execute NEST, you should 
-# install NEST directly as described in 
+# It is meant for those who would like to compile NEST or build NEST
+# documentation themselves. If you just want to execute NEST, you should
+# install NEST directly as described in
 # https://www.nest-simulator.org/installation.
 #
-# The listed requirements are used to build the conda environment defined 
+# The listed requirements are used to build the mamba environment defined
 # in the environment yaml file. If you want to build an environment
-# yourself, e.g., independent of conda, the requirements from this file
+# yourself, e.g., independent of mamba, the requirements from this file
 # can be installed by
 #
 #     pip install -r requirements_nest_server.txt

--- a/requirements_pynest.txt
+++ b/requirements_pynest.txt
@@ -6,9 +6,9 @@
 # NEST, you should install NEST directly as described in
 # https://www.nest-simulator.org/installation.
 #
-# The listed requirements are used to build the conda environment defined
+# The listed requirements are used to build the mamba environment defined
 # in the environment yaml file. If you want to build an environment
-# yourself, e.g., independent of conda, the requirements from this file
+# yourself, e.g., independent of mamba, the requirements from this file
 # can be installed by
 #
 #     pip install -r requirements_pynest.txt

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -6,9 +6,9 @@
 # NEST, you should install NEST directly as described in
 # https://www.nest-simulator.org/installation.
 #
-# The listed requirements are used to build the conda environment defined
+# The listed requirements are used to build the mamba environment defined
 # in the environment yaml file. If you want to build an environment
-# yourself, e.g., independent of conda, the requirements from this file
+# yourself, e.g., independent of mamba, the requirements from this file
 # can be installed by
 #
 #     pip install -r requirements_testing.txt


### PR DESCRIPTION
This PR updates the uses of 'conda' with 'mamba' (not including conda-forge).
The internal requirements for FZJ have changed regarding Anaconda and to mitigate issues we update the docs 
to use Mamba instead.
Some text was removed so there's less confusion between Conda and Mamba.
