### PR TITLE
Significantly accelerate GetConnection with source or target selection

### DIFF
--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -153,6 +153,15 @@ public:
     return false;
   }
 
+  /**
+   * @note Mark as local_receiver() so multimeter is properly identified as device.
+   */
+  bool
+  local_receiver() const override
+  {
+    return true;
+  }
+
   std::string
   get_element_type() const override
   {

--- a/models/music_event_in_proxy.h
+++ b/models/music_event_in_proxy.h
@@ -101,12 +101,17 @@ public:
   music_event_in_proxy( const music_event_in_proxy& );
 
   bool
-  has_proxies() const
+  has_proxies() const override
   {
     return false;
   }
   bool
-  one_node_per_process() const
+  one_node_per_process() const override
+  {
+    return true;
+  }
+  bool
+  local_receiver() const override
   {
     return true;
   }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1097,6 +1097,10 @@ nest::ConnectionManager::get_connections( const Dictionary& params )
     {
       throw KernelException( "GetConnection requires valid source NodeCollection." );
     }
+    if ( source_a->all_connect_as_neurons() == source_a->all_connect_as_devices() )
+    {
+      throw KernelException( "source must either contain only neurons or only devices." );
+    }
   }
   if ( params.known( names::target ) )
   {
@@ -1104,6 +1108,10 @@ nest::ConnectionManager::get_connections( const Dictionary& params )
     if ( not target_a->valid() )
     {
       throw KernelException( "GetConnection requires valid target NodeCollection." );
+    }
+    if ( target_a->all_connect_as_neurons() == target_a->all_connect_as_devices() )
+    {
+      throw KernelException( "target must either contain only neurons or only devices." );
     }
   }
 
@@ -1153,171 +1161,11 @@ nest::ConnectionManager::get_connections( const Dictionary& params )
 static inline std::deque< nest::ConnectionID >&
 extend_connectome( std::deque< nest::ConnectionID >& out, std::deque< nest::ConnectionID >& in )
 {
-  while ( not in.empty() )
-  {
-    out.push_back( in.front() );
-    in.pop_front();
-  }
+  out.insert( out.end(), std::make_move_iterator( in.begin() ), std::make_move_iterator( in.end() ) );
+
+  in.clear();  // src elements are now moved-from but still present; clear empties it
 
   return out;
-}
-
-void
-nest::ConnectionManager::split_to_neuron_device_vectors_( const size_t tid,
-  NodeCollectionPTR nodecollection,
-  std::vector< size_t >& neuron_node_ids,
-  std::vector< size_t >& device_node_ids ) const
-{
-  NodeCollection::const_iterator t_id = nodecollection->begin();
-  for ( ; t_id < nodecollection->end(); ++t_id )
-  {
-    const size_t node_id = ( *t_id ).node_id;
-    const auto node = kernel().node_manager.get_node_or_proxy( node_id, tid );
-    // Normal neuron nodes have proxies. Globally receiving devices, e.g. volume transmitter, don't have a local
-    // receiver, but are connected in the same way as normal neuron nodes. Therefore they have to be treated as such
-    // here.
-    if ( node->has_proxies() or not node->local_receiver() )
-    {
-      neuron_node_ids.push_back( node_id );
-    }
-    else
-    {
-      device_node_ids.push_back( node_id );
-    }
-  }
-}
-
-void
-nest::ConnectionManager::get_connections_( const size_t tid,
-  std::deque< ConnectionID >& conns_in_thread,
-  NodeCollectionPTR,
-  NodeCollectionPTR,
-  synindex syn_id,
-  long synapse_label ) const
-{
-  ConnectorBase* connections = connections_[ tid ][ syn_id ];
-  if ( connections )
-  {
-    // Passing target_node_id = 0 ignores target_node_id while getting connections.
-    const size_t num_connections_in_thread = connections->size();
-    for ( size_t lcid = 0; lcid < num_connections_in_thread; ++lcid )
-    {
-      const size_t source_node_id = source_table_.get_node_id( tid, syn_id, lcid );
-      connections->get_connection( source_node_id, 0, tid, lcid, synapse_label, conns_in_thread );
-    }
-  }
-
-  target_table_devices_.get_connections( 0, 0, tid, syn_id, synapse_label, conns_in_thread );
-}
-
-void
-nest::ConnectionManager::get_connections_to_targets_( const size_t tid,
-  std::deque< ConnectionID >& conns_in_thread,
-  NodeCollectionPTR,
-  NodeCollectionPTR target,
-  synindex syn_id,
-  long synapse_label ) const
-{
-  // Split targets into neuron- and device-vectors.
-  std::vector< size_t > target_neuron_node_ids;
-  std::vector< size_t > target_device_node_ids;
-  split_to_neuron_device_vectors_( tid, target, target_neuron_node_ids, target_device_node_ids );
-
-  // Getting regular connections, if they exist.
-  ConnectorBase* connections = connections_[ tid ][ syn_id ];
-  if ( connections )
-  {
-    const size_t num_connections_in_thread = connections->size();
-    for ( size_t lcid = 0; lcid < num_connections_in_thread; ++lcid )
-    {
-      const size_t source_node_id = source_table_.get_node_id( tid, syn_id, lcid );
-      connections->get_connection_with_specified_targets(
-        source_node_id, target_neuron_node_ids, tid, lcid, synapse_label, conns_in_thread );
-    }
-  }
-
-  // Getting connections from devices.
-  for ( auto t_node_id : target_neuron_node_ids )
-  {
-    target_table_devices_.get_connections_from_devices_( 0, t_node_id, tid, syn_id, synapse_label, conns_in_thread );
-  }
-
-  // Getting connections to devices.
-  for ( auto t_device_id : target_device_node_ids )
-  {
-    target_table_devices_.get_connections_to_devices_( 0, t_device_id, tid, syn_id, synapse_label, conns_in_thread );
-  }
-}
-
-void
-nest::ConnectionManager::get_connections_from_sources_( const size_t tid,
-  std::deque< ConnectionID >& conns_in_thread,
-  NodeCollectionPTR source,
-  NodeCollectionPTR target,
-  synindex syn_id,
-  long synapse_label ) const
-{
-  // Split targets into neuron- and device-vectors.
-  std::vector< size_t > target_neuron_node_ids;
-  std::vector< size_t > target_device_node_ids;
-  if ( target.get() )
-  {
-    split_to_neuron_device_vectors_( tid, target, target_neuron_node_ids, target_device_node_ids );
-  }
-
-  const ConnectorBase* connections = connections_[ tid ][ syn_id ];
-  if ( connections )
-  {
-    const size_t num_connections_in_thread = connections->size();
-    for ( size_t lcid = 0; lcid < num_connections_in_thread; ++lcid )
-    {
-      const size_t source_node_id = source_table_.get_node_id( tid, syn_id, lcid );
-      if ( source->contains( source_node_id ) )
-      {
-        if ( not target.get() )
-        {
-          // Passing target_node_id = 0 ignores target_node_id while getting
-          // connections.
-          connections->get_connection( source_node_id, 0, tid, lcid, synapse_label, conns_in_thread );
-        }
-        else
-        {
-          connections->get_connection_with_specified_targets(
-            source_node_id, target_neuron_node_ids, tid, lcid, synapse_label, conns_in_thread );
-        }
-      }
-    }
-  }
-
-  NodeCollection::const_iterator s_id = source->begin();
-  for ( ; s_id < source->end(); ++s_id )
-  {
-    const size_t source_node_id = ( *s_id ).node_id;
-    if ( not target.get() )
-    {
-      target_table_devices_.get_connections( source_node_id, 0, tid, syn_id, synapse_label, conns_in_thread );
-    }
-    else
-    {
-      for ( std::vector< size_t >::const_iterator t_node_id = target_neuron_node_ids.begin();
-        t_node_id != target_neuron_node_ids.end();
-        ++t_node_id )
-      {
-        // target_table_devices_ contains connections both to and from
-        // devices. First we get connections from devices.
-        target_table_devices_.get_connections_from_devices_(
-          source_node_id, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
-      }
-      for ( std::vector< size_t >::const_iterator t_node_id = target_device_node_ids.begin();
-        t_node_id != target_device_node_ids.end();
-        ++t_node_id )
-      {
-        // Then, we get connections to devices.
-        target_table_devices_.get_connections_to_devices_(
-          source_node_id, *t_node_id, tid, syn_id, synapse_label, conns_in_thread );
-      }
-    }
-  }
 }
 
 void
@@ -1339,7 +1187,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
       throw KernelException( "Invalid attempt to access connection information: source table was cleared." );
     }
 
-    size_t tid = kernel().vp_manager.get_thread_id();
+    const size_t tid = kernel().vp_manager.get_thread_id();
 
     std::deque< ConnectionID > conns_in_thread;
 
@@ -1363,6 +1211,184 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
         extend_connectome( connectome, conns_in_thread );
       }
     }
+  }
+}
+
+void
+nest::ConnectionManager::get_connections_( const size_t tid,
+  std::deque< ConnectionID >& conns_in_thread,
+  NodeCollectionPTR,
+  NodeCollectionPTR,
+  synindex syn_id,
+  long synapse_label ) const
+{
+  ConnectorBase* connections = connections_[ tid ][ syn_id ];
+  if ( connections )
+  {
+    const size_t num_connections_in_thread = connections->size();
+    for ( size_t lcid = 0; lcid < num_connections_in_thread; ++lcid )
+    {
+      const size_t source_node_id = source_table_.get_node_id( tid, syn_id, lcid );
+      // Passing target_node_id = 0 ignores target_node_id while getting connections.
+      connections->get_connection( source_node_id, 0, tid, lcid, synapse_label, conns_in_thread );
+    }
+  }
+
+  target_table_devices_.get_connections( 0, 0, tid, syn_id, synapse_label, conns_in_thread );
+}
+
+void
+nest::ConnectionManager::get_connections_to_targets_( const size_t tid,
+  std::deque< ConnectionID >& conns_in_thread,
+  NodeCollectionPTR,
+  NodeCollectionPTR target,
+  synindex syn_id,
+  long synapse_label ) const
+{
+  /*
+   * - Here, we accept connection from all sources and filter by targets only
+   * - Targets must be either only neuron-like or device-like.
+   * - Connections between neuron-like nodes are in connections_ and we filter them
+   *   only on the target collection.
+   * - Connections to/from/between device-like nodes are stored in target_table_devices_
+   *   and we need to collect from that table.
+   */
+  assert( target );
+
+  if ( target->all_connect_as_neurons() )
+  {
+    // Getting regular connections, if they exist.
+    ConnectorBase const* const connections = connections_[ tid ][ syn_id ];
+    if ( connections )
+    {
+      const size_t num_connections_in_thread = connections->size();
+      for ( size_t lcid = 0; lcid < num_connections_in_thread; ++lcid )
+      {
+        const size_t source_node_id = source_table_.get_node_id( tid, syn_id, lcid );
+        connections->get_connection_with_specified_targets(
+          source_node_id, target, tid, lcid, synapse_label, conns_in_thread );
+      }
+    }
+
+    // Getting connections from devices. Since target only contains neuron-like nodes,
+    //  we do not need to consider connections to devices.
+    for ( const auto& t_node : *target )
+    {
+      target_table_devices_.get_connections_from_devices_(
+        0, t_node.node_id, tid, syn_id, synapse_label, conns_in_thread );
+    }
+  }
+  else if ( target->all_connect_as_devices() )
+  {
+    // Getting connections to devices. When we get here, we want only connections to devices.
+    for ( const auto& t_device : *target )
+    {
+      target_table_devices_.get_connections_to_devices_(
+        0, t_device.node_id, tid, syn_id, synapse_label, conns_in_thread );
+    }
+  }
+  else
+  {
+    assert( false );  // should have been checked higher up
+  }
+}
+
+void
+nest::ConnectionManager::get_connections_from_sources_( const size_t tid,
+  std::deque< ConnectionID >& conns_in_thread,
+  NodeCollectionPTR source,
+  NodeCollectionPTR target,
+  synindex syn_id,
+  long synapse_label ) const
+{
+  /**
+   * Overall logic here:
+   * - source cannot be nullptr; if it were, we'd be in another method.
+   * - target maybe nullptr, then we do not select by target.
+   * - Both source and target either contain only neuron-like or only device-like nodes.
+   * - For normal connections (neuron-neuron), we iterate over existing connections
+   *   and check whether they are included in the source and target collections.
+   * - For connections from devices, loop over source (if devices) and look up all
+   *   connections from each source. Filter by target if necessary.
+   */
+  assert( source );
+  const bool target_filtering { target };
+
+  // Get connections from normal neurons, no target filtering
+  ConnectorBase const* const connections = connections_[ tid ][ syn_id ];
+  if ( connections )
+  {
+    const size_t num_connections_in_thread = connections->size();
+    for ( size_t lcid = 0; lcid < num_connections_in_thread; ++lcid )
+    {
+      const size_t source_node_id = source_table_.get_node_id( tid, syn_id, lcid );
+      if ( source->contains( source_node_id ) )
+      {
+        if ( not target_filtering )
+        {
+          // Passing target_node_id = 0 ignores target_node_id while getting connections.
+          connections->get_connection( source_node_id, 0, tid, lcid, synapse_label, conns_in_thread );
+        }
+        else
+        {
+          connections->get_connection_with_specified_targets(
+            source_node_id, target, tid, lcid, synapse_label, conns_in_thread );
+        }
+      }
+    }
+  }
+
+  // Look for connections from devices; only relevant if source contains devices.
+  if ( source->all_connect_as_devices() )
+  {
+    for ( const auto& s : *source )
+    {
+      if ( not target_filtering )
+      {
+        target_table_devices_.get_connections_from_devices_(
+          s.node_id, 0, tid, syn_id, synapse_label, conns_in_thread );
+      }
+      else
+      {
+        for ( const auto& t : *target )
+        {
+          // target_table_devices_ contains connections both to and from
+          // devices. First we get connections from devices.
+          target_table_devices_.get_connections_from_devices_(
+            s.node_id, t.node_id, tid, syn_id, synapse_label, conns_in_thread );
+        }
+      }
+    }
+  }
+  else if ( source->all_connect_as_neurons() )
+  {
+
+    if ( not target_filtering )
+    {
+      // Add all connections to devices
+      for ( const auto& s : *source )
+      {
+        target_table_devices_.get_connections_to_devices_( s.node_id, 0, tid, syn_id, synapse_label, conns_in_thread );
+      }
+    }
+    else if ( target->all_connect_as_devices() )
+    {
+      // We are only interested in neuron-like sources, so we only need to look for connections
+      // to device nodes here. If target also contains only neuron-like nodes, we got all relevant
+      // connections above, so here we only need to look for connections to devices.
+      for ( const auto& s : *source )
+      {
+        for ( const auto& t : *target )
+        {
+          target_table_devices_.get_connections_to_devices_(
+            s.node_id, t.node_id, tid, syn_id, synapse_label, conns_in_thread );
+        }
+      }
+    }
+  }
+  else
+  {
+    assert( false );  // should have been checked higher up
   }
 }
 

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -1080,10 +1080,10 @@ nest::ConnectionManager::get_num_connections( const synindex syn_id ) const
   return num_connections;
 }
 
-std::deque< nest::ConnectionID >
+std::vector< std::deque< nest::ConnectionID > >
 nest::ConnectionManager::get_connections( const Dictionary& params )
 {
-  std::deque< ConnectionID > connectome;
+  std::vector< std::deque< ConnectionID > > connectome;
   NodeCollectionPTR source_a = NodeCollectionPTR( nullptr );
   NodeCollectionPTR target_a = NodeCollectionPTR( nullptr );
 
@@ -1156,20 +1156,8 @@ nest::ConnectionManager::get_connections( const Dictionary& params )
   return connectome;
 }
 
-// Helper method which removes ConnectionIDs from input deque and
-// appends them to output deque.
-static inline std::deque< nest::ConnectionID >&
-extend_connectome( std::deque< nest::ConnectionID >& out, std::deque< nest::ConnectionID >& in )
-{
-  out.insert( out.end(), std::make_move_iterator( in.begin() ), std::make_move_iterator( in.end() ) );
-
-  in.clear();  // src elements are now moved-from but still present; clear empties it
-
-  return out;
-}
-
 void
-nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome,
+nest::ConnectionManager::get_connections( std::vector< std::deque< ConnectionID > >& connectome,
   NodeCollectionPTR source,
   NodeCollectionPTR target,
   synindex syn_id,
@@ -1206,9 +1194,9 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
 
     if ( conns_in_thread.size() > 0 )
     {
-#pragma omp critical( get_connections )
+#pragma omp critical
       {
-        extend_connectome( connectome, conns_in_thread );
+        connectome.push_back( std::move( conns_in_thread ) );
       }
     }
   }
@@ -1272,19 +1260,19 @@ nest::ConnectionManager::get_connections_to_targets_( const size_t tid,
 
     // Getting connections from devices. Since target only contains neuron-like nodes,
     //  we do not need to consider connections to devices.
-    for ( const auto& t_node : *target )
+    for ( const auto& t : *target )
     {
-      target_table_devices_.get_connections_from_devices_(
-        0, t_node.node_id, tid, syn_id, synapse_label, conns_in_thread );
+      target_table_devices_.get_connections_from_devices_( 0, t.node_id, tid, syn_id, synapse_label, conns_in_thread );
     }
   }
   else if ( target->all_connect_as_devices() )
   {
-    // Getting connections to devices. When we get here, we want only connections to devices.
-    for ( const auto& t_device : *target )
+    // Getting connections to devices. When we get here, logically we want only connections to devices.
+    // But to pick up device-to-device connections, we need to look also from the "from_device" perspective
+    // and therefore need to call the general get_connections() here.
+    for ( const auto& t : *target )
     {
-      target_table_devices_.get_connections_to_devices_(
-        0, t_device.node_id, tid, syn_id, synapse_label, conns_in_thread );
+      target_table_devices_.get_connections( 0, t.node_id, tid, syn_id, synapse_label, conns_in_thread );
     }
   }
   else
@@ -1362,7 +1350,6 @@ nest::ConnectionManager::get_connections_from_sources_( const size_t tid,
   }
   else if ( source->all_connect_as_neurons() )
   {
-
     if ( not target_filtering )
     {
       // Add all connections to devices

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -498,15 +498,6 @@ private:
   void remove_disabled_connections_( const size_t tid );
 
   /**
-   * Splits a TokenArray of node IDs to two vectors containing node IDs of neurons and
-   * node IDs of devices.
-   */
-  void split_to_neuron_device_vectors_( const size_t tid,
-    NodeCollectionPTR nodecollection,
-    std::vector< size_t >& neuron_node_ids,
-    std::vector< size_t >& device_node_ids ) const;
-
-  /**
    * Update delay extrema to current values.
    *
    * @note This entails MPI communication.

--- a/nestkernel/connection_manager.h
+++ b/nestkernel/connection_manager.h
@@ -244,10 +244,13 @@ public:
    * searched.
    * The function then iterates all entries in source and collects the
    * connection IDs to all neurons in target.
+   *
+   * @returns Vector of deques, each containing connections from one thread. May have fewer entries than threads if some
+   * threads have no connections.
    */
-  std::deque< ConnectionID > get_connections( const Dictionary& params );
+  std::vector< std::deque< ConnectionID > > get_connections( const Dictionary& params );
 
-  void get_connections( std::deque< ConnectionID >& connectome,
+  void get_connections( std::vector< std::deque< ConnectionID > >& connectome,
     NodeCollectionPTR source,
     NodeCollectionPTR target,
     synindex syn_id,
@@ -469,19 +472,19 @@ private:
 
   //! See get_connections()
   void get_connections_( const size_t tid,
-    std::deque< ConnectionID >& connectome,
+    std::deque< ConnectionID >& conns_in_thread,
     NodeCollectionPTR source,
     NodeCollectionPTR target,
     synindex syn_id,
     long synapse_label ) const;
   void get_connections_to_targets_( const size_t tid,
-    std::deque< ConnectionID >& connectome,
+    std::deque< ConnectionID >& conns_in_thread,
     NodeCollectionPTR source,
     NodeCollectionPTR target,
     synindex syn_id,
     long synapse_label ) const;
   void get_connections_from_sources_( const size_t tid,
-    std::deque< ConnectionID >& connectome,
+    std::deque< ConnectionID >& conns_in_thread,
     NodeCollectionPTR source,
     NodeCollectionPTR target,
     synindex syn_id,

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -43,6 +43,7 @@
 #include "event.h"
 #include "nest_names.h"
 #include "node.h"
+#include "node_collection.h"
 #include "source.h"
 #include "source_table.h"
 #include "spikecounter.h"
@@ -104,12 +105,14 @@ public:
     std::deque< ConnectionID >& conns ) const = 0;
 
   /**
-   * Add ConnectionID with given source_node_id and lcid to conns. If
-   * target_neuron_node_ids is given, only add connection if
-   * target_neuron_node_ids contains the node ID of the target of the connection.
+   * Add Connections with given source_node_id and lcid to conns. If target is given, only add connection if
+   * target contains the node ID of the target of the connection.
+   *
+   * @note target must be passed as const& to NodeCollectionPTR, because otherwise reference counting on
+   * the shared_ptr in a thread-parallel context will lead to significant thread contention.
    */
   virtual void get_connection_with_specified_targets( const size_t source_node_id,
-    const std::vector< size_t >& target_neuron_node_ids,
+    const NodeCollectionPTR& target,
     const size_t tid,
     const size_t lcid,
     const long synapse_label,
@@ -291,7 +294,7 @@ public:
       if ( synapse_label == UNLABELED_CONNECTION or C_[ lcid ].get_label() == synapse_label )
       {
         const size_t current_target_node_id = C_[ lcid ].get_target( tid )->get_node_id();
-        if ( current_target_node_id == target_node_id or target_node_id == 0 )
+        if ( target_node_id == 0 or target_node_id == current_target_node_id )
         {
           conns.push_back( ConnectionID( source_node_id, current_target_node_id, tid, syn_id_, lcid ) );
         }
@@ -301,7 +304,7 @@ public:
 
   void
   get_connection_with_specified_targets( const size_t source_node_id,
-    const std::vector< size_t >& target_neuron_node_ids,
+    const NodeCollectionPTR& target,
     const size_t tid,
     const size_t lcid,
     const long synapse_label,
@@ -312,8 +315,7 @@ public:
       if ( synapse_label == UNLABELED_CONNECTION or C_[ lcid ].get_label() == synapse_label )
       {
         const size_t current_target_node_id = C_[ lcid ].get_target( tid )->get_node_id();
-        if ( std::find( target_neuron_node_ids.begin(), target_neuron_node_ids.end(), current_target_node_id )
-          != target_neuron_node_ids.end() )
+        if ( target->contains( current_target_node_id ) )
         {
           conns.push_back( ConnectionID( source_node_id, current_target_node_id, tid, syn_id_, lcid ) );
         }

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -58,6 +58,7 @@ public:
   Model* clone( const std::string& ) const override;
 
   bool has_proxies() override;
+  bool local_receiver() override;
   bool one_node_per_process() override;
   bool is_off_grid() override;
   void calibrate_time( const TimeConverter& tc ) override;
@@ -159,6 +160,13 @@ inline bool
 GenericModel< ElementT >::has_proxies()
 {
   return proto_.has_proxies();
+}
+
+template < typename ElementT >
+inline bool
+GenericModel< ElementT >::local_receiver()
+{
+  return proto_.local_receiver();
 }
 
 template < typename ElementT >

--- a/nestkernel/layer_impl.h
+++ b/nestkernel/layer_impl.h
@@ -313,40 +313,43 @@ Layer< D >::dump_connections( std::ostream& out,
   // Iterate over connectome and write every connection, looking up source position only if source neuron changes
   size_t previous_source_node_id = 0;  // dummy initial value, cannot be node_id of any node
   Position< D > source_pos;            // dummy value
-  for ( const auto& conn : connectome )
+  for ( const auto& conn_part : connectome )
   {
-    const size_t source_node_id = conn.get_source_node_id();
-
-    // Search source_pos for source node only if it is a different node
-    if ( source_node_id != previous_source_node_id )
+    for ( const auto& conn : conn_part )
     {
-      const auto it = std::find_if( src_vec->begin(),
-        src_vec->end(),
-        [ source_node_id ]( const std::pair< Position< D >, size_t >& p ) { return p.second == source_node_id; } );
-      assert( it != src_vec->end() );  // internal error if node not found
+      const size_t source_node_id = conn.get_source_node_id();
 
-      source_pos = it->first;
-      previous_source_node_id = source_node_id;
+      // Search source_pos for source node only if it is a different node
+      if ( source_node_id != previous_source_node_id )
+      {
+        const auto it = std::find_if( src_vec->begin(),
+          src_vec->end(),
+          [ source_node_id ]( const std::pair< Position< D >, size_t >& p ) { return p.second == source_node_id; } );
+        assert( it != src_vec->end() );  // internal error if node not found
+
+        source_pos = it->first;
+        previous_source_node_id = source_node_id;
+      }
+
+      const Dictionary& result_dict = kernel().connection_manager.get_synapse_status( source_node_id,
+        conn.get_target_node_id(),
+        conn.get_target_thread(),
+        conn.get_synapse_model_id(),
+        conn.get_port() );
+
+      const auto target_node_id = result_dict.get< long >( names::target );
+      const auto weight = result_dict.get< double >( names::weight );
+      const auto delay = result_dict.get< double >( names::delay );
+
+      const Layer< D >* const tgt_layer = dynamic_cast< Layer< D >* >( target_layer.get() );
+      const long tnode_lid = tgt_layer->node_collection_->get_nc_index( target_node_id );
+      assert( tnode_lid >= 0 );
+
+      // Print source, target, weight, delay, rports
+      out << source_node_id << ' ' << target_node_id << ' ' << weight << ' ' << delay << ' ';
+      tgt_layer->compute_displacement( source_pos, tnode_lid ).print( out );
+      out << '\n';
     }
-
-    const Dictionary& result_dict = kernel().connection_manager.get_synapse_status( source_node_id,
-      conn.get_target_node_id(),
-      conn.get_target_thread(),
-      conn.get_synapse_model_id(),
-      conn.get_port() );
-
-    const auto target_node_id = result_dict.get< long >( names::target );
-    const auto weight = result_dict.get< double >( names::weight );
-    const auto delay = result_dict.get< double >( names::delay );
-
-    const Layer< D >* const tgt_layer = dynamic_cast< Layer< D >* >( target_layer.get() );
-    const long tnode_lid = tgt_layer->node_collection_->get_nc_index( target_node_id );
-    assert( tnode_lid >= 0 );
-
-    // Print source, target, weight, delay, rports
-    out << source_node_id << ' ' << target_node_id << ' ' << weight << ' ' << delay << ' ';
-    tgt_layer->compute_displacement( source_pos, tnode_lid ).print( out );
-    out << '\n';
   }
 }
 

--- a/nestkernel/model.h
+++ b/nestkernel/model.h
@@ -126,6 +126,7 @@ public:
   size_t mem_capacity();
 
   virtual bool has_proxies() = 0;
+  virtual bool local_receiver() = 0;
   virtual bool one_node_per_process() = 0;
   virtual bool is_off_grid() = 0;
   virtual void calibrate_time( const TimeConverter& tc ) = 0;

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -469,7 +469,7 @@ connect_sonata( const Dictionary& graph_specs, const long hyperslab_size )
   kernel().connection_manager.connect_sonata( graph_specs, hyperslab_size );
 }
 
-std::deque< ConnectionID >
+std::vector< std::deque< ConnectionID > >
 get_connections( const Dictionary& dict )
 {
   dict.init_access_flags();

--- a/nestkernel/nest.h
+++ b/nestkernel/nest.h
@@ -169,7 +169,7 @@ void connect_arrays( const long* sources,
 
 void connect_sonata( const Dictionary& graph_specs, const long hyperslab_size );
 
-std::deque< ConnectionID > get_connections( const Dictionary& dict );
+std::vector< std::deque< ConnectionID > > get_connections( const Dictionary& dict );
 
 void disconnect( const std::deque< ConnectionID >& conns );
 

--- a/nestkernel/node_collection.cpp
+++ b/nestkernel/node_collection.cpp
@@ -421,6 +421,7 @@ NodeCollectionPrimitive::NodeCollectionPrimitive( size_t first,
   , model_id_( model_id )
   , metadata_( meta )
   , nodes_have_no_proxies_( not kernel().model_manager.get_node_model( model_id_ )->has_proxies() )
+  , nodes_are_local_receivers_( kernel().model_manager.get_node_model( model_id_ )->local_receiver() )
 {
   assert( first_ <= last_ );
   assert_consistent_model_ids_( model_id_ );
@@ -432,6 +433,7 @@ NodeCollectionPrimitive::NodeCollectionPrimitive( size_t first, size_t last, siz
   , model_id_( model_id )
   , metadata_( nullptr )
   , nodes_have_no_proxies_( not kernel().model_manager.get_node_model( model_id_ )->has_proxies() )
+  , nodes_are_local_receivers_( kernel().model_manager.get_node_model( model_id_ )->local_receiver() )
 {
   assert( first_ <= last_ );
 }
@@ -456,7 +458,9 @@ NodeCollectionPrimitive::NodeCollectionPrimitive( size_t first, size_t last )
     }
   }
   model_id_ = first_model_id;
-  nodes_have_no_proxies_ = not kernel().model_manager.get_node_model( model_id_ )->has_proxies();
+  const auto& model = kernel().model_manager.get_node_model( model_id_ );
+  nodes_have_no_proxies_ = not model->has_proxies();
+  nodes_are_local_receivers_ = model->local_receiver();
 }
 
 NodeCollectionPrimitive::NodeCollectionPrimitive()
@@ -465,6 +469,7 @@ NodeCollectionPrimitive::NodeCollectionPrimitive()
   , model_id_( invalid_index )
   , metadata_( nullptr )
   , nodes_have_no_proxies_( false )
+  , nodes_are_local_receivers_( false )
 {
 }
 
@@ -1335,6 +1340,20 @@ NodeCollectionComposite::has_proxies() const
 {
   return std::all_of(
     parts_.begin(), parts_.end(), []( const NodeCollectionPrimitive& prim ) { return prim.has_proxies(); } );
+}
+
+bool
+NodeCollectionComposite::all_connect_as_neurons() const
+{
+  return std::all_of(
+    parts_.begin(), parts_.end(), []( const NodeCollectionPrimitive& prim ) { return prim.all_connect_as_neurons(); } );
+}
+
+bool
+NodeCollectionComposite::all_connect_as_devices() const
+{
+  return std::all_of(
+    parts_.begin(), parts_.end(), []( const NodeCollectionPrimitive& prim ) { return prim.all_connect_as_devices(); } );
 }
 
 std::ostream&

--- a/nestkernel/node_collection.h
+++ b/nestkernel/node_collection.h
@@ -763,9 +763,27 @@ public:
   /**
    * Returns whether the NodeCollection contains any nodes with proxies or not.
    *
-   * @return true if any nodes in the NodeCollection has proxies, false otherwise.
+   * @return true if any nodes in the NodeCollection have proxies, false otherwise.
    */
   virtual bool has_proxies() const = 0;
+
+  /**
+   * Returns true if all elements connect as neurons.
+   *
+   * This includes neurons with proxies and devices such as the volume transmitter.
+   *
+   * @note There are nodes that neither connect as neurons nor devices.
+   */
+  virtual bool all_connect_as_neurons() const = 0;
+
+  /**
+   * Returns true if all elements connect as devices.
+   *
+   * This includes most devices, but not globally receiving devices, e.g., the volume transmitter.
+   *
+   * @note There are nodes that neither connect as neurons nor devices.
+   */
+  virtual bool all_connect_as_devices() const = 0;
 
   /**
    * Collect metadata into dictionary.
@@ -807,6 +825,7 @@ private:
   size_t model_id_;                     //!< Model ID of the node IDs
   NodeCollectionMetadataPTR metadata_;  //!< Pointer to the metadata of the node IDs
   bool nodes_have_no_proxies_;          //!< Whether the primitive contains devices or not
+  bool nodes_are_local_receivers_;      //!< Whether the primitive contains local receivers
 
   /**
    * Raise an error if the model IDs of all nodes in the primitive are not the same as the expected model id.
@@ -900,6 +919,8 @@ public:
   long get_nc_index( const size_t ) const override;
 
   bool has_proxies() const override;
+  bool all_connect_as_neurons() const override;
+  bool all_connect_as_devices() const override;
 
   /**
    * Checks if node IDs in another primitive is a continuation of node IDs in this
@@ -1100,6 +1121,8 @@ public:
   long get_nc_index( const size_t ) const override;
 
   bool has_proxies() const override;
+  bool all_connect_as_neurons() const override;
+  bool all_connect_as_devices() const override;
 };
 
 inline std::ostream&
@@ -1355,6 +1378,21 @@ inline bool
 NodeCollectionPrimitive::has_proxies() const
 {
   return not nodes_have_no_proxies_;
+}
+
+inline bool
+NodeCollectionPrimitive::all_connect_as_neurons() const
+{
+  // Normal neuron nodes have proxies. Globally receiving devices, e.g. volume transmitter, don't have a local
+  // receiver, but are connected in the same way as normal neuron nodes. Therefore they have to be treated as such
+  // here.
+  return not nodes_have_no_proxies_ or not nodes_are_local_receivers_;
+}
+
+inline bool
+NodeCollectionPrimitive::all_connect_as_devices() const
+{
+  return not all_connect_as_neurons();
 }
 
 inline NodeCollection::const_iterator

--- a/nestkernel/stimulation_device.h
+++ b/nestkernel/stimulation_device.h
@@ -168,6 +168,11 @@ public:
   void set_status( const Dictionary& ) override;
 
   bool has_proxies() const override;
+
+  /**
+   * @note Mark as local_receiver() so multimeter is properly identified as device.
+   */
+  bool local_receiver() const override;
   std::string get_element_type() const override;
 
   using Device::init_buffers;
@@ -238,6 +243,12 @@ inline bool
 StimulationDevice::has_proxies() const
 {
   return false;
+}
+
+inline bool
+StimulationDevice::local_receiver() const
+{
+  return true;
 }
 
 }  // namespace nest

--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -140,7 +140,6 @@ nest::TargetTableDevices::get_connections_to_device_for_lid_( const size_t lid,
   if ( target_to_devices_[ tid ][ lid ].size() > 0 )
   {
     const size_t source_node_id = kernel().vp_manager.lid_to_node_id( lid );
-    // not the valid connector
     if ( source_node_id > 0 and target_to_devices_[ tid ][ lid ][ syn_id ] )
     {
       target_to_devices_[ tid ][ lid ][ syn_id ]->get_all_connections(

--- a/pynest/nest/lib/hl_api_connections.py
+++ b/pynest/nest/lib/hl_api_connections.py
@@ -55,17 +55,14 @@ __all__ = [
 def GetConnections(source=None, target=None, synapse_model=None, synapse_label=None):
     """Return a `SynapseCollection` representing the connection identifiers.
 
-    Any combination of `source`, `target`, `synapse_model` and
-    `synapse_label` parameters is permitted.
+    Any combination of `source`, `target`, `synapse_model` and `synapse_label` parameters is permitted.
 
     Parameters
     ----------
     source : NodeCollection, optional
-        Source node IDs, only connections from these
-        pre-synaptic neurons are returned
+        Source node IDs, only connections from these presynaptic neurons are returned
     target : NodeCollection, optional
-        Target node IDs, only connections to these
-        postsynaptic neurons are returned
+        Target node IDs, only connections to these postsynaptic neurons are returned
     synapse_model : str, optional
         Only connections with this synapse type are returned
     synapse_label : int, optional
@@ -83,8 +80,8 @@ def GetConnections(source=None, target=None, synapse_model=None, synapse_label=N
 
     Notes
     -----
-    Only connections with targets on the MPI process executing
-    the command are returned.
+    - Only connections with targets on the MPI process executing the command are returned.
+    - If `source` or `target` is given, it must be a node collection containing either only neurons or only devices.
     """
 
     params = {}

--- a/pynest/nestkernel_api.pxd
+++ b/pynest/nestkernel_api.pxd
@@ -183,7 +183,7 @@ cdef extern from "nest.h" namespace "nest":
     Dictionary get_model_defaults( const string& ) except +custom_exception_handler
     void set_model_defaults( const string&, const Dictionary& ) except +custom_exception_handler
     NodeCollectionPTR get_nodes( const Dictionary& params, const cbool local_only ) except +custom_exception_handler
-    deque[ConnectionID] get_connections( const Dictionary& dict ) except +custom_exception_handler
+    vector[deque[ConnectionID]] get_connections( const Dictionary& dict ) except +custom_exception_handler
     void set_kernel_status( const Dictionary& ) except +custom_exception_handler
     Dictionary get_nc_status( NodeCollectionPTR nc ) except +custom_exception_handler
     void set_nc_status( NodeCollectionPTR nc, vector[Dictionary]& params ) except +custom_exception_handler

--- a/pynest/nestkernel_api.pyx
+++ b/pynest/nestkernel_api.pyx
@@ -815,17 +815,21 @@ def llapi_dimension_parameter(object list_of_pos_params):
 
 def llapi_get_connections(object params):
     cdef Dictionary params_Dictionary = pydict_to_Dictionary(params)
-    cdef std_deque[ConnectionID] connections
+    cdef std_vector[std_deque[ConnectionID]] connections
 
     connections = get_connections(params_Dictionary)
 
     cdef connections_list = []
-    cdef std_deque[ConnectionID].iterator it = connections.begin()
-    while it != connections.end():
-        obj = ConnectionObject()
-        obj._set_connection_id(deref(it))
-        connections_list.append(obj)
-        inc(it)
+    cdef std_vector[std_deque[ConnectionID]].iterator vd_it = connections.begin()
+    cdef std_deque[ConnectionID].iterator it
+    while vd_it != connections.end():
+        it = deref(vd_it).begin()
+        while it != deref(vd_it).end():
+            obj = ConnectionObject()
+            obj._set_connection_id(deref(it))
+            connections_list.append(obj)
+            inc(it)
+        inc(vd_it)
 
     return nest.SynapseCollection(connections_list)
 

--- a/testsuite/pytests/connect/test_getconnections.py
+++ b/testsuite/pytests/connect/test_getconnections.py
@@ -190,6 +190,28 @@ class GetConnectionsTestCase(unittest.TestCase):
             conns = nest.GetConnections(target=tgt, synapse_label=label)
             self.assertEqual(reference_list, conns.synapse_model)
 
+    def test_GetConnectionsDeviceToDevice(self):
+        """
+        Ensure that connections directly from devices to devices are picked up correctly
+        """
+        nest.ResetKernel()
+        g = nest.Create("spike_generator", 4)
+        r = nest.Create("spike_recorder", 4)
+        nest.Connect(g, r, "one_to_one")
+        expected = sorted(zip(g.global_id, r.global_id))
+
+        actual = sorted(zip(*nest.GetConnections(target=r).get(["source", "target"]).values()))
+        assert actual == expected
+
+        actual = sorted(zip(*nest.GetConnections(source=g).get(["source", "target"]).values()))
+        assert actual == expected
+
+        actual = sorted(zip(*nest.GetConnections(source=g, target=r).get(["source", "target"]).values()))
+        assert actual == expected
+
+        actual = sorted(zip(*nest.GetConnections().get(["source", "target"]).values()))
+        assert actual == expected
+
 
 def suite():
     suite = unittest.makeSuite(GetConnectionsTestCase, "test")


### PR DESCRIPTION
The existing implementation of `GetConnection()` is very inefficient and does not scale properly under parallelization. This PR fixes this.

The benchmark shown below, picking 5 million out of 125 million connections, achieved the following times for `GetConnection()` for different code and parallelization choices (MacBook Pro M3, -O2):

 | MPI Procs | Threads | Main | This branch |
|-----:|---:|---:|---:|
| 1 | 4  | 10.5 | 0.39 |
| 2 | 2 | 10.4 | 0.27 |
| 4 | 1 | 10.3  | 0.21 |

Running on a single MPI process is slower than on four, because all 5 million connections need to be moved to the Python level.

The key change in is that connection collection is now done thread-parallel. Connections are collected into a `vector< deque< ConnectionID > >` structure, with one deque per thread. This structure is passed as-is up to the Python level and is flattened into a Python list only there.

Connection selection needs to handle connections to/from devices differently from connections between neurons proper. Distinguishing between these types of nodes currently depends on the `has_proxy()` and `local_receiver()` properties. This anything but an optimal solution, but needs to be addressed in the context of re-designing our devices.

```python
"""
Mini-benchmark for GetConnections with source and target selection

- 5 populations à 10.000 => 50.000 neurons
- In-degree 2.500 => 125 million synapses
- Select connections between two populations => 5 million synapses collected
- One VP by default
- Runs by default 10 times over to get decent times.

Usage

python demo.py [n_vp [n_reps]]
"""

import nest
from time import time
import sys

n_vp = int(sys.argv[1]) if len(sys.argv) > 1 else 1
n_reps = int(sys.argv[2]) if len(sys.argv) > 2 else 10

nest.total_num_virtual_procs = n_vp


pops = [nest.Create("parrot_neuron", n=10000) for _ in range(5)]
nrns = sum(pops)

tic = time()
nest.Connect(nrns, nrns, {"rule": "fixed_indegree", "indegree": 2500})
t_conn = time() - tic

# Force creation of pre-synaptic connection infrastructure
nest.GetConnections(source=pops[0][0])

tic = time()
for _ in range(n_reps):
    cg = nest.GetConnections(source=pops[0], target=pops[2])
t_get = time() - tic


print(f"{t_conn          = }")
print(f"t_get (per rep) = {t_get/n_reps}")
print(f"{len(cg)         = }")
```
