### PR TITLE
Test on CI without Boost and GSL and adjust tests where necessary

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -581,8 +581,8 @@ jobs:
         # available use flags (all default to "OFF"):
         # openmp, mpi, python, gsl, ltdl, boost, sionlib, libneurosim, optimize, warning, userdoc, music, readline
         use:
-          - "optimize, warning"
-          - "boost, optimize, warning"
+          - "python, optimize, warning"
+          - "python, boost, optimize, warning"
           - "openmp, python, gsl, ltdl, boost, optimize, warning"
           - "mpi, python, gsl, ltdl, boost, optimize, warning"
           - "openmp, mpi, python, gsl, ltdl, boost, hdf5, sionlib, libneurosim, optimize, warning, music, detailed-timers, threaded-timers, mpi-sync-timer"

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -581,6 +581,8 @@ jobs:
         # available use flags (all default to "OFF"):
         # openmp, mpi, python, gsl, ltdl, boost, sionlib, libneurosim, optimize, warning, userdoc, music, readline
         use:
+          - "optimize, warning"
+          - "boost, optimize, warning"
           - "openmp, python, gsl, ltdl, boost, optimize, warning"
           - "mpi, python, gsl, ltdl, boost, optimize, warning"
           - "openmp, mpi, python, gsl, ltdl, boost, hdf5, sionlib, libneurosim, optimize, warning, music, detailed-timers, threaded-timers, mpi-sync-timer"

--- a/testsuite/do_tests.sh
+++ b/testsuite/do_tests.sh
@@ -131,6 +131,7 @@ get_build_info ()
   ${PYTHON} -c "import nest; print(nest.build_info['$1'])" --quiet
 }
 
+HAVE_BOOST="$(get_build_info have_boost)"
 HAVE_MPI="$(get_build_info have_mpi)"
 HAVE_OPENMP="$(get_build_info have_threads)"
 HAVE_MUSIC=${MUSIC:+True}
@@ -444,6 +445,9 @@ if test "${HAVE_OPENMP}" = "True"; then
 fi
 if test "${HAVE_MUSIC}" = "True"; then
    SUMMARY_OPTS+=("--have-music")
+fi
+if test "${HAVE_BOOST}" = "True"; then
+   SUMMARY_OPTS+=("--have-boost")
 fi
 python3 "$(dirname "$0")/summarize_tests.py" "${SUMMARY_OPTS[@]}" "${REPORTDIR}"
 TESTSUITE_RESULT="$?"

--- a/testsuite/pytests/conftest.py
+++ b/testsuite/pytests/conftest.py
@@ -80,6 +80,10 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
+        "skipif_missing_boost: mark tests requiring Boost support in NEST",
+    )
+    config.addinivalue_line(
+        "markers",
         "skipif_missing_music: mark tests requiring MUSIC",
     )
     config.addinivalue_line(
@@ -168,11 +172,6 @@ def have_hdf5():
     return nest.build_info["have_hdf5"]
 
 
-@pytest.fixture(scope="session")
-def have_music():
-    return nest.build_info["have_music"]
-
-
 @pytest.fixture(autouse=True)
 def skipif_missing_hdf5(request, have_hdf5):
     """
@@ -181,6 +180,26 @@ def skipif_missing_hdf5(request, have_hdf5):
     """
     if not have_hdf5 and request.node.get_closest_marker("skipif_missing_hdf5"):
         pytest.skip("skipped because missing HDF5 support.")
+
+
+@pytest.fixture(scope="session")
+def have_boost():
+    return nest.build_info["have_boost"]
+
+
+@pytest.fixture(autouse=True)
+def skipif_missing_boost(request, have_boost):
+    """
+    Globally applied fixture that skips tests marked to be skipped when GSL is
+    missing.
+    """
+    if not have_boost and request.node.get_closest_marker("skipif_missing_boost"):
+        pytest.skip("skipped because missing Boost support.")
+
+
+@pytest.fixture(scope="session")
+def have_music():
+    return nest.build_info["have_music"]
 
 
 @pytest.fixture(autouse=True)

--- a/testsuite/pytests/connect/test_connect_tripartite_bernoulli.py
+++ b/testsuite/pytests/connect/test_connect_tripartite_bernoulli.py
@@ -25,7 +25,7 @@ import numpy as np
 import pytest
 import scipy.stats
 
-pytestmark = pytest.mark_skipif_missing_gsl
+pytestmark = pytest.mark.skipif_missing_gsl
 
 # Check that NEST is installed with MPI support and mpi4py is available.
 # If mpi4py is missing, we get an ImportError

--- a/testsuite/pytests/connect/test_connect_tripartite_bernoulli.py
+++ b/testsuite/pytests/connect/test_connect_tripartite_bernoulli.py
@@ -25,6 +25,8 @@ import numpy as np
 import pytest
 import scipy.stats
 
+pytestmark = pytest.mark_skipif_missing_gsl
+
 # Check that NEST is installed with MPI support and mpi4py is available.
 # If mpi4py is missing, we get an ImportError
 # If mpi4py is installed but libmpi is missing, we get a RuntimeError.

--- a/testsuite/pytests/connect/test_gap_junction.py
+++ b/testsuite/pytests/connect/test_gap_junction.py
@@ -27,6 +27,8 @@ Furthermore it is checked that the delay cannot be set for gap-junction connecti
 import nest
 import pytest
 
+pytestmark = pytest.mark.skipif_missing_gsl
+
 
 @pytest.fixture(autouse=True)
 def setup():

--- a/testsuite/pytests/connect/test_tripartite_connect.py
+++ b/testsuite/pytests/connect/test_tripartite_connect.py
@@ -58,6 +58,7 @@ def test_connect_all():
     assert len(nest.GetConnections(third, post)) == n_primary
 
 
+@pytest.mark.skipif_missing_gsl
 def test_connect_astro():
     n_pre, n_post, n_third = 4, 2, 3
     pre = nest.Create("aeif_cond_alpha_astro", n_pre)

--- a/testsuite/pytests/neurons/test_iaf_bw_2001.py
+++ b/testsuite/pytests/neurons/test_iaf_bw_2001.py
@@ -37,6 +37,9 @@ import numpy as np
 import numpy.testing as nptest
 import pytest
 
+pytestmark = [pytest.mark.skipif_missing_boost, pytest.mark.skipif_missing_gsl]
+
+
 w_ex = 40.0
 w_in = 15.0
 
@@ -64,7 +67,6 @@ def spiketrain_response(t, tau, spiketrain, w):
     return response
 
 
-@pytest.mark.skipif(not nest.build_info["have_boost"], reason="Boost is not available")
 def test_iaf_bw_2001():
     """
     Creates 4 neurons.
@@ -163,7 +165,6 @@ def test_iaf_bw_2001():
     nptest.assert_array_almost_equal(gaba_soln, mm_bw1.events["s_GABA"])
 
 
-@pytest.mark.skipif(not nest.build_info["have_boost"], reason="Boost is not available")
 def test_approximation_I_NMDA_V_m():
     """
     Creates 3 neurons.
@@ -225,7 +226,6 @@ def test_approximation_I_NMDA_V_m():
     assert np.max(np.abs(mm_approx.events["V_m"] - mm_exact.events["V_m"])) < 0.25
 
 
-@pytest.mark.skipif(not nest.build_info["have_boost"], reason="Boost is not available")
 def test_illegal_connection_error():
     """
     Test that connecting with NMDA synapses from iaf_cond_exp throws error.

--- a/testsuite/pytests/neurons/test_iaf_bw_2001_exact.py
+++ b/testsuite/pytests/neurons/test_iaf_bw_2001_exact.py
@@ -34,6 +34,8 @@ import numpy as np
 import numpy.testing as nptest
 import pytest
 
+pytestmark = pytest.mark.skipif_missing_gsl
+
 w_ex = 40.0
 w_in = 15.0
 

--- a/testsuite/pytests/other/test_memsize.py
+++ b/testsuite/pytests/other/test_memsize.py
@@ -42,7 +42,7 @@ def test_memsize():
 
     m_pre = nest.memory_size
 
-    n = nest.Create("aeif_cond_alpha", 2000)
+    n = nest.Create("iaf_psc_alpha_ps", 4000)
     nest.Connect(n, n, syn_spec={"synapse_model": "stdp_synapse"})
 
     m_post = nest.memory_size

--- a/testsuite/pytests/other/test_status.py
+++ b/testsuite/pytests/other/test_status.py
@@ -30,6 +30,8 @@ class StatusTestCase(unittest.TestCase):
     def test_kernel_attributes(self):
         """Test nest attribute access of kernel attributes"""
 
+        self.maxDiff = None
+
         nest.ResetKernel()
 
         # Remove entry containing numpy arrays from status dicts since they do not compare well

--- a/testsuite/pytests/other/test_status.py
+++ b/testsuite/pytests/other/test_status.py
@@ -30,15 +30,17 @@ class StatusTestCase(unittest.TestCase):
     def test_kernel_attributes(self):
         """Test nest attribute access of kernel attributes"""
 
-        self.maxDiff = None
-
         nest.ResetKernel()
 
-        # Remove entry containing numpy arrays from status dicts since they do not compare well
         gks_result = nest.GetKernelStatus()
         ks_result = nest.kernel_status
-        del gks_result["spike_buffer_resize_log"]
-        del ks_result["spike_buffer_resize_log"]
+
+        # Filter out keys that are difficult to test
+        # memory_size sometimes changes between the two calls above leading to spurious negatives
+        # spike_buffer_resize_log here contains empty numpy arrays, leading to "ambiguous truth value" issues
+        for ignored_key in ["memory_size", "spike_buffer_resize_log"]:
+            del gks_result[ignored_key]
+            del ks_result[ignored_key]
         self.assertEqual(gks_result, ks_result)
 
         self.assertEqual(nest.GetKernelStatus("resolution"), nest.resolution)

--- a/testsuite/pytests/regressions/test_issue_311.py
+++ b/testsuite/pytests/regressions/test_issue_311.py
@@ -30,6 +30,7 @@ import nest
 import pytest
 
 
+@pytest.mark.skipif_missing_gsl
 def test_nest_behaves_well_after_exception_during_update():
     # Pathological parameters to trigger numerical exception
     nrn = nest.Create("aeif_cond_alpha", params={"I_e": 10000000.0, "g_L": 0.01})

--- a/testsuite/pytests/regressions/test_issue_410.py
+++ b/testsuite/pytests/regressions/test_issue_410.py
@@ -26,7 +26,7 @@ Regression test for Issue #410 (GitHub).
 import nest
 import pytest
 
-pytestmark = [pytest.mark.skipif_missing_gsl, pytest.mark.skipif_missing_threads]
+pytestmark = pytest.mark.skipif_missing_threads
 
 
 def simulator(num_threads):
@@ -44,7 +44,7 @@ def simulator(num_threads):
     stim2 = nest.Create("dc_generator", params={"amplitude": 1000.0})
     nrn1 = nest.Create("iaf_psc_alpha", params={"C_m": 100.0, "tau_m": 10.0})
     nrn2 = nest.Create("iaf_psc_alpha", params={"C_m": 100.0, "tau_m": 10.0, "tau_minus": 10.0})
-    dopa = nest.Create("iaf_cond_alpha", 100, {"V_reset": -70.0, "C_m": 80.0, "V_th": -60.0})
+    dopa = nest.Create("iaf_psc_alpha", 100, {"V_reset": -70.0, "C_m": 80.0, "V_th": -60.0})
     vt = nest.Create("volume_transmitter")
 
     nest.CopyModel(
@@ -76,7 +76,7 @@ def simulator(num_threads):
     return weight
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def reference_weight():
     """
     Fixture that simulates reference.

--- a/testsuite/pytests/regressions/test_ticket_459.py
+++ b/testsuite/pytests/regressions/test_ticket_459.py
@@ -35,8 +35,9 @@ def reset():
 
 # Collect all models with E_L parameter.
 # Skip gif_cond_exp_multisynapse because it has numpy array parameter making check below difficult.
-models_with_EL = [model for model in nest.node_models if "E_L" in nest.GetDefaults(model)]
-models_with_EL.remove("gif_cond_exp_multisynapse")
+models_with_EL = [
+    model for model in nest.node_models if "E_L" in nest.GetDefaults(model) and model != "gif_cond_exp_multisynapse"
+]
 
 
 @pytest.mark.parametrize("model", models_with_EL)

--- a/testsuite/pytests/stimulating/test_sinusoidal_generators.py
+++ b/testsuite/pytests/stimulating/test_sinusoidal_generators.py
@@ -28,8 +28,8 @@ import numpy as np
 import numpy.testing as nptest
 import pytest
 
-# List of sinusoidal generator models
-gen_models = ["sinusoidal_poisson_generator", "sinusoidal_gamma_generator"]
+# Set of sinusoidal generator models
+gen_models = {"sinusoidal_poisson_generator", "sinusoidal_gamma_generator"} & set(nest.node_models)
 
 
 @pytest.fixture(autouse=True)

--- a/testsuite/pytests/synapses/test_multiple_synapses.py
+++ b/testsuite/pytests/synapses/test_multiple_synapses.py
@@ -23,440 +23,438 @@
 Multiple synapses tests
 """
 
-import unittest
-
 import nest
+import pytest
 
 
-class MultipleSynapsesTestCase(unittest.TestCase):
-    def setUp(self):
-        nest.ResetKernel()
-
-    def sort_connections(self, conns):
-        """
-        Sort connection dictionary based on source, target, weight and synapse model.
-
-        Sorting order is source, then target, then weight and lastly synapse_model.
-        Returns a list with tuples of source, target, weight, synapse_model.
-        """
-        src = conns.source
-        trgt = conns.target
-        weight = conns.weight
-        syn_model = conns.synapse_model
-
-        sorted_conn_list = sorted(zip(src, trgt, weight, syn_model))
-
-        return sorted_conn_list
-
-    def test_MultipleSynapses(self):
-        """Test co-location of synapses for very simple connection"""
-        node = nest.Create("iaf_psc_alpha")
-        nest.Connect(node, node, syn_spec=nest.CollocatedSynapses({"weight": -2.0}, {"weight": 3.0}))
-
-        self.assertEqual(2, nest.num_connections)
-
-        conns = nest.GetConnections()
-        self.assertEqual([-2, 3], conns.weight)
-
-    def test_MultipleSynapses_one_to_one(self):
-        """Test co-location of synapses when we use one_to_one as connection rule"""
-        num_src = 7
-        num_trg = 7
-        syn_spec = nest.CollocatedSynapses(
-            {"synapse_model": "stdp_synapse", "weight": -5.0},
-            {"weight": -1.5},
-            {"synapse_model": "stdp_synapse", "weight": 3},
-        )
-
-        src = nest.Create("iaf_psc_alpha", num_src)
-        trgt = nest.Create("iaf_psc_alpha", num_trg)
-
-        nest.Connect(src, trgt, "one_to_one", syn_spec=syn_spec)
-        conns = nest.GetConnections()
-
-        self.assertEqual(num_src * len(syn_spec), len(conns))
-
-        # source id's range from 1 to num_src
-        ref_src = [s for s in range(1, num_src + 1) for _ in range(len(syn_spec))]
-        # target id's range from (num_src + 1 to (num_src + num_trgt + 1))
-        ref_trgt = [t for t in range(num_src + 1, num_src + num_trg + 1) for _ in range(len(syn_spec))]
-        ref_weight = [-5.0, -1.5, 3.0] * num_src
-        ref_synapse_modules = ["stdp_synapse", "static_synapse", "stdp_synapse"] * num_src
-
-        ref_conn_list = list(zip(ref_src, ref_trgt, ref_weight, ref_synapse_modules))
-        sorted_conn_list = self.sort_connections(conns)
-
-        self.assertEqual(ref_conn_list, sorted_conn_list)
-
-    def test_MultipleSynapses_all_to_all(self):
-        """Test co-location of synapses when we use all_to_all as connection rule"""
-        num_src = 3
-        num_trg = 5
-        syn_spec = nest.CollocatedSynapses(
-            {"weight": -2.0}, {"synapse_model": "stdp_synapse", "weight": -1.5}, {"weight": 3}
-        )
-
-        src = nest.Create("iaf_psc_alpha", num_src)
-        trgt = nest.Create("iaf_psc_alpha", num_trg)
-
-        nest.Connect(src, trgt, "all_to_all", syn_spec=syn_spec)
-        conns = nest.GetConnections()
-
-        self.assertEqual(num_src * num_trg * len(syn_spec), len(conns))
-
-        # source id's range from 1 to num_src
-        ref_src = [s for s in range(1, num_src + 1) for _ in range(len(syn_spec) * num_trg)]
-        # target id's are 4, 5, 6, 7, 8
-        ref_trgt = []
-        for t in [4, 5, 6, 7, 8] * num_src:
-            # there are 3 elements in the syn_spec list
-            ref_trgt.extend([t, t, t])
-
-        ref_weight = [-2.0, -1.5, 3.0] * num_src * num_trg
-        ref_synapse_modules = ["static_synapse", "stdp_synapse", "static_synapse"] * num_src * num_trg
-
-        ref_conn_list = list(zip(ref_src, ref_trgt, ref_weight, ref_synapse_modules))
-        sorted_conn_list = self.sort_connections(conns)
-
-        self.assertEqual(ref_conn_list, sorted_conn_list)
-
-    def test_MultipleSynapses_fixed_indegree(self):
-        """Test co-location of synapses when we use fixed_indegree as connection rule"""
-        num_src = 7
-        num_trg = 3
-        indegree = 2
-        syn_spec = nest.CollocatedSynapses(
-            {"weight": -2.0},
-            {"synapse_model": "stdp_synapse", "weight": -1.5},
-            {"synapse_model": "stdp_synapse", "weight": 3},
-        )
-
-        src = nest.Create("iaf_psc_alpha", num_src)
-        trgt = nest.Create("iaf_psc_alpha", num_trg)
-
-        nest.Connect(src, trgt, {"rule": "fixed_indegree", "indegree": indegree}, syn_spec=syn_spec)
-        conns = nest.GetConnections()
-
-        self.assertEqual(num_trg * indegree * len(syn_spec), len(conns))
-
-        ref_trgt = [t for t in trgt.tolist() for _ in range(indegree * len(syn_spec))]
-        ref_sm = (
-            ["static_synapse"] * num_trg * indegree
-            + ["stdp_synapse"] * num_trg * indegree
-            + ["stdp_synapse"] * num_trg * indegree
-        )
-
-        self.assertEqual(sorted(ref_trgt), sorted(conns.target))
-        self.assertEqual(sorted(ref_sm), sorted(conns.synapse_model))
-
-    def test_MultipleSynapses_spatial_network(self):
-        """test co-location of synapses for spatial networks with fixed indegree"""
-        num_src = 11
-        num_trgt = 37
-        indegree = 3
-
-        spatial_nodes_src = nest.Create(
-            "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        )
-        spatial_nodes_trgt = nest.Create(
-            "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        )
-
-        nest.Connect(
-            spatial_nodes_src,
-            spatial_nodes_trgt,
-            {"rule": "fixed_indegree", "indegree": indegree},
-            nest.CollocatedSynapses(
-                {"weight": -3.0},
-                {"weight": nest.spatial_distributions.exponential(nest.spatial.distance), "delay": 1.4},
-            ),
-        )
-        conns = nest.GetConnections()
-
-        self.assertEqual(num_trgt * indegree * 2, len(conns))
-
-        weights = conns.weight
-        self.assertEqual(sorted(weights)[: num_trgt * indegree], [-3] * num_trgt * indegree)
-
-    def test_MultipleSynapses_spatial_network_label(self):
-        """test co-location of synapses for spatial networks with synapse label"""
-        num_src = 11
-        num_trgt = 37
-        indegree = 3
-
-        spatial_nodes_src = nest.Create(
-            "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        )
-        spatial_nodes_trgt = nest.Create(
-            "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        )
-
-        syn_label_a = 123
-        syn_label_b = 456
-        nest.Connect(
-            spatial_nodes_src,
-            spatial_nodes_trgt,
-            {"rule": "fixed_indegree", "indegree": indegree},
-            nest.CollocatedSynapses(
-                {"weight": 3.0, "synapse_model": "stdp_synapse_lbl", "synapse_label": syn_label_a},
-                {
-                    "weight": nest.spatial_distributions.exponential(nest.spatial.distance),
-                    "delay": 1.4,
-                    "synapse_model": "stdp_synapse_lbl",
-                    "synapse_label": syn_label_b,
-                },
-            ),
-        )
-        conns = nest.GetConnections()
-        self.assertEqual(num_trgt * indegree * 2, len(conns))
-        reference = sorted([syn_label_a, syn_label_b] * num_trgt * indegree)
-        self.assertEqual(sorted(conns.get("synapse_label")), reference)
-
-    def test_MultipleSynapses_spatial_network_receptor_type(self):
-        """test co-location of synapses for spatial networks with receptor_type"""
-        num_src = 11
-        num_trgt = 37
-        indegree = 3
-        max_receptor_type = 7
-
-        spatial_nodes_src = nest.Create(
-            "iaf_psc_exp_multisynapse",
-            num_src,
-            {"tau_syn": [0.1 + i for i in range(max_receptor_type)]},
-            positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2),
-        )
-        spatial_nodes_trgt = nest.Create(
-            "iaf_psc_exp_multisynapse",
-            num_trgt,
-            {"tau_syn": [0.1 + i for i in range(max_receptor_type)]},
-            positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2),
-        )
-
-        receptor_type_a = max_receptor_type - 3
-        receptor_type_b = max_receptor_type
-        nest.Connect(
-            spatial_nodes_src,
-            spatial_nodes_trgt,
-            {"rule": "fixed_indegree", "indegree": indegree},
-            nest.CollocatedSynapses(
-                {"weight": 3.0, "receptor_type": receptor_type_a},
-                {
-                    "weight": nest.spatial_distributions.exponential(nest.spatial.distance),
-                    "delay": 1.4,
-                    "receptor_type": receptor_type_b,
-                },
-            ),
-        )
-        conns = nest.GetConnections()
-        self.assertEqual(num_trgt * indegree * 2, len(conns))
-        reference = sorted([receptor_type_a, receptor_type_b] * num_trgt * indegree)
-        self.assertEqual(sorted(conns.receptor), reference)
-
-    def test_MultipleSynapses_spatial_network_fixedOutdegree(self):
-        """test co-location of synapses for spatial networks with fixed outdegree"""
-        num_src = 17
-        num_trgt = 23
-        outdegree = 4
-
-        spatial_nodes_src = nest.Create(
-            "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        )
-        spatial_nodes_trgt = nest.Create(
-            "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
-        )
-
-        nest.Connect(
-            spatial_nodes_src,
-            spatial_nodes_trgt,
-            {"rule": "fixed_outdegree", "outdegree": outdegree},
-            nest.CollocatedSynapses(
-                {"weight": -3.0, "synapse_model": "stdp_synapse"},
-                {"synapse_model": "tsodyks_synapse"},
-                {"weight": nest.spatial_distributions.exponential(nest.spatial.distance), "delay": 1.4},
-            ),
-        )
-        conns = nest.GetConnections()
-
-        self.assertEqual(num_src * outdegree * 3, len(conns))
-
-        weights = conns.weight
-        self.assertEqual(sorted(weights)[: num_src * outdegree], [-3] * num_src * outdegree)
-
-        ref_synapse_model = (
-            ["stdp_synapse"] * num_src * outdegree
-            + ["tsodyks_synapse"] * num_src * outdegree
-            + ["static_synapse"] * num_src * outdegree
-        )
-        self.assertEqual(sorted(conns.synapse_model), sorted(ref_synapse_model))
-
-    def test_MultipleSynapses_spatial_network_bernoulliSource(self):
-        """test co-location of synapses for 3D spatial networks with pairwise Bernoulli on source"""
-        num_src = 7
-        num_trgt = 19
-        p = 0.6
-
-        spatial_nodes_src = nest.Create(
-            "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
-        )
-        spatial_nodes_trgt = nest.Create(
-            "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
-        )
-
-        nest.Connect(
-            spatial_nodes_src,
-            spatial_nodes_trgt,
-            {"rule": "pairwise_bernoulli", "p": p},
-            nest.CollocatedSynapses(
-                {"delay": 1.7, "weight": nest.spatial_distributions.gaussian(nest.spatial.distance)},
-                {"synapse_model": "tsodyks_synapse"},
-                {"weight": -nest.spatial_distributions.gaussian(nest.spatial.distance), "delay": 1.4},
-            ),
-        )
-
-        conns = nest.GetConnections()
-        num_conns = len(conns)
-        num_conns_synapse = num_conns // 3
-
-        self.assertLess(num_src * num_trgt * p * 2, len(conns))
-
-        delays = [round(d, 1) for d in conns.delay]
-        ref_delays = [1.0] * num_conns_synapse + [1.4] * num_conns_synapse + [1.7] * num_conns_synapse
-
-        self.assertEqual(sorted(delays), ref_delays)
-
-        ref_synapse_model = ["tsodyks_synapse"] * num_conns_synapse + ["static_synapse"] * 2 * num_conns_synapse
-        self.assertEqual(sorted(conns.synapse_model), sorted(ref_synapse_model))
-
-        for w in sorted(conns.weight)[:num_conns_synapse]:
-            self.assertLess(w, 0)
-
-    def test_MultipleSynapses_spatial_network_bernoulliTarget(self):
-        """test co-location of synapses for 3D spatial networks with pairwise Bernoulli on target"""
-        num_src = 57
-        num_trgt = 21
-        p = 0.3
-
-        spatial_nodes_src = nest.Create(
-            "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
-        )
-        spatial_nodes_trgt = nest.Create(
-            "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
-        )
-
-        nest.Connect(
-            spatial_nodes_src,
-            spatial_nodes_trgt,
-            {"rule": "pairwise_bernoulli", "p": p, "use_on_source": False},
-            nest.CollocatedSynapses(
-                {"delay": 1.7, "weight": -1.4},
-                {"delay": nest.spatial_distributions.gaussian(nest.spatial.distance), "weight": 1.4},
-            ),
-        )
-
-        conns = nest.GetConnections()
-        num_conns = len(conns)
-        num_conns_synapse = num_conns // 2
-
-        self.assertGreater(num_src * num_trgt * p * 3, num_conns)
-
-        delays = [round(d, 1) for d in sorted(conns.delay)[num_conns_synapse:]]
-        ref_delays = [1.7] * num_conns_synapse
-
-        self.assertEqual(sorted(delays), ref_delays)
-
-        ref_weights = [-1.4] * num_conns_synapse + [1.4] * num_conns_synapse
-        self.assertEqual(sorted(conns.weight), ref_weights)
-
-    def test_MultipleSynapses_make_symmetric(self):
-        """Test co-location of synapses when we use one_to_one with make_symmetric as connection rule"""
-        num_src = 11
-        num_trg = 11
-        num_symmetric = 2
-        syn_spec = nest.CollocatedSynapses({"weight": -1.5}, {"synapse_model": "stdp_synapse", "weight": 3})
-
-        src = nest.Create("iaf_psc_alpha", num_src)
-        trgt = nest.Create("iaf_psc_alpha", num_trg)
-
-        nest.Connect(src, trgt, {"rule": "one_to_one", "make_symmetric": True}, syn_spec=syn_spec)
-        conns = nest.GetConnections()
-
-        self.assertEqual(num_src * len(syn_spec) * num_symmetric, len(conns))
-
-        # pre id's range from (1 to num_src) and (num_src+1 to (num_src + num_trgt)) because of make_symmetric
-        ref_pre = [s for s in range(1, num_src + 1) for _ in range(len(syn_spec))]
-        ref_pre = ref_pre + [t for t in range(num_src + 1, num_src + num_trg + 1) for _ in range(len(syn_spec))]
-
-        # post id's range from (num_src + 1 to (num_src + num_trgt + 1)) and (1 to num_src) because of make_symmetric
-        ref_post = [t for t in range(num_src + 1, num_src + num_trg + 1) for _ in range(len(syn_spec))]
-        ref_post = ref_post + [s for s in range(1, num_src + 1) for _ in range(len(syn_spec))]
-
-        ref_weight = [-1.5, 3.0] * num_src * num_symmetric
-        ref_synapse_modules = ["static_synapse", "stdp_synapse"] * num_src * num_symmetric
-
-        ref_conn_list = list(zip(ref_pre, ref_post, ref_weight, ref_synapse_modules))
-        sorted_conn_list = self.sort_connections(conns)
-
-        self.assertEqual(ref_conn_list, sorted_conn_list)
-
-    def test_MultipleSynapses_receptor_type(self):
-        """Test co-location of synapses with different receptor types"""
-        num_src = 7
-        num_trg = 7
-
-        src = nest.Create("iaf_psc_exp_multisynapse", num_src)
-        trgt = nest.Create("iaf_psc_exp_multisynapse", num_trg, {"tau_syn": [0.1 + i for i in range(num_trg)]})
-        node = nest.Create("iaf_psc_alpha")
-
-        syn_spec = nest.CollocatedSynapses(
-            {"synapse_model": "stdp_synapse", "weight": 5.0, "receptor_type": 2},
-            {"weight": 1.5, "receptor_type": 7},
-            {"synapse_model": "stdp_synapse", "weight": 3, "receptor_type": 5},
-        )
-
-        nest.Connect(src, trgt, "one_to_one", syn_spec=syn_spec)
-        nest.Connect(node, node)  # should have receptor 0
-
-        conns = nest.GetConnections()
-        ref_receptor_type = [0] + [2] * num_src + [5] * num_src + [7] * num_src
-
-        self.assertEqual(ref_receptor_type, sorted(conns.receptor))
-
-        node_index = list(conns.source).index(node.global_id)
-        node_receptor = conns.receptor[node_index]
-        self.assertEqual(0, node_receptor)
-
-    def test_MultipleSynapses_receptor_type_ht_neuron(self):
-        """Test co-location of synapses with different receptor types and ht_neuron"""
-        num_src = 9
-        num_trg = 9
-
-        src = nest.Create("ht_neuron", num_src)
-        trgt = nest.Create("ht_neuron", num_trg)
-
-        syn_spec = nest.CollocatedSynapses(
-            {"synapse_model": "stdp_synapse", "weight": 5.0, "receptor_type": 2},
-            {"weight": 1.5, "receptor_type": 4},
-            {"synapse_model": "stdp_synapse", "weight": 3, "receptor_type": 3},
-        )
-
-        nest.Connect(src, trgt, "one_to_one", syn_spec=syn_spec)
-
-        conns = nest.GetConnections()
-        # receptors are 1 less than receptor_type for ht_neuron
-        ref_receptor_type = [1] * num_src + [2] * num_src + [3] * num_src
-
-        self.assertEqual(ref_receptor_type, sorted(conns.receptor))
-
-
-def suite():
-    suite = unittest.makeSuite(MultipleSynapsesTestCase, "test")
-    return suite
-
-
-def run():
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite())
-
-
-if __name__ == "__main__":
-    run()
+@pytest.fixture(autouse=True)
+def reset():
+    nest.ResetKernel()
+
+
+def sort_connections(conns):
+    """
+    Sort connection dictionary based on source, target, weight and synapse model.
+
+    Sorting order is source, then target, then weight and lastly synapse_model.
+    Returns a list with tuples of source, target, weight, synapse_model.
+    """
+    src = conns.source
+    trgt = conns.target
+    weight = conns.weight
+    syn_model = conns.synapse_model
+
+    return sorted(zip(src, trgt, weight, syn_model))
+
+
+def test_MultipleSynapses():
+    """Test co-location of synapses for very simple connection"""
+    node = nest.Create("iaf_psc_alpha")
+    nest.Connect(node, node, syn_spec=nest.CollocatedSynapses({"weight": -2.0}, {"weight": 3.0}))
+
+    assert nest.num_connections == 2
+
+    conns = nest.GetConnections()
+    assert conns.weight == [-2, 3]
+
+
+def test_MultipleSynapses_one_to_one():
+    """Test co-location of synapses when we use one_to_one as connection rule"""
+    num_src = 7
+    num_trg = 7
+    syn_spec = nest.CollocatedSynapses(
+        {"synapse_model": "stdp_synapse", "weight": -5.0},
+        {"weight": -1.5},
+        {"synapse_model": "stdp_synapse", "weight": 3},
+    )
+
+    src = nest.Create("iaf_psc_alpha", num_src)
+    trgt = nest.Create("iaf_psc_alpha", num_trg)
+
+    nest.Connect(src, trgt, "one_to_one", syn_spec=syn_spec)
+    conns = nest.GetConnections()
+
+    assert len(conns) == num_src * len(syn_spec)
+
+    # source id's range from 1 to num_src
+    ref_src = [s for s in range(1, num_src + 1) for _ in range(len(syn_spec))]
+    # target id's range from (num_src + 1 to (num_src + num_trgt + 1))
+    ref_trgt = [t for t in range(num_src + 1, num_src + num_trg + 1) for _ in range(len(syn_spec))]
+    ref_weight = [-5.0, -1.5, 3.0] * num_src
+    ref_synapse_modules = ["stdp_synapse", "static_synapse", "stdp_synapse"] * num_src
+
+    ref_conn_list = list(zip(ref_src, ref_trgt, ref_weight, ref_synapse_modules))
+    sorted_conn_list = sort_connections(conns)
+
+    assert sorted_conn_list == ref_conn_list
+
+
+def test_MultipleSynapses_all_to_all():
+    """Test co-location of synapses when we use all_to_all as connection rule"""
+    num_src = 3
+    num_trg = 5
+    syn_spec = nest.CollocatedSynapses(
+        {"weight": -2.0}, {"synapse_model": "stdp_synapse", "weight": -1.5}, {"weight": 3}
+    )
+
+    src = nest.Create("iaf_psc_alpha", num_src)
+    trgt = nest.Create("iaf_psc_alpha", num_trg)
+
+    nest.Connect(src, trgt, "all_to_all", syn_spec=syn_spec)
+    conns = nest.GetConnections()
+
+    assert len(conns) == num_src * num_trg * len(syn_spec)
+
+    # source id's range from 1 to num_src
+    ref_src = [s for s in range(1, num_src + 1) for _ in range(len(syn_spec) * num_trg)]
+    # target id's are 4, 5, 6, 7, 8
+    ref_trgt = []
+    for t in [4, 5, 6, 7, 8] * num_src:
+        # there are 3 elements in the syn_spec list
+        ref_trgt.extend([t, t, t])
+
+    ref_weight = [-2.0, -1.5, 3.0] * num_src * num_trg
+    ref_synapse_modules = ["static_synapse", "stdp_synapse", "static_synapse"] * num_src * num_trg
+
+    ref_conn_list = list(zip(ref_src, ref_trgt, ref_weight, ref_synapse_modules))
+    sorted_conn_list = sort_connections(conns)
+
+    assert sorted_conn_list == ref_conn_list
+
+
+def test_MultipleSynapses_fixed_indegree():
+    """Test co-location of synapses when we use fixed_indegree as connection rule"""
+    num_src = 7
+    num_trg = 3
+    indegree = 2
+    syn_spec = nest.CollocatedSynapses(
+        {"weight": -2.0},
+        {"synapse_model": "stdp_synapse", "weight": -1.5},
+        {"synapse_model": "stdp_synapse", "weight": 3},
+    )
+
+    src = nest.Create("iaf_psc_alpha", num_src)
+    trgt = nest.Create("iaf_psc_alpha", num_trg)
+
+    nest.Connect(src, trgt, {"rule": "fixed_indegree", "indegree": indegree}, syn_spec=syn_spec)
+    conns = nest.GetConnections()
+
+    assert len(conns) == num_trg * indegree * len(syn_spec)
+
+    ref_trgt = [t for t in trgt.tolist() for _ in range(indegree * len(syn_spec))]
+    ref_sm = (
+        ["static_synapse"] * num_trg * indegree
+        + ["stdp_synapse"] * num_trg * indegree
+        + ["stdp_synapse"] * num_trg * indegree
+    )
+
+    assert sorted(conns.target) == sorted(ref_trgt)
+    assert sorted(conns.synapse_model) == sorted(ref_sm)
+
+
+def test_MultipleSynapses_spatial_network():
+    """test co-location of synapses for spatial networks with fixed indegree"""
+    num_src = 11
+    num_trgt = 37
+    indegree = 3
+
+    spatial_nodes_src = nest.Create(
+        "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    )
+    spatial_nodes_trgt = nest.Create(
+        "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    )
+
+    nest.Connect(
+        spatial_nodes_src,
+        spatial_nodes_trgt,
+        {"rule": "fixed_indegree", "indegree": indegree},
+        nest.CollocatedSynapses(
+            {"weight": -3.0},
+            {"weight": nest.spatial_distributions.exponential(nest.spatial.distance), "delay": 1.4},
+        ),
+    )
+    conns = nest.GetConnections()
+
+    assert len(conns) == num_trgt * indegree * 2
+
+    weights = conns.weight
+    assert [-3] * num_trgt * indegree == sorted(weights)[: num_trgt * indegree]
+
+
+def test_MultipleSynapses_spatial_network_label():
+    """test co-location of synapses for spatial networks with synapse label"""
+    num_src = 11
+    num_trgt = 37
+    indegree = 3
+
+    spatial_nodes_src = nest.Create(
+        "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    )
+    spatial_nodes_trgt = nest.Create(
+        "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    )
+
+    syn_label_a = 123
+    syn_label_b = 456
+    nest.Connect(
+        spatial_nodes_src,
+        spatial_nodes_trgt,
+        {"rule": "fixed_indegree", "indegree": indegree},
+        nest.CollocatedSynapses(
+            {"weight": 3.0, "synapse_model": "stdp_synapse_lbl", "synapse_label": syn_label_a},
+            {
+                "weight": nest.spatial_distributions.exponential(nest.spatial.distance),
+                "delay": 1.4,
+                "synapse_model": "stdp_synapse_lbl",
+                "synapse_label": syn_label_b,
+            },
+        ),
+    )
+    conns = nest.GetConnections()
+    assert len(conns) == num_trgt * indegree * 2
+    reference = sorted([syn_label_a, syn_label_b] * num_trgt * indegree)
+    assert reference == sorted(conns.get("synapse_label"))
+
+
+def test_MultipleSynapses_spatial_network_receptor_type():
+    """test co-location of synapses for spatial networks with receptor_type"""
+    num_src = 11
+    num_trgt = 37
+    indegree = 3
+    max_receptor_type = 7
+
+    spatial_nodes_src = nest.Create(
+        "iaf_psc_exp_multisynapse",
+        num_src,
+        {"tau_syn": [0.1 + i for i in range(max_receptor_type)]},
+        positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2),
+    )
+    spatial_nodes_trgt = nest.Create(
+        "iaf_psc_exp_multisynapse",
+        num_trgt,
+        {"tau_syn": [0.1 + i for i in range(max_receptor_type)]},
+        positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2),
+    )
+
+    receptor_type_a = max_receptor_type - 3
+    receptor_type_b = max_receptor_type
+    nest.Connect(
+        spatial_nodes_src,
+        spatial_nodes_trgt,
+        {"rule": "fixed_indegree", "indegree": indegree},
+        nest.CollocatedSynapses(
+            {"weight": 3.0, "receptor_type": receptor_type_a},
+            {
+                "weight": nest.spatial_distributions.exponential(nest.spatial.distance),
+                "delay": 1.4,
+                "receptor_type": receptor_type_b,
+            },
+        ),
+    )
+    conns = nest.GetConnections()
+    assert len(conns) == num_trgt * indegree * 2
+    reference = sorted([receptor_type_a, receptor_type_b] * num_trgt * indegree)
+    assert reference == sorted(conns.receptor)
+
+
+def test_MultipleSynapses_spatial_network_fixedOutdegree():
+    """test co-location of synapses for spatial networks with fixed outdegree"""
+    num_src = 17
+    num_trgt = 23
+    outdegree = 4
+
+    spatial_nodes_src = nest.Create(
+        "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    )
+    spatial_nodes_trgt = nest.Create(
+        "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=2)
+    )
+
+    nest.Connect(
+        spatial_nodes_src,
+        spatial_nodes_trgt,
+        {"rule": "fixed_outdegree", "outdegree": outdegree},
+        nest.CollocatedSynapses(
+            {"weight": -3.0, "synapse_model": "stdp_synapse"},
+            {"synapse_model": "tsodyks_synapse"},
+            {"weight": nest.spatial_distributions.exponential(nest.spatial.distance), "delay": 1.4},
+        ),
+    )
+    conns = nest.GetConnections()
+
+    assert len(conns) == num_src * outdegree * 3
+
+    weights = conns.weight
+    assert [-3] * num_src * outdegree == sorted(weights)[: num_src * outdegree]
+
+    ref_synapse_model = (
+        ["stdp_synapse"] * num_src * outdegree
+        + ["tsodyks_synapse"] * num_src * outdegree
+        + ["static_synapse"] * num_src * outdegree
+    )
+    assert sorted(ref_synapse_model) == sorted(conns.synapse_model)
+
+
+def test_MultipleSynapses_spatial_network_bernoulliSource():
+    """test co-location of synapses for 3D spatial networks with pairwise Bernoulli on source"""
+    num_src = 7
+    num_trgt = 19
+    p = 0.6
+
+    spatial_nodes_src = nest.Create(
+        "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
+    )
+    spatial_nodes_trgt = nest.Create(
+        "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
+    )
+
+    nest.Connect(
+        spatial_nodes_src,
+        spatial_nodes_trgt,
+        {"rule": "pairwise_bernoulli", "p": p},
+        nest.CollocatedSynapses(
+            {"delay": 1.7, "weight": nest.spatial_distributions.gaussian(nest.spatial.distance)},
+            {"synapse_model": "tsodyks_synapse"},
+            {"weight": -nest.spatial_distributions.gaussian(nest.spatial.distance), "delay": 1.4},
+        ),
+    )
+
+    conns = nest.GetConnections()
+    num_conns = len(conns)
+    num_conns_synapse = num_conns // 3
+
+    assert num_src * num_trgt * p * 2 < len(conns)
+
+    delays = [round(d, 1) for d in conns.delay]
+    ref_delays = [1.0] * num_conns_synapse + [1.4] * num_conns_synapse + [1.7] * num_conns_synapse
+
+    assert ref_delays == sorted(delays)
+
+    ref_synapse_model = ["tsodyks_synapse"] * num_conns_synapse + ["static_synapse"] * 2 * num_conns_synapse
+    assert sorted(ref_synapse_model) == sorted(conns.synapse_model)
+
+    for w in sorted(conns.weight)[:num_conns_synapse]:
+        assert w < 0
+
+
+def test_MultipleSynapses_spatial_network_bernoulliTarget():
+    """test co-location of synapses for 3D spatial networks with pairwise Bernoulli on target"""
+    num_src = 57
+    num_trgt = 21
+    p = 0.3
+
+    spatial_nodes_src = nest.Create(
+        "iaf_psc_alpha", n=num_src, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
+    )
+    spatial_nodes_trgt = nest.Create(
+        "iaf_psc_alpha", n=num_trgt, positions=nest.spatial.free(nest.random.uniform(), num_dimensions=3)
+    )
+
+    nest.Connect(
+        spatial_nodes_src,
+        spatial_nodes_trgt,
+        {"rule": "pairwise_bernoulli", "p": p, "use_on_source": False},
+        nest.CollocatedSynapses(
+            {"delay": 1.7, "weight": -1.4},
+            {"delay": nest.spatial_distributions.gaussian(nest.spatial.distance), "weight": 1.4},
+        ),
+    )
+
+    conns = nest.GetConnections()
+    num_conns = len(conns)
+    num_conns_synapse = num_conns // 2
+
+    assert num_src * num_trgt * p * 3 > num_conns
+
+    delays = [round(d, 1) for d in sorted(conns.delay)[num_conns_synapse:]]
+    ref_delays = [1.7] * num_conns_synapse
+
+    assert ref_delays == sorted(delays)
+
+    ref_weights = [-1.4] * num_conns_synapse + [1.4] * num_conns_synapse
+    assert ref_weights == sorted(conns.weight)
+
+
+def test_MultipleSynapses_make_symmetric():
+    """Test co-location of synapses when we use one_to_one with make_symmetric as connection rule"""
+    num_src = 11
+    num_trg = 11
+    num_symmetric = 2
+    syn_spec = nest.CollocatedSynapses({"weight": -1.5}, {"synapse_model": "stdp_synapse", "weight": 3})
+
+    src = nest.Create("iaf_psc_alpha", num_src)
+    trgt = nest.Create("iaf_psc_alpha", num_trg)
+
+    nest.Connect(src, trgt, {"rule": "one_to_one", "make_symmetric": True}, syn_spec=syn_spec)
+    conns = nest.GetConnections()
+
+    assert len(conns) == num_src * len(syn_spec) * num_symmetric
+
+    # pre id's range from (1 to num_src) and (num_src+1 to (num_src + num_trgt)) because of make_symmetric
+    ref_pre = [s for s in range(1, num_src + 1) for _ in range(len(syn_spec))]
+    ref_pre = ref_pre + [t for t in range(num_src + 1, num_src + num_trg + 1) for _ in range(len(syn_spec))]
+
+    # post id's range from (num_src + 1 to (num_src + num_trgt + 1)) and (1 to num_src) because of make_symmetric
+    ref_post = [t for t in range(num_src + 1, num_src + num_trg + 1) for _ in range(len(syn_spec))]
+    ref_post = ref_post + [s for s in range(1, num_src + 1) for _ in range(len(syn_spec))]
+
+    ref_weight = [-1.5, 3.0] * num_src * num_symmetric
+    ref_synapse_modules = ["static_synapse", "stdp_synapse"] * num_src * num_symmetric
+
+    ref_conn_list = list(zip(ref_pre, ref_post, ref_weight, ref_synapse_modules))
+    sorted_conn_list = sort_connections(conns)
+
+    assert sorted_conn_list == ref_conn_list
+
+
+def test_MultipleSynapses_receptor_type():
+    """Test co-location of synapses with different receptor types"""
+    num_src = 7
+    num_trg = 7
+
+    src = nest.Create("iaf_psc_exp_multisynapse", num_src)
+    trgt = nest.Create("iaf_psc_exp_multisynapse", num_trg, {"tau_syn": [0.1 + i for i in range(num_trg)]})
+    node = nest.Create("iaf_psc_alpha")
+
+    syn_spec = nest.CollocatedSynapses(
+        {"synapse_model": "stdp_synapse", "weight": 5.0, "receptor_type": 2},
+        {"weight": 1.5, "receptor_type": 7},
+        {"synapse_model": "stdp_synapse", "weight": 3, "receptor_type": 5},
+    )
+
+    nest.Connect(src, trgt, "one_to_one", syn_spec=syn_spec)
+    nest.Connect(node, node)  # should have receptor 0
+
+    conns = nest.GetConnections()
+    ref_receptor_type = [0] + [2] * num_src + [5] * num_src + [7] * num_src
+
+    assert sorted(conns.receptor) == ref_receptor_type
+
+    node_index = list(conns.source).index(node.global_id)
+    node_receptor = conns.receptor[node_index]
+    assert node_receptor == 0
+
+
+@pytest.mark.skipif_missing_gsl
+def test_MultipleSynapses_receptor_type_ht_neuron():
+    """Test co-location of synapses with different receptor types and ht_neuron"""
+    num_src = 9
+    num_trg = 9
+
+    src = nest.Create("ht_neuron", num_src)
+    trgt = nest.Create("ht_neuron", num_trg)
+
+    syn_spec = nest.CollocatedSynapses(
+        {"synapse_model": "stdp_synapse", "weight": 5.0, "receptor_type": 2},
+        {"weight": 1.5, "receptor_type": 4},
+        {"synapse_model": "stdp_synapse", "weight": 3, "receptor_type": 3},
+    )
+
+    nest.Connect(src, trgt, "one_to_one", syn_spec=syn_spec)
+
+    conns = nest.GetConnections()
+    # receptors are 1 less than receptor_type for ht_neuron
+    ref_receptor_type = [1] * num_src + [2] * num_src + [3] * num_src
+
+    assert sorted(conns.receptor) == ref_receptor_type

--- a/testsuite/pytests/synapses/test_stdp_pl_synapse_hom.py
+++ b/testsuite/pytests/synapses/test_stdp_pl_synapse_hom.py
@@ -376,7 +376,7 @@ class TestSTDPPlSynapse:
                 for self.max_delay in (3.0, 1.0):
                     self.min_delay = min(self.min_delay, self.max_delay)
                     self.max_delay = max(self.min_delay, self.max_delay)
-                    for self.nest_neuron_model in ("iaf_psc_exp", "iaf_cond_exp"):
+                    for self.nest_neuron_model in {"iaf_psc_exp", "iaf_cond_exp"} & set(nest.node_models):
                         for self.neuron_parameters["t_ref"] in (self.resolution, 0.5, 1.0, 1.1, 2.5):
                             fname_snip = "_[nest_neuron_mdl=" + self.nest_neuron_model + "]"
                             fname_snip += "_[dend_delay=" + str(self.dendritic_delay) + "]"

--- a/testsuite/pytests/synapses/test_stdp_synapse.py
+++ b/testsuite/pytests/synapses/test_stdp_synapse.py
@@ -412,7 +412,7 @@ class TestSTDPSynapse:
         plt.close(fig)
 
     @pytest.mark.parametrize("dend_delay", [RESOLUTION, 1.0])
-    @pytest.mark.parametrize("model", ["iaf_psc_exp", "iaf_cond_exp"])
+    @pytest.mark.parametrize("model", [model for model in ({"iaf_psc_exp", "iaf_cond_exp"} & set(nest.node_models))])
     @pytest.mark.parametrize("min_delay", (1.0, 0.4, RESOLUTION))
     @pytest.mark.parametrize("max_delay", (1.0, 3.0))
     @pytest.mark.parametrize("t_ref", (RESOLUTION, 0.5, 1.0, 1.1, 2.5))

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
     parser.add_argument("--have-mpi", action="store_true")
     parser.add_argument("--have-openmp", action="store_true")
     parser.add_argument("--have-music", action="store_true")
+    parser.add_argument("--have-boost", action="store_true")
     args = parser.parse_args()
 
     test_outdir = args.test_outdir
@@ -110,6 +111,7 @@ if __name__ == "__main__":
     have_mpi = args.have_mpi
     have_openmp = args.have_openmp
     have_music = args.have_music
+    have_boost = args.have_boost
 
     if not have_mpi:
         # keep only phases that do not contain mpi in their name
@@ -119,6 +121,9 @@ if __name__ == "__main__":
         del expected_num_tests["07 pynesttests mpi indirect"]
     if not have_music:
         del expected_num_tests["06 musictests"]
+    if not have_boost:
+        # We use Boost's unit test framework for cpptests
+        del expected_num_tests["08 cpptests"]
 
     results = {}
     totals = {"Tests": 0, "Skipped": 0, "Failures": 0, "Errors": 0, "Time": 0, "Failed tests": []}


### PR DESCRIPTION
This PR re-instates the two most minimal test cases we had in the testsuite. They were in the past always built without Python and therefore "fell off" when PyNEST-NG was merged—no more need to test without Python. But we overlooked then that this would remove the no-boost test case.

Once I added the cases without Boost or GSL, a number of test failed because they did not skip tests properly in the absence of GSL (or avoided models missing if GSL is missing). This is fixed here. Furthermore, when built without Boost, the testsuite summary no longer looks for Cpptests, which require Boost's unit testing framework.