### PR TITLE
Fix compiler warnings related to `size_t`

### DIFF
--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -228,11 +228,11 @@ nest::correlomatrix_detector::State_::reset( const Parameters_& p )
   count_covariance_.clear();
   count_covariance_.resize( p.N_channels_ );
 
-  for ( auto i = 0; i < p.N_channels_; ++i )
+  for ( size_t i = 0; i < p.N_channels_; ++i )
   {
     covariance_[ i ].resize( p.N_channels_ );
     count_covariance_[ i ].resize( p.N_channels_ );
-    for ( auto j = 0; j < p.N_channels_; ++j )
+    for ( size_t j = 0; j < p.N_channels_; ++j )
     {
       covariance_[ i ][ j ].resize( 1 + p.tau_max_.get_steps() / p.delta_tau_.get_steps(), 0 );
       count_covariance_[ i ][ j ].resize( 1 + p.tau_max_.get_steps() / p.delta_tau_.get_steps(), 0 );

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -392,7 +392,7 @@ nest::correlospinmatrix_detector::handle( SpikeEvent& e )
       // yet every impulse in the queue that is further in the past than
       // this minimum - tau_max cannot contribute to the count covariance
       long t_min_on = t_i_on;
-      for ( auto n = 0; n < P_.N_channels_; n++ )
+      for ( size_t n = 0; n < P_.N_channels_; n++ )
       {
         if ( S_.curr_state_[ n ] )
         {

--- a/models/iaf_bw_2001_exact.cpp
+++ b/models/iaf_bw_2001_exact.cpp
@@ -529,7 +529,7 @@ void
 nest::iaf_bw_2001_exact::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
-  assert( e.get_rport() <= static_cast< int >( B_.spikes_.size() ) );
+  assert( e.get_rport() <= B_.spikes_.size() );
 
   const double steps = e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() );
   const auto rport = e.get_rport();


### PR DESCRIPTION
This PR fixes compiler warnings related to `size_t`.