### PR TITLE
Fix connection generator code to work with PyNEST-NG

### DIFF
--- a/nestkernel/conn_builder_conngen.cpp
+++ b/nestkernel/conn_builder_conngen.cpp
@@ -100,8 +100,8 @@ ConnectionGeneratorBuilder::connect_()
       throw BadProperty( "The parameter map has to contain the indices of weight and delay." );
     }
 
-    const size_t d_idx = params_map_.get< size_t >( names::delay );
-    const size_t w_idx = params_map_.get< size_t >( names::weight );
+    const size_t d_idx = static_cast< size_t >( params_map_.get< long >( names::delay ) );
+    const size_t w_idx = static_cast< size_t >( params_map_.get< long >( names::weight ) );
 
     const bool d_idx_is_0_or_1 = d_idx == 0 or ( d_idx == 1 );
     const bool w_idx_is_0_or_1 = w_idx == 0 or ( w_idx == 1 );

--- a/pynest/CMakeLists.txt
+++ b/pynest/CMakeLists.txt
@@ -36,7 +36,7 @@ if ( HAVE_PYTHON )
   endif ()
 
   # PYNEST-NG-FUTURE: somehow it works without models being in here, but why?
-  target_link_libraries( nestkernel_api nestutil nestkernel )
+  target_link_libraries( nestkernel_api nestutil nestkernel ${LIBNEUROSIM_LIBRARIES} )
 
   if ( APPLE )
     set_target_properties( nestkernel_api PROPERTIES LINK_FLAGS "-undefined dynamic_lookup" )

--- a/pynest/nestkernel_api.pxd
+++ b/pynest/nestkernel_api.pxd
@@ -130,6 +130,11 @@ cdef extern from "mask.h" namespace "nest":
         MaskPTR()
 
 
+cdef extern from "pynestkernel_aux.h":
+    bint CYTHON_isConnectionGenerator(object)
+    void CYTHON_insertConnectionGenerator(Dictionary& d, string key, object obj)
+
+
 cdef extern from "nest.h" namespace "nest":
     void init_nest( int* argc, char** argv[] )
     void shutdown_nest( int exitcode )

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -252,6 +252,8 @@ cdef Dictionary pydict_to_Dictionary(object py_dict) except *:  # Adding "except
             cdict[pystr_to_string(key)] = (<ParameterObject>value).thisptr
         elif type(value) is type(nest.VerbosityLevel.ALL):  # ALL will always exist
             cdict[pystr_to_string(key)] = <VerbosityLevel>(value)
+        elif CYTHON_isConnectionGenerator(value):
+            CYTHON_insertConnectionGenerator(cdict, pystr_to_string(key), value)
         else:
             typename = type(value)
             if type(value) is list:

--- a/pynest/pynestkernel_aux.h
+++ b/pynest/pynestkernel_aux.h
@@ -29,32 +29,27 @@
 #if defined( HAVE_LIBNEUROSIM )
 
 // External includes:
+#include "dictionary.h"
+#include <memory>
+#include <neurosim/connection_generator.h>
 #include <neurosim/pyneurosim.h>
-
-// Includes from conngen:
-#include "conngenmodule.h"
+#include <string>
 
 #define CYTHON_isConnectionGenerator( x ) PNS::isConnectionGenerator( x )
 
-Datum*
-CYTHON_unpackConnectionGeneratorDatum( PyObject* obj )
+static inline void
+CYTHON_insertConnectionGenerator( Dictionary& d, const std::string& key, PyObject* obj )
 {
-  Datum* ret = NULL;
-  ConnectionGenerator* cg = NULL;
-
-  cg = PNS::unpackConnectionGenerator( obj );
-  if ( cg != NULL )
+  ConnectionGenerator* raw = PNS::unpackConnectionGenerator( obj );
+  if ( raw )
   {
-    ret = static_cast< Datum* >( new nest::ConnectionGeneratorDatum( cg ) );
+    d[ key ] = std::shared_ptr< ConnectionGenerator >( raw );
   }
-
-  return ret;
 }
 
 #else  // #if defined( HAVE_LIBNEUROSIM )
 
 #define CYTHON_isConnectionGenerator( x ) 0
-#define CYTHON_unpackConnectionGeneratorDatum( x ) NULL
 
 #endif  // #if defined( HAVE_LIBNEUROSIM )
 

--- a/pynest/pynestkernel_aux.h
+++ b/pynest/pynestkernel_aux.h
@@ -26,14 +26,20 @@
 // Generated includes:
 #include "config.h"
 
+// Always required: Dictionary and std::string must be visible in both the
+// HAVE_LIBNEUROSIM and no-op branches because Cython emits calls to both
+// CYTHON_isConnectionGenerator and CYTHON_insertConnectionGenerator
+// unconditionally in the generated C++ regardless of the preprocessor state.
+#include "dictionary.h"
+#include <Python.h>
+#include <string>
+
 #if defined( HAVE_LIBNEUROSIM )
 
 // External includes:
-#include "dictionary.h"
 #include <memory>
 #include <neurosim/connection_generator.h>
 #include <neurosim/pyneurosim.h>
-#include <string>
 
 #define CYTHON_isConnectionGenerator( x ) PNS::isConnectionGenerator( x )
 
@@ -50,6 +56,12 @@ CYTHON_insertConnectionGenerator( Dictionary& d, const std::string& key, PyObjec
 #else  // #if defined( HAVE_LIBNEUROSIM )
 
 #define CYTHON_isConnectionGenerator( x ) 0
+
+static inline void
+CYTHON_insertConnectionGenerator( Dictionary& /* d */, const std::string& /* key */, PyObject* /* obj */ )
+{
+  // no-op: libneurosim not available
+}
 
 #endif  // #if defined( HAVE_LIBNEUROSIM )
 


### PR DESCRIPTION
This is a solution found by Claude code.
csa_example.py and csa_spatial_example.py both worked in Docker container with these modifications
**The following text and code changes were done with AI:**

| File | Change |
|------|--------|
| `pynest/pynestkernel_aux.h` | Remove `conngenmodule.h` include; replace `Datum*`-returning `CYTHON_unpackConnectionGeneratorDatum` with `CYTHON_insertConnectionGenerator` that stores `shared_ptr<ConnectionGenerator>` into a `boost::any` Dictionary slot |
| `pynest/nestkernel_api.pxd` | Add `cdef extern` declarations for `CYTHON_isConnectionGenerator` and `CYTHON_insertConnectionGenerator` |
| `pynest/nestkernel_api.pyx` | Add `elif CYTHON_isConnectionGenerator` branch in `pydict_to_Dictionary` before the `AttributeError` fallthrough |
| `pynest/CMakeLists.txt` | Add `${LIBNEUROSIM_LIBRARIES}` to `nestkernel_api` link libraries |
| `nestkernel/conn_builder_conngen.cpp` | Read `params_map` indices as `long` not `size_t`; `static_cast` to `size_t` |

Fix: ConnectionGenerator (libneurosim/CSA) support in pynest-ng

## Background

When pynest-ng (Cython) was merged into `main`, the ConnectionGenerator
integration from the old SWIG-based pynest was not fully ported. There are
three distinct problems:

### Problem 1 — `pynestkernel_aux.h` exists but is broken and unused

The file `pynest/pynestkernel_aux.h` was carried over from the SWIG era but
was never wired into pynest-ng. It has two bugs that make it unusable as-is:

**Bug A — includes a module that no longer exists:**
```c
// Includes from conngen:
#include "conngenmodule.h"    // <-- ConngenModule was removed from NEST main
```
This line causes a compile error if the header is ever included while
`HAVE_LIBNEUROSIM` is defined.

**Bug B — returns `Datum*`, which is incompatible with pynest-ng:**
```c
Datum*
CYTHON_unpackConnectionGeneratorDatum( PyObject* obj )
{
  ...
  ret = static_cast< Datum* >( new nest::ConnectionGeneratorDatum( cg ) );
  return ret;
}
```
pynest-ng does not use the SLI `Datum` type. All values are stored in
`boost::any` fields inside a `Dictionary`. A function returning `Datum*` cannot
be used to insert a ConnectionGenerator into a pynest-ng Dictionary.

### Problem 2 — `pydict_to_Dictionary` has no ConnectionGenerator branch

`nestkernel_api.pyx` falls through to `raise AttributeError` for any type it
does not recognise. `pynestkernel_aux.h` is not included and its macros are
never called:

```
AttributeError: value of key (cg) is not a known type,
got <class 'csa.connset.ConnectionSet'>
```

### Problem 3 — `conn_builder_conngen.cpp` reads `params_map` as `size_t`

`boost::any` requires an exact type match. `pydict_to_Dictionary` stores Python
`int` values as `long`, but the conngen builder reads them as `size_t`:

```
NESTErrors.TypeMismatch: Failed to cast 'delay' from long to type unsigned long
```

---

## Reproducer

With NEST built with `libneurosim` support:

```python
import nest
import csa

pre  = nest.Create("iaf_psc_alpha", 4)
post = nest.Create("iaf_psc_alpha", 4)

cg = csa.cset(csa.oneToOne, 10000.0, 2.0)
params_map = {"weight": 0, "delay": 1}
connspec = {"rule": "conngen", "cg": cg, "params_map": params_map}

nest.Connect(pre, post, connspec)  # raises AttributeError  (problem 2)
                                   # after fixing problem 2: raises TypeMismatch (problem 3)
```

The existing test suite in
`testsuite/pytests/connect/test_connect_conngen.py` covers all four conngen
scenarios and serves as the regression suite for this fix.
