### PR TITLE
Replace deprecated `ast.Str` in extension

### DIFF
--- a/doc/htmldoc/_ext/extract_api_functions.py
+++ b/doc/htmldoc/_ext/extract_api_functions.py
@@ -65,7 +65,11 @@ def find_all_variables(file_path):
             if isinstance(target, ast.Name) and target.id == "__all__":
                 value = node.value
                 if isinstance(value, ast.List):
-                    all_variables = [elem.s for elem in value.elts if isinstance(elem, ast.Str)]
+                    all_variables = [
+                        elem.value
+                        for elem in value.elts
+                        if isinstance(elem, ast.Constant) and isinstance(elem.value, str)
+                    ]
                 break
 
     return all_variables


### PR DESCRIPTION
`ast.Str` is removed in Python 3.14; this change should make the  extension compatible for all versions of Python >=3.8,

Fixes #3840

Used Claude AI