### PR TITLE
Fix use-after-free of ltdl error string

### DIFF
--- a/nestkernel/module_manager.cpp
+++ b/nestkernel/module_manager.cpp
@@ -104,7 +104,7 @@ ModuleManager::get_status( Dictionary& d )
 }
 
 void
-ModuleManager::set_status( const Dictionary& d )
+ModuleManager::set_status( const Dictionary& )
 {
 }
 

--- a/nestkernel/module_manager.cpp
+++ b/nestkernel/module_manager.cpp
@@ -150,15 +150,17 @@ ModuleManager::install( const std::string& name )
 
   // see if we can find the "module" symbol in the module
   NESTExtensionInterface* extension = reinterpret_cast< NESTExtensionInterface* >( lt_dlsym( hModule, "module" ) );
-  char* errstr = ( char* ) lt_dlerror();
-  if ( errstr )
+  char* errcstr = ( char* ) lt_dlerror();
+  if ( errcstr )
   {
+    std::string errstr( errcstr );
     lt_dlclose( hModule );  // close module again
     lt_dlerror();           // remove any error caused by lt_dlclose()
     throw DynamicModuleManagementError(
-            "Module '" + name + "' could not be loaded.\n"
+            "Module '" + name + "' could not be loaded: could not find "
+            "module symbol in module.\n"
             "The dynamic loader returned the following error: '"
-            + std::string(errstr) + "'.");
+            + errstr + "'.");
   }
 
   // all is well and we can register module components


### PR DESCRIPTION
This PR fixes a small use-after-free bug in handling the ltdl error string in case of a specific failure.

The issue is as follows: we grab a pointer to the error string (a char*) returned by ltdl. We then call ``lt_dlclose()``, which frees the memory where the string is at, and then we construct a std::string using the pointer. This can result in incorrect detection of the error condition and garbled output, like:

``
DynamicModuleManagementError: Module '[snip]/foomodule.so' could not be loaded.
The dynamic loader returned the following error: ''00'.
``

``
DynamicModuleManagementError: Module '[snip]/foomodule.so' could not be loaded.
The dynamic loader returned the following error: 'j/j'.
``

This PR fixes the issue by converting to a std::string straight away.