### PR TITLE
Update the data serialization in hl_api_server.py

### DIFF
--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -1290,8 +1290,6 @@ def serialize_data(data):
                             numpy.int16, numpy.int32, numpy.int64, numpy.uint8,
                             numpy.uint16, numpy.uint32, numpy.uint64)):
         return int(data)
-    if isinstance(data, (numpy.ndarray, NodeCollection)):
-        return data.tolist()
     elif isinstance(data, SynapseCollection):
         # Get full information from SynapseCollection
         return serialize_data(data.get())

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -1286,6 +1286,12 @@ def serialize_data(data):
 
     if isinstance(data, (numpy.ndarray, NodeCollection)):
         return data.tolist()
+    if isinstance(data, (numpy.int_, numpy.intc, numpy.intp, numpy.int8,
+                            numpy.int16, numpy.int32, numpy.int64, numpy.uint8,
+                            numpy.uint16, numpy.uint32, numpy.uint64)):
+        return int(data)
+    if isinstance(data, (numpy.ndarray, NodeCollection)):
+        return data.tolist()
     elif isinstance(data, SynapseCollection):
         # Get full information from SynapseCollection
         return serialize_data(data.get())

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -277,7 +277,7 @@ def route_exec():
     if EXEC_CALL_ENABLED:
         args, kwargs = get_arguments(request)
         response = do_call("exec", args, kwargs)
-        return jsonify(response)
+        return jsonify(nest.serialize_data(response))
     else:
         flask.abort(
             403,
@@ -307,7 +307,7 @@ def route_api_call(call):
     args, kwargs = get_arguments(request)
     log("route_api_call", f"call={call}, args={args}, kwargs={kwargs}")
     response = api_client(call, args, kwargs)
-    return jsonify(response)
+    return jsonify(nest.serialize_data(response))
 
 
 # ----------------------


### PR DESCRIPTION
int64 cannot be serialized by default jsonify,

this change adds the serialization of all int* types to `serialize_data` function and uses it before sending the server response