### PR TITLE
bump forgotten ubuntu-20.04 version to 22.04

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -358,7 +358,7 @@ jobs:
           pylint --jobs=$(nproc) pynest/ testsuite/pytests/*.py testsuite/regressiontests/*.py
 
   isort:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout repository content"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
GitHub deprecated and now removed the `ubuntu-20.04` image in CI.

ref. https://github.com/actions/runner-images/issues/11101