### PR TITLE
Update dependabot.yml pip path and version strategy to `increase-if-necessary`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,17 @@ updates:
       interval: daily
 
   - package-ecosystem: pip
-    directory: /doc
+    # Scan the repo root so Dependabot follows the `-r` includes in
+    # requirements.txt (requirements_pynest.txt, requirements_testing.txt,
+    # doc/requirements.txt, requirements_nest_server.txt) as one set.
+    directory: /
     schedule:
       interval: daily
-    # package version bound updates
-    # see https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--
-    versioning-strategy: "widen"
+    # Only raise a lower bound when the current requirement does not already
+    # allow the new release; otherwise leave it unchanged. Keeps NEST broadly
+    # compatible instead of churning the floors (see issue #3866).
+    # NB: "widen" is documented but NOT implemented for pip, so it is rejected
+    # by the config schema. Valid pip values: auto, increase,
+    # increase-if-necessary, lockfile-only.
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
Fixes #3866 

Two changes to address the problems raised in the issue 

Pointing  the pip entry at `/`  makes Dependabot read root requirements.txt and follow the include chain
(although @terhorstd mentioned that requirements.txt  are checked and _pynest are ignored, I think it was doc/requirements.txt because the root requirements only has links to the other req files)

Note: The unbounded versions are basically ignored by dependabot so only packages that are bounded or pinned will be updated. Most of the packages listed in pynest/testing/nest_server are not bounded.

strategy 'widen' is not available for pip according to the error in the output: 

> "The property '#/updates/1/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary"

But this is not explicit in the official documentation. So it is not clear why `widen` is not acceptable. 
Note: There is an open issue in the dependabot repo about enabling `widen` for python:  https://github.com/dependabot/dependabot-core/issues/6630

The strategy `increase-if-necessary` should not increase the lower bound, unless the current requirement does not allow the new release. Since we have no upper bounds (with the exception of Sphinx), we should not see dependabot trying to update versions of packages. 

I think the main concern for dependabot for us is security and github-actions changes. So this behaviour, I think is ok.
