### PR TITLE
Root module cleanup and import-time creep

### DIFF
--- a/doc/htmldoc/_ext/extract_api_functions.py
+++ b/doc/htmldoc/_ext/extract_api_functions.py
@@ -21,7 +21,6 @@
 import ast
 import glob
 import os
-import re
 
 from sphinx.application import Sphinx
 
@@ -33,31 +32,50 @@ the API documentation (``ref_material/pynest_api/``)
 """
 
 
+def referenced_name(node):
+    """The name a reference node spells, e.g. ``KernelAttribute`` for ``ll_api.KernelAttribute``."""
+
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def find_kernel_attributes(tree):
+    """
+    Get the names of the kernel attributes, which are declared as module-level
+    annotations of the form ``name: Annotated[type, KernelAttribute(...)]``; see
+    ``_install_kernel_attributes`` in ``pynest/nest/__init__.py``.
+    """
+    names = []
+
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
+            continue
+        annotation = node.annotation
+        if not isinstance(annotation, ast.Subscript) or referenced_name(annotation.value) != "Annotated":
+            continue
+        # The first subscript argument is the type, the rest is the metadata.
+        metadata = annotation.slice.elts[1:] if isinstance(annotation.slice, ast.Tuple) else []
+        if any(isinstance(item, ast.Call) and referenced_name(item.func) == "KernelAttribute" for item in metadata):
+            names.append(node.target.id)
+
+    return names
+
+
 def find_all_variables(file_path):
     """
     Get the names of all functions listed in ``__all__`` in each of the PyNEST
     API files, along with the kernel attributes found in ``__init__.py`` of
     ``pynest/nest/``.
     """
-    all_variables = None
-
-    if "pynest/nest/__init__" in file_path:
-        # Read the __init__.py file
-        with open(file_path, "r") as init_file:
-            file_content = init_file.read()
-
-        # Find the class definition
-        match = re.search(r"class\s+NestModule\(.*?\):", file_content, re.DOTALL)
-        if match:
-            # Find the variable assignments within the class
-            all_variables = re.findall(r"(\w+)\s*=\s*KernelAttribute", file_content)
-
     with open(file_path, "r") as file:
         try:
             tree = ast.parse(file.read())
         except SyntaxError:
             # Skip files with syntax errors
             return None
+
+    all_variables = find_kernel_attributes(tree) if "pynest/nest/__init__" in file_path else None
 
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, ast.Assign) and len(node.targets) == 1:

--- a/doc/htmldoc/ref_material/pynest_api/nest.NestModule.rst
+++ b/doc/htmldoc/ref_material/pynest_api/nest.NestModule.rst
@@ -25,3 +25,8 @@ Here is a list of attributes that can be get and/or set on the ``nest`` module:
 .. autoclass:: nest.NestModule
    :members:
    :no-undoc-members:
+
+Besides the kernel attributes, the ``nest`` module exposes the communicator hook that
+an MPI-parallel simulation needs:
+
+.. autofunction:: nest.set_communicator

--- a/pynest/nest/__init__.py
+++ b/pynest/nest/__init__.py
@@ -40,86 +40,450 @@ r"""PyNEST - Python interface for the NEST Simulator
 For more information visit https://www.nest-simulator.org.
 """
 
-# WARINIG: Since this file uses a ton of trickery, linter warnings are mostly
-# disabled. This means that you need to make sure style is fine yourself!!!
+# The `nest` module is a container of lazily imported submodules, lazily loaded
+# attribute shortcuts to said submodules, and kernel attributes (which read and write
+# kernel values). The dynamic behaviour of the module is achieved by retyping this
+# module object to the `NestModule` type defined below. Assigning a module's
+# `__class__` is supported for exactly this purpose since Python 3.5; see
+# https://docs.python.org/3/reference/datamodel.html#module.__class__. There are two
+# main dynamic behaviours:
 #
-# pylint: disable=wrong-import-position, no-name-in-module, undefined-variable
-# pylint: disable=invalid-name, protected-access
+# 1. Submodule attribute shortcuts
+# --------------------------------
+#
+# All the public attributes of the nest submodules are directly available on the nest
+# module itself:
+#
+#     import nest
+#
+#     nest.Create(...)
+#
+# This is achieved by a `__getattr__` method on the `NestModule`, backed by a symbol
+# map between the public interface members that the submodules declare in their
+# `__all__` and the submodule that defines them. The map is read from the sources, so
+# building it imports nothing, and looking a member up imports only the one submodule
+# that defines it. Static typing is enabled by importing all submodules in a
+# type-checking only block (which is skipped at runtime).
+#
+# 2. Kernel attributes
+# --------------------
+#
+# Kernel attributes read and write values of the C++ nest kernel. They are declared as
+# static type hints, which `_install_kernel_attributes` turns into descriptors on the
+# `NestModule` type, so that reading and writing `nest.<name>` reads and writes the
+# kernel status.
+#
+# The layout of the file follows those two halves: it begins with the regular import
+# statements, then the static declarations (the type-checking block for (1) and the
+# kernel attribute type hints for (2)), then the `NestModule` type that gives them
+# their dynamic behaviour, and it ends by retyping the module object.
+#
+# pylint: disable=wildcard-import, unused-wildcard-import, no-name-in-module, invalid-name
 
-# WARNING: This file is only used to create the `NestModule` below and then
-# ignored. If you'd like to make changes to the root `nest` module, they need to
-# be made to the `NestModule` class/instance instead.
+import sys
+import types
+import typing
+from typing import Annotated
 
-################
+from . import ll_api as _ll_api  # noqa: F401  (importing `ll_api` starts the kernel)
+from .ll_api import KernelAttribute, set_communicator  # noqa: F401
 
-# Store interpreter-given module attributes to copy into replacement module
-# instance later on. Use `.copy()` to prevent pollution with other variables
-_original_module_attrs = globals().copy()
-
-import builtins  # noqa
-import importlib  # noqa
-import sys  # noqa
-import types  # noqa
-
-from .ll_api import KernelAttribute  # noqa
+if typing.TYPE_CHECKING:
+    # Static analysis has no way to follow `NestModule.__getattr__`, so the namespace it
+    # builds at runtime is spelled out here for the benefit of type checkers and IDEs.
+    # Nothing reads this block at runtime, since the runtime discovers both the submodules
+    # and the `hl_api` modules from the package directory, so a stale entry costs type
+    # information, never correctness. `test_api_surface.py` fails if the two drift apart.
+    from . import (  # noqa: F401
+        ll_api,
+        logic,
+        math,
+        random,
+        raster_plot,
+        server,
+        spatial,
+        spatial_distributions,
+        visualization,
+        voltage_trace,
+    )
+    from .lib.hl_api_connections import *  # noqa: F401,F403
+    from .lib.hl_api_info import *  # noqa: F401,F403
+    from .lib.hl_api_models import *  # noqa: F401,F403
+    from .lib.hl_api_nodes import *  # noqa: F401,F403
+    from .lib.hl_api_parallel_computing import *  # noqa: F401,F403
+    from .lib.hl_api_simulation import *  # noqa: F401,F403
+    from .lib.hl_api_sonata import *  # noqa: F401,F403
+    from .lib.hl_api_spatial import *  # noqa: F401,F403
+    from .lib.hl_api_types import *  # noqa: F401,F403
 
 try:
-    import versionchecker  # noqa: F401
+    # Bound under a private name so that it stays out of the `nest` API.
+    import versionchecker as _versionchecker  # noqa: F401
 except ImportError:
     pass
+
+NESTErrors = _ll_api.nestkernel.NESTErrors
+NESTError = _ll_api.nestkernel.NESTErrors.KernelException
+
+
+# Define the kernel attributes.
+#
+# FORMATTING NOTES:
+# * The description is dedented and a `.` is appended, so write it as a normal sentence
+#   and indent continuation lines to match the surrounding code.
+# * Strings containing a colon render incorrectly.
+
+kernel_status: Annotated[dict, KernelAttribute("Get the complete kernel status", readonly=True)]
+resolution: Annotated[float, KernelAttribute("The resolution of the simulation (in ms)", default=0.1)]
+biological_time: Annotated[float, KernelAttribute("The current simulation time (in ms)")]
+build_info: Annotated[
+    dict, KernelAttribute("Information about the build and compile configuration of NEST", readonly=True)
+]
+memory_size: Annotated[int, KernelAttribute("Memory size of NEST process in kB (-1 if unavailable)", readonly=True)]
+to_do: Annotated[int, KernelAttribute("The number of steps yet to be simulated", readonly=True)]
+max_delay: Annotated[float, KernelAttribute("The maximum delay in the network", default=0.1)]
+min_delay: Annotated[float, KernelAttribute("The minimum delay in the network", default=0.1)]
+ms_per_tic: Annotated[
+    float,
+    KernelAttribute("The number of milliseconds per tic. Calculated by ms_per_tic = 1 / tics_per_ms", readonly=True),
+]
+tics_per_ms: Annotated[
+    float,
+    KernelAttribute(
+        """
+        The number of tics per millisecond. Change of tics_per_ms requires simultaneous
+        specification of resolution
+        """,
+        default=1000.0,
+    ),
+]
+tics_per_step: Annotated[
+    int,
+    KernelAttribute(
+        """
+        The number of tics per simulation time step. Calculated as tics_per_step = resolution *
+        tics_per_ms
+        """,
+        readonly=True,
+    ),
+]
+T_max: Annotated[float, KernelAttribute("The largest representable time value", readonly=True)]
+T_min: Annotated[float, KernelAttribute("The smallest representable time value", readonly=True)]
+rng_types: Annotated[list[str], KernelAttribute("List of available random number generator types", readonly=True)]
+rng_type: Annotated[str, KernelAttribute("Name of random number generator type used by NEST", default="mt19937_64")]
+rng_seed: Annotated[
+    int,
+    KernelAttribute(
+        r"""
+        Seed value used as base for seeding NEST random number generators
+        (:math:`1 \leq s\leq 2^{32}-1`)
+        """,
+        default=143202461,
+    ),
+]
+total_num_virtual_procs: Annotated[int, KernelAttribute("The total number of virtual processes", default=1)]
+local_num_threads: Annotated[int, KernelAttribute("The local number of threads", default=1)]
+num_processes: Annotated[int, KernelAttribute("The number of MPI processes", readonly=True)]
+off_grid_spiking: Annotated[
+    bool, KernelAttribute("Whether to transmit precise spike times in MPI communication", readonly=True)
+]
+adaptive_target_buffers: Annotated[
+    bool, KernelAttribute("Whether MPI buffers for communication of connections resize on the fly", default=True)
+]
+send_buffer_size_secondary_events: Annotated[
+    int,
+    KernelAttribute(
+        """
+        Size of MPI send buffers for communicating secondary events (in bytes, per MPI rank, for
+        developers)
+        """,
+        readonly=True,
+    ),
+]
+recv_buffer_size_secondary_events: Annotated[
+    int,
+    KernelAttribute(
+        """
+        Size of MPI recv buffers for communicating secondary events (in bytes, per MPI rank, for
+        developers)
+        """,
+        readonly=True,
+    ),
+]
+buffer_size_spike_data: Annotated[
+    int, KernelAttribute("Total size of MPI buffer for communication of spikes", default=2)
+]
+buffer_size_target_data: Annotated[
+    int, KernelAttribute("Total size of MPI buffer for communication of connections", default=2)
+]
+growth_factor_buffer_target_data: Annotated[
+    float,
+    KernelAttribute(
+        """
+        If MPI buffers for communication of connections resize on the fly, grow them by this factor
+        each round
+        """,
+        default=1.5,
+    ),
+]
+max_buffer_size_target_data: Annotated[
+    int, KernelAttribute("Maximal size of MPI buffers for communication of connections", default=16777216)
+]
+spike_buffer_grow_extra: Annotated[
+    float,
+    KernelAttribute(
+        """
+        When spike exchange buffer is expanded, resize it to `(1 + spike_buffer_grow_extra) *
+        required_buffer_size`
+        """,
+        default=0.5,
+    ),
+]
+spike_buffer_shrink_limit: Annotated[
+    float,
+    KernelAttribute(
+        """
+        If the largest number of spikes sent from any rank to any rank is less than
+        `spike_buffer_shrink_limit * buffer_size`, then reduce buffer size.
+        `spike_buffer_shrink_limit == 0` means that buffers never shrink. See
+        ``spike_buffer_shrink_spare`` for how the new buffer size is determined
+        """,
+        default=0.2,
+    ),
+]
+spike_buffer_shrink_spare: Annotated[
+    float,
+    KernelAttribute(
+        """
+        When the buffer shrinks, set the new size to `(1 + spike_buffer_shrink_spare) *
+        required_buffer_size`. See `spike_buffer_shrink_limit` for when buffers shrink
+        """,
+        default=0.1,
+    ),
+]
+spike_buffer_resize_log: Annotated[
+    dict,
+    KernelAttribute(
+        """
+        Log of spike buffer resizing as a dictionary. It contains the `times` of the resizings
+        (simulation clock in steps, always multiple of ``min_delay``), ``global_max_spikes_sent``,
+        that is, the observed spike number that triggered the resize, and the ``new_buffer_size``.
+        Sizes for the buffer section sent from one rank to another rank
+        """,
+        readonly=True,
+    ),
+]
+cycle_time_log: Annotated[
+    dict, KernelAttribute("Information on the duration and spike counts within each update cycle.", readonly=True)
+]
+use_wfr: Annotated[bool, KernelAttribute("Whether to use waveform relaxation method", default=True)]
+wfr_comm_interval: Annotated[float, KernelAttribute("Desired waveform relaxation communication interval", default=1.0)]
+wfr_tol: Annotated[float, KernelAttribute("Convergence tolerance of waveform relaxation method", default=0.0001)]
+wfr_max_iterations: Annotated[
+    int, KernelAttribute("Maximal number of iterations used for waveform relaxation", default=15)
+]
+wfr_interpolation_order: Annotated[
+    int, KernelAttribute("Interpolation order of polynomial used in wfr iterations", default=3)
+]
+max_num_syn_models: Annotated[int, KernelAttribute("Maximal number of synapse models supported", readonly=True)]
+structural_plasticity_synapses: Annotated[
+    dict,
+    KernelAttribute(
+        """
+        Defines all synapses which are plastic for the structural plasticity algorithm. Each entry
+        in the dictionary is composed of a synapse model, the presynaptic element and the
+        postsynaptic element
+        """,
+    ),
+]
+structural_plasticity_update_interval: Annotated[
+    int,
+    KernelAttribute(
+        """
+        Defines the time interval in ms at which the structural plasticity manager will make changes
+        in the structure of the network ( creation and deletion of plastic synapses)
+        """,
+        default=10000,
+    ),
+]
+growth_curves: Annotated[
+    list[str], KernelAttribute("The list of the available structural plasticity growth curves", readonly=True)
+]
+use_compressed_spikes: Annotated[
+    bool,
+    KernelAttribute(
+        """
+        Whether to use spike compression; if a neuron has targets on multiple threads of a process,
+        this switch makes sure that only a single packet is sent to the process instead of one
+        packet per target thread; it implies that connections are sorted by source.
+        """,
+        default=True,
+    ),
+]
+data_path: Annotated[str, KernelAttribute("A path, where all data is written to, defaults to current directory")]
+data_prefix: Annotated[str, KernelAttribute("A common prefix for all data files")]
+overwrite_files: Annotated[bool, KernelAttribute("Whether to overwrite existing data files", default=False)]
+print_time: Annotated[
+    bool, KernelAttribute("Whether to print progress information during the simulation", default=False)
+]
+network_size: Annotated[int, KernelAttribute("The number of nodes in the network", readonly=True)]
+num_connections: Annotated[
+    int, KernelAttribute("The number of connections in the network", readonly=True, localonly=True)
+]
+connection_rules: Annotated[list[str], KernelAttribute("The list of available connection rules", readonly=True)]
+node_models: Annotated[
+    list[str], KernelAttribute("The list of the available node (i.e., neuron or device) models", readonly=True)
+]
+synapse_models: Annotated[list[str], KernelAttribute("The list of the available synapse models", readonly=True)]
+local_spike_counter: Annotated[
+    int,
+    KernelAttribute(
+        """
+        Number of spikes fired by neurons on a given MPI rank during the most recent call to
+        :py:func:`.Simulate`. Only spikes from "normal" neurons are counted, not spikes generated by
+        devices such as ``poisson_generator``. Resets on each call to ``Simulate`` or ``Run``.
+        """,
+        readonly=True,
+    ),
+]
+recording_backends: Annotated[
+    list[str], KernelAttribute("List of available backends for recording devices", readonly=True)
+]
+stimulation_backends: Annotated[
+    list[str], KernelAttribute("List of available backends for stimulation devices", readonly=True)
+]
+dict_miss_is_error: Annotated[
+    bool, KernelAttribute("Whether missed dictionary entries are treated as errors", default=True)
+]
+keep_source_table: Annotated[
+    bool, KernelAttribute("Whether to keep source table after connection setup is complete", default=True)
+]
+min_update_time: Annotated[
+    float, KernelAttribute("Shortest wall-clock time measured so far for a full update step [seconds]", readonly=True)
+]
+max_update_time: Annotated[
+    float, KernelAttribute("Longest wall-clock time measured so far for a full update step [seconds]", readonly=True)
+]
+update_time_limit: Annotated[
+    float,
+    KernelAttribute(
+        """
+        Maximum wall-clock time for one full update step [seconds]. This can be used to terminate
+        simulations that slow down significantly. Simulations may still get stuck if the slowdown
+        occurs within a single update step
+        """,
+        default=float("+inf"),
+    ),
+]
+eprop_update_interval: Annotated[
+    float, KernelAttribute("Task-specific update interval of the e-prop plasticity mechanism [ms].", default=1000.0)
+]
+eprop_learning_window: Annotated[
+    float, KernelAttribute("Task-specific learning window of the e-prop plasticity mechanism [ms].", default=1000.0)
+]
+eprop_reset_neurons_on_update: Annotated[
+    bool, KernelAttribute("If True, reset dynamic variables of e-prop neurons upon e-prop update.", default=True)
+]
+verbosity: Annotated[
+    _ll_api.nestkernel.VerbosityLevel,
+    KernelAttribute(
+        """
+        Controls NEST's verbosity. The following levels are available, from most to least chatty:
+        ALL, DEBUG, STATUS, INFO, PROGRESS, DEPRECATED, WARNING, ERROR, FATAL, QUIET. Default
+        verbosity is INFO. To start NEST with a different verbosity and supress the startup message,
+        set the environment variable PYNEST_QUIET=1
+        """,
+        default=_ll_api.nestkernel.VerbosityLevel.INFO,
+    ),
+]
 
 
 class NestModule(types.ModuleType):
     """
-    A module class for the ``nest`` root module to control the dynamic generation
-    of module level attributes such as the KernelAttributes, lazy loading
-    some submodules and importing the public APIs of the `lib` submodules.
+    Type of the ``nest`` root module.
+
+    The kernel attributes are descriptors: reading ``nest.<attribute>`` reads the
+    status of the running NEST kernel and assigning to it writes that status.
+    Descriptors are only honoured when they live on a type, which is why the ``nest``
+    module object is given this type rather than plain ``ModuleType``.
     """
 
-    from . import ll_api  # noqa
-    from . import logic  # noqa
-    from . import math  # noqa
-    from . import random  # noqa
-    from . import spatial_distributions  # noqa
-    from .ll_api import set_communicator
+    # Submodules that `nest` uses to reach the kernel or that only matter during
+    # start-up. They stay reachable, but `nest` does not advertise them.
+    _PRIVATE_SUBMODULES = frozenset({"lib", "nestkernel_api", "versionchecker"})
 
-    NESTErrors = ll_api.nestkernel.NESTErrors
-    NESTError = ll_api.nestkernel.NESTErrors.KernelException
+    # Filled in on first use by `_submodules()` and `_symbols()`.
+    _submodule_names = None
+    _symbol_map = None
 
-    def __init__(self, name):
-        super().__init__(name)
-        # Copy over the original module attributes to preserve all interpreter-given
-        # magic attributes such as `__name__`, `__path__`, `__package__`, ...
-        self.__dict__.update(_original_module_attrs)  # noqa
+    def _submodules(self):
+        """Names of the submodules `nest` exposes, read from the package directory."""
 
-        # Import public APIs of submodules into the `nest.` namespace
-        _rel_import_star(self, ".lib.hl_api_connections")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_info")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_models")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_nodes")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_parallel_computing")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_simulation")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_sonata")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_spatial")  # noqa: F821
-        _rel_import_star(self, ".lib.hl_api_types")  # noqa: F821
+        import pkgutil
 
-        # Lazy loaded modules. They are descriptors, so add them to the type object
-        type(self).raster_plot = _lazy_module_property("raster_plot")  # noqa: F821
-        type(self).server = _lazy_module_property("server")  # noqa: F821
-        type(self).spatial = _lazy_module_property("spatial")  # noqa: F821
-        type(self).visualization = _lazy_module_property("visualization")  # noqa: F821
-        type(self).voltage_trace = _lazy_module_property("voltage_trace")  # noqa: F821
+        if NestModule._submodule_names is None:
+            NestModule._submodule_names = frozenset(
+                name
+                for _, name, _ in pkgutil.iter_modules(self.__path__)
+                if not name.startswith("_") and name not in NestModule._PRIVATE_SUBMODULES
+            )
+        return NestModule._submodule_names
 
-        # Finalize the nest module with a public API.
-        _api = list(k for k in self.__dict__ if not k.startswith("_"))
-        _api.extend(k for k in dir(type(self)) if not k.startswith("_"))
-        self.__all__ = list(set(_api))
+    def _symbols(self):
+        """
+        Map each name that the ``lib.hl_api_*`` modules export onto the module that
+        exports it. The whole map is built on first use and kept on the class, and it
+        is read from the sources, so building it imports nothing and resolving a name
+        imports only the one module that owns it. The ``*_helper`` modules are internal
+        and are skipped, as they are by the documentation build.
 
-        # Add version for backward compatibility
-        self.__version__ = NestModule.ll_api.nestkernel.llapi_get_kernel_status()["build_info"]["version"]
+        `os` rather than `pathlib`, because `nest` has already imported the one and
+        importing the other costs more than the whole map build.
+        """
 
-        # Block setting of unknown attributes
-        type(self).__setattr__ = _setattr_error
+        import os
+
+        if NestModule._symbol_map is None:
+            symbols = {}
+            lib = os.path.join(self.__path__[0], "lib")
+            for filename in sorted(os.listdir(lib)):
+                if filename.startswith("hl_api_") and filename.endswith(".py") and "helper" not in filename:
+                    module = f".lib.{filename[:-len('.py')]}"
+                    with open(os.path.join(lib, filename), encoding="utf-8") as source:
+                        symbols.update((name, module) for name in self._exported_names(source.read()))
+            NestModule._symbol_map = symbols
+        return NestModule._symbol_map
+
+    def _exported_names(self, source):
+        """
+        The names that `source` declares in its ``__all__``.
+
+        In every `hl_api` module that declaration is a plain list of string literals, so
+        it is matched directly instead of parsing or tokenizing the module, which is
+        what keeps building the whole map to well under a millisecond. Two details do
+        the work of a parser. The anchor is `__all__ = [` at the start of a line, which
+        prose in a docstring cannot satisfy. And comments go before the closing bracket
+        is looked for, so a bracket written inside one cannot end the list early.
+
+        A declaration this does not understand yields fewer names, never different ones,
+        because only quoted words between the brackets are read. `test_api_surface.py`
+        checks the map against what the modules really export, so a declaration that
+        outgrows this fails the test suite rather than `nest` itself.
+        """
+
+        import re
+
+        opening = re.search(r"^__all__\s*=\s*\[", source, re.MULTILINE)
+        if opening is None:
+            return []
+
+        # An exported name holds no `#`, so every `#` that is left starts a comment.
+        body = re.sub(r"#.*", "", source[opening.end() :])
+        closing = body.find("]")
+        if closing == -1:
+            return []
+
+        return re.findall(r"[\"'](\w+)[\"']", body[:closing])
 
     def set(self, **kwargs):
         "Forward kernel attribute setting to `SetKernelStatus()`."
@@ -134,315 +498,68 @@ class NestModule(types.ModuleType):
         return self.GetKernelStatus(args)
 
     def __dir__(self):
-        return list(set(vars(self).keys()) | set(self.__all__))
+        # `__all__` first: building it caches it in the module dictionary, so that the
+        # `vars(self)` below sees it.
+        api = set(self.__all__)
+        return list(api | {name for name in vars(self) if name not in NestModule._PRIVATE_SUBMODULES})
 
-    # Define the kernel attributes.
-    #
-    # FORMATTING NOTES:
-    # * Multiline strings render incorrectly, join multiple single-quote
-    #   strings instead.
-    # * Strings containing `:` render incorrectly.
-    # * Do not end docstrings with punctuation. A `.` or `,` is added by the
-    #   formatting logic.
+    def __getattr__(self, attr):
+        """
+        Resolve a name that `nest` exposes but has not imported yet: one of its
+        submodules, or one of the names that a ``lib.hl_api_*`` module exports. The
+        symbol map names the module that defines it, so only that one module is
+        imported. The result is cached in the module dictionary, so this runs once per
+        name.
+        """
+        import importlib
 
-    kernel_status = KernelAttribute("dict", "Get the complete kernel status", readonly=True)
-    resolution = KernelAttribute("float", "The resolution of the simulation (in ms)", default=0.1)
-    biological_time = KernelAttribute("float", "The current simulation time (in ms)")
-    build_info = KernelAttribute(
-        "dict",
-        "Information about the build and compile configuration of NEST",
-        readonly=True,
-    )
-    memory_size = KernelAttribute("int", "Memory size of NEST process in kB (-1 if unavailable)", readonly=True)
-    to_do = KernelAttribute("int", "The number of steps yet to be simulated", readonly=True)
-    max_delay = KernelAttribute("float", "The maximum delay in the network", default=0.1)
-    min_delay = KernelAttribute("float", "The minimum delay in the network", default=0.1)
-    ms_per_tic = KernelAttribute(
-        "float",
-        ("The number of milliseconds per tic. Calculated by " + "ms_per_tic = 1 / tics_per_ms"),
-        readonly=True,
-    )
-    tics_per_ms = KernelAttribute(
-        "float",
-        (
-            "The number of tics per millisecond. Change of tics_per_ms "
-            + "requires simultaneous specification of resolution"
-        ),
-        default=1000.0,
-    )
-    tics_per_step = KernelAttribute(
-        "int",
-        "The number of tics per simulation time step. Calculated as tics_per_step = resolution * tics_per_ms",
-        readonly=True,
-    )
-    T_max = KernelAttribute("float", "The largest representable time value", readonly=True)
-    T_min = KernelAttribute("float", "The smallest representable time value", readonly=True)
-    rng_types = KernelAttribute(
-        "list[str]",
-        "List of available random number generator types",
-        readonly=True,
-    )
-    rng_type = KernelAttribute(
-        "str",
-        "Name of random number generator type used by NEST",
-        default="mt19937_64",
-    )
-    rng_seed = KernelAttribute(
-        "int",
-        ("Seed value used as base for seeding NEST random number generators " + r"(:math:`1 \leq s\leq 2^{32}-1`)"),
-        default=143202461,
-    )
-    total_num_virtual_procs = KernelAttribute("int", "The total number of virtual processes", default=1)
-    local_num_threads = KernelAttribute("int", "The local number of threads", default=1)
-    num_processes = KernelAttribute("int", "The number of MPI processes", readonly=True)
-    off_grid_spiking = KernelAttribute(
-        "bool",
-        "Whether to transmit precise spike times in MPI communication",
-        readonly=True,
-    )
-    adaptive_target_buffers = KernelAttribute(
-        "bool",
-        "Whether MPI buffers for communication of connections resize on the fly",
-        default=True,
-    )
-    send_buffer_size_secondary_events = KernelAttribute(
-        "int",
-        ("Size of MPI send buffers for communicating secondary events " + "(in bytes, per MPI rank, for developers)"),
-        readonly=True,
-    )
-    recv_buffer_size_secondary_events = KernelAttribute(
-        "int",
-        ("Size of MPI recv buffers for communicating secondary events " + "(in bytes, per MPI rank, for developers)"),
-        readonly=True,
-    )
-    buffer_size_spike_data = KernelAttribute(
-        "int",
-        "Total size of MPI buffer for communication of spikes",
-        default=2,
-    )
-    buffer_size_target_data = KernelAttribute(
-        "int",
-        "Total size of MPI buffer for communication of connections",
-        default=2,
-    )
-    growth_factor_buffer_target_data = KernelAttribute(
-        "float",
-        ("If MPI buffers for communication of connections resize on the " + "fly, grow them by this factor each round"),
-        default=1.5,
-    )
-    max_buffer_size_target_data = KernelAttribute(
-        "int",
-        "Maximal size of MPI buffers for communication of connections",
-        default=16777216,
-    )
-    spike_buffer_grow_extra = KernelAttribute(
-        "float",
-        "When spike exchange buffer is expanded, resize it to "
-        + "`(1 + spike_buffer_grow_extra) * required_buffer_size`",
-        default=0.5,
-    )
-    spike_buffer_shrink_limit = KernelAttribute(
-        "float",
-        (
-            "If the largest number of spikes sent from any rank to any rank is less than "
-            + "`spike_buffer_shrink_limit * buffer_size`, then reduce buffer size. "
-            + "`spike_buffer_shrink_limit == 0` means that buffers never shrink. "
-            + "See ``spike_buffer_shrink_spare`` for how the new buffer size is determined"
-        ),
-        default=0.2,
-    )
-    spike_buffer_shrink_spare = KernelAttribute(
-        "float",
-        (
-            "When the buffer shrinks, set the new size to "
-            + "`(1 + spike_buffer_shrink_spare) * required_buffer_size`. "
-            + "See `spike_buffer_shrink_limit` for when buffers shrink"
-        ),
-        default=0.1,
-    )
-    spike_buffer_resize_log = KernelAttribute(
-        "dict",
-        (
-            "Log of spike buffer resizing as a dictionary. It contains the "
-            + "`times` of the resizings (simulation clock in steps, always multiple of ``min_delay``), "
-            + "``global_max_spikes_sent``, that is, the observed spike number that triggered the resize, "
-            + "and the ``new_buffer_size``. Sizes for the buffer section sent from one rank to another rank"
-        ),
-        readonly=True,
-    )
-    cycle_time_log = KernelAttribute(
-        "dict",
-        ("Information on the duration and spike counts within each update cycle."),
-        readonly=True,
-    )
-    use_wfr = KernelAttribute("bool", "Whether to use waveform relaxation method", default=True)
-    wfr_comm_interval = KernelAttribute(
-        "float",
-        "Desired waveform relaxation communication interval",
-        default=1.0,
-    )
-    wfr_tol = KernelAttribute(
-        "float",
-        "Convergence tolerance of waveform relaxation method",
-        default=0.0001,
-    )
-    wfr_max_iterations = KernelAttribute(
-        "int",
-        "Maximal number of iterations used for waveform relaxation",
-        default=15,
-    )
-    wfr_interpolation_order = KernelAttribute(
-        "int", "Interpolation order of polynomial used in wfr iterations", default=3
-    )
-    max_num_syn_models = KernelAttribute("int", "Maximal number of synapse models supported", readonly=True)
-    structural_plasticity_synapses = KernelAttribute(
-        "dict",
-        (
-            "Defines all synapses which are plastic for the structural"
-            + " plasticity algorithm. Each entry in the dictionary is composed"
-            + " of a synapse model, the presynaptic element and the"
-            + " postsynaptic element"
-        ),
-    )
-    structural_plasticity_update_interval = KernelAttribute(
-        "int",
-        (
-            "Defines the time interval in ms at which the structural plasticity"
-            + " manager will make changes in the structure of the network ("
-            + " creation and deletion of plastic synapses)"
-        ),
-        default=10000,
-    )
-    growth_curves = KernelAttribute(
-        "list[str]",
-        "The list of the available structural plasticity growth curves",
-        readonly=True,
-    )
-    use_compressed_spikes = KernelAttribute(
-        "bool",
-        (
-            "Whether to use spike compression; if a neuron has targets on"
-            + " multiple threads of a process, this switch makes sure that only"
-            + " a single packet is sent to the process instead of one packet"
-            + " per target thread; it implies that connections are sorted by source."
-        ),
-        default=True,
-    )
-    data_path = KernelAttribute(
-        "str",
-        "A path, where all data is written to, defaults to current directory",
-    )
-    data_prefix = KernelAttribute("str", "A common prefix for all data files")
-    overwrite_files = KernelAttribute("bool", "Whether to overwrite existing data files", default=False)
-    print_time = KernelAttribute(
-        "bool",
-        "Whether to print progress information during the simulation",
-        default=False,
-    )
-    network_size = KernelAttribute("int", "The number of nodes in the network", readonly=True)
-    num_connections = KernelAttribute(
-        "int",
-        "The number of connections in the network",
-        readonly=True,
-        localonly=True,
-    )
-    connection_rules = KernelAttribute(
-        "list[str]",
-        "The list of available connection rules",
-        readonly=True,
-    )
-    node_models = KernelAttribute(
-        "list[str]",
-        "The list of the available node (i.e., neuron or device) models",
-        readonly=True,
-    )
-    synapse_models = KernelAttribute(
-        "list[str]",
-        "The list of the available synapse models",
-        readonly=True,
-    )
-    local_spike_counter = KernelAttribute(
-        "int",
-        (
-            "Number of spikes fired by neurons on a given MPI rank during the"
-            + " most recent call to :py:func:`.Simulate`. Only spikes from"
-            + ' "normal" neurons are counted, not spikes generated by devices'
-            + " such as ``poisson_generator``. Resets on each call to ``Simulate`` or ``Run``."
-        ),
-        readonly=True,
-    )
-    recording_backends = KernelAttribute(
-        "list[str]",
-        "List of available backends for recording devices",
-        readonly=True,
-    )
-    stimulation_backends = KernelAttribute(
-        "list[str]",
-        "List of available backends for stimulation devices",
-        readonly=True,
-    )
-    dict_miss_is_error = KernelAttribute(
-        "bool",
-        "Whether missed dictionary entries are treated as errors",
-        default=True,
-    )
-    keep_source_table = KernelAttribute(
-        "bool",
-        "Whether to keep source table after connection setup is complete",
-        default=True,
-    )
-    min_update_time = KernelAttribute(
-        "float",
-        "Shortest wall-clock time measured so far for a full update step [seconds]",
-        readonly=True,
-    )
-    max_update_time = KernelAttribute(
-        "float",
-        "Longest wall-clock time measured so far for a full update step [seconds]",
-        readonly=True,
-    )
-    update_time_limit = KernelAttribute(
-        "float",
-        (
-            "Maximum wall-clock time for one full update step [seconds]."
-            + " This can be used to terminate simulations that slow down"
-            + " significantly. Simulations may still get stuck if the slowdown"
-            + " occurs within a single update step"
-        ),
-        default=float("+inf"),
-    )
-    eprop_update_interval = KernelAttribute(
-        "float",
-        ("Task-specific update interval of the e-prop plasticity mechanism [ms]."),
-        default=1000.0,
-    )
-    eprop_learning_window = KernelAttribute(
-        "float",
-        ("Task-specific learning window of the e-prop plasticity mechanism [ms]."),
-        default=1000.0,
-    )
-    eprop_reset_neurons_on_update = KernelAttribute(
-        "bool",
-        ("If True, reset dynamic variables of e-prop neurons upon e-prop update."),
-        default=True,
-    )
-    verbosity = KernelAttribute(
-        "VerbosityLevel",
-        (
-            "Controls NEST's verbosity. The following levels are available,"
-            + " from most to least chatty: ALL, DEBUG, STATUS, INFO,"
-            + " PROGRESS, DEPRECATED, WARNING, ERROR, FATAL, QUIET."
-            + " Default verbosity is INFO. To start NEST with a different verbosity"
-            + " and supress the startup message, set the environment variable PYNEST_QUIET=1"
-        ),
-        default=ll_api.nestkernel.VerbosityLevel.INFO,
-    )
+        if attr == "__all__":
+            api = {name for name in vars(self) if not name.startswith("_")}
+            api |= {name for name in dir(type(self)) if not name.startswith("_")}
+            api |= self._submodules()
+            api |= set(self._symbols())
+            # `NestModule` is reachable as `nest.NestModule` for the documentation
+            # build, but it is machinery rather than API.
+            api -= NestModule._PRIVATE_SUBMODULES | {"NestModule"}
+            self.__dict__["__all__"] = sorted(api)
+            return self.__dict__["__all__"]
 
-    # Kernel attribute indices, used for fast lookup in `ll_api.py`
-    _kernel_attr_names = builtins.set(k for k, v in vars().items() if isinstance(v, KernelAttribute))
-    _readonly_kernel_attrs = builtins.set(
-        k for k, v in vars().items() if isinstance(v, KernelAttribute) and v._readonly
-    )
+        if not attr.startswith("_"):
+            if attr in self._submodules():
+                module = importlib.import_module("." + attr, __name__)
+                self.__dict__[attr] = module
+                return module
+
+            module = self._symbols().get(attr)
+            if module is not None:
+                value = getattr(importlib.import_module(module, __name__), attr)
+                self.__dict__[attr] = value
+                return value
+
+        raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
+
+    def __setattr__(self, attr, value):
+        """
+        Refuse to assign a name that no descriptor on `NestModule` claims: the module
+        namespace is a curated API, not a scratch pad. Use `nest.userdict` to attach
+        data of your own.
+
+        Writing a kernel attribute needs nothing from this method. `object.__setattr__`
+        finds the `KernelAttribute` on the type and calls its `__set__`, which is what
+        carries the value to the kernel.
+        """
+        # Imported here to keep `types` out of the `nest` namespace.
+        import types
+
+        if isinstance(value, types.ModuleType):
+            # The import machinery attaches submodules to their parent package.
+            self.__dict__[attr] = value
+            return
+
+        descriptor = getattr(type(self), attr, None)
+        if descriptor is None or not hasattr(descriptor, "__set__"):
+            raise AttributeError(f"Cannot set attribute '{attr}' on module 'nest'")
+        super().__setattr__(attr, value)
 
     userdict = {}
     """
@@ -452,100 +569,39 @@ class NestModule(types.ModuleType):
     """
 
 
-def _setattr_error(self, attr, val):
+def _install_kernel_attributes(cls, annotations):
     """
-    When attributes on the `nest` module instance are set, check if it exists on the
-    module type and try to call `__set__` on them. Without this explicit check `nest`s
-    `__setattr__` shadows class attributes and descriptors (such as `KernelAttribute`s).
+    Turn the ``Annotated[<type>, KernelAttribute(...)]`` declarations above into
+    descriptors on `cls`, and record their names for `SetKernelStatus()` to validate
+    against.
 
-    Once this function exists on the `nest` module, new attributes can only be added using
-    `__dict__` manipulation. It is added onto the module at the end of `__init__`,
-    "freezing" the module.
-    """
-    if isinstance(val, types.ModuleType):
-        # Allow import machinery to set imported modules on `nest`
-        self.__dict__[attr] = val
-    else:
-        err = AttributeError(f"Cannot set attribute '{attr}' on module 'nest'")
-        try:
-            cls_attr = getattr(type(self), attr)
-        except AttributeError:
-            raise err from None
-        else:
-            if hasattr(cls_attr, "__set__"):
-                cls_attr.__set__(self, val)
-            else:
-                raise err from None
-
-
-def _rel_import_star(module, import_module_name):
-    """Emulates `from X import *` into `module`"""
-
-    imported = importlib.import_module(import_module_name, __name__)
-    imp_iter = imported.__dict__.items()
-    _dict = module.__dict__
-    if hasattr(imported, "__all__"):
-        # If a public api is defined using the `__all__` attribute, copy that.
-        _dict.update(kv for kv in imp_iter if kv[0] in imported.__all__)
-    else:
-        # Otherwise follow "underscore is private" convention.
-        _dict.update(kv for kv in imp_iter if not kv[0].startswith("_"))
-
-
-def _lazy_module_property(module_name, optional=False, optional_hint=""):
-    """
-    Returns a property that lazy loads a module and substitutes itself with it.
-    The class variable name must match given `module_name`::
-
-      class ModuleClass(types.ModuleType):
-          lazy_module_xy = _lazy_module_property("lazy_module_xy")
-
-    :param module_name: Name of the lazy loadable module.
-    :type module_name: str
-    :param optional: Optional modules raise more descriptive errors.
-    :type optional: bool
-    :param optional_hint: Message appended in case of import errors, to help
-      users install missing optional modules
-    :type optional_hint: str
+    The annotation is the whole declaration of a kernel attribute: its type is what
+    static analysis reports for ``nest.<name>`` and what the ``:type:`` field of the
+    generated docstring shows, and its metadata carries description and defaults.
     """
 
-    def lazy_loader(self):
-        "Wrap lazy loaded property."
-        cls = type(self)
-        delattr(cls, module_name)
-        try:
-            module = importlib.import_module("." + module_name, __name__)
-        except ImportError as e:
-            if optional:
-                raise ImportError(
-                    f"This functionality requires the optional module {module_name}.{optional_hint}"
-                ) from None
-            else:
-                raise e from None
-        setattr(cls, module_name, module)
-        return module
+    attributes = {}
+    for name, annotation in annotations.items():
+        metadata = getattr(annotation, "__metadata__", ())
+        attribute = next((meta for meta in metadata if isinstance(meta, KernelAttribute)), None)  # noqa: F405
+        if attribute is None:
+            continue
+        attribute.bind(name, typing.get_args(annotation)[0])  # noqa: F405
+        setattr(cls, name, attribute)
+        attributes[name] = attribute
 
-    return property(lazy_loader)
+    # Kernel attribute indices, used for fast lookup in `lib/hl_api_simulation.py`
+    cls._kernel_attr_names = frozenset(attributes)
+    cls._readonly_kernel_attrs = frozenset(name for name, a in attributes.items() if a.readonly)
 
 
-# Instantiate a NestModule to replace the nest Python module. Based on
-# https://mail.python.org/pipermail/python-ideas/2012-May/014969.html
-_module = NestModule(__name__)
-# A reference to the class of the module is required for the documentation.
-_module.__dict__["NestModule"] = NestModule
-# Set the nest module object as the return value of `import nest` using sys
-sys.modules[__name__] = _module
-# Some compiled/binary components (`nestkernel_api.pyx` for example) of NEST
-# obtain a reference to this file's original module object instead of what's in
-# `sys.modules`. For these edge cases we make available all attributes of the
-# nest module instance to this file's module object.
-globals().update(_module.__dict__)
+_install_kernel_attributes(NestModule, __annotations__)
 
-# Clean up obsolete references
-# Since these references are deleted, flake8 complains with an error
-# `F821 undefined name` where these variables are used. Hence we mark all those
-# lines with a `# noqa`
-del _rel_import_star, _lazy_module_property, _original_module_attrs
+__version__ = _ll_api.nestkernel.llapi_get_kernel_status()["build_info"]["version"]
 
+# Retype the module object, putting the kernel attribute descriptors in force.
+sys.modules[__name__].__class__ = NestModule
 
-del _module
+# What is left in this file's namespace is the `nest` namespace, so drop the scaffolding
+# this file needed to build it.
+del sys, types, typing, Annotated, KernelAttribute, _ll_api, _install_kernel_attributes

--- a/pynest/nest/lib/hl_api_info.py
+++ b/pynest/nest/lib/hl_api_info.py
@@ -31,13 +31,7 @@ import webbrowser
 import nest
 
 from .. import nestkernel_api as nestkernel
-from .hl_api_helper import (
-    broadcast,
-    deprecated,
-    is_iterable,
-    load_help,
-    show_help_with_pager,
-)
+from .hl_api_helper import broadcast, deprecated, is_iterable, load_help, show_help_with_pager
 from .hl_api_types import to_json
 
 __all__ = ["GetStatus", "help", "SetStatus", "VerbosityLevel", "message", "get_verbosity", "set_verbosity"]
@@ -137,7 +131,7 @@ def SetStatus(nodes_or_conns, params, val=None):
 
 def message(
     message,
-    severity=nest.NestModule.ll_api.nestkernel.VerbosityLevel.INFO,
+    severity=nestkernel.VerbosityLevel.INFO,
     *,
     function=None,
     filename=None,
@@ -165,13 +159,13 @@ def message(
 def get_verbosity():
     """Return numeric value for NEST verbosity"""
 
-    return int(nest.NestModule.ll_api.nestkernel.llapi_get_kernel_status()["verbosity"])
+    return int(nestkernel.llapi_get_kernel_status()["verbosity"])
 
 
 @deprecated("", "Provided for backward compatibility only. Set `nest.verbosity = nest.VerbosityLevel.XYZ` instead.")
 def set_verbosity(level):
     """Change verbosity level for NEST's messages."""
 
-    nest.NestModule.ll_api.nestkernel.llapi_set_kernel_status(
+    nestkernel.llapi_set_kernel_status(
         {"verbosity": getattr(nestkernel.VerbosityLevel, level.split("_")[1])}
     )  # level must be of form "M_XYZ"

--- a/pynest/nest/lib/hl_api_nodes.py
+++ b/pynest/nest/lib/hl_api_nodes.py
@@ -112,9 +112,7 @@ def Create(model, n=1, params=None, positions=None):
         raise TypeError("params must be either a dict of parameters or a list or tuple of dicts")
 
     if positions is not None:
-        # Explicitly retrieve lazy loaded spatial property from the module class.
-        # This is needed because the automatic lookup fails. See #2135.
-        spatial = getattr(nest.NestModule, "spatial")
+        spatial = nest.spatial
         # We only accept positions as either a free object or a grid object.
         if not isinstance(positions, (spatial.free, spatial.grid)):
             raise TypeError("`positions` must be either a nest.spatial.free or a nest.spatial.grid object")

--- a/pynest/nest/lib/hl_api_sonata.py
+++ b/pynest/nest/lib/hl_api_sonata.py
@@ -36,21 +36,28 @@ from .hl_api_nodes import Create
 from .hl_api_simulation import GetKernelStatus, SetKernelStatus, Simulate
 from .hl_api_types import NodeCollection
 
-try:
-    import pandas as pd
 
-    have_pandas = True
-except ImportError:
-    have_pandas = False
+def _import_sonata_dependency(module_name):
+    """Import one of the optional third-party dependencies of `SonataNetwork`.
 
-try:
-    import h5py
+    They are imported here rather than at module level because `hl_api_sonata` is
+    imported by `nest` itself, and neither Pandas nor h5py should be the price of
+    `import nest` for the scripts that never build a SONATA network.
 
-    have_h5py = True
-except ImportError:
-    have_h5py = False
+    Raises
+    ------
+    ModuleNotFoundError
+        If the module is not installed.
+    """
 
-have_hdf5 = GetKernelStatus("build_info")["have_hdf5"]
+    import importlib
+
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        msg = f"'SonataNetwork' unavailable because '{module_name}' could not be loaded."
+        raise ModuleNotFoundError(msg) from None
+
 
 __all__ = ["SonataNetwork"]
 
@@ -104,12 +111,10 @@ class SonataNetwork:
     """
 
     def __init__(self, config, sim_config=None):
-        if not have_hdf5:
+        if not GetKernelStatus("build_info")["have_hdf5"]:
             raise ModuleNotFoundError("'SonataNetwork' unavailable because NEST was compiled without 'HDF5' support")
-        if not have_h5py:
-            raise ModuleNotFoundError("'SonataNetwork' unavailable because 'h5py' could not be loaded.")
-        if not have_pandas:
-            raise ModuleNotFoundError("'SonataNetwork' unavailable because 'pandas' could not be loaded.")
+        _import_sonata_dependency("h5py")
+        _import_sonata_dependency("pandas")
 
         self._node_collections = {}
         self._edges_maps = []
@@ -203,6 +208,8 @@ class SonataNetwork:
             for each population. The population names are keys.
         """
 
+        import pandas as pd
+
         # Iterate node config files
         for nodes_conf in self._conf["networks"]["nodes"]:
             csv_fn = nodes_conf["node_types_file"]
@@ -242,6 +249,8 @@ class SonataNetwork:
         csv_fn : str
             Name of current CSV file. Used for more informative error messages.
         """
+
+        import h5py
 
         node_types_map = self._create_node_type_parameter_map(nodes_df, csv_fn)
 
@@ -301,6 +310,8 @@ class SonataNetwork:
         nodes_conf : dict
             Config as dictionary specifying filenames
         """
+
+        import h5py
 
         with h5py.File(nodes_conf["nodes_file"], "r") as nodes_h5f:
             for pop_name in nodes_h5f["nodes"]:
@@ -417,6 +428,8 @@ class SonataNetwork:
             to create the connections. Default: ``2**20``.
         """
 
+        import h5py
+
         if not self._are_nodes_created:
             raise RuntimeError("The SONATA network nodes must be created before any connections can be made.")
 
@@ -496,6 +509,8 @@ class SonataNetwork:
         each edge CSV file. The associated edge HDF5 filename is included in
         the map as well.
         """
+
+        import pandas as pd
 
         # Iterate edge config files
         for edges_conf in self._conf["networks"]["edges"]:

--- a/pynest/nest/lib/hl_api_spatial.py
+++ b/pynest/nest/lib/hl_api_spatial.py
@@ -33,15 +33,6 @@ from .hl_api_helper import is_iterable, stringify_path
 from .hl_api_parallel_computing import NumProcesses, Rank
 from .hl_api_types import NodeCollection
 
-try:
-    import matplotlib as mpl
-    import matplotlib.patches as mpatches
-    import matplotlib.path as mpath
-
-    HAVE_MPL = True
-except ImportError:
-    HAVE_MPL = False
-
 __all__ = [
     "CreateMask",
     "Displacement",
@@ -992,12 +983,30 @@ def SelectNodesByMask(layer, anchor, mask_obj):
     return nestkernel.llapi_select_nodes_by_mask(layer._datum, anchor, mask_datum)
 
 
+def _import_pyplot():
+    """Import `matplotlib.pyplot` on demand.
+
+    Importing Matplotlib when `nest` is imported would make every NEST script pay for
+    it, and would fix the backend before the user gets a chance to choose one.
+
+    Raises
+    ------
+    ImportError
+        If Matplotlib is not installed.
+    """
+
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise ImportError("Matplotlib could not be imported") from None
+
+    return plt
+
+
 def _draw_extent(ax, xctr, yctr, xext, yext):
     """Draw extent and set aspect ration, limits"""
 
-    # import pyplot here and not at toplevel to avoid preventing users
-    # from changing matplotlib backend after importing nest
-    import matplotlib.pyplot as plt
+    plt = _import_pyplot()
 
     # thin gray line indicating extent
     llx, lly = xctr - xext / 2.0, yctr - yext / 2.0
@@ -1074,12 +1083,7 @@ def PlotLayer(layer, fig=None, nodecolor="b", nodesize=20):
             plt.show()
     """
 
-    # import pyplot here and not at toplevel to avoid preventing users
-    # from changing matplotlib backend after importing nest
-    import matplotlib.pyplot as plt
-
-    if not HAVE_MPL:
-        raise ImportError("Matplotlib could not be imported")
+    plt = _import_pyplot()
 
     if not isinstance(layer, NodeCollection):
         raise TypeError("layer must be a NodeCollection.")
@@ -1217,12 +1221,7 @@ def PlotTargets(
             plt.show()
     """
 
-    # import pyplot here and not at toplevel to avoid preventing users
-    # from changing matplotlib backend after importing nest
-    import matplotlib.pyplot as plt
-
-    if not HAVE_MPL:
-        raise ImportError("Matplotlib could not be imported")
+    plt = _import_pyplot()
 
     if not isinstance(src_nrn, NodeCollection) or len(src_nrn) != 1:
         raise TypeError("src_nrn must be a single element NodeCollection.")
@@ -1375,9 +1374,7 @@ def PlotSources(
             plt.show()
     """
 
-    # import pyplot here and not at toplevel to avoid preventing users
-    # from changing matplotlib backend after importing nest
-    import matplotlib.pyplot as plt
+    plt = _import_pyplot()
 
     if not isinstance(tgt_nrn, NodeCollection) or len(tgt_nrn) != 1:
         raise TypeError("tgt_nrn must be a single element NodeCollection.")
@@ -1451,10 +1448,11 @@ def PlotSources(
 def _create_mask_patches(mask, periodic, extent, source_pos, face_color="yellow"):
     """Create Matplotlib Patch objects representing the mask"""
 
-    # import pyplot here and not at toplevel to avoid preventing users
-    # from changing matplotlib backend after importing nest
-    import matplotlib as mtpl
-    import matplotlib.pyplot as plt
+    plt = _import_pyplot()
+
+    import matplotlib as mpl
+    import matplotlib.patches as mpatches
+    import matplotlib.path as mpath
 
     edge_color = "black"
     alpha = 0.2
@@ -1520,7 +1518,7 @@ def _create_mask_patches(mask, periodic, extent, source_pos, face_color="yellow"
 
         patch = plt.Rectangle(pos, width, height, fc=face_color, ec=edge_color, alpha=alpha, lw=line_width)
         # Need to rotate about center
-        trnsf = mtpl.transforms.Affine2D().rotate_deg_around(cntr[0], cntr[1], angle) + plt.gca().transData
+        trnsf = mpl.transforms.Affine2D().rotate_deg_around(cntr[0], cntr[1], angle) + plt.gca().transData
         patch.set_transform(trnsf)
         mask_patches.append(patch)
 
@@ -1530,7 +1528,7 @@ def _create_mask_patches(mask, periodic, extent, source_pos, face_color="yellow"
 
                 cntr = [pos[0] + width / 2, pos[1] + height / 2]
                 # Need to rotate about center
-                trnsf = mtpl.transforms.Affine2D().rotate_deg_around(cntr[0], cntr[1], angle) + plt.gca().transData
+                trnsf = mpl.transforms.Affine2D().rotate_deg_around(cntr[0], cntr[1], angle) + plt.gca().transData
                 patch.set_transform(trnsf)
                 mask_patches.append(patch)
     elif "elliptical" in mask:
@@ -1605,12 +1603,7 @@ def PlotProbabilityParameter(
         a new one is created.
     """
 
-    # import pyplot here and not at toplevel to avoid preventing users
-    # from changing matplotlib backend after importing nest
-    import matplotlib.pyplot as plt
-
-    if not HAVE_MPL:
-        raise ImportError("Matplotlib could not be imported")
+    plt = _import_pyplot()
 
     if parameter is None and mask is None:
         raise ValueError("At least one of parameter or mask must be specified")

--- a/pynest/nest/lib/hl_api_types.py
+++ b/pynest/nest/lib/hl_api_types.py
@@ -30,21 +30,9 @@ from math import floor, log
 import numpy
 
 from .. import nestkernel_api as nestkernel
-from .hl_api_helper import (
-    get_parameters,
-    get_parameters_hierarchical_addressing,
-    is_iterable,
-    restructure_data,
-)
+from .hl_api_helper import get_parameters, get_parameters_hierarchical_addressing, is_iterable, restructure_data
 from .hl_api_parallel_computing import NumProcesses, Rank
 from .hl_api_simulation import GetKernelStatus
-
-try:
-    import pandas
-
-    HAVE_PANDAS = True
-except ImportError:
-    HAVE_PANDAS = False
 
 # A NumPy2 conformant implementation of NodeCollection.__array__() must have the signature
 # __array__(object, dtype=None, copy=None), where copy is passed on to numpy.array(..., copy=copy).
@@ -57,6 +45,28 @@ try:
     _ARRAY_COPY_DEFAULT = None
 except ValueError:
     _ARRAY_COPY_DEFAULT = True
+
+
+def _import_pandas():
+    """Import `pandas` on demand.
+
+    Importing it when `nest` is imported would make every NEST script pay for Pandas,
+    while only the ``output="pandas"`` branches of `NodeCollection.get()` and
+    `SynapseCollection.get()` need it.
+
+    Raises
+    ------
+    ImportError
+        If Pandas is not installed.
+    """
+
+    try:
+        import pandas
+    except ImportError:
+        raise ImportError("Pandas could not be imported") from None
+
+    return pandas
+
 
 __all__ = [
     "CollocatedSynapses",
@@ -392,8 +402,9 @@ class NodeCollection:
             output = ""
         elif "output" in kwargs:
             output = kwargs["output"]
-            if output == "pandas" and not HAVE_PANDAS:
-                raise ImportError("Pandas could not be imported")
+            if output == "pandas":
+                # Report a missing Pandas before doing any work.
+                _import_pandas()
         else:
             raise TypeError("Got unexpected keyword argument")
 
@@ -430,7 +441,7 @@ class NodeCollection:
             if len(self) == 1:
                 index = [index]
                 result = {key: [val] for key, val in result.items()}
-            result = pandas.DataFrame(result, index=index)
+            result = _import_pandas().DataFrame(result, index=index)
         elif output == "json":
             result = to_json(result)
 
@@ -865,8 +876,8 @@ class SynapseCollection:
         """
 
         pandas_output = output == "pandas"
-        if pandas_output and not HAVE_PANDAS:
-            raise ImportError("Pandas could not be imported")
+        if pandas_output:
+            pandas = _import_pandas()
 
         # Return empty dictionary if we have no connections
         # We also return if the network is empty after a ResetKernel.

--- a/pynest/nest/ll_api.py
+++ b/pynest/nest/ll_api.py
@@ -26,9 +26,11 @@ Low-level API of PyNEST Module
 # Since this is a low level module, we need some more trickery, thus:
 # pylint: disable=wrong-import-position
 import atexit
+import inspect
 import keyword
 import os
 import sys
+import typing
 
 # This is a workaround to avoid segmentation faults when importing
 # scipy *after* nest. See https://github.com/numpy/numpy/issues/2521
@@ -75,42 +77,73 @@ def set_communicator(comm):
 
 class KernelAttribute:
     """
-    Descriptor that dispatches attribute access to the nest kernel.
+    Descriptor that maps an attribute of the ``nest`` module onto an entry of the
+    kernel status dictionary.
+
+    Reading the attribute reads the kernel status, assigning to it writes the kernel
+    status. Kernel attributes are declared as the metadata of a module-level
+    annotation in ``nest/__init__.py``::
+
+        resolution: Annotated[float, KernelAttribute("The resolution of the simulation (in ms)", default=0.1)]
+
+    The annotated type is both what static analysis reports for ``nest.resolution``
+    and what `bind` renders as the ``:type:`` field of the docstring, so it is stated
+    once. `bind` turns such a declaration into a descriptor on `nest.NestModule`.
+
+    Parameters
+    ----------
+    description : str
+        What the attribute means, as one reStructuredText paragraph. It is what
+        ``help()`` and the :ref:`sec_kernel_attributes` page show. Indentation is
+        stripped, so a triple-quoted string indented to match the surrounding code
+        renders correctly. A trailing period is optional; one is always rendered.
+    readonly : bool, optional
+        Whether assigning to the attribute raises an `AttributeError`.
+    default : optional
+        Value of the attribute in a freshly reset kernel. Documented only; the kernel,
+        not this descriptor, applies it.
+    localonly : bool, optional
+        Whether the value describes the local MPI rank rather than the whole
+        simulation.
     """
 
-    def __init__(self, typehint, description, readonly=False, default=None, localonly=False):
-        self._readonly = readonly
-        self._localonly = localonly
-        self._default = default
+    def __init__(self, description, readonly=False, default=None, localonly=False):
+        self.description = description
+        self.readonly = readonly
+        self.localonly = localonly
+        self.default = default
 
-        readonly = readonly and "**read only**"
-        localonly = localonly and "**local only**"
+    def bind(self, name, typehint):
+        """Attach this descriptor to the kernel status entry `name`, of type `typehint`."""
 
-        self.__doc__ = (
-            description
-            + ("." if default is None else f", defaults to ``{default}``.")
-            + ("\n\n" if readonly or localonly else "")
-            + ", ".join(c for c in (readonly, localonly) if c)
-            + f"\n\n:type: {typehint}"
-        )
-
-    def __set_name__(self, cls, name):
         self._name = name
-        self._full_status = name == "kernel_status"
+        # `list[str].__name__` is "list", so subscripted generics have to be rendered
+        # through `str()` to keep their parameters.
+        self.typehint = str(typehint) if typing.get_origin(typehint) else typehint.__name__
+        self.__doc__ = self._build_docstring()
+
+    def _build_docstring(self):
+        summary = inspect.cleandoc(self.description).rstrip()
+        if summary.endswith("."):
+            summary = summary[:-1]
+        if self.default is not None:
+            summary += f", defaults to ``{self.default}``"
+        scope = ", ".join(
+            label
+            for label, applies in (("**read only**", self.readonly), ("**local only**", self.localonly))
+            if applies
+        )
+        return "\n\n".join(block for block in (summary + ".", scope, f":type: {self.typehint}") if block)
 
     def __get__(self, instance, cls=None):
         if instance is None:
             return self
-
-        status_root = nestkernel.llapi_get_kernel_status()
-
-        if self._full_status:
-            return status_root
-        else:
-            return status_root[self._name]
+        status = nestkernel.llapi_get_kernel_status()
+        # `kernel_status` exposes the status dictionary itself, not an entry of it.
+        return status if self._name == "kernel_status" else status[self._name]
 
     def __set__(self, instance, value):
-        if self._readonly:
+        if self.readonly:
             raise AttributeError(f"`{self._name}` is a read only kernel attribute.")
         nestkernel.llapi_set_kernel_status({self._name: value})
 

--- a/testsuite/pytests/other/test_api_surface.py
+++ b/testsuite/pytests/other/test_api_surface.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# test_api_surface.py
+#
+# This file is part of NEST.
+#
+# Copyright (C) 2004 The NEST Initiative
+#
+# NEST is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# NEST is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NEST.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Tests for the namespace of the ``nest`` root module.
+
+``nest`` resolves its namespace lazily: submodules are imported on first access by
+``NestModule.__getattr__``, and so are the ``lib.hl_api_*`` modules, through a symbol
+map that the module reads from the sources. Static analysers cannot follow that, so
+``nest/__init__.py`` spells the same namespace out in an ``if TYPE_CHECKING:`` block.
+Nothing reads that block at runtime, which is exactly why it needs a test.
+"""
+
+import ast
+import importlib.util
+import pathlib
+
+import nest
+import pytest
+
+
+def _type_checking_imports():
+    """Return the submodules and ``lib`` modules imported in the TYPE_CHECKING block."""
+
+    tree = ast.parse(pathlib.Path(nest.__file__).read_text())
+    guard = next(
+        node for node in tree.body if isinstance(node, ast.If) and ast.unparse(node.test).endswith("TYPE_CHECKING")
+    )
+
+    submodules, api_modules = set(), set()
+    for node in ast.walk(guard):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module is None:  # `from . import a, b, c`
+            submodules |= {alias.name for alias in node.names}
+        elif node.module.startswith("lib."):  # `from .lib.hl_api_x import *`
+            api_modules.add(node.module.split(".", 1)[1])
+
+    return submodules, api_modules
+
+
+def test_type_checking_block_lists_every_submodule():
+    """The TYPE_CHECKING block must cover the submodules the runtime exposes."""
+
+    declared, _ = _type_checking_imports()
+    assert declared == set(nest._submodules())
+
+
+def test_type_checking_block_lists_every_api_module():
+    """The TYPE_CHECKING block must cover the `hl_api` modules the symbol map draws from."""
+
+    _, declared = _type_checking_imports()
+    assert declared == {module.rsplit(".", 1)[1] for module in nest._symbols().values()}
+
+
+def test_symbol_map_matches_the_imported_modules():
+    """
+    The symbol map is read from the sources without importing them, so it can disagree
+    with what the modules export once imported. It must not: a name missing from the
+    map does not resolve on `nest`, and a name mapped to the wrong module resolves to
+    the wrong object.
+    """
+
+    mapped = {}
+    for module_name in set(nest._symbols().values()):
+        module = importlib.import_module(module_name, "nest")
+        for name in module.__all__:
+            assert name not in mapped, f"'{name}' is exported by both {mapped[name]} and {module_name}"
+            mapped[name] = module_name
+
+    assert nest._symbols() == mapped
+
+
+def test_all_covers_the_lazily_resolved_namespace():
+    """Every name in ``nest.__all__`` must actually resolve on the module."""
+
+    for name in nest.__all__:
+        if name in nest._kernel_attr_names:
+            # Reading one of these queries the kernel; only check that the descriptor
+            # made it onto the module type.
+            assert hasattr(type(nest), name), f"'{name}' has no kernel attribute descriptor"
+        elif name in nest._submodules():
+            # Importing these can need optional third-party packages, so only check
+            # that the submodule the name promises is there.
+            assert importlib.util.find_spec(f"nest.{name}") is not None, f"'nest.{name}' does not exist"
+        else:
+            assert hasattr(nest, name), f"'{name}' is advertised in __all__ but does not resolve"
+
+
+def test_unknown_attribute_raises():
+    with pytest.raises(AttributeError):
+        nest.thisAttributeDoesNotExist

--- a/testsuite/pytests/other/test_nest_set_get.py
+++ b/testsuite/pytests/other/test_nest_set_get.py
@@ -44,7 +44,7 @@ def test_nest_get():
 
     kst = nest.get("keep_source_table")
     assert kst == nest.keep_source_table
-    assert kst == type(nest).keep_source_table._default
+    assert kst == type(nest).keep_source_table.default
 
 
 def test_nest_get_unknown_attr_raises():


### PR DESCRIPTION
I am the original author that introduced lazy importing and kernel attributes to the root NEST module. It had 2 goals:

* Defer any actions other than starting the NEST kernel to AFTER `import nest` had completed. This required lazy importing of submodules, and lazy attribute accessors for submodules (for example `nest.Create` as a shortcut for `nest.hl_api_nodes.Create`). The rationale was to shave off import time which could take up to 2 seconds on slow machines and was at that time dropped to 40ms on the same slow machines.
* Create kernel attribute accessors to get and set kernel attributes simply as `nest.resolution` instead of `nest.GetStatus("resolution")`

Both required a dynamic module, which up until today is still only supported by what is considered by most as a "dirty hack": manipulating/replacing the module object. This is still the case as recent PEPs to try to allow for more module customizations were rejected with this pattern once more confirmed (https://peps.python.org/pep-0726/) with the rejection message reading:

> There are already workarounds that people can use to achieve similar results. That some people consider those workarounds such as replacing a module with another object to be gross is not considered a problem as it is an uncommon need.

The initial implementation achieved its goal but drastically reduced clarity by requiring at least 4 distinct patches on top of the already dirty hack in order to obtain a well behaved `nest` module object during bootstrap, at runtime, and during doc building (Sphinx is finnicky).

After more tinkering it turns out that all of these patches collapse if instead of **duplicating and reconstructing** a quasi-identical novel model object that we replace in `sys.modules`, we instead simply retype the existing module object with a `obj.__class__ = NestModule` reassignment.

This PR as a result can present a much cleaner `__init__.py` and adds full static typing on top (so IDEs and other tools can correctly autocomplete and inspect the public API of the `nest` module).  I've also extended the comments in the file to make sure any first time reader gets a thorough introduction to each of the mechanisms and the structure of the file.

I've also once more moved all optional imports of heavy modules that aren't on the main code path for most users (such as `matplotlib`, `pandas`, and `h5py`) into local imports to optimize import times from ~400ms to ~120ms on my machine. The last 120ms is mostly due to importing `numpy` which we can maybe avoid importing but it was deeper in the Cython code so I didn't touch it for now.