### PR TITLE
Accept plain venv as Python context

### DIFF
--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -300,7 +300,7 @@ function( NEST_PROCESS_WITH_PYTHON )
     if ( Python_FOUND )
       if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
         execute_process( COMMAND "${Python_EXECUTABLE}" "-c"
-          "import sys, os; print(int(bool(os.environ.get('CONDA_DEFAULT_ENV', False)) or (sys.prefix != sys.base_prefix)))"
+          "import sys, os; print(int(bool(os.environ.get('VIRTUAL_ENV', False)) or bool(os.environ.get('CONDA_DEFAULT_ENV', False)) or (sys.prefix != sys.base_prefix)))"
           OUTPUT_VARIABLE Python_InVirtualEnv OUTPUT_STRIP_TRAILING_WHITESPACE )
 
         if ( NOT Python_InVirtualEnv AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )


### PR DESCRIPTION
Formerly only Conda was hard-coded to be checked for virtual environment paths. This adds the `VIRTUAL_ENV` variable to be checked, too. Neither is the perfect approach and the Python install mechanism needs to be cleaned up (#3737), for now this allows to install with plain `venv`/`virtualenv` setup.