### PR TITLE
Derive astrocyte_lr_1994 directly from Node

### DIFF
--- a/models/astrocyte_lr_1994.cpp
+++ b/models/astrocyte_lr_1994.cpp
@@ -328,7 +328,7 @@ nest::astrocyte_lr_1994::Buffers_::Buffers_( const Buffers_&, astrocyte_lr_1994&
  * ---------------------------------------------------------------- */
 
 nest::astrocyte_lr_1994::astrocyte_lr_1994()
-  : StructuralPlasticityNode()
+  : Node()
   , P_()
   , S_( P_ )
   , B_( *this )
@@ -337,7 +337,7 @@ nest::astrocyte_lr_1994::astrocyte_lr_1994()
 }
 
 nest::astrocyte_lr_1994::astrocyte_lr_1994( const astrocyte_lr_1994& n )
-  : StructuralPlasticityNode( n )
+  : Node( n )
   , P_( n.P_ )
   , S_( n.S_ )
   , B_( n.B_, *this )

--- a/models/astrocyte_lr_1994.h
+++ b/models/astrocyte_lr_1994.h
@@ -248,7 +248,7 @@ EndUserDocs */
 
 void register_astrocyte_lr_1994( const std::string& name );
 
-class astrocyte_lr_1994 : public StructuralPlasticityNode
+class astrocyte_lr_1994 : public Node
 {
 
 public:
@@ -471,7 +471,7 @@ astrocyte_lr_1994::get_status( DictionaryDatum& d ) const
 {
   P_.get( d );
   S_.get( d );
-  StructuralPlasticityNode::get_status( d );
+  // Node::get_status( d );
 
   ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }
@@ -488,7 +488,7 @@ astrocyte_lr_1994::set_status( const DictionaryDatum& d )
   // write them back to (P_, S_) before we are also sure that
   // the properties to be set in the parent class are internally
   // consistent.
-  StructuralPlasticityNode::set_status( d );
+  // Node::set_status( d );
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;

--- a/models/astrocyte_lr_1994.h
+++ b/models/astrocyte_lr_1994.h
@@ -487,7 +487,6 @@ astrocyte_lr_1994::set_status( const DictionaryDatum& d )
   // write them back to (P_, S_) before we are also sure that
   // the properties to be set in the parent class are internally
   // consistent.
-  // Node::set_status( d );
 
   // if we get here, temporaries contain consistent set of properties
   P_ = ptmp;

--- a/models/astrocyte_lr_1994.h
+++ b/models/astrocyte_lr_1994.h
@@ -471,7 +471,6 @@ astrocyte_lr_1994::get_status( DictionaryDatum& d ) const
 {
   P_.get( d );
   S_.get( d );
-  // Node::get_status( d );
 
   ( *d )[ names::recordables ] = recordablesMap_.get_list();
 }

--- a/pynest/examples/astrocytes/astrocyte_brunel_fixed_indegree.py
+++ b/pynest/examples/astrocytes/astrocyte_brunel_fixed_indegree.py
@@ -315,7 +315,7 @@ def run_simulation():
     # NEST configuration
     nest.ResetKernel()
     nest.resolution = sim_params["dt"]
-    nest.local_num_threads = sim_params["n_threads"]
+    nest.local_num_threads = sim_params["n_vp"]
     nest.print_time = True
     nest.overwrite_files = True
 


### PR DESCRIPTION
This PR slightly simplifies the NEST class hierarchy by deriving `astrocyte_lr_1994` directly from `Node`. It also fixes a small error in an example.