### PR TITLE
Add missing include needed on macOS 26.4

### DIFF
--- a/libnestutil/numerics.h
+++ b/libnestutil/numerics.h
@@ -29,6 +29,7 @@
 // C++ includes:
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 
 #if HAVE_EXPM1


### PR DESCRIPTION
Since updating to macOS 26.4 yesterday, NEST wouldn't compile any more (with clang at least) due to `size_t` here https://github.com/nest/nest-simulator/blob/2478f94eb03fb0b63b6ea98c7940e57b1d92eb42/libnestutil/numerics.h#L181 when included from here  https://github.com/nest/nest-simulator/blob/2478f94eb03fb0b63b6ea98c7940e57b1d92eb42/models/stdp_dopamine_synapse.h#L27. Interestingly, `size_t` is not a built-in datatype in the C++ language but actually defined in `cstddef` (and some other headers). Some change in libc++ likely lead to `size_t` suddenly no longer being available, so I now add it explicitly.

Labeling as critical because it precludes building NEST on macOS 26.4.