### PR TITLE
Make summarization robust against lack entirely missing results

### DIFF
--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     cols = ["Tests", "Skipped", "Failures", "Errors", "Time"]
 
     col_w = max(len(c) for c in cols) + 2
-    first_col_w = max(len(k) for k in results.keys())
+    first_col_w = max(len(k) for k in results.keys(), default=0)
 
     tline = "-" * (len(cols) * col_w + first_col_w)
 

--- a/testsuite/summarize_tests.py
+++ b/testsuite/summarize_tests.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     cols = ["Tests", "Skipped", "Failures", "Errors", "Time"]
 
     col_w = max(len(c) for c in cols) + 2
-    first_col_w = max(len(k) for k in results.keys(), default=0)
+    first_col_w = max((len(k) for k in results.keys()), default=0)
 
     tline = "-" * (len(cols) * col_w + first_col_w)
 


### PR DESCRIPTION
`max([])` does not work, while `max([], default=0)` will return zero, which makes sense in this case.

See https://github.com/terhorstd/nest-simulator/actions/runs/28035709820/job/82990320660#step:32:253 for an example where his was needed.

A single reviewer should suffice here.