### PR TITLE
Add note in iaf_cond* models about setting inhibitory and excitatory synapses

### DIFF
--- a/doc/htmldoc/neurons/neuron_types.rst
+++ b/doc/htmldoc/neurons/neuron_types.rst
@@ -315,6 +315,161 @@ inputs as currents or conductances.
 
 
 
+.. _synapse_selection:
+
+Selecting the target synapse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many neuron models provide more than one synapse, most commonly an excitatory and an
+inhibitory one with their own time constants (``tau_syn_ex`` and ``tau_syn_in``) and, for
+conductance-based models, their own reversal potentials (``E_ex`` and ``E_in``).
+How you direct an incoming spike to one synapse or the other is not the same for all
+models. It is fixed by the neuron model you connect to, and neither the synapse model nor
+the :py:func:`.Connect` call can change it.
+
+NEST models use one of the following three mechanisms.
+
+Sign of the weight
+^^^^^^^^^^^^^^^^^^
+
+Most models with an excitatory and an inhibitory synapse use the **sign of the connection
+weight** to choose between them. A positive weight targets the excitatory synapse, a
+negative weight the inhibitory one. Spike connections must use the default
+``receptor_type`` of 0. Requesting any other receptor raises an ``UnknownReceptorType``
+error when the connection is created.
+
+The one exception is :doc:`/models/iaf_tum_2000`, where ``receptor_type`` selects the input
+channel rather than the synapse. Connections from another ``iaf_tum_2000`` must use
+receptor 1, and the weight sign still chooses excitatory or inhibitory. Note also that a
+few models, such as :doc:`/models/iaf_psc_exp`, accept a non-zero ``receptor_type`` for
+*current* input from a generator. That is unrelated to how spikes are routed.
+
+.. code-block:: python
+
+    n = nest.Create("iaf_cond_exp")
+    pg_ex = nest.Create("poisson_generator", params={"rate": 80.0})
+    pg_in = nest.Create("poisson_generator", params={"rate": 80.0})
+
+    # positive weight -> excitatory synapse (E_ex, tau_syn_ex)
+    nest.Connect(pg_ex, n, syn_spec={"weight": 1.0, "delay": 1.0})
+
+    # negative weight -> inhibitory synapse (E_in, tau_syn_in)
+    nest.Connect(pg_in, n, syn_spec={"weight": -1.0, "delay": 1.0})
+
+What the sign controls differs between the two model classes:
+
+* In **current-based** models, the sign selects the time constant and also sets the
+  direction of the post-synaptic current. A negative weight is hyperpolarizing.
+
+* In **conductance-based** models, the sign selects the time constant and the reversal
+  potential, but only the *absolute value* of the weight sets the conductance amplitude.
+  Whether the input depolarizes or hyperpolarizes the neuron then follows from the
+  reversal potential relative to the membrane potential, not from the sign of the weight.
+
+.. note::
+
+   Describe your connections as having positive or negative weights, and do not rely on
+   the behavior of a weight of exactly zero. Models are not consistent about which synapse
+   a zero weight is routed to, though a zero-weight connection has no effect either way.
+
+.. dropdown:: Models that select the synapse by weight sign
+
+   Current-based:
+
+   * :doc:`/models/aeif_psc_alpha`
+   * :doc:`/models/aeif_psc_exp`
+   * :doc:`/models/amat2_psc_exp`
+   * :doc:`/models/gif_pop_psc_exp`
+   * :doc:`/models/gif_psc_exp`
+   * :doc:`/models/hh_psc_alpha`
+   * :doc:`/models/hh_psc_alpha_clopath`
+   * :doc:`/models/hh_psc_alpha_gap`
+   * :doc:`/models/iaf_psc_alpha`
+   * :doc:`/models/iaf_psc_alpha_ps`
+   * :doc:`/models/iaf_psc_exp`
+   * :doc:`/models/iaf_psc_exp_htum`
+   * :doc:`/models/iaf_psc_exp_ps`
+   * :doc:`/models/iaf_psc_exp_ps_lossless`
+   * :doc:`/models/iaf_tum_2000`
+   * :doc:`/models/mat2_psc_exp`
+
+   Conductance-based:
+
+   * :doc:`/models/aeif_cond_alpha`
+   * :doc:`/models/aeif_cond_alpha_astro`
+   * :doc:`/models/aeif_cond_exp`
+   * :doc:`/models/gif_cond_exp`
+   * :doc:`/models/hh_cond_beta_gap_traub`
+   * :doc:`/models/hh_cond_exp_traub`
+   * :doc:`/models/iaf_chxk_2008`
+   * :doc:`/models/iaf_cond_alpha`
+   * :doc:`/models/iaf_cond_beta`
+   * :doc:`/models/iaf_cond_exp`
+   * :doc:`/models/iaf_cond_exp_sfa_rr`
+
+Receptor type
+^^^^^^^^^^^^^
+
+Multisynapse, multi-compartment and multi-receptor models instead select the synapse by
+:ref:`receptor type <receptor-types>`. Each synapse or compartment has its own integer ID,
+which you pass as ``receptor_type`` in the ``syn_spec`` dictionary. The sign of the weight
+plays no part in the choice.
+
+.. code-block:: python
+
+    n = nest.Create("iaf_psc_exp_multisynapse", params={"tau_syn": [2.0, 10.0]})
+    pg = nest.Create("poisson_generator", params={"rate": 80.0})
+
+    nest.Connect(pg, n, syn_spec={"weight": 1.0, "delay": 1.0, "receptor_type": 2})
+
+For the current-based models in this group, a negative weight gives a hyperpolarizing
+current on the chosen receptor, as usual. For the conductance-based ones, a negative
+weight gives a negative conductance, which is not physically meaningful. These models do
+not check the sign, so use positive weights and let the reversal potential of the chosen
+receptor determine the effect.
+
+.. dropdown:: Models that select the synapse by receptor type
+
+   * :doc:`/models/gif_psc_exp_multisynapse`
+   * :doc:`/models/glif_cond`
+   * :doc:`/models/glif_psc`
+   * :doc:`/models/glif_psc_double_alpha`
+   * :doc:`/models/ht_neuron`
+   * :doc:`/models/iaf_bw_2001`
+   * :doc:`/models/iaf_bw_2001_exact`
+   * :doc:`/models/iaf_cond_alpha_mc`
+   * :doc:`/models/iaf_psc_alpha_multisynapse`
+   * :doc:`/models/iaf_psc_exp_multisynapse`
+   * :doc:`/models/pp_cond_exp_mc_urbanczik`
+
+Receptor type, with negative weights rejected
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The conductance-based multisynapse models and the compartmental model select the synapse
+by receptor type as above, but additionally reject negative weights with an error when the
+spike is delivered, rather than letting a negative conductance through.
+
+.. dropdown:: Models that reject negative weights
+
+   * :doc:`/models/aeif_cond_alpha_multisynapse`
+   * :doc:`/models/aeif_cond_beta_multisynapse`
+   * :doc:`/models/cm_default`
+   * :doc:`/models/gif_cond_exp_multisynapse`
+   * :doc:`/models/astrocyte_lr_1994`
+
+Models with a single synapse
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Models with delta-shaped post-synaptic responses, along with the e-prop and Izhikevich
+models, sum all input into one channel. There is no synapse to select. The sign of the
+weight still determines whether an input depolarizes or hyperpolarizes the neuron.
+
+.. warning::
+
+   :doc:`/models/iaf_chs_2007` has a single synapse and **silently discards** spikes
+   arriving with a negative weight. No error or warning is raised.
+
+
 Post-synaptic input responses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/htmldoc/synapses/synapse_specification.rst
+++ b/doc/htmldoc/synapses/synapse_specification.rst
@@ -440,6 +440,33 @@ shows the setup and connection of such a model in more detail:
 
     nest.Connect(A, B, syn_spec={'receptor_type': 2})
 
+.. note::
+
+   For single-compartment conductance-based neuron models (``iaf_cond_exp``,
+   ``iaf_cond_alpha``, ``iaf_cond_beta``, ``iaf_cond_exp_sfa_rr``), ``receptor_type``
+   is **not** used to select the excitatory or inhibitory synapse. Instead, the **sign of
+   the connection weight** determines the target synapse: a positive weight connects to
+   the excitatory synapse (``E_ex``), while a negative weight connects to the inhibitory
+   synapse (``E_in``). Only the absolute value of the weight determines the conductance
+   amplitude. Attempting to set ``receptor_type`` to a value other than 0 for these models
+   raises an ``UnknownReceptorType`` error at runtime.
+
+   .. code-block:: python
+
+       n = nest.Create('iaf_cond_exp')
+       pg_e = nest.Create('poisson_generator', params={'rate': 80.0})
+       pg_i = nest.Create('poisson_generator', params={'rate': 80.0})
+
+       # Positive weight → excitatory synapse (E_ex, tau_syn_ex)
+       nest.Connect(pg_e, n, syn_spec={'weight': 1.0, 'delay': 1.0})
+
+       # Negative weight → inhibitory synapse (E_in, tau_syn_in)
+       nest.Connect(pg_i, n, syn_spec={'weight': -1.0, 'delay': 1.0})
+
+   This convention is shared by all ``iaf_cond_*`` models and mirrors the sign convention
+   used in the ``iaf_psc_*`` current-based models, making it straightforward to switch
+   between the two families.
+
 
 .. _synapse-types:
 

--- a/doc/htmldoc/synapses/synapse_specification.rst
+++ b/doc/htmldoc/synapses/synapse_specification.rst
@@ -442,14 +442,14 @@ shows the setup and connection of such a model in more detail:
 
 .. note::
 
-   For single-compartment conductance-based neuron models (``iaf_cond_exp``,
-   ``iaf_cond_alpha``, ``iaf_cond_beta``, ``iaf_cond_exp_sfa_rr``), ``receptor_type``
-   is **not** used to select the excitatory or inhibitory synapse. Instead, the **sign of
+   Many single-compartment conductance-based neuron models (``iaf_cond_exp``,
+   ``iaf_cond_alpha``, ``iaf_cond_beta``, ``iaf_cond_exp_sfa_rr``) do **not** use
+   ``receptor_type`` to select the excitatory or inhibitory synapse. Instead, the **sign of
    the connection weight** determines the target synapse: a positive weight connects to
-   the excitatory synapse (``E_ex``), while a negative weight connects to the inhibitory
-   synapse (``E_in``). Only the absolute value of the weight determines the conductance
-   amplitude. Attempting to set ``receptor_type`` to a value other than 0 for these models
-   raises an ``UnknownReceptorType`` error at runtime.
+   the excitatory synapse (``E_ex``, ``tau_syn_ex``), while a negative weight connects
+   to the inhibitory synapse (``E_in``, ``tau_syn_in``). The absolute value of the weight
+   determines the conductance amplitude. Attempting to set ``receptor_type`` to a value
+   other than 0 for these models raises an ``UnknownReceptorType`` error at runtime.
 
    .. code-block:: python
 

--- a/doc/htmldoc/synapses/synapse_specification.rst
+++ b/doc/htmldoc/synapses/synapse_specification.rst
@@ -442,30 +442,12 @@ shows the setup and connection of such a model in more detail:
 
 .. note::
 
-   For single-compartment conductance-based neuron models (``iaf_cond_exp``,
-   ``iaf_cond_alpha``, ``iaf_cond_beta``, ``iaf_cond_exp_sfa_rr``), ``receptor_type``
-   is **not** used to select the excitatory or inhibitory synapse. Instead, the **sign of
-   the connection weight** determines the target synapse: a positive weight connects to
-   the excitatory synapse (``E_ex``), while a negative weight connects to the inhibitory
-   synapse (``E_in``). Only the absolute value of the weight determines the conductance
-   amplitude. Attempting to set ``receptor_type`` to a value other than 0 for these models
-   raises an ``UnknownReceptorType`` error at runtime.
+   Many neuron models do not use ``receptor_type`` to select between their excitatory and
+   inhibitory synapses. They use the **sign of the connection weight** instead, and require
+   ``receptor_type`` to be left at 0. Which mechanism applies is fixed by the neuron model
+   you connect to.
 
-   .. code-block:: python
-
-       n = nest.Create('iaf_cond_exp')
-       pg_e = nest.Create('poisson_generator', params={'rate': 80.0})
-       pg_i = nest.Create('poisson_generator', params={'rate': 80.0})
-
-       # Positive weight → excitatory synapse (E_ex, tau_syn_ex)
-       nest.Connect(pg_e, n, syn_spec={'weight': 1.0, 'delay': 1.0})
-
-       # Negative weight → inhibitory synapse (E_in, tau_syn_in)
-       nest.Connect(pg_i, n, syn_spec={'weight': -1.0, 'delay': 1.0})
-
-   This convention is shared by all ``iaf_cond_*`` models and mirrors the sign convention
-   used in the ``iaf_psc_*`` current-based models, making it straightforward to switch
-   between the two families.
+   See :ref:`synapse_selection` for the mechanism each model uses.
 
 
 .. _synapse-types:

--- a/models/aeif_cond_alpha.h
+++ b/models/aeif_cond_alpha.h
@@ -112,6 +112,15 @@ For the reference implementation of this model, see
 
     To avoid such unphysiological behavior, you should set a refractory time ``t_ref > 0``.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/aeif_cond_alpha_astro.h
+++ b/models/aeif_cond_alpha_astro.h
@@ -119,6 +119,15 @@ model, see the
 
     To avoid such unphysiological behavior, you should set a refractory time ``t_ref > 0``.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/aeif_cond_exp.h
+++ b/models/aeif_cond_exp.h
@@ -115,6 +115,15 @@ For implementation details see the
     To avoid such unphysiological behavior, you should set a refractory time ``t_ref > 0``.
 
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 The following parameters can be set in the status Dictionary.

--- a/models/aeif_psc_alpha.h
+++ b/models/aeif_psc_alpha.h
@@ -103,6 +103,15 @@ For implementation details see the
 
     To avoid such unphysiological behavior, you should set a refractory time ``t_ref > 0``.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/aeif_psc_exp.h
+++ b/models/aeif_psc_exp.h
@@ -103,6 +103,15 @@ For implementation details see the
 
     To avoid such unphysiological behavior, you should set a refractory time ``t_ref > 0``.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/amat2_psc_exp.h
+++ b/models/amat2_psc_exp.h
@@ -85,6 +85,15 @@ The following state variables can be read out using a multimeter:
 
 See also [4]_.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/gif_cond_exp.h
+++ b/models/gif_cond_exp.h
@@ -134,6 +134,15 @@ The same formula applies for :math:`q_{\gamma}`.
 
 The shape of synaptic conductance is exponential.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/gif_pop_psc_exp.h
+++ b/models/gif_pop_psc_exp.h
@@ -77,6 +77,15 @@ neuron in each population. An approximation of random connectivity can be
 implemented by connecting populations using a ``bernoulli_synapse``.
 
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/gif_psc_exp.h
+++ b/models/gif_psc_exp.h
@@ -131,6 +131,15 @@ The shape of postsynaptic current is exponential.
   For implementation details see the
   `IAF Integration Singularity notebook <../model_details/IAF_Integration_Singularity.ipynb>`_.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/hh_cond_beta_gap_traub.h
+++ b/models/hh_cond_beta_gap_traub.h
@@ -119,6 +119,15 @@ Gap Junctions are implemented by a gap current of the form
    Traub and Miles used :math:`t_{ref} = 3` ms ([1]_, p 118), while we used
    :math:`t_{ref} = 2` ms in [1]_.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/hh_cond_exp_traub.h
+++ b/models/hh_cond_exp_traub.h
@@ -96,6 +96,15 @@ simulators covered is available from ModelDB [3]_.
    For further details on asynchronicity in spike and firing events with Hodgkin Huxley models
    see :ref:`here <hh_details>`.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/hh_psc_alpha.h
+++ b/models/hh_psc_alpha.h
@@ -86,6 +86,15 @@ See also [1]_, [2]_, [3]_.
 For details on asynchronicity in spike and firing events with Hodgkin Huxley models
 see :ref:`here <hh_details>`.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/hh_psc_alpha_clopath.h
+++ b/models/hh_psc_alpha_clopath.h
@@ -87,6 +87,15 @@ See also [1]_, [2]_, [3]_, [4]_, [5]_, [6]_.
 For details on asynchronicity in spike and firing events with Hodgkin Huxley models
 see :ref:`here <hh_details>`.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/hh_psc_alpha_gap.h
+++ b/models/hh_psc_alpha_gap.h
@@ -91,6 +91,15 @@ See also [1]_, [2]_, [3]_, [4]_.
 For details on asynchronicity in spike and firing events with Hodgkin Huxley models
 see :ref:`here <hh_details>`.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_chxk_2008.h
+++ b/models/iaf_chxk_2008.h
@@ -81,6 +81,15 @@ follow alpha-function time courses as in the ``iaf_cond_alpha`` model.
    currents in particular during periods of high spiking activity. Set
    ``ahp_bug`` to ``true`` to obtain this behavior in the model.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -74,6 +74,18 @@ at :math:`t = \tau_{syn}`.
 
 See also [1]_, [2]_, [3]_.
 
+.. note::
+
+   The **sign of the synaptic weight** determines which synapse receives the input: a positive
+   weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
+   while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
+   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
+   This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
+   the two model families.
+
+   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
+   ``UnknownReceptorType`` error.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -76,10 +76,10 @@ See also [1]_, [2]_, [3]_.
 
 .. note::
 
-   The **sign of the synaptic weight** determines which synapse receives the input: a positive
+   The **sign of the synaptic weight** determines which synapse receives an incoming spike: a positive
    weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
    while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
-   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
+   ``tau_syn_in``). The absolute value of the weight determines the change in conductance amplitude.
    This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
    the two model families.
 

--- a/models/iaf_cond_alpha.h
+++ b/models/iaf_cond_alpha.h
@@ -76,15 +76,12 @@ See also [1]_, [2]_, [3]_.
 
 .. note::
 
-   The **sign of the synaptic weight** determines which synapse receives the input: a positive
-   weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
-   while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
-   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
-   This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
-   the two model families.
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
 
-   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
-   ``UnknownReceptorType`` error.
+   See :ref:`synapse_selection` for the conventions used by other models.
 
 Parameters
 ++++++++++

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -73,12 +73,16 @@ is normalized such that an event of weight 1.0 results in a peak conductance of
 1 nS at :math:`t = \tau_{rise\_[ex|in]}`.
 
 .. note::
-   Per 2009-04-17, this class has been revised to our newest
-   insights into class design. Please use THIS CLASS as a reference
-   when designing your own models with nonlinear dynamics.
-   One weakness of this class is that it distinguishes between
-   inputs to the two synapses by the sign of the synaptic weight.
-   It would be better to use ``receptor_types``, cf ``iaf_cond_alpha_mc``.
+
+   The **sign of the synaptic weight** determines which synapse receives the input: a positive
+   weight routes the spike to the excitatory synapse (governed by ``E_ex``, ``tau_rise_ex``, and
+   ``tau_decay_ex``), while a negative weight routes it to the inhibitory synapse (governed by
+   ``E_in``, ``tau_rise_in``, and ``tau_decay_in``). Only the absolute value of the weight
+   determines the conductance amplitude. This convention mirrors the ``iaf_psc_*`` current-based
+   models to simplify migration between the two model families.
+
+   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
+   ``UnknownReceptorType`` error.
 
 See also [1]_, [2]_, [3]_, [4]_, [5]_.
 

--- a/models/iaf_cond_beta.h
+++ b/models/iaf_cond_beta.h
@@ -74,15 +74,12 @@ is normalized such that an event of weight 1.0 results in a peak conductance of
 
 .. note::
 
-   The **sign of the synaptic weight** determines which synapse receives the input: a positive
-   weight routes the spike to the excitatory synapse (governed by ``E_ex``, ``tau_rise_ex``, and
-   ``tau_decay_ex``), while a negative weight routes it to the inhibitory synapse (governed by
-   ``E_in``, ``tau_rise_in``, and ``tau_decay_in``). Only the absolute value of the weight
-   determines the conductance amplitude. This convention mirrors the ``iaf_psc_*`` current-based
-   models to simplify migration between the two model families.
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
 
-   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
-   ``UnknownReceptorType`` error.
+   See :ref:`synapse_selection` for the conventions used by other models.
 
 See also [1]_, [2]_, [3]_, [4]_, [5]_.
 

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -135,6 +135,18 @@ where :math:`\Theta(x)` is the Heaviside step function. The conductances are nor
 
 where :math:`w` is a weight (excitatory if :math:`w > 0` or inhibitory if :math:`w < 0`).
 
+.. note::
+
+   The **sign of the synaptic weight** determines which synapse receives the input: a positive
+   weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
+   while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
+   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
+   This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
+   the two model families.
+
+   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
+   ``UnknownReceptorType`` error.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -137,15 +137,12 @@ where :math:`w` is a weight (excitatory if :math:`w > 0` or inhibitory if :math:
 
 .. note::
 
-   The **sign of the synaptic weight** determines which synapse receives the input: a positive
-   weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
-   while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
-   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
-   This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
-   the two model families.
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
 
-   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
-   ``UnknownReceptorType`` error.
+   See :ref:`synapse_selection` for the conventions used by other models.
 
 Parameters
 ++++++++++

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -82,6 +82,18 @@ decay exponentially with time constants ``tau_sfa`` and ``tau_rr``, respectively
 
 See also [1]_.
 
+.. note::
+
+   The **sign of the synaptic weight** determines which synapse receives the input: a positive
+   weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
+   while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
+   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
+   This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
+   the two model families.
+
+   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
+   ``UnknownReceptorType`` error.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -84,15 +84,12 @@ See also [1]_.
 
 .. note::
 
-   The **sign of the synaptic weight** determines which synapse receives the input: a positive
-   weight routes the spike to the excitatory synapse (governed by ``E_ex`` and ``tau_syn_ex``),
-   while a negative weight routes it to the inhibitory synapse (governed by ``E_in`` and
-   ``tau_syn_in``). Only the absolute value of the weight determines the conductance amplitude.
-   This convention mirrors the ``iaf_psc_*`` current-based models to simplify migration between
-   the two model families.
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one. Only the absolute value of the weight sets the conductance
+   amplitude. Spike connections must use the default ``receptor_type`` of 0.
 
-   ``receptor_type`` is not used in this model; setting it to any value other than 0 raises an
-   ``UnknownReceptorType`` error.
+   See :ref:`synapse_selection` for the conventions used by other models.
 
 Parameters
 ++++++++++

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -137,6 +137,15 @@ hyperpolarization to biophysically plausible values, set parameter
    `IAF Integration Singularity notebook <../model_details/IAF_Integration_Singularity.ipynb>`_.
 
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -99,6 +99,15 @@ can only change at on-grid times.
 For details about exact subthreshold integration, please see
 :doc:`../neurons/exact-integration`.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -162,6 +162,15 @@ For conversion between postsynaptic potentials (PSPs) and PSCs,
 please refer to the ``postsynaptic_potential_to_current`` function in
 `PyNEST Microcircuit: Helper Functions <https://github.com/INM-6/microcircuit-PD14-model/blob/main/PyNEST/src/microcircuit/helpers.py>`_.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_psc_exp_htum.h
+++ b/models/iaf_psc_exp_htum.h
@@ -98,6 +98,15 @@ neuron like dynamics interacting by point events is described in
 
 See also [4]_.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -95,6 +95,15 @@ can only change at on-grid times.
 For details about exact subthreshold integration, please see
 :doc:`../neurons/exact-integration`.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_psc_exp_ps_lossless.h
+++ b/models/iaf_psc_exp_ps_lossless.h
@@ -77,6 +77,15 @@ meets the threshold.
   For implementation details see the
   `IAF Integration Singularity notebook <../model_details/IAF_Integration_Singularity.ipynb>`_.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -100,6 +100,16 @@ presynaptic and postsynaptic neuron must be of type ``iaf_tum_2000``.
   Using precise spike timing will result in incorrect dynamics and must therefore
   be avoided.
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   ``receptor_type`` selects the input channel rather than the synapse, and connections from
+   another ``iaf_tum_2000`` must use ``receptor_type`` 1.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 

--- a/models/mat2_psc_exp.h
+++ b/models/mat2_psc_exp.h
@@ -81,6 +81,15 @@ The following state variables can be read out with the multimeter device:
  V_th  mV    Two-timescale adaptive threshold
 ====== ====  =================================
 
+.. note::
+
+   Incoming spikes are routed to the excitatory or inhibitory synapse by the **sign of the
+   connection weight**. A positive weight targets the excitatory synapse, a negative weight
+   the inhibitory one, and also sets the direction of the post-synaptic current.
+   Spike connections must use the default ``receptor_type`` of 0.
+
+   See :ref:`synapse_selection` for the conventions used by other models.
+
 Parameters
 ++++++++++
 


### PR DESCRIPTION
This PR takes the explanation from the issue about how iaf_cond models set excitatory and inhibitory synapsaes and puts it in the model and synapse_spec docs

closes #3615 