### PR TITLE
Remove xcode in workflow docs on IDEs

### DIFF
--- a/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
+++ b/doc/htmldoc/developer_space/workflows/nest_with_ides.rst
@@ -122,7 +122,7 @@ Requirements and limitations
 
 * Assumes a suitable compiler (GCC/Clang/etc.) is installed.
 * Assumes CMake version 3.15 or newer is installed.
-* C++ debugging assumes GDB is installed if on Linux, and Xcode and LLDB is installed if on macOS.
+* C++ debugging assumes GDB is installed if on Linux, and LLDB is installed if on macOS.
 * Tested with VS Code 1.53.2.
 
 Preparations
@@ -224,32 +224,6 @@ documentation on Python debugging in VS Code, see the
    the hotkey ``F5``).
 #. A panel with output will open, and the program will run until it finishes, or encounters an error or a breakpoint.
 
-Xcode Workflow
---------------
-
-This section contains instructions on how to develop NEST on a Mac (OSX 10.10.3 as of this writing) using Xcode (Version 6.3.2). As the shipped gcc, aka clang (based on LLVM 3.6.0svn), does not support OpenMP and there is no :hxt_ref:`MPI` shipped by default, this also explains how to get a proper gcc (with OpenMP and MPI enabled) installed on Mac.
-
-Setup Infrastructure
-~~~~~~~~~~~~~~~~~~~~
-
-We need several packages installed, before we can become productive with NEST:
-
-* gcc
-* openmpi 1.6 (or later)
-* gsl
-* cmake
-* libtool
-* ipython, python, cython, ... The best way to install all the python requirements is to use `Mamba <https://mamba.readthedocs.io/en/latest/index.html/>`_.
-
-We present two ways to install the rest: MacPorts and Homebrew. For both versions you need to have Xcode and Xcode command line tools installed:
-
-1. Install Xcode from the AppStore.
-1. Install the Xcode command line tools by executing the following line in the Terminal and following the instructions in the windows that will pop up
-
-   .. code-block:: sh
-
-      xcode-select --install
-
 
 Homebrew
 ^^^^^^^^
@@ -323,73 +297,11 @@ Install NEST
 
 .. note::
 
-   It is important, that the ``cmake`` command is *not* executed with relative paths, in order for Xcode to find source files mentioned in the build logs.
-
-.. note::
-
-   If you want to debug your code with Xcode later, it has to be compiled with ``debug-options`` enabled.
-
-.. note::
-
-   Always supply a concrete ``CMAKE_C_COMPILER`` and ``CMAKE_CXX_COMPILER`` for the configure: e.g. ``-DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5`` (for Homebrew) or ``-DCMAKE_C_COMPILER=gcc-mp-4.8 -DCMAKE_CXX_COMPILER=g++-mp-4.8`` (for MacPorts). Otherwise Xcode will prefer to use the gcc/clang version.
+   Always supply a concrete ``CMAKE_C_COMPILER`` and ``CMAKE_CXX_COMPILER`` for the configure: e.g. ``-DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5`` (for Homebrew) or ``-DCMAKE_C_COMPILER=gcc-mp-4.8 -DCMAKE_CXX_COMPILER=g++-mp-4.8`` (for MacPorts).
 
 .. note::
 
    Even if you want to build with MPI enabled, do not set the wrapper compilers for ``CMAKE_*_COMPILER``, as cmake will figure out the correct compiler options on its own.
-
-.. note::
-
-   With cmake it is also possible, to generate the XCode project files with ``-G Xcode``, but this will require you to build with ``gcc/clang``. The following instructions assume, that you do not use this option.
-
-
-Get Xcode working with NEST
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Create a new project, which we will call ``NEST-fork`` in this article. In the menu select File -> New -> Project... . Then select OS X -> Other -> External Build System (with build tool ``/usr/bin/make``)
-2. Add the NEST sources to the project. There is a ``+`` in the left-bottom corner. Click ``Add Files to "NEST-fork"...``. Then select the ``<somebase>/NEST/src/`` folder (do not copy items and use groups).
-
-Also add the generated files:
-
-  .. code-block::
-
-    <somebase>/NEST/build/libnestutil/config.h
-
-3. On the left panel select the newly created project ``NEST-fork``, then select the created target.
-
-   Here you set set Directory to ``<somebase>/NEST/build``. This will be the directory, in which the ``make`` command is executed. Also check ``Pass build settings in environment``.
-
-4. Next select the ``Build Settings`` panel.
-
-  Here you ``Add User-Defined Setting`` and name it ``PATH``. In the ``NEST-fork`` column (the second) you copy the content of your ``PATH`` variable (do ``echo $PATH`` in the Terminal).
-
-5. The build system (CMD+B) should work from now on.
-
-Running NEST from Xcode
-~~~~~~~~~~~~~~~~~~~~~~~
-
-We have to edit the Targets Scheme:
-
-1. In the menu select: Product -> Scheme -> Manage Schemes...
-2. Select the ``NEST-fork`` target and hit ``Edit...``
-3. Select the ``Run`` option on the left and then on the right select ``Info``.
-4. As ``Executable`` select ``<somebase>/NEST/install/bin/nest``.
-5. You can specify arguments in the ``Arguments`` panel.
-
-.. note::
-
-   The executable ``<somebase>/NEST/install/bin/nest`` will only be updated, if you execute ``make install`` in the terminal.
-
-
-Code Completion in Xcode
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-We have to create a new target and configure it appropriately:
-
-1. In the menu select: File -> New -> Target....
-2. Make the target a OS X -> Command Line Tool (Next), of type C++ in your project (preselected). We call it ``completion``
-3. Remove all files and folders that are created with the new target.
-4. In the tab "Build Phase" of the new target, under "Compile Sources" add all ``*.h``, ``*.hpp``, ``*.c``, ``*.cc``, ``*.cpp`` files from the list (you can use CMD+a).
-5. Now Xcode generates its index and after that code completion should work.
 
 
 CLion


### PR DESCRIPTION
Removing the very outdated xcode instructions. 
If in the future we want to update it we can create a new PR


there may still be lingering instructions that do not make sense with the removal of xcode mentions, but I am not sure how far in the mac world the instructions make sense.

closes #3056
