### PR TITLE
Avoid thread data race in connection_manager

### DIFF
--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -137,8 +137,8 @@ nest::ConnectionManager::initialize( const bool adjust_number_of_threads_or_rng_
 #pragma omp parallel
   {
     const size_t tid = kernel().vp_manager.get_thread_id();
-    connections_.at( tid ) = std::vector< ConnectorBase* >( num_conn_models );
-    secondary_recv_buffer_pos_.at( tid ) = std::vector< std::vector< size_t > >();
+    connections_.at( tid ).resize( num_conn_models );
+    secondary_recv_buffer_pos_.at( tid ).clear();
   } // of omp parallel
 
   source_table_.initialize();


### PR DESCRIPTION
ThreadSanitizer is reporting data races related to the initialization of `connections_` and `secondary_recv_buffer_pos_` within the `ConnectionManager::initialize` method. The serial region's `resize` operation is conflicting with the assignments being performed by worker threads inside of the `pragma omp parallel` region. We are reassigning new objects to already-existing elements, and this patch fixes it by allowing the serial region to construct, and the parallel region just resize.

My AI tells me: 

> When `std::vector::resize()` is called, it default-constructs the elements. If these elements are themselves `std::vector`'s, they will be default-constructed as empty vectors. Then, inside the parallel region, you are reassigning new `std::vector` objects to these already-existing elements. This reassignment involves operations on the internal state of the `std::vector` objects (like pointers to data, size, capacity) which can race if the original resize operation hasn't fully completed for all elements or if `std::vector::operator=` has unexpected concurrent side-effects with the main thread's allocator or vector management. To resolve this, you should ensure that the initial allocation and default construction (`resize`) happens completely in the serial region, and then, inside the parallel region, you modify the existing `std::vector` elements using methods like `resize()` or `clear()` which operate in-place, rather than assigning new temporary `std::vector` objects.

The original reported warnings:
```
==================
WARNING: ThreadSanitizer: data race (pid=970197)
  Read of size 8 at 0x7ffe6cfdf8c8 by thread T12:
    #0 nest::ConnectionManager::initialize(bool) [clone ._omp_fn.0] nest-simulator/nestkernel/connection_manager.cpp:138 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbb0435)
    #1 gomp_thread_start /spec/compilers/src/gcc-15.2.0/libgomp/team.c:129 (libgomp.so.1+0x23d4d)

  Previous write of size 8 at 0x7ffe6cfdf8c8 by main thread:
    #0 nest::ConnectionManager::initialize(bool) nest-simulator/nestkernel/connection_manager.cpp:138 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc2791)
    #1 nest::KernelManager::initialize() nest-simulator/nestkernel/kernel_manager.cpp:95 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbfdfb8)
    #2 nest::init_nest(int*, char***) nest-simulator/nestkernel/nest.cpp:46 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xc6a160)
    #3 neststartup(int*, char***, SLIInterpreter&) nest-simulator/nest/neststartup.cpp:74 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x8dad2d)
    #4 main nest-simulator/nest/main.cpp:40 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x49f1f7)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x1f8c8)

  Thread T12 (tid=970210, running) created by main thread at:
    #0 pthread_create /spec/compilers/src/gcc-15.2.0/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5f090)
    #1 gomp_team_start /spec/compilers/src/gcc-15.2.0/libgomp/team.c:859 (libgomp.so.1+0x2434a)
    #2 nest::KernelManager::initialize() nest-simulator/nestkernel/kernel_manager.cpp:95 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbfdfb8)
    #3 nest::init_nest(int*, char***) nest-simulator/nestkernel/nest.cpp:46 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xc6a160)
    #4 neststartup(int*, char***, SLIInterpreter&) nest-simulator/nest/neststartup.cpp:74 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x8dad2d)
    #5 main nest-simulator/nest/main.cpp:40 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x49f1f7)

SUMMARY: ThreadSanitizer: data race nest-simulator/nestkernel/connection_manager.cpp:138 in nest::ConnectionManager::initialize(bool) [clone ._omp_fn.0]
==================
```
```
==================
WARNING: ThreadSanitizer: data race (pid=970197)
  Read of size 8 at 0x726000000120 by thread T12:
    #0 std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_impl_data::_M_copy_data(std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_impl_data const&) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:121 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbb0513)
    #1 std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_impl_data::_M_swap_data(std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_impl_data&) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:133 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbb0513)
    #2 std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_M_move_assign(std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >&&, std::integral_constant<bool, true>) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:2263 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbb0513)
    #3 std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::operator=(std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >&&) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:838 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbb0513)
    #4 nest::ConnectionManager::initialize(bool) [clone ._omp_fn.0] nest-simulator/nestkernel/connection_manager.cpp:142 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbb0513)
    #5 gomp_thread_start /spec/compilers/src/gcc-15.2.0/libgomp/team.c:129 (libgomp.so.1+0x23d4d)

  Previous write of size 8 at 0x726000000120 by main thread:
    #0 std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_impl_data::_Vector_impl_data() /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:106 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #1 std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_impl::_Vector_impl() /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:148 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #2 std::_Vector_base<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::_Vector_base() /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:321 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #3 std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >::vector() /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:561 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #4 void std::_Construct<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >>(std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_construct.h:133 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #5 std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >* std::__uninitialized_default_n_1<false>::__uninit_default_n<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*, unsigned long>(std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*, unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_uninitialized.h:876 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #6 std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >* std::__uninitialized_default_n<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*, unsigned long>(std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*, unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_uninitialized.h:947 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #7 std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >* std::__uninitialized_default_n_a<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*, unsigned long, std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > >(std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >*, unsigned long, std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > >&) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_uninitialized.h:1002 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #8 std::vector<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >, std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > > >::_M_default_append(unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/vector.tcc:794 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7377)
    #9 std::vector<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >, std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > > >::resize(unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:1146 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc2da0)
    #10 nest::ConnectionManager::initialize(bool) nest-simulator/nestkernel/connection_manager.cpp:124 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc2da0)
    #11 nest::KernelManager::initialize() nest-simulator/nestkernel/kernel_manager.cpp:95 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbfdfb8)
    #12 nest::init_nest(int*, char***) nest-simulator/nestkernel/nest.cpp:46 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xc6a160)
    #13 neststartup(int*, char***, SLIInterpreter&) nest-simulator/nest/neststartup.cpp:74 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x8dad2d)
    #14 main nest-simulator/nest/main.cpp:40 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x49f1f7)

  Location is heap block of size 960 at 0x726000000000 allocated by main thread:
    #0 operator new(unsigned long) /spec/compilers/src/gcc-15.2.0/libsanitizer/tsan/tsan_new_delete.cpp:64 (libtsan.so.2+0xa7421)
    #1 std::__new_allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > >::allocate(unsigned long, void const*) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/new_allocator.h:151 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7350)
    #2 std::allocator_traits<std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > > >::allocate(std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > >&, unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/alloc_traits.h:614 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7350)
    #3 std::_Vector_base<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >, std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > > >::_M_allocate(unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:387 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7350)
    #4 std::vector<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >, std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > > >::_M_default_append(unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/vector.tcc:789 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc7350)
    #5 std::vector<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> >, std::allocator<std::vector<nest::ConnectorBase*, std::allocator<nest::ConnectorBase*> > > >::resize(unsigned long) /spec/compilers/gcc-15.2.0/include/c++/15.2.0/bits/stl_vector.h:1146 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc2da0)
    #6 nest::ConnectionManager::initialize(bool) nest-simulator/nestkernel/connection_manager.cpp:124 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbc2da0)
    #7 nest::KernelManager::initialize() nest-simulator/nestkernel/kernel_manager.cpp:95 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbfdfb8)
    #8 nest::init_nest(int*, char***) nest-simulator/nestkernel/nest.cpp:46 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xc6a160)
    #9 neststartup(int*, char***, SLIInterpreter&) nest-simulator/nest/neststartup.cpp:74 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x8dad2d)
    #10 main nest-simulator/nest/main.cpp:40 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x49f1f7)

  Thread T12 (tid=970210, running) created by main thread at:
    #0 pthread_create /spec/compilers/src/gcc-15.2.0/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5f090)
    #1 gomp_team_start /spec/compilers/src/gcc-15.2.0/libgomp/team.c:859 (libgomp.so.1+0x2434a)
    #2 nest::KernelManager::initialize() nest-simulator/nestkernel/kernel_manager.cpp:95 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xbfdfb8)
    #3 nest::init_nest(int*, char***) nest-simulator/nestkernel/nest.cpp:46 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0xc6a160)
    #4 neststartup(int*, char***, SLIInterpreter&) nest-simulator/nest/neststartup.cpp:74 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x8dad2d)
    #5 main nest-simulator/nest/main.cpp:40 (nest_s_base.drm-gcc-15.2.0-64-sanitize_thread+0x49f1f7)

SUMMARY: ThreadSanitizer: data race nest-simulator/nestkernel/connection_manager.cpp:142 in nest::ConnectionManager::initialize(bool) [clone ._omp_fn.0]
==================
```