### PR TITLE
Fix issue with latest Cython release

### DIFF
--- a/pynest/pynestkernel.pyx
+++ b/pynest/pynestkernel.pyx
@@ -361,7 +361,7 @@ cdef inline Datum* python_object_to_datum(obj) except NULL:
 
     if isinstance(obj, bool):
         ret = <Datum*> new BoolDatum(obj)
-    elif isinstance(obj, (int, long)):
+    elif isinstance(obj, int):  # removed 'long'
         ret = <Datum*> new IntegerDatum(obj)
     elif isinstance(obj, float):
         ret = <Datum*> new DoubleDatum(obj)


### PR DESCRIPTION
There is currently an error in the CI:
```

Error compiling Cython file:
------------------------------------------------------------
...

    cdef string obj_str

    if isinstance(obj, bool):
        ret = <Datum*> new BoolDatum(obj)
    elif isinstance(obj, (int, long)):
                               ^
------------------------------------------------------------

/home/runner/work/nest-simulator/nest-simulator/pynest/pynestkernel.pyx:364:31: undeclared name not builtin: long

```
As a quick fix, i have removed the 'long' type check from python_object_to_datum function.
This allows the CI to function again.

Fixes issue #3495.