### PR TITLE
Add ArchivingNode::pre_run_hook_() and call it from every model

### DIFF
--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -424,6 +424,8 @@ nest::aeif_cond_alpha::init_buffers_()
 void
 nest::aeif_cond_alpha::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_cond_alpha_astro.cpp
+++ b/models/aeif_cond_alpha_astro.cpp
@@ -426,6 +426,8 @@ nest::aeif_cond_alpha_astro::init_buffers_()
 void
 nest::aeif_cond_alpha_astro::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -435,6 +435,8 @@ aeif_cond_alpha_multisynapse::init_buffers_()
 void
 aeif_cond_alpha_multisynapse::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -442,6 +442,8 @@ aeif_cond_beta_multisynapse::init_buffers_()
 void
 aeif_cond_beta_multisynapse::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -419,6 +419,8 @@ nest::aeif_cond_exp::init_buffers_()
 void
 nest::aeif_cond_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -414,6 +414,8 @@ nest::aeif_psc_alpha::init_buffers_()
 void
 nest::aeif_psc_alpha::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -390,6 +390,8 @@ nest::aeif_psc_delta::init_buffers_()
 void
 nest::aeif_psc_delta::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -458,6 +458,8 @@ nest::aeif_psc_delta_clopath::init_buffers_()
 void
 nest::aeif_psc_delta_clopath::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -409,6 +409,8 @@ nest::aeif_psc_exp::init_buffers_()
 void
 nest::aeif_psc_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -262,6 +262,8 @@ nest::amat2_psc_exp::init_buffers_()
 void
 nest::amat2_psc_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -429,6 +429,8 @@ template < class TGainfunction >
 void
 binary_neuron< TGainfunction >::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
   V_.rng_ = get_vp_specific_rng( get_thread() );

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -293,6 +293,8 @@ nest::cm_default::init_recordables_pointers_()
 void
 nest::cm_default::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   logger_.init();
 
   // initialize the pointers within the compartment tree

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -435,6 +435,8 @@ nest::gif_cond_exp::init_buffers_()
 void
 nest::gif_cond_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -435,6 +435,8 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
 void
 nest::gif_cond_exp_multisynapse::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.sys_.dimension = S_.y_.size();
 
   B_.logger_.init();

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -269,6 +269,8 @@ nest::gif_psc_exp::init_buffers_()
 void
 nest::gif_psc_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -284,6 +284,8 @@ nest::gif_psc_exp_multisynapse::init_buffers_()
 void
 nest::gif_psc_exp_multisynapse::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -549,6 +549,8 @@ nest::glif_cond::init_buffers_()
 void
 nest::glif_cond::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();  // in ms

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -391,6 +391,8 @@ nest::glif_psc::init_buffers_()
 void
 nest::glif_psc::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();  // in ms

--- a/models/glif_psc_double_alpha.cpp
+++ b/models/glif_psc_double_alpha.cpp
@@ -422,6 +422,8 @@ nest::glif_psc_double_alpha::init_buffers_()
 void
 nest::glif_psc_double_alpha::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();  // in ms

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -451,6 +451,8 @@ nest::hh_cond_beta_gap_traub::get_normalisation_factor( double tau_rise, double 
 void
 nest::hh_cond_beta_gap_traub::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -373,6 +373,8 @@ nest::hh_cond_exp_traub::init_buffers_()
 void
 nest::hh_cond_exp_traub::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
   V_.refractory_counts_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -370,6 +370,8 @@ nest::hh_psc_alpha::init_buffers_()
 void
 nest::hh_psc_alpha::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -398,6 +398,8 @@ nest::hh_psc_alpha_clopath::init_buffers_()
 void
 nest::hh_psc_alpha_clopath::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -436,6 +436,8 @@ nest::hh_psc_alpha_gap::init_buffers_()
 void
 nest::hh_psc_alpha_gap::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -714,6 +714,8 @@ nest::ht_neuron::get_synapse_constant( double tau_1, double tau_2, double g_peak
 void
 nest::ht_neuron::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -195,6 +195,8 @@ nest::iaf_chs_2007::init_buffers_()
 void
 nest::iaf_chs_2007::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -342,6 +342,8 @@ nest::iaf_chxk_2008::init_buffers_()
 void
 nest::iaf_chxk_2008::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -356,6 +356,8 @@ nest::iaf_cond_alpha::init_buffers_()
 void
 nest::iaf_cond_alpha::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -525,6 +525,8 @@ nest::iaf_cond_alpha_mc::init_buffers_()
 void
 nest::iaf_cond_alpha_mc::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -369,6 +369,8 @@ nest::iaf_cond_beta::get_normalisation_factor( double tau_rise, double tau_decay
 void
 nest::iaf_cond_beta::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -334,6 +334,8 @@ nest::iaf_cond_exp::init_buffers_()
 void
 nest::iaf_cond_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -370,6 +370,8 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
 void
 nest::iaf_cond_exp_sfa_rr::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -247,6 +247,8 @@ iaf_psc_alpha::init_buffers_()
 void
 iaf_psc_alpha::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -281,6 +281,8 @@ iaf_psc_alpha_multisynapse::init_buffers_()
 void
 iaf_psc_alpha_multisynapse::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -262,6 +262,8 @@ nest::iaf_psc_alpha_ps::init_buffers_()
 void
 nest::iaf_psc_alpha_ps::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   V_.h_ms_ = Time::get_resolution().get_ms();

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -233,6 +233,8 @@ nest::iaf_psc_delta::init_buffers_()
 void
 nest::iaf_psc_delta::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();

--- a/models/iaf_psc_delta_ps.cpp
+++ b/models/iaf_psc_delta_ps.cpp
@@ -243,6 +243,8 @@ nest::iaf_psc_delta_ps::init_buffers_()
 void
 iaf_psc_delta_ps::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   V_.h_ms_ = Time::get_resolution().get_ms();

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -243,6 +243,8 @@ nest::iaf_psc_exp::init_buffers_()
 void
 nest::iaf_psc_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -230,6 +230,8 @@ nest::iaf_psc_exp_htum::init_buffers_()
 void
 nest::iaf_psc_exp_htum::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   const double h = Time::get_resolution().get_ms();

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -269,6 +269,8 @@ iaf_psc_exp_multisynapse::init_buffers_()
 void
 nest::iaf_psc_exp_multisynapse::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -251,6 +251,8 @@ nest::iaf_psc_exp_ps::init_buffers_()
 void
 nest::iaf_psc_exp_ps::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -272,6 +272,8 @@ nest::iaf_psc_exp_ps_lossless::init_buffers_()
 void
 nest::iaf_psc_exp_ps_lossless::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -184,6 +184,8 @@ nest::izhikevich::init_buffers_()
 void
 nest::izhikevich::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 }
 

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -241,6 +241,8 @@ nest::mat2_psc_exp::init_buffers_()
 void
 nest::mat2_psc_exp::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -536,6 +536,8 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
 void
 nest::pp_cond_exp_mc_urbanczik::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
   V_.rng_ = get_vp_specific_rng( get_thread() );

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -288,6 +288,8 @@ nest::pp_psc_delta::init_buffers_()
 void
 nest::pp_psc_delta::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();
 
   V_.h_ = Time::get_resolution().get_ms();

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -234,6 +234,8 @@ template < class TNonlinearities >
 void
 nest::rate_neuron_ipn< TNonlinearities >::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 
   const double h = Time::get_resolution().get_ms();

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -218,6 +218,8 @@ template < class TNonlinearities >
 void
 nest::rate_neuron_opn< TNonlinearities >::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 
   const double h = Time::get_resolution().get_ms();

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -162,6 +162,8 @@ template < class TNonlinearities >
 void
 nest::rate_transformer_node< TNonlinearities >::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 }
 

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -293,6 +293,8 @@ nest::siegert_neuron::init_buffers_()
 void
 nest::siegert_neuron::pre_run_hook()
 {
+  ArchivingNode::pre_run_hook_();
+
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 
   const double h = Time::get_resolution().get_ms();

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -66,8 +66,6 @@ nest::ArchivingNode::ArchivingNode( const ArchivingNode& n )
 void
 ArchivingNode::pre_run_hook_()
 {
-  // Intentionally empty for now; gives subclasses a place to hook into
-  // per-run setup without overriding Node::pre_run_hook() themselves.
 }
 
 void

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -64,6 +64,13 @@ nest::ArchivingNode::ArchivingNode( const ArchivingNode& n )
 }
 
 void
+ArchivingNode::pre_run_hook_()
+{
+  // Intentionally empty for now; gives subclasses a place to hook into
+  // per-run setup without overriding Node::pre_run_hook() themselves.
+}
+
+void
 ArchivingNode::register_stdp_connection( double t_first_read, double delay )
 {
   // Mark all entries in the deque, which we will not read in future as read by

--- a/nestkernel/archiving_node.h
+++ b/nestkernel/archiving_node.h
@@ -97,6 +97,8 @@ public:
   void set_status( const Dictionary& d ) override;
 
 protected:
+  void pre_run_hook_();
+
   /**
    * Record spike history
    */


### PR DESCRIPTION
Gives ArchivingNode a protected pre_run_hook_() extension point (in addition to the existing `Node::pre_run_hook()`) and wires it into every model's own pre_run_hook() override.
The main reason for this PR is to reduce the changeset of the #2989 ax-delay PR.