### PR TITLE
Enhance gunicorn options in NEST Server

### DIFF
--- a/bin/nest-server
+++ b/bin/nest-server
@@ -80,7 +80,7 @@ status() {
   PS_AUX="$(pgrep -af "gunicorn nest.server.app")"
   printf "PID\t\tHTTP-SOCKET\t\tLOGFILE\n"
   echo "${PS_AUX}" | head -n 1 | \
-  awk '{ for(i=1;i<=NF;i++) {if ( i == 1 || i == 6 || i == 8 ) printf $i"\t\t"}; printf "\n" }'
+    awk '{ for(i=1;i<=NF;i++) {if ( i == 1 || i == 6 || i == 8 ) printf $i"\t\t"}; printf "\n" }'
 }
 
 stop() {

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -79,8 +79,8 @@ status() {
   # List all processes of NEST Server.
   PS_AUX="$(pgrep -af "gunicorn nest.server.app")"
   printf "PID\t\tHTTP-SOCKET\t\tLOGFILE\n"
-  echo "${PS_AUX}" | head -n 1 | \
-    awk '{ for(i=1;i<=NF;i++) {if ( i == 1 || i == 6 || i == 8 ) printf $i"\t\t"}; printf "\n" }'
+  echo "${PS_AUX}" | head -n 1 | awk \
+    '{ for(i=1;i<=NF;i++) {if ( i == 1 || i == 6 || i == 8 ) printf $i"\t\t"}; printf "\n" }'
 }
 
 stop() {

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -71,7 +71,8 @@ start() {
     fi
 
     set-gunicorn_opts
-    exec gunicorn nest.server:app "${GUNICORN_OPTS}"
+    # shellcheck disable=SC2086
+    exec gunicorn nest.server:app $GUNICORN_OPTS
   fi
 }
 

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -5,11 +5,13 @@ HOST="${NEST_SERVER_HOST:-127.0.0.1}"
 LOGFILE="${NEST_SERVER_LOGFILE:-/tmp/nest-server.log}"
 PORT="${NEST_SERVER_PORT:-52425}"
 STDOUT="${NEST_SERVER_STDOUT:-0}"
+TIMEOUT="${NEST_SERVER_TIMEOUT:-30}"
+WORKERS="${NEST_SERVER_WORKERS:-1}"
 
 usage() {
   echo "NEST Server"
   echo "-----------"
-  echo "Usage: nest-server log|status|start|stop|restart [-d] [-h <HOST>] [-o] [-p <PORT>]"
+  echo "Usage: nest-server log|status|start|stop|restart [-d] [-h <HOST>] [-o] [-p <PORT>] [-t <TIMEOUT>] [-w <WORKERS>]"
   echo ""
   echo "Commands:"
   echo "  log         display the server output log"
@@ -23,6 +25,8 @@ usage() {
   echo "  -h <HOST>          use hostname/IP address <HOST> for the server [default: 127.0.0.1]"
   echo "  -o                 print NEST outputs to the console"
   echo "  -p <PORT>          use port <PORT> for opening the socket [default: 52425]"
+  echo "  -t <TIMEOUT>       workers silent for more than this many seconds are killed and restarted [default: 30]"
+  echo "  -w <WORKERS>       the number of worker processes for handling requests [default: 1]"
 }
 
 log() {
@@ -38,13 +42,19 @@ pid() {
 set-gunicorn_opts() {
   # Set opts for gunicorn.
   GUNICORN_OPTS="--bind ${HOST}:${PORT}"
+  GUNICORN_OPTS="${GUNICORN_OPTS} --log-file ${LOGFILE}"
   if [ "${DAEMON}" -eq 1 ]; then
     GUNICORN_OPTS="${GUNICORN_OPTS} --daemon"
   fi
   if [ "${STDOUT}" -eq 0 ]; then
     GUNICORN_OPTS="${GUNICORN_OPTS} --capture-output"
   fi
-  GUNICORN_OPTS="${GUNICORN_OPTS} --log-file ${LOGFILE}"
+  if [ "${TIMEOUT}" -ne 30 ]; then
+    GUNICORN_OPTS="${GUNICORN_OPTS} --timeout ${TIMEOUT}"
+  fi
+  if [ "${WORKERS}" -gt 1 ]; then
+    GUNICORN_OPTS="${GUNICORN_OPTS} --workers ${WORKERS}"
+  fi
 }
 
 start() {
@@ -61,15 +71,16 @@ start() {
     fi
 
     set-gunicorn_opts
-    exec gunicorn nest.server:app ${GUNICORN_OPTS}
+    exec gunicorn nest.server:app "${GUNICORN_OPTS}"
   fi
 }
 
 status() {
   # List all processes of NEST Server.
-  PS_AUX="$(ps aux | grep "[g]unicorn nest.server.app")"
-  printf "USER\t\t\tPID\t\tHTTP-SOCKET\n"
-  echo "${PS_AUX}" | head -n 1 | awk '{ for(i=1;i<=NF;i++) {if ( i == 1 || i == 2 || i == 15 ) printf $i"\t\t"}; printf "\n" }'
+  PS_AUX="$(pgrep -af "gunicorn nest.server.app")"
+  printf "PID\t\tHTTP-SOCKET\t\tLOGFILE\n"
+  echo "${PS_AUX}" | head -n 1 | \
+  awk '{ for(i=1;i<=NF;i++) {if ( i == 1 || i == 6 || i == 8 ) printf $i"\t\t"}; printf "\n" }'
 }
 
 stop() {
@@ -84,12 +95,15 @@ stop() {
 }
 
 CMD=$1; shift
-while getopts "dh:op:" opt; do
+while getopts "dh:op:t:w:" opt; do
     case $opt in
         d) DAEMON=1 ;;
         h) HOST=$OPTARG ;;
         o) STDOUT=1 ;;
         p) PORT=$OPTARG ;;
+        t) TIMEOUT=$OPTARG ;;
+        w) WORKERS=$OPTARG ;;
+        *) echo "Invalid option"
     esac
 done
 

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -43,18 +43,10 @@ set-gunicorn_opts() {
   # Set opts for gunicorn.
   GUNICORN_OPTS="--bind ${HOST}:${PORT}"
   GUNICORN_OPTS="${GUNICORN_OPTS} --log-file ${LOGFILE}"
-  if [ "${DAEMON}" -eq 1 ]; then
-    GUNICORN_OPTS="${GUNICORN_OPTS} --daemon"
-  fi
-  if [ "${STDOUT}" -eq 0 ]; then
-    GUNICORN_OPTS="${GUNICORN_OPTS} --capture-output"
-  fi
-  if [ "${TIMEOUT}" -ne 30 ]; then
-    GUNICORN_OPTS="${GUNICORN_OPTS} --timeout ${TIMEOUT}"
-  fi
-  if [ "${WORKERS}" -gt 1 ]; then
-    GUNICORN_OPTS="${GUNICORN_OPTS} --workers ${WORKERS}"
-  fi
+  [[ "${DAEMON}" -eq 1 ]] && GUNICORN_OPTS="${GUNICORN_OPTS} --daemon"
+  [[ "${STDOUT}" -eq 0 ]] && GUNICORN_OPTS="${GUNICORN_OPTS} --capture-output"
+  [[ "${TIMEOUT}" -ne 30 ]] && GUNICORN_OPTS="${GUNICORN_OPTS} --timeout ${TIMEOUT}"
+  [[ "${WORKERS}" -gt 1 ]] && GUNICORN_OPTS="${GUNICORN_OPTS} --workers ${WORKERS}"
 }
 
 start() {
@@ -65,9 +57,7 @@ start() {
     echo "NEST Server is now running at http://${HOST}:${PORT}."
     if [ "${DAEMON}" -eq 0 ]; then
       echo "Use CTRL + C to stop this service."
-      if [ "${STDOUT}" -eq 1 ]; then
-        echo "-----------------------------------------------------"
-      fi
+      [[ "${STDOUT}" -eq 1 ]] && echo "-----------------------------------------------------"
     fi
 
     set-gunicorn_opts

--- a/bin/nest-server
+++ b/bin/nest-server
@@ -72,7 +72,7 @@ start() {
 
     set-gunicorn_opts
     # shellcheck disable=SC2086
-    exec gunicorn nest.server:app $GUNICORN_OPTS
+    exec gunicorn nest.server:app ${GUNICORN_OPTS}
   fi
 }
 


### PR DESCRIPTION
It adds options for gunicorn such as` TIMEOUT` or `WORKERS`. 

When the requests last longer than `TIMEOUT` it raises error.
I would like to modify the TIMEOUT of the gunicorn for NEST Server.