### PR TITLE
Make parsing of XML files robust against extra > at end of file

### DIFF
--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -28,4 +28,3 @@ mypy >= 0.8
 junitparser >= 2
 clang-format == 17.0.4
 attrs
-lxml

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -28,3 +28,4 @@ mypy >= 0.8
 junitparser >= 2
 clang-format == 17.0.4
 attrs
+lxml

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -63,8 +63,8 @@ def parse_result_file(fname):
         # extraneous > at end of file xml file. No other corruption has ever
         # been seen so far. So check and correct for that.
         # fromstring() below requires bytes, so we read in binary mode.
+        # See also #3193.
         xml_text = open(fname, "rb").read().rstrip()
-        print("Text: ", xml_text)
         if xml_text.endswith(b">>"):
             xml_text = xml_text[:-1]
         results = jp.JUnitXml.fromstring(xml_text)


### PR DESCRIPTION
This occurs regularly for mpi/4 tests and I have never observed any other problem there. The cause is multiple MPI processes writing simultaneously.