### PR TITLE
Limit scipy to <1.18 due to regression in scipy

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          pip install mypy matplotlib numpy "scipy!=1.18.0" data-science-types
+          pip install mypy matplotlib numpy "scipy<1.18" data-science-types
 
       - name: "Run mypy..."
         run: |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -17,7 +17,7 @@ nbsphinx >= 0.9.1
 numpy >= 1.22.0
 numpydoc >= 1.5.0
 pydot >= 1.4.2
-scipy >= 1.10.1, != 1.18.0
+scipy >= 1.10.1, < 1.18
 seaborn >= 0.12.2
 sphinx >= 6.2.1, <8.2.0
 sphinx-carousel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
   "black",
   "isort",
   "mypy",
-  "scipy != 1.18.0",
+  "scipy < 1.18",
   "pandas"
 ]
 docs = [
@@ -293,7 +293,7 @@ test-requires = [
   "pytest-cov",
   "pytest-timeout",
   "pytest-xdist",
-  "scipy != 1.18.0",
+  "scipy < 1.18",
 ]
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/requirements_pynest.txt
+++ b/requirements_pynest.txt
@@ -16,7 +16,7 @@
 cython>=3.0.0
 numpy
 pandas
-scipy!=1.18.0
+scipy<1.18
 matplotlib
 mpi4py
 h5py


### PR DESCRIPTION
This is a follow-up to #3881 and #3937. In #3881, I had assumed that the problem would be fixed upstream by SciPy 1.18.1 since a PR already existed ((scipy/scipy#25468[https://github.com/scipy/scipy/pull/25468]), but that was clearly optimistic: The regression persists in SciPy 1.18.1.

Therefore, this PR changes the requirement from "!= 1.18.0" to "< 1.18".

This PR needs only on reviewer. Marked as Critical because it breaks CI on macOS.