### PR TITLE
Corrected unit of q_stc to pA in gif_psc_exp

### DIFF
--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -354,7 +354,7 @@ nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
     if ( S_.r_ref_ == 0 ) // neuron is not in refractory period
     {
 
-      S_.V_ = V_.P30_ * ( S_.I_stim_ + P_.I_e_ - S_.stc_ ) + V_.P33_ * S_.V_ + V_.P31_ * P_.E_L_
+      S_.V_ = V_.P30_ * ( S_.I_stim_ + P_.I_e_ - S_.stc_ * 1000.0 ) + V_.P33_ * S_.V_ + V_.P31_ * P_.E_L_
         + S_.I_syn_ex_ * V_.P21ex_ + S_.I_syn_in_ * V_.P21in_;
 
       const double lambda = P_.lambda_0_ * std::exp( ( S_.V_ - S_.sfa_ ) / P_.Delta_V_ );

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -151,7 +151,7 @@ The following parameters can be set in the status dictionary.
 =========  ========== ====================================================
 **Spike adaptation and firing intensity parameters**
 --------------------------------------------------------------------------
-q_stc      list of nA   Values added to spike-triggered currents (stc)
+q_stc      list of pA   Values added to spike-triggered currents (stc)
                         after each spike emission
 tau_stc    list of ms   Time constants of stc variables
 q_sfa      list of mV   Values added to spike-frequency adaptation


### PR DESCRIPTION
This is my first contribution, and I noticed that the adaptive current q_stc was mentioned in nA, but it should be in pA.

I made two changes:

Updated the comment to correctly state pA instead of nA.
Converted the value by multiplying it by 1000 to properly reflect pA in the calculation.

Changes made in:
File: models/gif_psc_exp.cpp
Line: 357

I haven’t tested this yet since it’s my first issue, but I followed the logic and made the necessary correction.