### PR TITLE
Change version of isort CI OS image from Ubuntu 20.04 to Ubuntu 22.04

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -358,7 +358,7 @@ jobs:
           pylint --jobs=$(nproc) pynest/ testsuite/pytests/*.py testsuite/regressiontests/*.py
 
   isort:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: "Checkout repository content"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
+++ b/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
@@ -114,7 +114,7 @@ Visual Studio Code
 ------------------
 
 The following section will guide you through setting up Visual Studio Code (VS Code) for editing, building,
-running, and debugging NEST. Tested with Ubuntu 20.04. Steps for macOS should be equivalent, but with ``⌘``
+running, and debugging NEST. Tested with Ubuntu 22.04. Steps for macOS should be equivalent, but with ``⌘``
 instead of ``ctrl`` in keyboard shortcuts.
 
 Requirements and limitations


### PR DESCRIPTION
Our CI didn't run through anymore since yesterday, because of this:
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101