### PR TITLE
Fix mailing list URLs in documentation return HTTP 400

### DIFF
--- a/doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst
+++ b/doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst
@@ -8,8 +8,7 @@ Guidelines for contributing to the mailing list
 To ensure community members provide accurate and quick responses to questions on the mailing list,
 please follow the guidelines below:
 
-#. Check the `Mailing List Archive <https://www.nest-initiative.org/mailinglist/hyperkitty/list/
-   users@nest-simulator.org/>`_ and `GitHub issues <https://github.com/nest/nest-simulator/issues>`_ to see if your
+#. Check the `Mailing List Archive <https://www.nest-simulator.org/mailinglist/hyperkitty/list/users@nest-simulator.org/>`_ and `GitHub issues <https://github.com/nest/nest-simulator/issues>`_ to see if your
    question has already been addressed.
 
    You can also look at our :ref:`troubleshooting page <troubleshooting>` for installation issues.
@@ -42,7 +41,7 @@ please follow the guidelines below:
 
    .. grid-item-card:: |mailicon| Access the mailing list
        :link-type: url
-       :link: https://www.nest-initiative.org/mailinglist/
+       :link: https://www.nest-simulator.org/mailinglist/
 
 
 ----


### PR DESCRIPTION
**Describe the flaw**

The mailing list links in the documentation point to outdated URLs under nest-initiative.org, which return an HTTP 400 error.

**Affected Files**

`doc/htmldoc/developer_space/guidelines/mailing_list_guidelines.rst`

**Changes**

Replaced outdated mailing list URLs:

From: 
 - https://www.nest-initiative.org/mailinglist/
 - https://www.nest-initiative.org/mailinglist/hyperkitty/list/users@nest-simulator.org/

To: 
 - https://www.nest-simulator.org/mailinglist/
 - https://www.nest-simulator.org/mailinglist/hyperkitty/list/users@nest-simulator.org/

**Supporting materials**
<img width="2263" height="1282" alt="grafik" src="https://github.com/user-attachments/assets/7641b286-c034-4d33-97c3-41f75b18a713" />
