### PR TITLE
nest-server: BadRequest: 400 Bad Request: name '<function name>' is not defined

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -198,14 +198,14 @@ def do_exec(args, kwargs):
         with Capturing() as stdout:
             globals_ = globals().copy()
             globals_.update(get_modules_from_env())
-            get_or_error(exec)(source_cleaned, globals_, locals_)
+            get_or_error(exec)(source_cleaned, globals_)
         if len(stdout) > 0:
             response["stdout"] = "\n".join(stdout)
     else:
         code = RestrictedPython.compile_restricted(source_cleaned, "<inline>", "exec")  # noqa
         globals_ = get_restricted_globals()
         globals_.update(get_modules_from_env())
-        get_or_error(exec)(code, globals_, locals_)
+        get_or_error(exec)(code, globals_)
         if "_print" in locals_:
             response["stdout"] = "".join(locals_["_print"].txt)
 
@@ -303,7 +303,7 @@ def route_api():
 @app.route("/api/<call>", methods=["GET", "POST"])
 def route_api_call(call):
     """Route to call function in NEST."""
-    print(f"\n{'='*40}\n", flush=True)
+    print(f"\n{'=' * 40}\n", flush=True)
     args, kwargs = get_arguments(request)
     log("route_api_call", f"call={call}, args={args}, kwargs={kwargs}")
     response = api_client(call, args, kwargs)
@@ -588,7 +588,14 @@ def combine(call_name, response):
         return None
 
     # return the master response if all responses are known to be the same
-    if call_name in ("exec", "Create", "GetDefaults", "GetKernelStatus", "SetKernelStatus", "SetStatus"):
+    if call_name in (
+        "exec",
+        "Create",
+        "GetDefaults",
+        "GetKernelStatus",
+        "SetKernelStatus",
+        "SetStatus",
+    ):
         return response[0]
 
     # return a single response if there is only one which is not None

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -192,20 +192,20 @@ def do_exec(args, kwargs):
     source_code = kwargs.get("source", "")
     source_cleaned = clean_code(source_code)
 
-    locals_ = dict()
+    locals_ = globals()
     response = dict()
     if RESTRICTION_DISABLED:
         with Capturing() as stdout:
             globals_ = globals().copy()
             globals_.update(get_modules_from_env())
-            get_or_error(exec)(source_cleaned, globals_)
+            get_or_error(exec)(source_cleaned, globals_, locals_)
         if len(stdout) > 0:
             response["stdout"] = "\n".join(stdout)
     else:
         code = RestrictedPython.compile_restricted(source_cleaned, "<inline>", "exec")  # noqa
         globals_ = get_restricted_globals()
         globals_.update(get_modules_from_env())
-        get_or_error(exec)(code, globals_)
+        get_or_error(exec)(code, globals_, locals_)
         if "_print" in locals_:
             response["stdout"] = "".join(locals_["_print"].txt)
 


### PR DESCRIPTION
Fixes #2666

 #####  `exec(script: string|bytes, globals: dict, locals: dict)`:
```python
# script.py
def foo():  # stored in locals
    pass

def bar(): # stored in locals
    foo()  # is it in `bar.__locals__`?, if yes then ok, found it, 
           # if not, seach in bar._globals__ (same as the provided global), if not found, then search in __builtin__  
           # --> result `foo` not found
```
here, we must set `locals` to `globals`, to be able to call the defined functions within other defined functions.