### PR TITLE
Fix a number of problems with GetNodes

### DIFF
--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -318,7 +318,7 @@ nest::MPIManager::get_processor_name()
 }
 
 void
-nest::MPIManager::communicate( std::vector< size_t >& local_nodes, std::vector< size_t >& global_nodes )
+nest::MPIManager::communicate( std::vector< long >& local_nodes, std::vector< long >& global_nodes )
 {
   const size_t num_procs = get_num_processes();
 
@@ -347,14 +347,14 @@ nest::MPIManager::communicate( std::vector< size_t >& local_nodes, std::vector< 
   }
 
   // Avoid dereferencing empty vector. As long as sendcount is 0, we can pass any pointer for sendbuf.
-  size_t dummy = 0;
+  long dummy = 0;
   MPI_Allgatherv( num_local_nodes > 0 ? &local_nodes[ 0 ] : &dummy,
     num_local_nodes,
-    MPI_Type< size_t >::type,
+    MPI_Type< long >::type,
     &global_nodes[ 0 ],
     &num_nodes_per_rank[ 0 ],
     &displacements[ 0 ],
-    MPI_Type< size_t >::type,
+    MPI_Type< long >::type,
     comm );
 }
 
@@ -1071,7 +1071,7 @@ nest::MPIManager::communicate( double send_val, std::vector< double >& recv_buff
 }
 
 void
-nest::MPIManager::communicate( std::vector< size_t >&, std::vector< size_t >& )
+nest::MPIManager::communicate( std::vector< long >&, std::vector< long >& )
 {
 }
 

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -318,39 +318,43 @@ nest::MPIManager::get_processor_name()
 }
 
 void
-nest::MPIManager::communicate( std::vector< long >& local_nodes, std::vector< long >& global_nodes )
+nest::MPIManager::communicate( std::vector< size_t >& local_nodes, std::vector< size_t >& global_nodes )
 {
-  size_t np = get_num_processes();
-  // Get size of buffers
-  std::vector< int > num_nodes_per_rank( np );
-  num_nodes_per_rank[ get_rank() ] = local_nodes.size();
-  communicate( num_nodes_per_rank );
+  const size_t num_procs = get_num_processes();
 
-  const size_t num_globals = std::accumulate( num_nodes_per_rank.begin(), num_nodes_per_rank.end(), 0 );
+  // We need to work with int in much what follows, because several MPI_Allgatherv() arguments must be int.
+  assert( local_nodes.size() <= std::numeric_limits< int >::max() );
+  const int num_local_nodes = static_cast< int >( local_nodes.size() );
+
+  // Get number of nodes per rank and total.
+  std::vector< int > num_nodes_per_rank( num_procs );
+  num_nodes_per_rank[ get_rank() ] = num_local_nodes;
+  communicate( num_nodes_per_rank );
+  const int num_globals = std::accumulate( num_nodes_per_rank.begin(), num_nodes_per_rank.end(), 0 );
   if ( num_globals == 0 )
   {
-    return; // must return here to avoid passing address to empty global_nodes below
+    return; // Must return here to avoid passing address to empty global_nodes below
   }
 
   global_nodes.resize( num_globals, 0L );
 
   // Set up displacements vector. Entry i specifies the displacement (relative
   // to recv_buffer ) at which to place the incoming data from process i
-  std::vector< int > displacements( np, 0 );
-  for ( size_t i = 1; i < np; ++i )
+  std::vector< int > displacements( num_procs, 0 );
+  for ( size_t i = 1; i < num_procs; ++i )
   {
     displacements.at( i ) = displacements.at( i - 1 ) + num_nodes_per_rank.at( i - 1 );
   }
 
-  // avoid dereferencing empty vector
-  const auto send_ptr = local_nodes.empty() ? nullptr : &local_nodes[ 0 ];
-  MPI_Allgatherv( send_ptr,
-    local_nodes.size(),
-    MPI_Type< long >::type,
+  // Avoid dereferencing empty vector. As long as sendcount is 0, we can pass any pointer for sendbuf.
+  size_t dummy = 0;
+  MPI_Allgatherv( num_local_nodes > 0 ? &local_nodes[ 0 ] : &dummy,
+    num_local_nodes,
+    MPI_Type< size_t >::type,
     &global_nodes[ 0 ],
     &num_nodes_per_rank[ 0 ],
     &displacements[ 0 ],
-    MPI_Type< long >::type,
+    MPI_Type< size_t >::type,
     comm );
 }
 
@@ -1067,7 +1071,7 @@ nest::MPIManager::communicate( double send_val, std::vector< double >& recv_buff
 }
 
 void
-nest::MPIManager::communicate( std::vector< long >&, std::vector< long >& )
+nest::MPIManager::communicate( std::vector< size_t >&, std::vector< size_t >& )
 {
 }
 

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -122,7 +122,7 @@ public:
 
   // gather all send_buffer vectors on other mpi process to recv_buffer
   // vector
-  void communicate( std::vector< size_t >& send_buffer, std::vector< size_t >& recv_buffer );
+  void communicate( std::vector< long >& send_buffer, std::vector< long >& recv_buffer );
 
   /**
    * communicate (on-grid) if compiled without MPI

--- a/nestkernel/mpi_manager.h
+++ b/nestkernel/mpi_manager.h
@@ -122,7 +122,7 @@ public:
 
   // gather all send_buffer vectors on other mpi process to recv_buffer
   // vector
-  void communicate( std::vector< long >& send_buffer, std::vector< long >& recv_buffer );
+  void communicate( std::vector< size_t >& send_buffer, std::vector< size_t >& recv_buffer );
 
   /**
    * communicate (on-grid) if compiled without MPI

--- a/nestkernel/node_manager.cpp
+++ b/nestkernel/node_manager.cpp
@@ -350,7 +350,7 @@ NodeManager::get_nodes( const DictionaryDatum& params, const bool local_only )
     nodes_on_thread.resize( kernel().vp_manager.get_num_threads() );
 #pragma omp parallel
     {
-      size_t tid = kernel().vp_manager.get_thread_id();
+      const size_t tid = kernel().vp_manager.get_thread_id();
 
       for ( auto node : get_local_nodes( tid ) )
       {
@@ -387,6 +387,12 @@ NodeManager::get_nodes( const DictionaryDatum& params, const bool local_only )
               break;
             }
           }
+          else
+          {
+            // We were looking for a parameter not existing in the node, so it is no match.
+            match = false;
+            break;
+          }
         }
         if ( match )
         {
@@ -408,15 +414,14 @@ NodeManager::get_nodes( const DictionaryDatum& params, const bool local_only )
         nodes.push_back( globalnodes[ i ] );
       }
     }
-
-    // get rid of any multiple entries
-    std::sort( nodes.begin(), nodes.end() );
-    std::vector< long >::iterator it;
-    it = std::unique( nodes.begin(), nodes.end() );
-    nodes.resize( it - nodes.begin() );
   }
 
-  std::sort( nodes.begin(), nodes.end() ); // ensure nodes are sorted prior to creating the NodeCollection
+  // get rid of any multiple entries
+  std::sort( nodes.begin(), nodes.end() );
+  std::vector< long >::iterator it;
+  it = std::unique( nodes.begin(), nodes.end() );
+  nodes.resize( it - nodes.begin() );
+
   IntVectorDatum nodes_datum( nodes );
   NodeCollectionDatum nodecollection( NodeCollection::create( nodes_datum ) );
 

--- a/testsuite/pytests/mpi/2/test_getnodes.py
+++ b/testsuite/pytests/mpi/2/test_getnodes.py
@@ -1,0 +1,1 @@
+../../test_getnodes.py

--- a/testsuite/pytests/test_getnodes.py
+++ b/testsuite/pytests/test_getnodes.py
@@ -57,7 +57,7 @@ class TestGetNodes:
         nodes_ref = nest.NodeCollection(list(range(1, nest.network_size + 1)))
         if nodes_ref and local_only:
             # Need to go via global_id to get empty node collection if no locals
-            nodes_ref = nest.NodeCollection(n.global_id for n in nodes_ref if n.local)
+            nodes_ref = nest.NodeCollection([n.global_id for n in nodes_ref if n.local])
 
         nodes = nest.GetNodes(local_only=local_only)
 
@@ -78,7 +78,7 @@ class TestGetNodes:
         nodes_ref = nest.NodeCollection(expected_ids)
         if local_only:
             # Need to go via global_id to get empty node collection if no locals
-            nodes_ref = nest.NodeCollection(n.global_id for n in nodes_ref if n.local)
+            nodes_ref = nest.NodeCollection([n.global_id for n in nodes_ref if n.local])
 
         nodes = nest.GetNodes(properties=filter, local_only=local_only)
         assert nodes == nodes_ref

--- a/testsuite/pytests/test_getnodes.py
+++ b/testsuite/pytests/test_getnodes.py
@@ -27,7 +27,9 @@ import nest
 import pytest
 
 
-@pytest.fixture(autouse=True, params=[1, 2])
+# Apply parameterization over number of threads here, each test will be run once for
+# each parameter value. Need to protect in case we are running without threads.
+@pytest.fixture(autouse=True, params=[1, 2] if nest.build_info["have_threads"] else [1])
 def create_neurons(request):
     nest.ResetKernel()
     nest.local_num_threads = request.param


### PR DESCRIPTION
This PR is a backport of a corresponding fix in PyNEST-NG. It fixes code leading to undefined MPI behaviour (passing `nullptr` for `sendbuf` to `MPI_Allgatherv()` and corrects the selection logic if only neurons with certain parameters are requested, as well as fixing a doubling of device entries from threads. It furthermore extends the tests to cover more cases, especially parallel and including devices.

The code for `GetNodes()` could be further improved. I have done this in the PyNEST-NG branch, see https://github.com/heplesser/nest-simulator/blob/da99c325a540b1a769c59530b5e1436bae65f1ea/nestkernel/node_manager.cpp#L338, but will not backport this here any more.