### PR TITLE
Add missing compiler flags to nest-config

### DIFF
--- a/bin/nest-config.in
+++ b/bin/nest-config.in
@@ -66,7 +66,7 @@ while test $# -gt 0; do
         echo "@ALL_INCLUDES@"
         ;;
     --cflags)
-        echo "@ALL_CXXFLAGS@ -std=c++@CMAKE_CXX_STANDARD@"
+        echo "@ALL_CXXFLAGS@ @OpenMP_CXX_FLAGS@ @MPI_CXX_COMPILE_FLAGS@ -std=c++@CMAKE_CXX_STANDARD@"
         ;;
     --libs)
         echo "-L${prefix}/@CMAKE_INSTALL_LIBDIR@/nest @MODULE_LINK_LIBS@"


### PR DESCRIPTION
This PR fixed #3933 by adding OpenMP (and MPI) related compiler flags to the `nest-config` script again.

A minor fix that requires only a single reviewer.
