### PR TITLE
Fix CI trigger for `nest-extension-module`

### DIFF
--- a/.github/workflows/build_dispatch.yml
+++ b/.github/workflows/build_dispatch.yml
@@ -1,3 +1,5 @@
+name: Trigger nest-extension-module CI
+
 on: [push]
 
 permissions:
@@ -5,7 +7,7 @@ permissions:
 
 jobs:
   trigger_externals:
-    if: ${{ github.repository_owner == 'nest' && github.ref_name == 'master' }}
+    if: ${{ github.repository_owner == 'nest' && github.ref_name == 'main' }}
     name: "Trigger downstream repos"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The branch name in the dispatch YAML file still points to `master`, which causes the workflow that triggers the `nest-extension-module` CI to be skipped. This PR fixes the branch name to `main`.