### PR TITLE
Fix pynest dependencies in macOS build

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -821,7 +821,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -c "import setuptools; print('package location:', setuptools.__file__)"
-          python -m pip install --force-reinstall --upgrade -r requirements_testing.txt
+          python -m pip install --force-reinstall --upgrade -r requirements_pynest.txt -r requirements_testing.txt
           test \! -e "=2"   # assert junitparser is correctly quoted and '>' is not interpreted as shell redirect
           python -c "import pytest; print('package location:', pytest.__file__)"
           pip list


### PR DESCRIPTION
This fixes the issue seen on #3935. The changes are only a symptomatic fix, the `nestbuildmatrix.yml` dependency management should be cleaned up in a separate PR. See #3936.