### PR TITLE
Hide default thumbnail image from autogenerated sphinx-gallery

### DIFF
--- a/doc/htmldoc/static/css/custom.css
+++ b/doc/htmldoc/static/css/custom.css
@@ -90,6 +90,9 @@ section#kernel-attributes-nest-nestmodule dd {
  display: none;
 }
 
+.sphx-glr-thumbcontainer img {
+	display: none;
+}
 
 .autosummary tr {
         border: none;


### PR DESCRIPTION
This PR hides the default sphinx-gallery thumbnail so only the title now is visible. This was done because the default image was confusing. The examples that are single files are not affected. Examples contained in their own subdirectories and have README which is visible on Read the Docs are affected.