### PR TITLE
Change dependabot versioning-strategy for Python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: /doc
     schedule:
       interval: daily
+    # package version bound updates
+    # see https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--
+    versioning-strategy: "widen"


### PR DESCRIPTION
This changes the behavior of dependabot to stop suggesting to increase lower version bounds (such as #3825 and similar). To keep NEST compatible with various ecosystems, the lower version bounds are only to be increased when new functionality is used that requires the stricter requirement.