### PR TITLE
Fix assertion to ensure range index is properly cast to size_t

### DIFF
--- a/nestkernel/modelrange_manager.cpp
+++ b/nestkernel/modelrange_manager.cpp
@@ -104,6 +104,7 @@ ModelRangeManager::get_model_id( size_t node_id ) const
       range_idx -= ( range_idx - left ) / 2;
     }
     assert( left + 1 < right );
+    assert( range_idx >= 0 );
     assert( static_cast< size_t >( range_idx ) < modelranges_.size() );
   }
   return modelranges_[ range_idx ].get_model_id();


### PR DESCRIPTION
Fix the following warning thrown by the compiler:

```bash
modelrange_manager.cpp:107:23: warning: comparison of integer expressions of different signedness: 'long int' and 'std:
:vector<nest::modelrange>::size_type' {aka 'long unsigned int'} [-Wsign-compare]                 
  107 |     assert( range_idx < modelranges_.size() );                        
```