### PR TITLE
Load `NMNIST_pixels_blocklist.txt` relative to script directory

### DIFF
--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
@@ -77,6 +77,7 @@ References
 
 import os
 import zipfile
+from pathlib import Path
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -182,7 +183,7 @@ nest.set_verbosity("M_FATAL")
 # pixels. By omitting spike generators for pixels on this blocklist, we effectively reduce the total number of
 # input neurons and spike generators required, optimizing the network's resource usage.
 
-pixels_blocklist = np.loadtxt("./NMNIST_pixels_blocklist.txt")
+pixels_blocklist = np.loadtxt(Path(__file__).resolve().parent / "NMNIST_pixels_blocklist.txt")
 
 pixels_dict = {
     "n_x": 34,  # number of pixels in horizontal direction


### PR DESCRIPTION
This PR fixes part of issue #3658 by loading `N_MNIST_pixels_blocklist.txt` relative to the script directory instead of the current working directory, enabling execution from outside the parent directory.
