### PR TITLE
Bump formatting to new black version

### DIFF
--- a/doc/htmldoc/developer_space/templates/pynest_api_template.py
+++ b/doc/htmldoc/developer_space/templates/pynest_api_template.py
@@ -21,18 +21,18 @@
 
 """[[ This template demonstrates how to create a docstring for the PyNEST API.
 
-   If you have modified an API, please ensure you update the docstring!
+If you have modified an API, please ensure you update the docstring!
 
-   The format is based on `NumPy style docstring
-   <https://numpydoc.readthedocs.io/en/latest/format.html>`_ and uses
-   reStructuredText markup. Please review the syntax rules if you are
-   unfamiliar with either reStructuredText or NumPy style docstrings.
+The format is based on `NumPy style docstring
+<https://numpydoc.readthedocs.io/en/latest/format.html>`_ and uses
+reStructuredText markup. Please review the syntax rules if you are
+unfamiliar with either reStructuredText or NumPy style docstrings.
 
-   Copy this file and replace the sample text with a description of the API.
-   The double bracketed sections [[ ]], which provide explanations, should be
-   completely removed from your final version - Including this entire
-   docstring!
-   ]]
+Copy this file and replace the sample text with a description of the API.
+The double bracketed sections [[ ]], which provide explanations, should be
+completely removed from your final version - Including this entire
+docstring!
+]]
 """
 
 

--- a/pynest/examples/EI_clustered_network/stimulus_params_EI.py
+++ b/pynest/examples/EI_clustered_network/stimulus_params_EI.py
@@ -19,11 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-""" PyNEST EI-clustered network: Stimulus Parameters
------------------------------------------------------
+"""
+PyNEST EI-clustered network: Stimulus Parameters
+------------------------------------------------
 
 A dictionary with parameters for an optinal stimulation of clusters.
-
 """
 
 stim_dict = {

--- a/pynest/examples/Potjans_2014/stimulus_params.py
+++ b/pynest/examples/Potjans_2014/stimulus_params.py
@@ -19,12 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-""" PyNEST Microcircuit: Stimulus Parameters
------------------------------------------------
+"""
+PyNEST Microcircuit: Stimulus Parameters
+----------------------------------------
 
 A dictionary with parameters for an optional external transient stimulation.
 Thalamic input and DC input can be switched on individually.
-
 """
 
 import numpy as np

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -756,11 +756,11 @@ class SynapseCollection:
         # 35 is arbitrarily chosen.
         if len(srcs) >= MAX_SIZE_FULL_PRINT and not self.print_full:
             # u'\u22EE ' is the unicode for vertical ellipsis, used when we have many connections
-            srcs = srcs[:15] + ["\u22EE "] + srcs[-15:]
-            trgt = trgt[:15] + ["\u22EE "] + trgt[-15:]
-            wght = wght[:15] + ["\u22EE "] + wght[-15:]
-            dlay = dlay[:15] + ["\u22EE "] + dlay[-15:]
-            s_model = s_model[:15] + ["\u22EE "] + s_model[-15:]
+            srcs = srcs[:15] + ["\u22ee "] + srcs[-15:]
+            trgt = trgt[:15] + ["\u22ee "] + trgt[-15:]
+            wght = wght[:15] + ["\u22ee "] + wght[-15:]
+            dlay = dlay[:15] + ["\u22ee "] + dlay[-15:]
+            s_model = s_model[:15] + ["\u22ee "] + s_model[-15:]
 
         headers = f"{src_h:^{src_len}} {trg_h:^{trg_len}} {sm_h:^{sm_len}} {w_h:^{w_len}} {d_h:^{d_len}}" + "\n"
         borders = (

--- a/pynest/nest/raster_plot.py
+++ b/pynest/nest/raster_plot.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-""" Functions for raster plotting."""
+"""Functions for raster plotting."""
 
 import nest
 import numpy

--- a/testsuite/pytests/sli2py_neurons/test_model_node_init.py
+++ b/testsuite/pytests/sli2py_neurons/test_model_node_init.py
@@ -21,12 +21,12 @@
 
 
 """
-   Makeshift test to see if setting model params and then creating a neuron
-   and creating a neuron and then setting node params lead to the same
-   results.
+Makeshift test to see if setting model params and then creating a neuron
+and creating a neuron and then setting node params lead to the same
+results.
 
-   Works by connecting device to iaf_psc_alpha, measuring voltage trace over 1s
-   and comparing traces.
+Works by connecting device to iaf_psc_alpha, measuring voltage trace over 1s
+and comparing traces.
 """
 
 import nest


### PR DESCRIPTION
Most of these changes are required by [#3406](https://github.com/nest/nest-simulator/pull/3406). Some fixing of doc-string title underlines was added on the fly.