### PR TITLE
Add pandoc to the environment dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,6 +41,7 @@ dependencies:
   - cppcheck
   - doxygen
   - graphviz
+  - pandoc
 
   # mpi4py must be installed by mamba in order to automatically find the path
   # to OpenMPI installed by mamba. Note that mpi4py also is included in


### PR DESCRIPTION
Building the user documentation with the provided conda environment recipes fails due to a missing pandoc dependency on a clean setup. This PR adds pandoc to the conda environment file.