### PR TITLE
Exclude SciPy version 1.18.0 due to regression

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          pip install mypy matplotlib numpy scipy data-science-types
+          pip install mypy matplotlib numpy "scipy~=1.18.0" data-science-types
 
       - name: "Run mypy..."
         run: |
@@ -698,7 +698,7 @@ jobs:
         # These could go to a separate venv…
         run: |
           python -m pip install 'junitparser>=2' pytest pytest-timeout pytest-xdist terminaltables
-          python -m pip install numpy scipy pandas matplotlib
+          python -m pip install numpy 'scipy~=1.18.0' pandas matplotlib
           test \! -e "=2"   # assert junitparser is correctly quoted and '>' is not interpreted as shell redirect
           python -c "import pytest; print('package location:', pytest.__file__)"
 
@@ -888,7 +888,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -c "import setuptools; print('package location:', setuptools.__file__)"
-          python -m pip install --force-reinstall --upgrade scipy 'junitparser>=2' numpy pytest pytest-timeout pytest-xdist mpi4py h5py cython matplotlib terminaltables pandoc pandas
+          python -m pip install --force-reinstall --upgrade 'scipy~=1.18.0' 'junitparser>=2' numpy pytest pytest-timeout pytest-xdist mpi4py h5py cython matplotlib terminaltables pandoc pandas
           test \! -e "=2"   # assert junitparser is correctly quoted and '>' is not interpreted as shell redirect
           python -c "import pytest; print('package location:', pytest.__file__)"
           pip list

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          pip install mypy matplotlib numpy "scipy~=1.18.0" data-science-types
+          pip install mypy matplotlib numpy "scipy!=1.18.0" data-science-types
 
       - name: "Run mypy..."
         run: |
@@ -698,7 +698,7 @@ jobs:
         # These could go to a separate venv…
         run: |
           python -m pip install 'junitparser>=2' pytest pytest-timeout pytest-xdist terminaltables
-          python -m pip install numpy 'scipy~=1.18.0' pandas matplotlib
+          python -m pip install numpy 'scipy!=1.18.0' pandas matplotlib
           test \! -e "=2"   # assert junitparser is correctly quoted and '>' is not interpreted as shell redirect
           python -c "import pytest; print('package location:', pytest.__file__)"
 
@@ -888,7 +888,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -c "import setuptools; print('package location:', setuptools.__file__)"
-          python -m pip install --force-reinstall --upgrade 'scipy~=1.18.0' 'junitparser>=2' numpy pytest pytest-timeout pytest-xdist mpi4py h5py cython matplotlib terminaltables pandoc pandas
+          python -m pip install --force-reinstall --upgrade 'scipy!=1.18.0' 'junitparser>=2' numpy pytest pytest-timeout pytest-xdist mpi4py h5py cython matplotlib terminaltables pandoc pandas
           test \! -e "=2"   # assert junitparser is correctly quoted and '>' is not interpreted as shell redirect
           python -c "import pytest; print('package location:', pytest.__file__)"
           pip list

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,7 +17,7 @@ nbsphinx >= 0.9.1
 numpy >= 1.22.0
 numpydoc >= 1.5.0
 pydot >= 1.4.2
-scipy >= 1.10.1
+scipy >= 1.10.1, ~=1.18.0
 seaborn >= 0.12.2
 sphinx >= 6.2.1, <8.2.0
 sphinx-carousel

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,7 +17,7 @@ nbsphinx >= 0.9.1
 numpy >= 1.22.0
 numpydoc >= 1.5.0
 pydot >= 1.4.2
-scipy >= 1.10.1, ~=1.18.0
+scipy >= 1.10.1, != 1.18.0
 seaborn >= 0.12.2
 sphinx >= 6.2.1, <8.2.0
 sphinx-carousel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
   "black",
   "isort",
   "mypy",
-  "scipy ~= 1.18.0",
+  "scipy != 1.18.0",
   "pandas"
 ]
 docs = [
@@ -287,7 +287,7 @@ test-requires = [
   "pytest",
   "pytest-cov",
   "pytest-xdist",
-  "scipy ~= 1.18.0",
+  "scipy != 1.18.0",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
   "black",
   "isort",
   "mypy",
-  "scipy",
+  "scipy ~= 1.18.0",
   "pandas"
 ]
 docs = [
@@ -287,7 +287,7 @@ test-requires = [
   "pytest",
   "pytest-cov",
   "pytest-xdist",
-  "scipy",
+  "scipy ~= 1.18.0",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements_pynest.txt
+++ b/requirements_pynest.txt
@@ -16,7 +16,7 @@
 cython>=3.0.0
 numpy
 pandas
-scipy
+scipy~=1.18.0
 matplotlib
 mpi4py
 h5py

--- a/requirements_pynest.txt
+++ b/requirements_pynest.txt
@@ -16,7 +16,7 @@
 cython>=3.0.0
 numpy
 pandas
-scipy~=1.18.0
+scipy!=1.18.0
 matplotlib
 mpi4py
 h5py


### PR DESCRIPTION
SciPy 1.18.0 has a regression that breaks some of our tests. The problem is known on the SciPy side (https://github.com/scipy/scipy/issues/25448) and they have a PR for it (https://github.com/scipy/scipy/pull/25468), so I assume it will be fixed with SciPy 1.18.1 and exclude only this specific version.

Labeling as critical as it breaks the CI.