### PR TITLE
Improved wrappers and OpenMPI handling in Python MPI tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ markers = [
     "skipif_missing_hdf5: skip test if NEST was built without HDF5 support",
     "skipif_missing_mpi: skip test if NEST was built without MPI support",
     "skipif_missing_threads: skip test if NEST was built without multithreading support",
+    "skipif_incompatible_mpi: skip if NEST with built with MPI that does not work with subprocess",
     "simulation: the simulation class to use. Always pass a 2nd dummy argument"
 ]
 

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -508,7 +508,7 @@ if test "${PYTHON}"; then
 	XUNIT_FILE="${REPORTDIR}/${XUNIT_NAME}_sli2py_mpi.xml"
 	env
 	set +e
-	"${PYTHON}" -m pytest --noconftest --verbose --timeout $TIME_LIMIT --junit-xml="${XUNIT_FILE}" --numprocesses=1 \
+	"${PYTHON}" -m pytest --verbose --timeout $TIME_LIMIT --junit-xml="${XUNIT_FILE}" --numprocesses=1 \
 		    "${PYNEST_TEST_DIR}/sli2py_mpi" 2>&1 | tee -a "${TEST_LOGFILE}"
 	set -e
     fi

--- a/testsuite/pytests/sli2py_mpi/mpi_test_wrapper.py
+++ b/testsuite/pytests/sli2py_mpi/mpi_test_wrapper.py
@@ -41,6 +41,8 @@ be fixed while the number of MPI processes is varied, but this is not required.
     - No decorators are written to the `runner.py` file.
     - Test files must import all required modules (especially `nest`) inside the
       test function.
+    - The docstring for the test function shall in its last line specify what data
+      the test function outputs for comparison by the test.
     - In `runner.py`, the following constants are defined:
          - `SPIKE_LABEL`
          - `MULTI_LABEL`

--- a/testsuite/pytests/sli2py_mpi/mpi_test_wrapper.py
+++ b/testsuite/pytests/sli2py_mpi/mpi_test_wrapper.py
@@ -29,6 +29,9 @@ be fixed while the number of MPI processes is varied, but this is not required.
 
 - The process is managed by subclasses of the `MPITestWrapper` base class
 - Each test file must contain **exactly one** test function
+    - The test function must be protected with the `@pytest.mark.skipif_incompatible_mpi`
+      marker to protect against buggy OpenMPI versions (at least up to 4.1.6; 5.0.7 and
+      later are definitely good).
     - The test function must be decorated with a subclass of `MPITestWrapper`
     - The wrapper will write a modified version of the test file as `runner.py`
       to a temporary directory and mpirun it from there; results are collected
@@ -36,7 +39,8 @@ be fixed while the number of MPI processes is varied, but this is not required.
     - The test function can be decorated with other pytest decorators. These
       are evaluated in the wrapping process
     - No decorators are written to the `runner.py` file.
-    - Test files **must not import nest** outside the test function
+    - Test files must import all required modules (especially `nest`) inside the
+      test function.
     - In `runner.py`, the following constants are defined:
          - `SPIKE_LABEL`
          - `MULTI_LABEL`
@@ -44,14 +48,12 @@ be fixed while the number of MPI processes is varied, but this is not required.
       They must be used as `label` for spike recorders and multimeters, respectively,
       or for other files for output data (CSV files). They are format strings expecting
       the number of processes with which NEST is run as argument.
-- `conftest.py` must not be loaded, otherwise mpirun will return a non-zero exit code;
-  use `pytest --noconftest`
 - Set `debug=True` on the decorator to see debug output and keep the
   temporary directory that has been created (latter works only in
   Python 3.12 and later)
 - Evaluation criteria are determined by the `MPITestWrapper` subclass
 
-This is still work in progress.
+
 """
 
 import ast

--- a/testsuite/pytests/sli2py_mpi/test_all_to_all.py
+++ b/testsuite/pytests/sli2py_mpi/test_all_to_all.py
@@ -19,8 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import pandas
 import pytest
 from mpi_test_wrapper import MPITestAssertEqual
 
@@ -32,12 +30,11 @@ from mpi_test_wrapper import MPITestAssertEqual
 def test_all_to_all(N):
     """
     Confirm that all-to-all connections created correctly for more targets than local nodes.
+
+    The test is performed on connection data written to OTHER_LABEL.
     """
 
     import nest
-    import pandas as pd
-
-    nest.ResetKernel()
 
     nrns = nest.Create("parrot_neuron", n=N)
     nest.Connect(nrns, nrns, "all_to_all")

--- a/testsuite/pytests/sli2py_mpi/test_all_to_all.py
+++ b/testsuite/pytests/sli2py_mpi/test_all_to_all.py
@@ -26,6 +26,7 @@ from mpi_test_wrapper import MPITestAssertEqual
 
 
 # Parametrization over the number of nodes here only to show hat it works
+@pytest.mark.skipif_incompatible_mpi
 @pytest.mark.parametrize("N", [4, 7])
 @MPITestAssertEqual([1, 4], debug=False)
 def test_all_to_all(N):

--- a/testsuite/pytests/sli2py_mpi/test_gap_junctions_mpi.py
+++ b/testsuite/pytests/sli2py_mpi/test_gap_junctions_mpi.py
@@ -19,10 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-
+import pytest
 from mpi_test_wrapper import MPITestAssertEqual
 
 
+@pytest.mark.skipif_incompatible_mpi
+@pytest.mark.skipif_missing_gsl
 @MPITestAssertEqual([1, 2, 4], debug=False)
 def test_gap_junctions_mpi():
     """

--- a/testsuite/pytests/sli2py_mpi/test_gap_junctions_mpi.py
+++ b/testsuite/pytests/sli2py_mpi/test_gap_junctions_mpi.py
@@ -32,14 +32,11 @@ def test_gap_junctions_mpi():
 
     This is an overall test of the hh_psc_alpha_gap model connected by gap_junction.
     The test checks if the gap junction functionality works in parallel.
+
+    The test is performed on the spike data recorded to SPIKE_LABEL during the simulation.
     """
 
     import nest
-    import pandas as pd
-
-    # We can only test here if GSL is available
-    if not nest.ll_api.sli_func("statusdict/have_gsl ::"):
-        return
 
     total_vps = 4
     h = 0.1

--- a/testsuite/pytests/sli2py_mpi/test_issue_1957.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_1957.py
@@ -28,6 +28,8 @@ from mpi_test_wrapper import MPITestAssertEqual
 def test_issue_1957():
     """
     Confirm that GetConnections works in parallel without hanging if not all ranks have connections.
+
+    The test is performed on connection data written to OTHER_LABEL.
     """
 
     import nest

--- a/testsuite/pytests/sli2py_mpi/test_issue_1957.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_1957.py
@@ -19,10 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-
+import pytest
 from mpi_test_wrapper import MPITestAssertEqual
 
 
+@pytest.mark.skipif_incompatible_mpi
 @MPITestAssertEqual([2, 4])
 def test_issue_1957():
     """

--- a/testsuite/pytests/sli2py_mpi/test_issue_2119.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_2119.py
@@ -38,6 +38,8 @@ random_params = [
 def test_issue_2119(kind, specs):
     """
     Confirm that randomized node parameters work correctly under MPI and OpenMP.
+
+    The test is performed on GID-V_m data written to OTHER_LABEL.
     """
 
     import nest

--- a/testsuite/pytests/sli2py_mpi/test_issue_2119.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_2119.py
@@ -32,6 +32,7 @@ random_params = [
 ]
 
 
+@pytest.mark.skipif_incompatible_mpi
 @pytest.mark.parametrize(["kind", "specs"], random_params)
 @MPITestAssertEqual([1, 2, 4])
 def test_issue_2119(kind, specs):

--- a/testsuite/pytests/sli2py_mpi/test_issue_281.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_281.py
@@ -20,9 +20,11 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import pytest
 from mpi_test_wrapper import MPITestAssertCompletes
 
 
+@pytest.mark.skipif_incompatible_mpi
 @MPITestAssertCompletes([1, 2, 4])
 def test_issue_281():
     """

--- a/testsuite/pytests/sli2py_mpi/test_issue_281.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_281.py
@@ -29,10 +29,11 @@ from mpi_test_wrapper import MPITestAssertCompletes
 def test_issue_281():
     """
     Confirm that ConnectLayers works MPI-parallel for fixed fan-out.
+
+    This test only confirms completion, no data is tested.
     """
 
     import nest
-    import pandas as pd
 
     layer = nest.Create("parrot_neuron", positions=nest.spatial.grid(shape=[3, 3]))
     nest.Connect(

--- a/testsuite/pytests/sli2py_mpi/test_issue_600.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_600.py
@@ -20,9 +20,11 @@
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import pytest
 from mpi_test_wrapper import MPITestAssertEqual
 
 
+@pytest.mark.skipif_incompatible_mpi
 @MPITestAssertEqual([1, 2, 4], debug=False)
 def test_issue_600():
     """

--- a/testsuite/pytests/sli2py_mpi/test_issue_600.py
+++ b/testsuite/pytests/sli2py_mpi/test_issue_600.py
@@ -25,18 +25,16 @@ from mpi_test_wrapper import MPITestAssertEqual
 
 
 @pytest.mark.skipif_incompatible_mpi
+@pytest.mark.skipif_missing_gsl
 @MPITestAssertEqual([1, 2, 4], debug=False)
 def test_issue_600():
     """
     Confirm that waveform relaxation works with MPI.
+
+    The test compares data written by spike recorder to SPIKE_LABEL.
     """
 
     import nest
-    import pandas as pd
-
-    # We can only test here if GSL is available
-    if not nest.ll_api.sli_func("statusdict/have_gsl ::"):
-        return
 
     total_vps = 4
     h = 0.1

--- a/testsuite/pytests/sli2py_mpi/test_mini_brunel_ps.py
+++ b/testsuite/pytests/sli2py_mpi/test_mini_brunel_ps.py
@@ -28,11 +28,11 @@ from mpi_test_wrapper import MPITestAssertEqual
 def test_mini_brunel_ps():
     """
     Confirm that downscaled Brunel net with precise neurons is invariant under number of MPI ranks.
+
+    The test compares data written by spike_recorder to SPIKE_LABEL.
     """
 
     import nest
-
-    nest.ResetKernel()
 
     nest.set(total_num_virtual_procs=4, overwrite_files=True)
 

--- a/testsuite/pytests/sli2py_mpi/test_mini_brunel_ps.py
+++ b/testsuite/pytests/sli2py_mpi/test_mini_brunel_ps.py
@@ -19,10 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-
+import pytest
 from mpi_test_wrapper import MPITestAssertEqual
 
 
+@pytest.mark.skipif_incompatible_mpi
 @MPITestAssertEqual([1, 2, 4])
 def test_mini_brunel_ps():
     """

--- a/testsuite/pytests/sli2py_mpi/test_self_get_conns_with_empty_ranks.py
+++ b/testsuite/pytests/sli2py_mpi/test_self_get_conns_with_empty_ranks.py
@@ -26,9 +26,11 @@ from mpi_test_wrapper import MPITestAssertEqual
 # Parametrization over the number of nodes here only to show hat it works
 @pytest.mark.skipif_incompatible_mpi
 @MPITestAssertEqual([1, 2, 4], debug=False)
-def test_self_get_conns_with_empty_ranks():
+def test_get_conns_with_empty_ranks():
     """
-    Selftest: Confirm that connections can be gathered correctly even if some ranks have no neurons.
+    Confirm that connections can be gathered correctly even if some ranks have no neurons.
+
+    The test compares connection data written to OTHER_LABEL.
     """
 
     import nest

--- a/testsuite/pytests/sli2py_mpi/test_self_get_conns_with_empty_ranks.py
+++ b/testsuite/pytests/sli2py_mpi/test_self_get_conns_with_empty_ranks.py
@@ -19,13 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with NEST.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import pandas
 import pytest
 from mpi_test_wrapper import MPITestAssertEqual
 
 
 # Parametrization over the number of nodes here only to show hat it works
+@pytest.mark.skipif_incompatible_mpi
 @MPITestAssertEqual([1, 2, 4], debug=False)
 def test_self_get_conns_with_empty_ranks():
     """


### PR DESCRIPTION
This PR fixes the problem we had with `subprocess` and `mpirun`. Thus, mpitests can now be run with `conftest.py` and the usual "missing" decorators can be applied to MPI tests.

See also https://github.com/nest/nest-simulator/issues/3466.