### PR TITLE
Pin isort version to 9.0.1 and adjust import ordering

### DIFF
--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -359,7 +359,7 @@ jobs:
       - name: "Run isort..."
         uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326  # 1.1.1
         with:
-          isort-version: 8.0.1
+          isort-version: 9.0.1
           configuration: --profile=black --thirdparty="nest" --check-only --diff
 
   black:

--- a/.github/workflows/nestbuildmatrix.yml
+++ b/.github/workflows/nestbuildmatrix.yml
@@ -359,6 +359,7 @@ jobs:
       - name: "Run isort..."
         uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326  # 1.1.1
         with:
+          isort-version: 8.0.1
           configuration: --profile=black --thirdparty="nest" --check-only --diff
 
   black:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pycqa/isort
-    rev: 8.0.1
+    rev: 9.0.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--thirdparty", "nest"]

--- a/pynest/nest/spatial/__init__.py
+++ b/pynest/nest/spatial/__init__.py
@@ -21,8 +21,8 @@
 
 import functools as _functools
 
-from .hl_api_spatial import DistanceParameter as _DistanceParameter
 from .hl_api_spatial import *  # noqa: F401,F403
+from .hl_api_spatial import DistanceParameter as _DistanceParameter
 
 
 @_functools.lru_cache(maxsize=None)


### PR DESCRIPTION
This PR fixes #3939 by pinning isort to 9.0.1 and adapting import order in one file correspondingly.

This PR is critical because the problem blocks our CI. As single reviewer should suffice here.