### PR TITLE
Fix failing weight plot in e-prop examples

### DIFF
--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
@@ -870,10 +870,11 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
         for target in set(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
-                if np.any(idc_syn):
-                    idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
-                        weights_pre_train[label]["target"] == target
-                    )
+                idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
+                    weights_pre_train[label]["target"] == target
+                )
+
+                if np.any(idc_syn) and np.any(idc_syn_pre):
                     times = np.concatenate([[0.0], events["times"][idc_syn]])
 
                     weights = np.concatenate(

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
@@ -617,8 +617,8 @@ class TrainingPipeline:
         cond2 = times <= self.n_iter_sim * batch_size * duration["sequence"] + duration["total_offset"]
         idc = cond1 & cond2
 
-        readout_signal = np.array([readout_signal[idc][senders[idc] == i] for i in set(senders)])
-        target_signal = np.array([target_signal[idc][senders[idc] == i] for i in set(senders)])
+        readout_signal = np.array([readout_signal[idc][senders[idc] == i] for i in np.unique(senders)])
+        target_signal = np.array([target_signal[idc][senders[idc] == i] for i in np.unique(senders)])
 
         readout_signal = readout_signal.reshape((n_out, 1, batch_size, steps["sequence"]))
         target_signal = target_signal.reshape((n_out, 1, batch_size, steps["sequence"]))
@@ -798,7 +798,7 @@ fig.tight_layout()
 
 
 def plot_recordable(ax, events, recordable, ylabel, xlims):
-    for sender in set(events["senders"]):
+    for sender in np.unique(events["senders"]):
         idc_sender = events["senders"] == sender
         idc_times = (events["times"][idc_sender] > xlims[0]) & (events["times"][idc_sender] < xlims[1])
         ax.plot(events["times"][idc_sender][idc_times], events[recordable][idc_sender][idc_times], lw=0.5)
@@ -866,8 +866,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in set(events_wr["senders"]):
-        for target in set(events_wr["targets"]):
+    for sender in np.unique(events["senders"]):
+        for target in np.unique(events["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
@@ -942,10 +942,11 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
         for target in set(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
-                if np.any(idc_syn):
-                    idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
-                        weights_pre_train[label]["target"] == target
-                    )
+                idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
+                    weights_pre_train[label]["target"] == target
+                )
+
+                if np.any(idc_syn) and np.any(idc_syn_pre):
                     times = np.concatenate([[0.0], events["times"][idc_syn]])
 
                     weights = np.concatenate(

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
@@ -694,8 +694,8 @@ class TrainingPipeline:
         cond2 = times <= self.n_iter_sim * group_size * duration["sequence"] + duration["total_offset"]
         idc = cond1 & cond2
 
-        readout_signal = np.array([readout_signal[idc][senders[idc] == i] for i in set(senders)])
-        target_signal = np.array([target_signal[idc][senders[idc] == i] for i in set(senders)])
+        readout_signal = np.array([readout_signal[idc][senders[idc] == i] for i in np.unique(senders)])
+        target_signal = np.array([target_signal[idc][senders[idc] == i] for i in np.unique(senders)])
 
         readout_signal = readout_signal.reshape((n_out, 1, group_size, steps["sequence"]))
         target_signal = target_signal.reshape((n_out, 1, group_size, steps["sequence"]))
@@ -877,7 +877,7 @@ fig.tight_layout()
 
 
 def plot_recordable(ax, events, recordable, ylabel, xlims):
-    for sender in set(events["senders"]):
+    for sender in np.unique(events["senders"]):
         idc_sender = events["senders"] == sender
         idc_times = (events["times"][idc_sender] > xlims[0]) & (events["times"][idc_sender] < xlims[1])
         ax.plot(events["times"][idc_sender][idc_times], events[recordable][idc_sender][idc_times], lw=0.5)
@@ -938,8 +938,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in set(events_wr["senders"]):
-        for target in set(events_wr["targets"]):
+    for sender in np.unique(events_wr["senders"]):
+        for target in np.unique(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_neuromorphic_mnist.py
@@ -938,8 +938,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in np.unique(events_wr["senders"]):
-        for target in np.unique(events_wr["targets"]):
+    for sender in np.unique(events["senders"]):
+        for target in np.unique(events["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
@@ -682,8 +682,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in np.unique(events_wr["senders"]):
-        for target in np.unique(events_wr["targets"]):
+    for sender in np.unique(events["senders"]):
+        for target in np.unique(events["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
@@ -686,10 +686,11 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
         for target in set(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
-                if np.any(idc_syn):
-                    idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
-                        weights_pre_train[label]["target"] == target
-                    )
+                idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
+                    weights_pre_train[label]["target"] == target
+                )
+
+                if np.any(idc_syn) and np.any(idc_syn_pre):
                     times = np.concatenate([[0.0], events["times"][idc_syn]])
 
                     weights = np.concatenate(

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_handwriting_bsshslm_2020.py
@@ -538,13 +538,13 @@ target_signal = events_mm_out["target_signal"]
 senders = events_mm_out["senders"]
 
 loss_list = []
-for sender in set(senders):
+for sender in np.unique(senders):
     idc = senders == sender
     error = (readout_signal[idc] - target_signal[idc]) ** 2
     loss_list.append(0.5 * np.add.reduceat(error, np.arange(0, steps["task"], steps["sequence"])))
 
-readout_signal = np.array([readout_signal[senders == i] for i in set(senders)])
-target_signal = np.array([target_signal[senders == i] for i in set(senders)])
+readout_signal = np.array([readout_signal[senders == i] for i in np.unique(senders)])
+target_signal = np.array([target_signal[senders == i] for i in np.unique(senders)])
 
 readout_signal = readout_signal.reshape((n_out, n_iter, batch_size, steps["sequence"]))
 target_signal = target_signal.reshape((n_out, n_iter, batch_size, steps["sequence"]))
@@ -623,7 +623,7 @@ fig.tight_layout()
 
 
 def plot_recordable(ax, events, recordable, ylabel, xlims):
-    for sender in set(events["senders"]):
+    for sender in np.unique(events["senders"]):
         idc_sender = events["senders"] == sender
         idc_times = (events["times"][idc_sender] > xlims[0]) & (events["times"][idc_sender] < xlims[1])
         ax.plot(events["times"][idc_sender][idc_times], events[recordable][idc_sender][idc_times], lw=0.5)
@@ -682,8 +682,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in set(events_wr["senders"]):
-        for target in set(events_wr["targets"]):
+    for sender in np.unique(events_wr["senders"]):
+        for target in np.unique(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
@@ -663,8 +663,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in np.unique(events_wr["senders"]):
-        for target in np.unique(events_wr["targets"]):
+    for sender in np.unique(events["senders"]):
+        for target in np.unique(events["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
@@ -519,13 +519,13 @@ target_signal = events_mm_out["target_signal"]
 senders = events_mm_out["senders"]
 
 loss_list = []
-for sender in set(senders):
+for sender in np.unique(senders):
     idc = senders == sender
     error = (readout_signal[idc] - target_signal[idc]) ** 2
     loss_list.append(0.5 * np.add.reduceat(error, np.arange(0, steps["task"], steps["sequence"])))
 
-readout_signal = np.array([readout_signal[senders == i] for i in set(senders)])
-target_signal = np.array([target_signal[senders == i] for i in set(senders)])
+readout_signal = np.array([readout_signal[senders == i] for i in np.unique(senders)])
+target_signal = np.array([target_signal[senders == i] for i in np.unique(senders)])
 
 readout_signal = readout_signal.reshape((n_out, n_iter, batch_size, steps["sequence"]))
 target_signal = target_signal.reshape((n_out, n_iter, batch_size, steps["sequence"]))
@@ -604,7 +604,7 @@ fig.tight_layout()
 
 
 def plot_recordable(ax, events, recordable, ylabel, xlims):
-    for sender in set(events["senders"]):
+    for sender in np.unique(events["senders"]):
         idc_sender = events["senders"] == sender
         idc_times = (events["times"][idc_sender] > xlims[0]) & (events["times"][idc_sender] < xlims[1])
         ax.plot(events["times"][idc_sender][idc_times], events[recordable][idc_sender][idc_times], lw=0.5)
@@ -663,8 +663,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in set(events_wr["senders"]):
-        for target in set(events_wr["targets"]):
+    for sender in np.unique(events_wr["senders"]):
+        for target in np.unique(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_lemniscate_bsshslm_2020.py
@@ -667,10 +667,11 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
         for target in set(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
-                if np.any(idc_syn):
-                    idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
-                        weights_pre_train[label]["target"] == target
-                    )
+                idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
+                    weights_pre_train[label]["target"] == target
+                )
+
+                if np.any(idc_syn) and np.any(idc_syn_pre):
                     times = np.concatenate([[0.0], events["times"][idc_syn]])
 
                     weights = np.concatenate(

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
@@ -532,8 +532,8 @@ readout_signal = events_mm_out["readout_signal"]
 target_signal = events_mm_out["target_signal"]
 senders = events_mm_out["senders"]
 
-readout_signal = np.array([readout_signal[senders == i] for i in set(senders)])
-target_signal = np.array([target_signal[senders == i] for i in set(senders)])
+readout_signal = np.array([readout_signal[senders == i] for i in np.unique(senders)])
+target_signal = np.array([target_signal[senders == i] for i in np.unique(senders)])
 
 readout_signal = readout_signal.reshape((n_out, n_iter, group_size, steps["sequence"]))
 target_signal = target_signal.reshape((n_out, n_iter, group_size, steps["sequence"]))
@@ -589,7 +589,7 @@ fig.tight_layout()
 
 
 def plot_recordable(ax, events, recordable, ylabel, xlims):
-    for sender in set(events["senders"]):
+    for sender in np.unique(events["senders"]):
         idc_sender = events["senders"] == sender
         idc_times = (events["times"][idc_sender] > xlims[0]) & (events["times"][idc_sender] < xlims[1])
         ax.plot(events["times"][idc_sender][idc_times], events[recordable][idc_sender][idc_times], lw=0.5)
@@ -647,8 +647,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in set(events_wr["senders"]):
-        for target in set(events_wr["targets"]):
+    for sender in np.unique(events_wr["senders"]):
+        for target in np.unique(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
@@ -651,10 +651,11 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
         for target in set(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
-                if np.any(idc_syn):
-                    idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
-                        weights_pre_train[label]["target"] == target
-                    )
+                idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
+                    weights_pre_train[label]["target"] == target
+                )
+
+                if np.any(idc_syn) and np.any(idc_syn_pre):
                     times = np.concatenate([[0.0], events["times"][idc_syn]])
 
                     weights = np.concatenate(

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
@@ -647,8 +647,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in np.unique(events_wr["senders"]):
-        for target in np.unique(events_wr["targets"]):
+    for sender in np.unique(events["senders"]):
+        for target in np.unique(events["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
@@ -612,8 +612,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in np.unique(events_wr["senders"]):
-        for target in np.unique(events_wr["targets"]):
+    for sender in np.unique(events["senders"]):
+        for target in np.unique(events["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
@@ -497,8 +497,8 @@ readout_signal = events_mm_out["readout_signal"]
 target_signal = events_mm_out["target_signal"]
 senders = events_mm_out["senders"]
 
-readout_signal = np.array([readout_signal[senders == i] for i in set(senders)])
-target_signal = np.array([target_signal[senders == i] for i in set(senders)])
+readout_signal = np.array([readout_signal[senders == i] for i in np.unique(senders)])
+target_signal = np.array([target_signal[senders == i] for i in np.unique(senders)])
 
 readout_signal = readout_signal.reshape((n_out, n_iter, batch_size, steps["sequence"]))
 target_signal = target_signal.reshape((n_out, n_iter, batch_size, steps["sequence"]))
@@ -554,7 +554,7 @@ fig.tight_layout()
 
 
 def plot_recordable(ax, events, recordable, ylabel, xlims):
-    for sender in set(events["senders"]):
+    for sender in np.unique(events["senders"]):
         idc_sender = events["senders"] == sender
         idc_times = (events["times"][idc_sender] > xlims[0]) & (events["times"][idc_sender] < xlims[1])
         ax.plot(events["times"][idc_sender][idc_times], events[recordable][idc_sender][idc_times], lw=0.5)
@@ -612,8 +612,8 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
     nrns_senders = nrns[sender_label]
     nrns_targets = nrns[target_label]
 
-    for sender in set(events_wr["senders"]):
-        for target in set(events_wr["targets"]):
+    for sender in np.unique(events_wr["senders"]):
+        for target in np.unique(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
                 idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
@@ -616,10 +616,11 @@ def plot_weight_time_course(ax, events, nrns, label, ylabel):
         for target in set(events_wr["targets"]):
             if sender in nrns_senders and target in nrns_targets:
                 idc_syn = (events["senders"] == sender) & (events["targets"] == target)
-                if np.any(idc_syn):
-                    idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
-                        weights_pre_train[label]["target"] == target
-                    )
+                idc_syn_pre = (weights_pre_train[label]["source"] == sender) & (
+                    weights_pre_train[label]["target"] == target
+                )
+
+                if np.any(idc_syn) and np.any(idc_syn_pre):
                     times = np.concatenate([[0.0], events["times"][idc_syn]])
 
                     weights = np.concatenate(


### PR DESCRIPTION
This PR fixes the failing weight plotting routine by introducing a guard against the behavior of the weight recorder to record weights from non-existent connections.