### PR TITLE
Enable distributed parameter values for `EpropArchivingNode`, `FlushEventMechanism`, `IgnoreAndSpikeMechanism`

### DIFF
--- a/models/parrot_neuron.cpp
+++ b/models/parrot_neuron.cpp
@@ -97,7 +97,7 @@ void
 parrot_neuron::set_status( const Dictionary& d )
 {
   ArchivingNode::set_status( d );
-  FlushEventMechanism::set_status( d );
+  FlushEventMechanism::set_status( d, this );
 }
 
 void

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -265,7 +265,7 @@ nest::ArchivingNode::set_status( const Dictionary& d )
     clear_history();
   }
 
-  IgnoreAndSpikeMechanism::set_status( d );
+  IgnoreAndSpikeMechanism::set_status( d, this );
 }
 
 void

--- a/nestkernel/eprop_archiving_node_readout.h
+++ b/nestkernel/eprop_archiving_node_readout.h
@@ -100,7 +100,7 @@ EpropArchivingNodeReadout< hist_shift_required >::set_status( const Dictionary& 
   {
     double eprop_isi_trace_cutoff_tmp = eprop_isi_trace_cutoff_;
 
-    d.update_value( names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_tmp );
+    update_value_param( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_tmp, this );
 
     if ( eprop_isi_trace_cutoff_tmp < 0.0 )
     {

--- a/nestkernel/eprop_archiving_node_recurrent.h
+++ b/nestkernel/eprop_archiving_node_recurrent.h
@@ -285,14 +285,14 @@ template < bool hist_shift_required >
 inline void
 EpropArchivingNodeRecurrent< hist_shift_required >::set_status( const Dictionary& d )
 {
-  FlushEventMechanism::set_status( d, hist_shift_required );
-  IgnoreAndSpikeMechanism::set_status( d );
+  FlushEventMechanism::set_status( d, this, hist_shift_required );
+  IgnoreAndSpikeMechanism::set_status( d, this );
 
   if constexpr ( not hist_shift_required )
   {
     double eprop_isi_trace_cutoff_tmp = eprop_isi_trace_cutoff_;
 
-    d.update_value( names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_tmp );
+    update_value_param( d, names::eprop_isi_trace_cutoff, eprop_isi_trace_cutoff_tmp, this );
 
     if ( eprop_isi_trace_cutoff_tmp < 0.0 )
     {

--- a/nestkernel/flush_event_mechanism.cpp
+++ b/nestkernel/flush_event_mechanism.cpp
@@ -59,11 +59,11 @@ FlushEventMechanism::get_status( Dictionary& d ) const
 }
 
 void
-FlushEventMechanism::set_status( const Dictionary& d, const bool check_eprop_constraint )
+FlushEventMechanism::set_status( const Dictionary& d, Node* node, const bool check_eprop_constraint )
 {
   double flush_event_send_interval_tmp = flush_event_send_interval_;
 
-  d.update_value( names::flush_event_send_interval, flush_event_send_interval_tmp );
+  update_value_param( d, names::flush_event_send_interval, flush_event_send_interval_tmp, node );
 
   if ( flush_event_send_interval_tmp <= 0.0 )
   {

--- a/nestkernel/flush_event_mechanism.h
+++ b/nestkernel/flush_event_mechanism.h
@@ -111,7 +111,7 @@ public:
    * @param d Dictionary with parameters.
    * @param check_eprop_constraint If true, validate that flush_event_send_interval >= eprop_update_interval.
    */
-  void set_status( const Dictionary& d, const bool check_eprop_constraint = false );
+  void set_status( const Dictionary& d, Node* node, const bool check_eprop_constraint = false );
 
 protected:
   //! Interval since previous event after which a flush event is sent (ms).

--- a/nestkernel/ignore_and_spike_mechanism.cpp
+++ b/nestkernel/ignore_and_spike_mechanism.cpp
@@ -73,7 +73,7 @@ IgnoreAndSpikeMechanism::get_status( Dictionary& d ) const
 void
 IgnoreAndSpikeMechanism::set_status( const Dictionary& d, Node* node )
 {
-  update_value_param( d, names::ignore_and_spike, ignore_and_spike_, node );
+  d.update_value( names::ignore_and_spike, ignore_and_spike_ );
 
   double offset_tmp = offset_;
   double interval_tmp = interval_;

--- a/nestkernel/ignore_and_spike_mechanism.cpp
+++ b/nestkernel/ignore_and_spike_mechanism.cpp
@@ -71,15 +71,15 @@ IgnoreAndSpikeMechanism::get_status( Dictionary& d ) const
 }
 
 void
-IgnoreAndSpikeMechanism::set_status( const Dictionary& d )
+IgnoreAndSpikeMechanism::set_status( const Dictionary& d, Node* node )
 {
-  d.update_value( names::ignore_and_spike, ignore_and_spike_ );
+  update_value_param( d, names::ignore_and_spike, ignore_and_spike_, node );
 
   double offset_tmp = offset_;
   double interval_tmp = interval_;
 
-  const bool updated_offset = d.update_value( names::ignore_and_spike_offset, offset_tmp );
-  const bool updated_interval = d.update_value( names::ignore_and_spike_interval, interval_tmp );
+  const bool updated_offset = update_value_param( d, names::ignore_and_spike_offset, offset_tmp, node );
+  const bool updated_interval = update_value_param( d, names::ignore_and_spike_interval, interval_tmp, node );
 
   if ( offset_tmp <= 0.0 )
   {

--- a/nestkernel/ignore_and_spike_mechanism.h
+++ b/nestkernel/ignore_and_spike_mechanism.h
@@ -93,7 +93,7 @@ public:
    *
    * @param d Dictionary from which parameters are set.
    */
-  void set_status( const Dictionary& d );
+  void set_status( const Dictionary& d, Node* node );
 
 private:
   /**


### PR DESCRIPTION
This PR enables setting distributed parameter values by using  `update_value_param()` instead of `update_value()`.