### PR TITLE
Fix incorrect conversion of string inf to double seen on MinGW

### DIFF
--- a/sli/slidata.cc
+++ b/sli/slidata.cc
@@ -1383,7 +1383,7 @@ Cvd_sFunction::execute( SLIInterpreter* i ) const
 
   StringDatum* obj = dynamic_cast< StringDatum* >( i->OStack.top().datum() );
   assert( obj );
-  Token t( new DoubleDatum( std::atof( obj->c_str() ) ) );
+  Token t( new DoubleDatum( std::strtod( obj->c_str(), nullptr ) ) );  
   i->OStack.top().swap( t );
   i->EStack.pop();
 }


### PR DESCRIPTION
This PR changes the string-to-double conversion when reading SLI from std::atoi() to std::strtod(). This resolves an error observed in MinGW in which the value "inf" is converted to 0 instead of infinity. 

This is related to https://github.com/nest/nest-simulator/issues/3217.
