### PR TITLE
Fix return data in `nest-server`

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -217,7 +217,7 @@ def do_exec(args, kwargs):
         else:
             data = locals_.get(kwargs["return"], None)
 
-            response["data"] = get_or_error(nest.serialize_data)(data)
+        response["data"] = get_or_error(nest.serialize_data)(data)
     return response
 
 


### PR DESCRIPTION
This PR fixes #3471. Now it always returns with data, even if it is `None`.