### PR TITLE
Ensure NEST can be built without Boost

### DIFF
--- a/libnestutil/dictionary.cpp
+++ b/libnestutil/dictionary.cpp
@@ -79,7 +79,7 @@ double
 dictionary_::cast_value_< double >( const any_type& value, const std::string& key ) const
 {
   return std::visit(
-    [ &key, debug_name = debug_type( value ) ]( auto&& arg ) -> double
+    [ &key, debug_name = get_typename( value ) ]( auto&& arg ) -> double
     {
       using T = std::decay_t< decltype( arg ) >;
       if constexpr ( std::is_arithmetic_v< T > )
@@ -121,7 +121,7 @@ dictionary_::cast_value_< std::vector< double > >( const any_type& value, const 
   catch ( const std::bad_variant_access& )
   {
     const std::string msg =
-      String::compose( "Failed to cast '%1' from %2 to type std::vector<double>", key, debug_type( value ) );
+      String::compose( "Failed to cast '%1' from %2 to type std::vector<double>", key, get_typename( value ) );
     throw nest::TypeMismatch( msg );
   }
 }
@@ -147,32 +147,32 @@ dictionary_::cast_value_< std::vector< std::string > >( const any_type& value, c
   catch ( const std::bad_variant_access& )
   {
     const std::string msg =
-      String::compose( "Failed to cast '%1' from %2 to type std::vector<string>", key, debug_type( value ) );
+      String::compose( "Failed to cast '%1' from %2 to type std::vector<string>", key, get_typename( value ) );
     throw nest::TypeMismatch( msg );
   }
 }
 
 std::string
-debug_type( const any_type& operand )
+get_typename( const any_type& operand )
 {
   return std::visit(
     []( auto&& arg ) -> std::string
     {
       using T = std::decay_t< decltype( arg ) >;
-      return boost::typeindex::type_id< T >().pretty_name();
+      return pretty_typename< T >();
     },
     operand );
 }
 
 std::string
-debug_dict_types( const Dictionary& dict )
+get_dict_typenames( const Dictionary& dict )
 {
   std::string s = "[Dictionary]\n";
 
   for ( auto& kv : dict )
   {
     s += kv.first + ": ";
-    s += debug_type( kv.second.item ) + "\n";
+    s += get_typename( kv.second.item ) + "\n";
   }
   return s;
 }
@@ -225,11 +225,11 @@ operator<<( std::ostream& os, const Dictionary& dict )
     } )->first.length();
 
   const auto max_type_length =
-    debug_type( std::max_element( dict.begin(),
-                  dict.end(),
-                  []( const dictionary_::value_type s1, const dictionary_::value_type s2 )
-                  { return debug_type( s1.second.item ).length() < debug_type( s2.second.item ).length(); } )
-                  ->second.item )
+    get_typename( std::max_element( dict.begin(),
+                    dict.end(),
+                    []( const dictionary_::value_type s1, const dictionary_::value_type s2 )
+                    { return get_typename( s1.second.item ).length() < get_typename( s2.second.item ).length(); } )
+                    ->second.item )
       .length();
 
   const std::string pre_padding = "    ";
@@ -237,7 +237,7 @@ operator<<( std::ostream& os, const Dictionary& dict )
   for ( const auto& [ key, val ] : dict )
   {
     const auto& item = val.item;
-    const auto& type = debug_type( item );
+    const auto& type = get_typename( item );
 
     const auto key_padding = max_key_length - key.length() + 2;
     const auto type_padding = max_type_length - type.length() + 2;

--- a/libnestutil/dictionary.h
+++ b/libnestutil/dictionary.h
@@ -31,11 +31,13 @@
 #include <variant>
 #include <vector>
 
-#include <boost/type_index.hpp>
-
+#include "config.h"
 #include "exceptions.h"
-
 #include "logging.h"
+
+#ifdef HAVE_BOOST
+#include <boost/type_index.hpp>
+#endif
 
 namespace nest
 {
@@ -342,18 +344,35 @@ public:
 };
 
 /**
+ * Return typename boost-prettified if available, otherwise as returned by typename().
+ *
+ * @note This function isolates the boost-dependency of pretty-printing the type.
+ * @ingroup nestdict
+ */
+template < typename T >
+std::string
+pretty_typename()
+{
+#ifdef HAVE_BOOST
+  return boost::typeindex::type_id< T >().pretty_name();
+#else
+  return typeid( T ).name();
+#endif
+}
+
+/**
  * @brief Return typename of @c operand.
  *
  * @ingroup nestdict
  */
-std::string debug_type( const any_type& operand );
+std::string get_typename( const any_type& operand );
 
 /**
  * @brief Return multi-line string displaying dictionary content.
  *
  * @ingroup nestdict
  */
-std::string debug_dict_types( const Dictionary& dict );
+std::string get_dict_typenames( const Dictionary& dict );
 
 /**
  * Represent value in dictionary entry with access information.
@@ -414,10 +433,8 @@ class dictionary_ : public std::map< std::string, DictEntry_ >
     }
     catch ( const std::bad_variant_access& )
     {
-      std::string msg = String::compose( "Failed to cast '%1' from %2 to type %3",
-        key,
-        debug_type( value ),
-        boost::typeindex::type_id< T >().pretty_name() );
+      std::string msg =
+        String::compose( "Failed to cast '%1' from %2 to type %3", key, get_typename( value ), pretty_typename< T >() );
       throw nest::TypeMismatch( msg );
     }
   }

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -90,7 +90,7 @@ nest::weight_recorder::Parameters_::set( const Dictionary& d )
       }
       else
       {
-        throw TypeMismatch( "NodeCollection", debug_type( d.at( key ) ) );
+        throw TypeMismatch( "NodeCollection", get_typename( d.at( key ) ) );
       }
     }
   };

--- a/nestkernel/conn_parameter.cpp
+++ b/nestkernel/conn_parameter.cpp
@@ -59,7 +59,7 @@ nest::ConnParameter::create( const any_type& value, const size_t nthreads )
     return new ArrayLongParameter( std::get< std::vector< long > >( value ), nthreads );
   }
 
-  throw BadProperty( std::string( "Cannot handle parameter type. Received " ) + debug_type( value ) );
+  throw BadProperty( std::string( "Cannot handle parameter type. Received " ) + get_typename( value ) );
 }
 
 

--- a/nestkernel/conn_parameter.h
+++ b/nestkernel/conn_parameter.h
@@ -27,8 +27,6 @@
 #include <limits>
 #include <vector>
 
-#include <boost/any.hpp>
-
 // Includes from nestkernel:
 #include "exceptions.h"
 #include "parameter.h"

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -189,7 +189,7 @@ get_nc_status( NodeCollectionPTR nc )
         catch ( const std::bad_variant_access& e )
         {
           throw std::runtime_error( String::compose(
-            "result[%1] contained type %2, expected vector<any_type>.", key, debug_type( p->second.item ) ) );
+            "result[%1] contained type %2, expected vector<any_type>.", key, get_typename( p->second.item ) ) );
         }
       }
       else
@@ -615,7 +615,7 @@ create_parameter( const any_type& value )
       else
       {
         throw BadProperty(
-          std::string( "Parameter must be parametertype, constant or dictionary, got " ) + debug_type( value ) );
+          std::string( "Parameter must be parametertype, constant or dictionary, got " ) + get_typename( value ) );
       }
     },
     value );

--- a/pynest/nestkernel_api.pxd
+++ b/pynest/nestkernel_api.pxd
@@ -71,8 +71,8 @@ cdef extern from "dictionary.h":
         dictionary_.const_iterator begin()
         dictionary_.const_iterator end()
         cbool known(const string&)
-    string debug_type(const any_type&)
-    string debug_dict_types(const Dictionary&)
+    string get_typename(const any_type&)
+    string get_dict_typenames(const Dictionary&)
     cppclass AnyVector:
         vector[any_type].const_iterator begin()
         vector[any_type].const_iterator end()

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -132,7 +132,7 @@ cdef object dictionary_to_pydict(Dictionary cdict):
         tmp[key] = any_to_pyobj(deref(it).second.item)
         if tmp[key] is None:
             # If we end up here, the value in the Dictionary is of a type that any_to_pyobj() cannot handle.
-            raise RuntimeError('Could not convert: ' + key + ' of type ' + string_to_pystr(debug_type(deref(it).second.item)))
+            raise RuntimeError('Could not convert: ' + key + ' of type ' + string_to_pystr(get_typename(deref(it).second.item)))
         inc(it)
     return tmp
 
@@ -197,7 +197,7 @@ cdef object any_to_pyobj(any_type operand):
     if holds_alternative[VerbosityLevel](operand):
         return get[VerbosityLevel](operand)
 
-    raise RuntimeError(f"Cannot convert value of type '{debug_type(operand)}' returned by NEST kernel to Python object.")
+    raise RuntimeError(f"Cannot convert value of type '{get_typename(operand)}' returned by NEST kernel to Python object.")
 
 
 cdef is_list_tuple_ndarray_of_float(v):


### PR DESCRIPTION
This PR ensures that NEST can be built if Boost is not available or deselected `-Dwith-boost=OFF`. It also improves some function names.
As before, connection sorting falls back on a hand-written quicksort instead of spreadsort when Boost is missing.
The change leads to slightly less pretty type names displayed in error messages:

- With Boost: `TypeMismatch: Expected datatype: Failed to cast 'V_m' from std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> to type double.`
- Without Boost: `TypeMismatch: Expected datatype: Failed to cast 'V_m' from NSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE to type double.`