### PR TITLE
Fix destructor warning by updating PoolWrapper destructor signature

### DIFF
--- a/nestkernel/connection_creator_impl.h
+++ b/nestkernel/connection_creator_impl.h
@@ -167,7 +167,7 @@ ConnectionCreator::PoolWrapper_< D >::PoolWrapper_()
 }
 
 template < int D >
-ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_< D >()
+ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_()
 {
   if ( masked_layer_ )
   {


### PR DESCRIPTION
Fix the following warning thrown by the compiler:

```bash
connection_creator_impl.h:170:39: warning: template-id not allowed for destructor in C++20 [-Wtemplate-id-cdtor]
  170 | ConnectionCreator::PoolWrapper_< D >::~PoolWrapper_< D >()            
```