### PR TITLE
Unify the nest:: namespacing in the entire codebase

### DIFF
--- a/models/ac_generator.cpp
+++ b/models/ac_generator.cpp
@@ -35,6 +35,7 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
 void
@@ -51,13 +52,12 @@ RecordablesMap< ac_generator >::create()
 {
   insert_( names::I, &ac_generator::get_I_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::ac_generator::Parameters_::Parameters_()
+ac_generator::Parameters_::Parameters_()
   : amp_( 0.0 )      // pA
   , offset_( 0.0 )   // pA
   , freq_( 0.0 )     // Hz
@@ -65,7 +65,7 @@ nest::ac_generator::Parameters_::Parameters_()
 {
 }
 
-nest::ac_generator::Parameters_::Parameters_( const Parameters_& p )
+ac_generator::Parameters_::Parameters_( const Parameters_& p )
   : amp_( p.amp_ )
   , offset_( p.offset_ )
   , freq_( p.freq_ )
@@ -73,8 +73,8 @@ nest::ac_generator::Parameters_::Parameters_( const Parameters_& p )
 {
 }
 
-nest::ac_generator::Parameters_&
-nest::ac_generator::Parameters_::operator=( const Parameters_& p )
+ac_generator::Parameters_&
+ac_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -89,19 +89,19 @@ nest::ac_generator::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::ac_generator::State_::State_()
+ac_generator::State_::State_()
   : y_0_( 0.0 )
   , y_1_( 0.0 )  // pA
   , I_( 0.0 )    // pA
 {
 }
 
-nest::ac_generator::Buffers_::Buffers_( ac_generator& n )
+ac_generator::Buffers_::Buffers_( ac_generator& n )
   : logger_( n )
 {
 }
 
-nest::ac_generator::Buffers_::Buffers_( const Buffers_&, ac_generator& n )
+ac_generator::Buffers_::Buffers_( const Buffers_&, ac_generator& n )
   : logger_( n )
 {
 }
@@ -111,7 +111,7 @@ nest::ac_generator::Buffers_::Buffers_( const Buffers_&, ac_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::ac_generator::Parameters_::get( Dictionary& d ) const
+ac_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::amplitude ] = amp_;
   d[ names::offset ] = offset_;
@@ -120,14 +120,14 @@ nest::ac_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::ac_generator::State_::get( Dictionary& d ) const
+ac_generator::State_::get( Dictionary& d ) const
 {
   d[ names::y_0 ] = y_0_;
   d[ names::y_1 ] = y_1_;
 }
 
 void
-nest::ac_generator::Parameters_::set( const Dictionary& d, Node* node )
+ac_generator::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::amplitude, amp_, node );
   update_value_param( d, names::offset, offset_, node );
@@ -140,7 +140,7 @@ nest::ac_generator::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::ac_generator::ac_generator()
+ac_generator::ac_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -149,7 +149,7 @@ nest::ac_generator::ac_generator()
   recordablesMap_.create();
 }
 
-nest::ac_generator::ac_generator( const ac_generator& n )
+ac_generator::ac_generator( const ac_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -163,20 +163,20 @@ nest::ac_generator::ac_generator( const ac_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::ac_generator::init_state_()
+ac_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::ac_generator::init_buffers_()
+ac_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
 }
 
 void
-nest::ac_generator::pre_run_hook()
+ac_generator::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -201,7 +201,7 @@ nest::ac_generator::pre_run_hook()
 }
 
 void
-nest::ac_generator::update( Time const& origin, const long from, const long to )
+ac_generator::update( Time const& origin, const long from, const long to )
 {
   long start = origin.get_steps();
 
@@ -226,7 +226,7 @@ nest::ac_generator::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::ac_generator::handle( DataLoggingRequest& e )
+ac_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -236,7 +236,7 @@ nest::ac_generator::handle( DataLoggingRequest& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::ac_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+ac_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -259,3 +259,5 @@ nest::ac_generator::set_data_from_stimulation_backend( std::vector< double >& in
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/aeif_cond_alpha.cpp
+++ b/models/aeif_cond_alpha.cpp
@@ -42,14 +42,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_cond_alpha > nest::aeif_cond_alpha::recordablesMap_;
+RecordablesMap< aeif_cond_alpha > aeif_cond_alpha::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_aeif_cond_alpha( const std::string& name )
 {
@@ -68,17 +68,16 @@ RecordablesMap< aeif_cond_alpha >::create()
   insert_( names::g_in, &aeif_cond_alpha::get_y_elem_< aeif_cond_alpha::State_::G_INH > );
   insert_( names::w, &aeif_cond_alpha::get_y_elem_< aeif_cond_alpha::State_::W > );
 }
-}
 
 extern "C" int
-nest::aeif_cond_alpha_dynamics( double, const double y[], double f[], void* pnode )
+aeif_cond_alpha_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_cond_alpha::State_ S;
+  typedef aeif_cond_alpha::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_cond_alpha& node = *( reinterpret_cast< nest::aeif_cond_alpha* >( pnode ) );
+  const aeif_cond_alpha& node = *( reinterpret_cast< aeif_cond_alpha* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -130,7 +129,7 @@ nest::aeif_cond_alpha_dynamics( double, const double y[], double f[], void* pnod
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_cond_alpha::Parameters_::Parameters_()
+aeif_cond_alpha::Parameters_::Parameters_()
   : V_peak_( 0.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 0.0 )      // ms
@@ -151,7 +150,7 @@ nest::aeif_cond_alpha::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_cond_alpha::State_::State_( const Parameters_& p )
+aeif_cond_alpha::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -161,7 +160,7 @@ nest::aeif_cond_alpha::State_::State_( const Parameters_& p )
   }
 }
 
-nest::aeif_cond_alpha::State_::State_( const State_& s )
+aeif_cond_alpha::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -170,8 +169,8 @@ nest::aeif_cond_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_cond_alpha::State_&
-nest::aeif_cond_alpha::State_::operator=( const State_& s )
+aeif_cond_alpha::State_&
+aeif_cond_alpha::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -186,7 +185,7 @@ nest::aeif_cond_alpha::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_alpha::Parameters_::get( Dictionary& d ) const
+aeif_cond_alpha::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th ] = V_th;
@@ -208,7 +207,7 @@ nest::aeif_cond_alpha::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_cond_alpha::Parameters_::set( const Dictionary& d, Node* node )
+aeif_cond_alpha::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th, node );
   update_value_param( d, names::V_peak, V_peak_, node );
@@ -284,7 +283,7 @@ nest::aeif_cond_alpha::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::aeif_cond_alpha::State_::get( Dictionary& d ) const
+aeif_cond_alpha::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::g_ex ] = y_[ G_EXC ];
@@ -295,7 +294,7 @@ nest::aeif_cond_alpha::State_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_cond_alpha::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_cond_alpha::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::g_ex, y_[ G_EXC ], node );
@@ -309,7 +308,7 @@ nest::aeif_cond_alpha::State_::set( const Dictionary& d, const Parameters_&, Nod
   }
 }
 
-nest::aeif_cond_alpha::Buffers_::Buffers_( aeif_cond_alpha& n )
+aeif_cond_alpha::Buffers_::Buffers_( aeif_cond_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -319,7 +318,7 @@ nest::aeif_cond_alpha::Buffers_::Buffers_( aeif_cond_alpha& n )
   // init_buffers_().
 }
 
-nest::aeif_cond_alpha::Buffers_::Buffers_( const Buffers_&, aeif_cond_alpha& n )
+aeif_cond_alpha::Buffers_::Buffers_( const Buffers_&, aeif_cond_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -333,7 +332,7 @@ nest::aeif_cond_alpha::Buffers_::Buffers_( const Buffers_&, aeif_cond_alpha& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_cond_alpha::aeif_cond_alpha()
+aeif_cond_alpha::aeif_cond_alpha()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -342,7 +341,7 @@ nest::aeif_cond_alpha::aeif_cond_alpha()
   recordablesMap_.create();
 }
 
-nest::aeif_cond_alpha::aeif_cond_alpha( const aeif_cond_alpha& n )
+aeif_cond_alpha::aeif_cond_alpha( const aeif_cond_alpha& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -350,7 +349,7 @@ nest::aeif_cond_alpha::aeif_cond_alpha( const aeif_cond_alpha& n )
 {
 }
 
-nest::aeif_cond_alpha::~aeif_cond_alpha()
+aeif_cond_alpha::~aeif_cond_alpha()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -372,7 +371,7 @@ nest::aeif_cond_alpha::~aeif_cond_alpha()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_alpha::init_buffers_()
+aeif_cond_alpha::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -422,7 +421,7 @@ nest::aeif_cond_alpha::init_buffers_()
 }
 
 void
-nest::aeif_cond_alpha::pre_run_hook()
+aeif_cond_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -447,7 +446,7 @@ nest::aeif_cond_alpha::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_alpha::update( Time const& origin, const long from, const long to )
+aeif_cond_alpha::update( Time const& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -533,7 +532,7 @@ nest::aeif_cond_alpha::update( Time const& origin, const long from, const long t
 }
 
 void
-nest::aeif_cond_alpha::handle( SpikeEvent& e )
+aeif_cond_alpha::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -550,7 +549,7 @@ nest::aeif_cond_alpha::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_cond_alpha::handle( CurrentEvent& e )
+aeif_cond_alpha::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -561,9 +560,11 @@ nest::aeif_cond_alpha::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_cond_alpha::handle( DataLoggingRequest& e )
+aeif_cond_alpha::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/aeif_cond_alpha_astro.cpp
+++ b/models/aeif_cond_alpha_astro.cpp
@@ -41,14 +41,15 @@
 #include "nest_names.h"
 #include "universal_data_logger_impl.h"
 
+
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_cond_alpha_astro > nest::aeif_cond_alpha_astro::recordablesMap_;
+RecordablesMap< aeif_cond_alpha_astro > aeif_cond_alpha_astro::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_aeif_cond_alpha_astro( const std::string& name )
 {
@@ -68,17 +69,16 @@ RecordablesMap< aeif_cond_alpha_astro >::create()
   insert_( names::w, &aeif_cond_alpha_astro::get_y_elem_< aeif_cond_alpha_astro::State_::W > );
   insert_( names::I_SIC, &aeif_cond_alpha_astro::get_I_sic_ );
 }
-}
 
 extern "C" int
-nest::aeif_cond_alpha_astro_dynamics( double, const double y[], double f[], void* pnode )
+aeif_cond_alpha_astro_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_cond_alpha_astro::State_ S;
+  typedef aeif_cond_alpha_astro::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_cond_alpha_astro& node = *( reinterpret_cast< nest::aeif_cond_alpha_astro* >( pnode ) );
+  const aeif_cond_alpha_astro& node = *( reinterpret_cast< aeif_cond_alpha_astro* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -130,7 +130,7 @@ nest::aeif_cond_alpha_astro_dynamics( double, const double y[], double f[], void
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_cond_alpha_astro::Parameters_::Parameters_()
+aeif_cond_alpha_astro::Parameters_::Parameters_()
   : V_peak_( 0.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 0.0 )      // ms
@@ -151,7 +151,7 @@ nest::aeif_cond_alpha_astro::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_cond_alpha_astro::State_::State_( const Parameters_& p )
+aeif_cond_alpha_astro::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -161,7 +161,7 @@ nest::aeif_cond_alpha_astro::State_::State_( const Parameters_& p )
   }
 }
 
-nest::aeif_cond_alpha_astro::State_::State_( const State_& s )
+aeif_cond_alpha_astro::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -170,8 +170,8 @@ nest::aeif_cond_alpha_astro::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_cond_alpha_astro::State_&
-nest::aeif_cond_alpha_astro::State_::operator=( const State_& s )
+aeif_cond_alpha_astro::State_&
+aeif_cond_alpha_astro::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -186,7 +186,7 @@ nest::aeif_cond_alpha_astro::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_alpha_astro::Parameters_::get( Dictionary& d ) const
+aeif_cond_alpha_astro::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th ] = V_th;
@@ -208,7 +208,7 @@ nest::aeif_cond_alpha_astro::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_cond_alpha_astro::Parameters_::set( const Dictionary& d, Node* node )
+aeif_cond_alpha_astro::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th, node );
   update_value_param( d, names::V_peak, V_peak_, node );
@@ -284,7 +284,7 @@ nest::aeif_cond_alpha_astro::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::aeif_cond_alpha_astro::State_::get( Dictionary& d ) const
+aeif_cond_alpha_astro::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::g_ex ] = y_[ G_EXC ];
@@ -295,7 +295,7 @@ nest::aeif_cond_alpha_astro::State_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_cond_alpha_astro::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_cond_alpha_astro::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::g_ex, y_[ G_EXC ], node );
@@ -309,7 +309,7 @@ nest::aeif_cond_alpha_astro::State_::set( const Dictionary& d, const Parameters_
   }
 }
 
-nest::aeif_cond_alpha_astro::Buffers_::Buffers_( aeif_cond_alpha_astro& n )
+aeif_cond_alpha_astro::Buffers_::Buffers_( aeif_cond_alpha_astro& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -319,7 +319,7 @@ nest::aeif_cond_alpha_astro::Buffers_::Buffers_( aeif_cond_alpha_astro& n )
   // init_buffers_().
 }
 
-nest::aeif_cond_alpha_astro::Buffers_::Buffers_( const Buffers_&, aeif_cond_alpha_astro& n )
+aeif_cond_alpha_astro::Buffers_::Buffers_( const Buffers_&, aeif_cond_alpha_astro& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -333,7 +333,7 @@ nest::aeif_cond_alpha_astro::Buffers_::Buffers_( const Buffers_&, aeif_cond_alph
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_cond_alpha_astro::aeif_cond_alpha_astro()
+aeif_cond_alpha_astro::aeif_cond_alpha_astro()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -342,7 +342,7 @@ nest::aeif_cond_alpha_astro::aeif_cond_alpha_astro()
   recordablesMap_.create();
 }
 
-nest::aeif_cond_alpha_astro::aeif_cond_alpha_astro( const aeif_cond_alpha_astro& n )
+aeif_cond_alpha_astro::aeif_cond_alpha_astro( const aeif_cond_alpha_astro& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -350,7 +350,7 @@ nest::aeif_cond_alpha_astro::aeif_cond_alpha_astro( const aeif_cond_alpha_astro&
 {
 }
 
-nest::aeif_cond_alpha_astro::~aeif_cond_alpha_astro()
+aeif_cond_alpha_astro::~aeif_cond_alpha_astro()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -372,7 +372,7 @@ nest::aeif_cond_alpha_astro::~aeif_cond_alpha_astro()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_alpha_astro::init_buffers_()
+aeif_cond_alpha_astro::init_buffers_()
 {
   B_.spike_exc_.clear();     // includes resize
   B_.spike_inh_.clear();     // includes resize
@@ -424,7 +424,7 @@ nest::aeif_cond_alpha_astro::init_buffers_()
 }
 
 void
-nest::aeif_cond_alpha_astro::pre_run_hook()
+aeif_cond_alpha_astro::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -449,7 +449,7 @@ nest::aeif_cond_alpha_astro::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_alpha_astro::update( Time const& origin, const long from, const long to )
+aeif_cond_alpha_astro::update( Time const& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -536,7 +536,7 @@ nest::aeif_cond_alpha_astro::update( Time const& origin, const long from, const 
 }
 
 void
-nest::aeif_cond_alpha_astro::handle( SpikeEvent& e )
+aeif_cond_alpha_astro::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -553,7 +553,7 @@ nest::aeif_cond_alpha_astro::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_cond_alpha_astro::handle( CurrentEvent& e )
+aeif_cond_alpha_astro::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -564,7 +564,7 @@ nest::aeif_cond_alpha_astro::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_cond_alpha_astro::handle( SICEvent& e )
+aeif_cond_alpha_astro::handle( SICEvent& e )
 {
   const double weight = e.get_weight();
   const long delay = e.get_delay_steps() - kernel().connection_manager.get_min_delay();
@@ -580,9 +580,11 @@ nest::aeif_cond_alpha_astro::handle( SICEvent& e )
 }
 
 void
-nest::aeif_cond_alpha_astro::handle( DataLoggingRequest& e )
+aeif_cond_alpha_astro::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -104,8 +104,7 @@ aeif_cond_alpha_multisynapse_dynamics( double, const double y[], double f[], voi
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const aeif_cond_alpha_multisynapse& node =
-    *( reinterpret_cast< aeif_cond_alpha_multisynapse* >( pnode ) );
+  const aeif_cond_alpha_multisynapse& node = *( reinterpret_cast< aeif_cond_alpha_multisynapse* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 

--- a/models/aeif_cond_alpha_multisynapse.cpp
+++ b/models/aeif_cond_alpha_multisynapse.cpp
@@ -38,7 +38,7 @@
 #include "universal_data_logger_impl.h"
 
 
-namespace nest  // template specialization must be placed in namespace
+namespace nest
 {
 void
 register_aeif_cond_alpha_multisynapse( const std::string& name )
@@ -100,12 +100,12 @@ aeif_cond_alpha_multisynapse_dynamics( double, const double y[], double f[], voi
   // y[] is the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
-  typedef nest::aeif_cond_alpha_multisynapse::State_ S;
+  typedef aeif_cond_alpha_multisynapse::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_cond_alpha_multisynapse& node =
-    *( reinterpret_cast< nest::aeif_cond_alpha_multisynapse* >( pnode ) );
+  const aeif_cond_alpha_multisynapse& node =
+    *( reinterpret_cast< aeif_cond_alpha_multisynapse* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 

--- a/models/aeif_cond_beta_multisynapse.cpp
+++ b/models/aeif_cond_beta_multisynapse.cpp
@@ -38,7 +38,8 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-namespace nest  // template specialization must be placed in namespace
+
+namespace nest
 {
 void
 register_aeif_cond_beta_multisynapse( const std::string& name )
@@ -100,11 +101,11 @@ aeif_cond_beta_multisynapse_dynamics( double, const double y[], double f[], void
   // y[] is the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
 
-  typedef nest::aeif_cond_beta_multisynapse::State_ S;
+  typedef aeif_cond_beta_multisynapse::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_cond_beta_multisynapse& node = *( reinterpret_cast< nest::aeif_cond_beta_multisynapse* >( pnode ) );
+  const aeif_cond_beta_multisynapse& node = *( reinterpret_cast< aeif_cond_beta_multisynapse* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 

--- a/models/aeif_cond_exp.cpp
+++ b/models/aeif_cond_exp.cpp
@@ -42,14 +42,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_cond_exp > nest::aeif_cond_exp::recordablesMap_;
+RecordablesMap< aeif_cond_exp > aeif_cond_exp::recordablesMap_;
 
-namespace nest
-{
 void
 register_aeif_cond_exp( const std::string& name )
 {
@@ -72,18 +72,17 @@ RecordablesMap< aeif_cond_exp >::create()
   insert_( names::g_in, &aeif_cond_exp::get_y_elem_< aeif_cond_exp::State_::G_INH > );
   insert_( names::w, &aeif_cond_exp::get_y_elem_< aeif_cond_exp::State_::W > );
 }
-}
 
 
 extern "C" int
-nest::aeif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
+aeif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_cond_exp::State_ S;
+  typedef aeif_cond_exp::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_cond_exp& node = *( reinterpret_cast< nest::aeif_cond_exp* >( pnode ) );
+  const aeif_cond_exp& node = *( reinterpret_cast< aeif_cond_exp* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -129,7 +128,7 @@ nest::aeif_cond_exp_dynamics( double, const double y[], double f[], void* pnode 
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_cond_exp::Parameters_::Parameters_()
+aeif_cond_exp::Parameters_::Parameters_()
   : V_peak_( 0.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 0.0 )      // ms
@@ -150,7 +149,7 @@ nest::aeif_cond_exp::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_cond_exp::State_::State_( const Parameters_& p )
+aeif_cond_exp::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -160,7 +159,7 @@ nest::aeif_cond_exp::State_::State_( const Parameters_& p )
   }
 }
 
-nest::aeif_cond_exp::State_::State_( const State_& s )
+aeif_cond_exp::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -169,8 +168,8 @@ nest::aeif_cond_exp::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_cond_exp::State_&
-nest::aeif_cond_exp::State_::operator=( const State_& s )
+aeif_cond_exp::State_&
+aeif_cond_exp::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -185,7 +184,7 @@ nest::aeif_cond_exp::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_exp::Parameters_::get( Dictionary& d ) const
+aeif_cond_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th ] = V_th;
@@ -207,7 +206,7 @@ nest::aeif_cond_exp::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
+aeif_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th, node );
   update_value_param( d, names::V_peak, V_peak_, node );
@@ -283,7 +282,7 @@ nest::aeif_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::aeif_cond_exp::State_::get( Dictionary& d ) const
+aeif_cond_exp::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::g_ex ] = y_[ G_EXC ];
@@ -292,7 +291,7 @@ nest::aeif_cond_exp::State_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::g_ex, y_[ G_EXC ], node );
@@ -304,7 +303,7 @@ nest::aeif_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node*
   }
 }
 
-nest::aeif_cond_exp::Buffers_::Buffers_( aeif_cond_exp& n )
+aeif_cond_exp::Buffers_::Buffers_( aeif_cond_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -314,7 +313,7 @@ nest::aeif_cond_exp::Buffers_::Buffers_( aeif_cond_exp& n )
   // init_buffers_().
 }
 
-nest::aeif_cond_exp::Buffers_::Buffers_( const Buffers_&, aeif_cond_exp& n )
+aeif_cond_exp::Buffers_::Buffers_( const Buffers_&, aeif_cond_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -328,7 +327,7 @@ nest::aeif_cond_exp::Buffers_::Buffers_( const Buffers_&, aeif_cond_exp& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_cond_exp::aeif_cond_exp()
+aeif_cond_exp::aeif_cond_exp()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -337,7 +336,7 @@ nest::aeif_cond_exp::aeif_cond_exp()
   recordablesMap_.create();
 }
 
-nest::aeif_cond_exp::aeif_cond_exp( const aeif_cond_exp& n )
+aeif_cond_exp::aeif_cond_exp( const aeif_cond_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -345,7 +344,7 @@ nest::aeif_cond_exp::aeif_cond_exp( const aeif_cond_exp& n )
 {
 }
 
-nest::aeif_cond_exp::~aeif_cond_exp()
+aeif_cond_exp::~aeif_cond_exp()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -367,7 +366,7 @@ nest::aeif_cond_exp::~aeif_cond_exp()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_exp::init_buffers_()
+aeif_cond_exp::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -417,7 +416,7 @@ nest::aeif_cond_exp::init_buffers_()
 }
 
 void
-nest::aeif_cond_exp::pre_run_hook()
+aeif_cond_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -440,7 +439,7 @@ nest::aeif_cond_exp::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_cond_exp::update( const Time& origin, const long from, const long to )
+aeif_cond_exp::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -523,7 +522,7 @@ nest::aeif_cond_exp::update( const Time& origin, const long from, const long to 
 }
 
 void
-nest::aeif_cond_exp::handle( SpikeEvent& e )
+aeif_cond_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -540,7 +539,7 @@ nest::aeif_cond_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_cond_exp::handle( CurrentEvent& e )
+aeif_cond_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -551,9 +550,11 @@ nest::aeif_cond_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_cond_exp::handle( DataLoggingRequest& e )
+aeif_cond_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/aeif_psc_alpha.cpp
+++ b/models/aeif_psc_alpha.cpp
@@ -42,14 +42,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_psc_alpha > nest::aeif_psc_alpha::recordablesMap_;
+RecordablesMap< aeif_psc_alpha > aeif_psc_alpha::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_aeif_psc_alpha( const std::string& name )
 {
@@ -68,17 +68,16 @@ RecordablesMap< aeif_psc_alpha >::create()
   insert_( names::I_syn_in, &aeif_psc_alpha::get_y_elem_< aeif_psc_alpha::State_::I_INH > );
   insert_( names::w, &aeif_psc_alpha::get_y_elem_< aeif_psc_alpha::State_::W > );
 }
-}
 
 extern "C" int
-nest::aeif_psc_alpha_dynamics( double, const double y[], double f[], void* pnode )
+aeif_psc_alpha_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_psc_alpha::State_ S;
+  typedef aeif_psc_alpha::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_psc_alpha& node = *( reinterpret_cast< nest::aeif_psc_alpha* >( pnode ) );
+  const aeif_psc_alpha& node = *( reinterpret_cast< aeif_psc_alpha* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -126,7 +125,7 @@ nest::aeif_psc_alpha_dynamics( double, const double y[], double f[], void* pnode
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_alpha::Parameters_::Parameters_()
+aeif_psc_alpha::Parameters_::Parameters_()
   : V_peak_( 0.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 0.0 )      // ms
@@ -145,7 +144,7 @@ nest::aeif_psc_alpha::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_psc_alpha::State_::State_( const Parameters_& p )
+aeif_psc_alpha::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -155,7 +154,7 @@ nest::aeif_psc_alpha::State_::State_( const Parameters_& p )
   }
 }
 
-nest::aeif_psc_alpha::State_::State_( const State_& s )
+aeif_psc_alpha::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -164,8 +163,8 @@ nest::aeif_psc_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_alpha::State_&
-nest::aeif_psc_alpha::State_::operator=( const State_& s )
+aeif_psc_alpha::State_&
+aeif_psc_alpha::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -180,7 +179,7 @@ nest::aeif_psc_alpha::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_alpha::Parameters_::get( Dictionary& d ) const
+aeif_psc_alpha::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th ] = V_th;
@@ -200,7 +199,7 @@ nest::aeif_psc_alpha::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_alpha::Parameters_::set( const Dictionary& d, Node* node )
+aeif_psc_alpha::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th, node );
   update_value_param( d, names::V_peak, V_peak_, node );
@@ -274,7 +273,7 @@ nest::aeif_psc_alpha::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::aeif_psc_alpha::State_::get( Dictionary& d ) const
+aeif_psc_alpha::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::I_syn_ex ] = y_[ I_EXC ];
@@ -285,7 +284,7 @@ nest::aeif_psc_alpha::State_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_alpha::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_psc_alpha::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::I_syn_ex, y_[ I_EXC ], node );
@@ -299,7 +298,7 @@ nest::aeif_psc_alpha::State_::set( const Dictionary& d, const Parameters_&, Node
   }
 }
 
-nest::aeif_psc_alpha::Buffers_::Buffers_( aeif_psc_alpha& n )
+aeif_psc_alpha::Buffers_::Buffers_( aeif_psc_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -309,7 +308,7 @@ nest::aeif_psc_alpha::Buffers_::Buffers_( aeif_psc_alpha& n )
   // init_buffers_().
 }
 
-nest::aeif_psc_alpha::Buffers_::Buffers_( const Buffers_&, aeif_psc_alpha& n )
+aeif_psc_alpha::Buffers_::Buffers_( const Buffers_&, aeif_psc_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -323,7 +322,7 @@ nest::aeif_psc_alpha::Buffers_::Buffers_( const Buffers_&, aeif_psc_alpha& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_alpha::aeif_psc_alpha()
+aeif_psc_alpha::aeif_psc_alpha()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -332,7 +331,7 @@ nest::aeif_psc_alpha::aeif_psc_alpha()
   recordablesMap_.create();
 }
 
-nest::aeif_psc_alpha::aeif_psc_alpha( const aeif_psc_alpha& n )
+aeif_psc_alpha::aeif_psc_alpha( const aeif_psc_alpha& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -340,7 +339,7 @@ nest::aeif_psc_alpha::aeif_psc_alpha( const aeif_psc_alpha& n )
 {
 }
 
-nest::aeif_psc_alpha::~aeif_psc_alpha()
+aeif_psc_alpha::~aeif_psc_alpha()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -362,7 +361,7 @@ nest::aeif_psc_alpha::~aeif_psc_alpha()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_alpha::init_buffers_()
+aeif_psc_alpha::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -412,7 +411,7 @@ nest::aeif_psc_alpha::init_buffers_()
 }
 
 void
-nest::aeif_psc_alpha::pre_run_hook()
+aeif_psc_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -437,7 +436,7 @@ nest::aeif_psc_alpha::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_alpha::update( Time const& origin, const long from, const long to )
+aeif_psc_alpha::update( Time const& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -523,7 +522,7 @@ nest::aeif_psc_alpha::update( Time const& origin, const long from, const long to
 }
 
 void
-nest::aeif_psc_alpha::handle( SpikeEvent& e )
+aeif_psc_alpha::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -540,7 +539,7 @@ nest::aeif_psc_alpha::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_psc_alpha::handle( CurrentEvent& e )
+aeif_psc_alpha::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -551,9 +550,11 @@ nest::aeif_psc_alpha::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_psc_alpha::handle( DataLoggingRequest& e )
+aeif_psc_alpha::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/aeif_psc_delta.cpp
+++ b/models/aeif_psc_delta.cpp
@@ -42,14 +42,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_psc_delta > nest::aeif_psc_delta::recordablesMap_;
+RecordablesMap< aeif_psc_delta > aeif_psc_delta::recordablesMap_;
 
-namespace nest
-{
 void
 register_aeif_psc_delta( const std::string& name )
 {
@@ -70,18 +70,17 @@ RecordablesMap< aeif_psc_delta >::create()
   insert_( names::V_m, &aeif_psc_delta::get_y_elem_< aeif_psc_delta::State_::V_M > );
   insert_( names::w, &aeif_psc_delta::get_y_elem_< aeif_psc_delta::State_::W > );
 }
-}
 
 
 extern "C" int
-nest::aeif_psc_delta_dynamics( double, const double y[], double f[], void* pnode )
+aeif_psc_delta_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_psc_delta::State_ S;
+  typedef aeif_psc_delta::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_psc_delta& node = *( reinterpret_cast< nest::aeif_psc_delta* >( pnode ) );
+  const aeif_psc_delta& node = *( reinterpret_cast< aeif_psc_delta* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -115,7 +114,7 @@ nest::aeif_psc_delta_dynamics( double, const double y[], double f[], void* pnode
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_delta::Parameters_::Parameters_()
+aeif_psc_delta::Parameters_::Parameters_()
   : V_peak_( 0.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 0.0 )      // ms
@@ -133,7 +132,7 @@ nest::aeif_psc_delta::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_psc_delta::State_::State_( const Parameters_& p )
+aeif_psc_delta::State_::State_( const Parameters_& p )
   : refr_spikes_buffer_( 0.0 )
   , r_( 0 )
 {
@@ -144,7 +143,7 @@ nest::aeif_psc_delta::State_::State_( const Parameters_& p )
   }
 }
 
-nest::aeif_psc_delta::State_::State_( const State_& s )
+aeif_psc_delta::State_::State_( const State_& s )
   : refr_spikes_buffer_( s.refr_spikes_buffer_ )
   , r_( s.r_ )
 {
@@ -154,8 +153,8 @@ nest::aeif_psc_delta::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_delta::State_&
-nest::aeif_psc_delta::State_::operator=( const State_& s )
+aeif_psc_delta::State_&
+aeif_psc_delta::State_::operator=( const State_& s )
 {
   refr_spikes_buffer_ = s.refr_spikes_buffer_;
   r_ = s.r_;
@@ -171,7 +170,7 @@ nest::aeif_psc_delta::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_delta::Parameters_::get( Dictionary& d ) const
+aeif_psc_delta::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th ] = V_th;
@@ -190,7 +189,7 @@ nest::aeif_psc_delta::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
+aeif_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th, node );
   update_value_param( d, names::V_peak, V_peak_, node );
@@ -263,21 +262,21 @@ nest::aeif_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::aeif_psc_delta::State_::get( Dictionary& d ) const
+aeif_psc_delta::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::w ] = y_[ W ];
 }
 
 void
-nest::aeif_psc_delta::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_psc_delta::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::w, y_[ W ], node );
 }
 
 
-nest::aeif_psc_delta::Buffers_::Buffers_( aeif_psc_delta& n )
+aeif_psc_delta::Buffers_::Buffers_( aeif_psc_delta& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -287,7 +286,7 @@ nest::aeif_psc_delta::Buffers_::Buffers_( aeif_psc_delta& n )
   // init_buffers_().
 }
 
-nest::aeif_psc_delta::Buffers_::Buffers_( const Buffers_&, aeif_psc_delta& n )
+aeif_psc_delta::Buffers_::Buffers_( const Buffers_&, aeif_psc_delta& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -301,7 +300,7 @@ nest::aeif_psc_delta::Buffers_::Buffers_( const Buffers_&, aeif_psc_delta& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_delta::aeif_psc_delta()
+aeif_psc_delta::aeif_psc_delta()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -310,7 +309,7 @@ nest::aeif_psc_delta::aeif_psc_delta()
   recordablesMap_.create();
 }
 
-nest::aeif_psc_delta::aeif_psc_delta( const aeif_psc_delta& n )
+aeif_psc_delta::aeif_psc_delta( const aeif_psc_delta& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -318,7 +317,7 @@ nest::aeif_psc_delta::aeif_psc_delta( const aeif_psc_delta& n )
 {
 }
 
-nest::aeif_psc_delta::~aeif_psc_delta()
+aeif_psc_delta::~aeif_psc_delta()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -340,7 +339,7 @@ nest::aeif_psc_delta::~aeif_psc_delta()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_delta::init_buffers_()
+aeif_psc_delta::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // includes resize
@@ -388,7 +387,7 @@ nest::aeif_psc_delta::init_buffers_()
 }
 
 void
-nest::aeif_psc_delta::pre_run_hook()
+aeif_psc_delta::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -415,7 +414,7 @@ nest::aeif_psc_delta::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_delta::update( const Time& origin, const long from, const long to )
+aeif_psc_delta::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -518,7 +517,7 @@ nest::aeif_psc_delta::update( const Time& origin, const long from, const long to
 }
 
 void
-nest::aeif_psc_delta::handle( SpikeEvent& e )
+aeif_psc_delta::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -527,7 +526,7 @@ nest::aeif_psc_delta::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_psc_delta::handle( CurrentEvent& e )
+aeif_psc_delta::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -539,9 +538,11 @@ nest::aeif_psc_delta::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_psc_delta::handle( DataLoggingRequest& e )
+aeif_psc_delta::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/aeif_psc_delta_clopath.cpp
+++ b/models/aeif_psc_delta_clopath.cpp
@@ -42,14 +42,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_psc_delta_clopath > nest::aeif_psc_delta_clopath::recordablesMap_;
+RecordablesMap< aeif_psc_delta_clopath > aeif_psc_delta_clopath::recordablesMap_;
 
-namespace nest
-{
 void
 register_aeif_psc_delta_clopath( const std::string& name )
 {
@@ -75,18 +75,17 @@ RecordablesMap< aeif_psc_delta_clopath >::create()
   insert_( names::u_bar_minus, &aeif_psc_delta_clopath::get_y_elem_< aeif_psc_delta_clopath::State_::U_BAR_MINUS > );
   insert_( names::u_bar_bar, &aeif_psc_delta_clopath::get_y_elem_< aeif_psc_delta_clopath::State_::U_BAR_BAR > );
 }
-}
 
 
 extern "C" int
-nest::aeif_psc_delta_clopath_dynamics( double, const double y[], double f[], void* pnode )
+aeif_psc_delta_clopath_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_psc_delta_clopath::State_ S;
+  typedef aeif_psc_delta_clopath::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_psc_delta_clopath& node = *( reinterpret_cast< nest::aeif_psc_delta_clopath* >( pnode ) );
+  const aeif_psc_delta_clopath& node = *( reinterpret_cast< aeif_psc_delta_clopath* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
   const bool is_clamped = node.S_.clamp_r_ > 0;
@@ -137,7 +136,7 @@ nest::aeif_psc_delta_clopath_dynamics( double, const double y[], double f[], voi
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_delta_clopath::Parameters_::Parameters_()
+aeif_psc_delta_clopath::Parameters_::Parameters_()
   : V_peak_( 33.0 )          // mV
   , V_reset_( -60.0 )        // mV
   , t_ref_( 0.0 )            // ms
@@ -163,7 +162,7 @@ nest::aeif_psc_delta_clopath::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_psc_delta_clopath::State_::State_( const Parameters_& p )
+aeif_psc_delta_clopath::State_::State_( const Parameters_& p )
   : r_( 0 )
   , clamp_r_( 0 )
 {
@@ -178,7 +177,7 @@ nest::aeif_psc_delta_clopath::State_::State_( const Parameters_& p )
   y_[ U_BAR_BAR ] = p.E_L;
 }
 
-nest::aeif_psc_delta_clopath::State_::State_( const State_& s )
+aeif_psc_delta_clopath::State_::State_( const State_& s )
   : r_( s.r_ )
   , clamp_r_( s.clamp_r_ )
 {
@@ -188,8 +187,8 @@ nest::aeif_psc_delta_clopath::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_delta_clopath::State_&
-nest::aeif_psc_delta_clopath::State_::operator=( const State_& s )
+aeif_psc_delta_clopath::State_&
+aeif_psc_delta_clopath::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   clamp_r_ = s.clamp_r_;
@@ -205,7 +204,7 @@ nest::aeif_psc_delta_clopath::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_delta_clopath::Parameters_::get( Dictionary& d ) const
+aeif_psc_delta_clopath::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th_max ] = V_th_max;
@@ -232,7 +231,7 @@ nest::aeif_psc_delta_clopath::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_delta_clopath::Parameters_::set( const Dictionary& d, Node* node )
+aeif_psc_delta_clopath::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th_max, V_th_max, node );
   update_value_param( d, names::V_th_rest, V_th_rest, node );
@@ -324,7 +323,7 @@ nest::aeif_psc_delta_clopath::Parameters_::set( const Dictionary& d, Node* node 
 }
 
 void
-nest::aeif_psc_delta_clopath::State_::get( Dictionary& d ) const
+aeif_psc_delta_clopath::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::w ] = y_[ W ];
@@ -334,7 +333,7 @@ nest::aeif_psc_delta_clopath::State_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_delta_clopath::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_psc_delta_clopath::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::w, y_[ W ], node );
@@ -343,7 +342,7 @@ nest::aeif_psc_delta_clopath::State_::set( const Dictionary& d, const Parameters
   update_value_param( d, names::u_bar_bar, y_[ U_BAR_BAR ], node );
 }
 
-nest::aeif_psc_delta_clopath::Buffers_::Buffers_( aeif_psc_delta_clopath& n )
+aeif_psc_delta_clopath::Buffers_::Buffers_( aeif_psc_delta_clopath& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -353,7 +352,7 @@ nest::aeif_psc_delta_clopath::Buffers_::Buffers_( aeif_psc_delta_clopath& n )
   // init_buffers_().
 }
 
-nest::aeif_psc_delta_clopath::Buffers_::Buffers_( const Buffers_&, aeif_psc_delta_clopath& n )
+aeif_psc_delta_clopath::Buffers_::Buffers_( const Buffers_&, aeif_psc_delta_clopath& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -367,7 +366,7 @@ nest::aeif_psc_delta_clopath::Buffers_::Buffers_( const Buffers_&, aeif_psc_delt
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_delta_clopath::aeif_psc_delta_clopath()
+aeif_psc_delta_clopath::aeif_psc_delta_clopath()
   : ClopathArchivingNode()
   , P_()
   , S_( P_ )
@@ -376,7 +375,7 @@ nest::aeif_psc_delta_clopath::aeif_psc_delta_clopath()
   recordablesMap_.create();
 }
 
-nest::aeif_psc_delta_clopath::aeif_psc_delta_clopath( const aeif_psc_delta_clopath& n )
+aeif_psc_delta_clopath::aeif_psc_delta_clopath( const aeif_psc_delta_clopath& n )
   : ClopathArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -384,7 +383,7 @@ nest::aeif_psc_delta_clopath::aeif_psc_delta_clopath( const aeif_psc_delta_clopa
 {
 }
 
-nest::aeif_psc_delta_clopath::~aeif_psc_delta_clopath()
+aeif_psc_delta_clopath::~aeif_psc_delta_clopath()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -406,7 +405,7 @@ nest::aeif_psc_delta_clopath::~aeif_psc_delta_clopath()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_delta_clopath::init_buffers_()
+aeif_psc_delta_clopath::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // includes resize
@@ -456,7 +455,7 @@ nest::aeif_psc_delta_clopath::init_buffers_()
 }
 
 void
-nest::aeif_psc_delta_clopath::pre_run_hook()
+aeif_psc_delta_clopath::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -474,7 +473,7 @@ nest::aeif_psc_delta_clopath::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_delta_clopath::update( const Time& origin, const long from, const long to )
+aeif_psc_delta_clopath::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -597,7 +596,7 @@ nest::aeif_psc_delta_clopath::update( const Time& origin, const long from, const
 }
 
 void
-nest::aeif_psc_delta_clopath::handle( SpikeEvent& e )
+aeif_psc_delta_clopath::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -606,7 +605,7 @@ nest::aeif_psc_delta_clopath::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_psc_delta_clopath::handle( CurrentEvent& e )
+aeif_psc_delta_clopath::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -618,9 +617,11 @@ nest::aeif_psc_delta_clopath::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_psc_delta_clopath::handle( DataLoggingRequest& e )
+aeif_psc_delta_clopath::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/aeif_psc_exp.cpp
+++ b/models/aeif_psc_exp.cpp
@@ -42,14 +42,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::aeif_psc_exp > nest::aeif_psc_exp::recordablesMap_;
+RecordablesMap< aeif_psc_exp > aeif_psc_exp::recordablesMap_;
 
-namespace nest
-{
 void
 register_aeif_psc_exp( const std::string& name )
 {
@@ -72,18 +72,17 @@ RecordablesMap< aeif_psc_exp >::create()
   insert_( names::I_syn_in, &aeif_psc_exp::get_y_elem_< aeif_psc_exp::State_::I_INH > );
   insert_( names::w, &aeif_psc_exp::get_y_elem_< aeif_psc_exp::State_::W > );
 }
-}
 
 
 extern "C" int
-nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
+aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::aeif_psc_exp::State_ S;
+  typedef aeif_psc_exp::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::aeif_psc_exp& node = *( reinterpret_cast< nest::aeif_psc_exp* >( pnode ) );
+  const aeif_psc_exp& node = *( reinterpret_cast< aeif_psc_exp* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -125,7 +124,7 @@ nest::aeif_psc_exp_dynamics( double, const double y[], double f[], void* pnode )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_exp::Parameters_::Parameters_()
+aeif_psc_exp::Parameters_::Parameters_()
   : V_peak_( 0.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 0.0 )      // ms
@@ -144,7 +143,7 @@ nest::aeif_psc_exp::Parameters_::Parameters_()
 {
 }
 
-nest::aeif_psc_exp::State_::State_( const Parameters_& p )
+aeif_psc_exp::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -154,7 +153,7 @@ nest::aeif_psc_exp::State_::State_( const Parameters_& p )
   }
 }
 
-nest::aeif_psc_exp::State_::State_( const State_& s )
+aeif_psc_exp::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -163,8 +162,8 @@ nest::aeif_psc_exp::State_::State_( const State_& s )
   }
 }
 
-nest::aeif_psc_exp::State_&
-nest::aeif_psc_exp::State_::operator=( const State_& s )
+aeif_psc_exp::State_&
+aeif_psc_exp::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -179,7 +178,7 @@ nest::aeif_psc_exp::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_exp::Parameters_::get( Dictionary& d ) const
+aeif_psc_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::C_m ] = C_m;
   d[ names::V_th ] = V_th;
@@ -199,7 +198,7 @@ nest::aeif_psc_exp::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
+aeif_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th, node );
   update_value_param( d, names::V_peak, V_peak_, node );
@@ -273,7 +272,7 @@ nest::aeif_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::aeif_psc_exp::State_::get( Dictionary& d ) const
+aeif_psc_exp::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::I_syn_ex ] = y_[ I_EXC ];
@@ -282,7 +281,7 @@ nest::aeif_psc_exp::State_::get( Dictionary& d ) const
 }
 
 void
-nest::aeif_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+aeif_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::I_syn_ex, y_[ I_EXC ], node );
@@ -294,7 +293,7 @@ nest::aeif_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* 
   }
 }
 
-nest::aeif_psc_exp::Buffers_::Buffers_( aeif_psc_exp& n )
+aeif_psc_exp::Buffers_::Buffers_( aeif_psc_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -304,7 +303,7 @@ nest::aeif_psc_exp::Buffers_::Buffers_( aeif_psc_exp& n )
   // init_buffers_().
 }
 
-nest::aeif_psc_exp::Buffers_::Buffers_( const Buffers_&, aeif_psc_exp& n )
+aeif_psc_exp::Buffers_::Buffers_( const Buffers_&, aeif_psc_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -318,7 +317,7 @@ nest::aeif_psc_exp::Buffers_::Buffers_( const Buffers_&, aeif_psc_exp& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::aeif_psc_exp::aeif_psc_exp()
+aeif_psc_exp::aeif_psc_exp()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -327,7 +326,7 @@ nest::aeif_psc_exp::aeif_psc_exp()
   recordablesMap_.create();
 }
 
-nest::aeif_psc_exp::aeif_psc_exp( const aeif_psc_exp& n )
+aeif_psc_exp::aeif_psc_exp( const aeif_psc_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -335,7 +334,7 @@ nest::aeif_psc_exp::aeif_psc_exp( const aeif_psc_exp& n )
 {
 }
 
-nest::aeif_psc_exp::~aeif_psc_exp()
+aeif_psc_exp::~aeif_psc_exp()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -357,7 +356,7 @@ nest::aeif_psc_exp::~aeif_psc_exp()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_exp::init_buffers_()
+aeif_psc_exp::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -407,7 +406,7 @@ nest::aeif_psc_exp::init_buffers_()
 }
 
 void
-nest::aeif_psc_exp::pre_run_hook()
+aeif_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -430,7 +429,7 @@ nest::aeif_psc_exp::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
+aeif_psc_exp::update( const Time& origin, const long from, const long to )
 {
   assert( State_::V_M == 0 );
 
@@ -512,7 +511,7 @@ nest::aeif_psc_exp::update( const Time& origin, const long from, const long to )
 }
 
 void
-nest::aeif_psc_exp::handle( SpikeEvent& e )
+aeif_psc_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -529,7 +528,7 @@ nest::aeif_psc_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::aeif_psc_exp::handle( CurrentEvent& e )
+aeif_psc_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -540,9 +539,11 @@ nest::aeif_psc_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::aeif_psc_exp::handle( DataLoggingRequest& e )
+aeif_psc_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/amat2_psc_exp.cpp
+++ b/models/amat2_psc_exp.cpp
@@ -34,14 +34,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::amat2_psc_exp > nest::amat2_psc_exp::recordablesMap_;
+RecordablesMap< amat2_psc_exp > amat2_psc_exp::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_amat2_psc_exp( const std::string& name )
 {
@@ -63,13 +63,12 @@ RecordablesMap< amat2_psc_exp >::create()
   insert_( names::I_syn_ex, &amat2_psc_exp::get_I_syn_ex_ );
   insert_( names::I_syn_in, &amat2_psc_exp::get_I_syn_in_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::amat2_psc_exp::Parameters_::Parameters_()
+amat2_psc_exp::Parameters_::Parameters_()
   : Tau_( 10.0 )      // in ms
   , C_( 200.0 )       // in pF (R=50MOhm)
   , tau_ref_( 2.0 )   // in ms
@@ -89,7 +88,7 @@ nest::amat2_psc_exp::Parameters_::Parameters_()
 {
 }
 
-nest::amat2_psc_exp::State_::State_()
+amat2_psc_exp::State_::State_()
   : i_0_( 0.0 )
   , I_syn_ex_( 0.0 )
   , I_syn_in_( 0.0 )
@@ -107,7 +106,7 @@ nest::amat2_psc_exp::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::amat2_psc_exp::Parameters_::get( Dictionary& d ) const
+amat2_psc_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;  // Resting potential
   d[ names::I_e ] = I_e_;
@@ -126,7 +125,7 @@ nest::amat2_psc_exp::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::amat2_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
+amat2_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -181,7 +180,7 @@ nest::amat2_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::amat2_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
+amat2_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = V_m_ + p.E_L_;  // Membrane potential
   // Adaptive threshold
@@ -192,7 +191,7 @@ nest::amat2_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::amat2_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+amat2_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, V_m_, node ) )
   {
@@ -208,14 +207,14 @@ nest::amat2_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, dou
   update_value_param( d, names::V_th_v, V_th_v_, node );
 }
 
-nest::amat2_psc_exp::Buffers_::Buffers_( amat2_psc_exp& n )
+amat2_psc_exp::Buffers_::Buffers_( amat2_psc_exp& n )
   : logger_( n )
 {
   // The other member variables are left uninitialised or are
   // automatically initialised by their default constructor.
 }
 
-nest::amat2_psc_exp::Buffers_::Buffers_( const Buffers_&, amat2_psc_exp& n )
+amat2_psc_exp::Buffers_::Buffers_( const Buffers_&, amat2_psc_exp& n )
   : logger_( n )
 {
   // The other member variables are left uninitialised or are
@@ -226,7 +225,7 @@ nest::amat2_psc_exp::Buffers_::Buffers_( const Buffers_&, amat2_psc_exp& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::amat2_psc_exp::amat2_psc_exp()
+amat2_psc_exp::amat2_psc_exp()
   : ArchivingNode()
   , P_()
   , S_()
@@ -235,7 +234,7 @@ nest::amat2_psc_exp::amat2_psc_exp()
   recordablesMap_.create();
 }
 
-nest::amat2_psc_exp::amat2_psc_exp( const amat2_psc_exp& n )
+amat2_psc_exp::amat2_psc_exp( const amat2_psc_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -248,7 +247,7 @@ nest::amat2_psc_exp::amat2_psc_exp( const amat2_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::amat2_psc_exp::init_buffers_()
+amat2_psc_exp::init_buffers_()
 {
   ArchivingNode::clear_history();
 
@@ -260,7 +259,7 @@ nest::amat2_psc_exp::init_buffers_()
 }
 
 void
-nest::amat2_psc_exp::pre_run_hook()
+amat2_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -364,7 +363,7 @@ nest::amat2_psc_exp::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::amat2_psc_exp::update( Time const& origin, const long from, const long to )
+amat2_psc_exp::update( Time const& origin, const long from, const long to )
 {
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
@@ -425,7 +424,7 @@ nest::amat2_psc_exp::update( Time const& origin, const long from, const long to 
 
 
 void
-nest::amat2_psc_exp::handle( SpikeEvent& e )
+amat2_psc_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -442,7 +441,7 @@ nest::amat2_psc_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::amat2_psc_exp::handle( CurrentEvent& e )
+amat2_psc_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -454,7 +453,9 @@ nest::amat2_psc_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::amat2_psc_exp::handle( DataLoggingRequest& e )
+amat2_psc_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/astrocyte_lr_1994.cpp
+++ b/models/astrocyte_lr_1994.cpp
@@ -40,10 +40,11 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-nest::RecordablesMap< nest::astrocyte_lr_1994 > nest::astrocyte_lr_1994::recordablesMap_;
 
 namespace nest
 {
+RecordablesMap< astrocyte_lr_1994 > astrocyte_lr_1994::recordablesMap_;
+
 void
 register_astrocyte_lr_1994( const std::string& name )
 {
@@ -66,11 +67,11 @@ extern "C" int
 astrocyte_lr_1994_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::astrocyte_lr_1994::State_ S;
+  typedef astrocyte_lr_1994::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::astrocyte_lr_1994& node = *( reinterpret_cast< nest::astrocyte_lr_1994* >( pnode ) );
+  const astrocyte_lr_1994& node = *( reinterpret_cast< astrocyte_lr_1994* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -103,13 +104,12 @@ astrocyte_lr_1994_dynamics( double, const double y[], double f[], void* pnode )
 
   return GSL_SUCCESS;
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::astrocyte_lr_1994::Parameters_::Parameters_()
+astrocyte_lr_1994::Parameters_::Parameters_()
   // parameters based on Nadkarni & Jung (2003)
   : Ca_tot_( 2.0 )       // µM
   , IP3_0_( 0.16 )       // µM
@@ -130,7 +130,7 @@ nest::astrocyte_lr_1994::Parameters_::Parameters_()
 {
 }
 
-nest::astrocyte_lr_1994::State_::State_( const Parameters_& p )
+astrocyte_lr_1994::State_::State_( const Parameters_& p )
 {
   // initial values based on Li & Rinzel (1994) and Nadkarni & Jung (2003)
   y_[ IP3 ] = p.IP3_0_;
@@ -138,7 +138,7 @@ nest::astrocyte_lr_1994::State_::State_( const Parameters_& p )
   y_[ h_IP3R ] = 0.793;
 }
 
-nest::astrocyte_lr_1994::State_::State_( const State_& s )
+astrocyte_lr_1994::State_::State_( const State_& s )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
   {
@@ -146,8 +146,8 @@ nest::astrocyte_lr_1994::State_::State_( const State_& s )
   }
 }
 
-nest::astrocyte_lr_1994::State_&
-nest::astrocyte_lr_1994::State_::operator=( const State_& s )
+astrocyte_lr_1994::State_&
+astrocyte_lr_1994::State_::operator=( const State_& s )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
   {
@@ -161,7 +161,7 @@ nest::astrocyte_lr_1994::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::astrocyte_lr_1994::Parameters_::get( Dictionary& d ) const
+astrocyte_lr_1994::Parameters_::get( Dictionary& d ) const
 {
   d[ names::Ca_tot ] = Ca_tot_;
   d[ names::IP3_0 ] = IP3_0_;
@@ -182,7 +182,7 @@ nest::astrocyte_lr_1994::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::astrocyte_lr_1994::Parameters_::set( const Dictionary& d, Node* node )
+astrocyte_lr_1994::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::Ca_tot, Ca_tot_, node );
   update_value_param( d, names::IP3_0, IP3_0_, node );
@@ -272,7 +272,7 @@ nest::astrocyte_lr_1994::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::astrocyte_lr_1994::State_::get( Dictionary& d ) const
+astrocyte_lr_1994::State_::get( Dictionary& d ) const
 {
   d[ names::IP3 ] = y_[ IP3 ];
   d[ names::Ca_astro ] = y_[ Ca_astro ];
@@ -280,7 +280,7 @@ nest::astrocyte_lr_1994::State_::get( Dictionary& d ) const
 }
 
 void
-nest::astrocyte_lr_1994::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+astrocyte_lr_1994::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::IP3, y_[ IP3 ], node );
   update_value_param( d, names::Ca_astro, y_[ Ca_astro ], node );
@@ -300,7 +300,7 @@ nest::astrocyte_lr_1994::State_::set( const Dictionary& d, const Parameters_&, N
   }
 }
 
-nest::astrocyte_lr_1994::Buffers_::Buffers_( astrocyte_lr_1994& n )
+astrocyte_lr_1994::Buffers_::Buffers_( astrocyte_lr_1994& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -310,7 +310,7 @@ nest::astrocyte_lr_1994::Buffers_::Buffers_( astrocyte_lr_1994& n )
   // init_buffers_().
 }
 
-nest::astrocyte_lr_1994::Buffers_::Buffers_( const Buffers_&, astrocyte_lr_1994& n )
+astrocyte_lr_1994::Buffers_::Buffers_( const Buffers_&, astrocyte_lr_1994& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -324,7 +324,7 @@ nest::astrocyte_lr_1994::Buffers_::Buffers_( const Buffers_&, astrocyte_lr_1994&
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::astrocyte_lr_1994::astrocyte_lr_1994()
+astrocyte_lr_1994::astrocyte_lr_1994()
   : Node()
   , P_()
   , S_( P_ )
@@ -333,7 +333,7 @@ nest::astrocyte_lr_1994::astrocyte_lr_1994()
   recordablesMap_.create();
 }
 
-nest::astrocyte_lr_1994::astrocyte_lr_1994( const astrocyte_lr_1994& n )
+astrocyte_lr_1994::astrocyte_lr_1994( const astrocyte_lr_1994& n )
   : Node( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -341,7 +341,7 @@ nest::astrocyte_lr_1994::astrocyte_lr_1994( const astrocyte_lr_1994& n )
 {
 }
 
-nest::astrocyte_lr_1994::~astrocyte_lr_1994()
+astrocyte_lr_1994::~astrocyte_lr_1994()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -363,7 +363,7 @@ nest::astrocyte_lr_1994::~astrocyte_lr_1994()
  * ---------------------------------------------------------------- */
 
 void
-nest::astrocyte_lr_1994::init_buffers_()
+astrocyte_lr_1994::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.currents_.clear();
@@ -411,7 +411,7 @@ nest::astrocyte_lr_1994::init_buffers_()
 }
 
 void
-nest::astrocyte_lr_1994::pre_run_hook()
+astrocyte_lr_1994::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -427,7 +427,7 @@ nest::astrocyte_lr_1994::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 inline void
-nest::astrocyte_lr_1994::update( Time const& origin, const long from, const long to )
+astrocyte_lr_1994::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -488,7 +488,7 @@ nest::astrocyte_lr_1994::update( Time const& origin, const long from, const long
 }
 
 void
-nest::astrocyte_lr_1994::handle( SpikeEvent& e )
+astrocyte_lr_1994::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -504,7 +504,7 @@ nest::astrocyte_lr_1994::handle( SpikeEvent& e )
 }
 
 void
-nest::astrocyte_lr_1994::handle( CurrentEvent& e )
+astrocyte_lr_1994::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -515,9 +515,11 @@ nest::astrocyte_lr_1994::handle( CurrentEvent& e )
 }
 
 void
-nest::astrocyte_lr_1994::handle( DataLoggingRequest& e )
+astrocyte_lr_1994::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/bernoulli_synapse.cpp
+++ b/models/bernoulli_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_bernoulli_synapse( const std::string& name )
+register_bernoulli_synapse( const std::string& name )
 {
   register_connection_model< bernoulli_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/binary_neuron.h
+++ b/models/binary_neuron.h
@@ -316,7 +316,7 @@ binary_neuron< TGainfunction >::set_status( const Dictionary& d )
 }
 
 template < typename TGainfunction >
-RecordablesMap< nest::binary_neuron< TGainfunction > > nest::binary_neuron< TGainfunction >::recordablesMap_;
+RecordablesMap< binary_neuron< TGainfunction > > binary_neuron< TGainfunction >::recordablesMap_;
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state

--- a/models/clopath_synapse.cpp
+++ b/models/clopath_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_clopath_synapse( const std::string& name )
+register_clopath_synapse( const std::string& name )
 {
   register_connection_model< clopath_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/cm_compartmentcurrents.cpp
+++ b/models/cm_compartmentcurrents.cpp
@@ -22,7 +22,9 @@
 #include "cm_compartmentcurrents.h"
 
 
-nest::Na::Na( double v_comp )
+namespace nest
+{
+Na::Na( double v_comp )
   // state variables
   : m_Na_( 0.0 )
   , h_Na_( 0.0 )
@@ -34,7 +36,7 @@ nest::Na::Na( double v_comp )
   // some default initialization
   init_statevars( v_comp );
 }
-nest::Na::Na( double v_comp, const Dictionary& channel_params )
+Na::Na( double v_comp, const Dictionary& channel_params )
   // state variables
   : m_Na_( 0.0 )
   , h_Na_( 0.0 )
@@ -57,7 +59,7 @@ nest::Na::Na( double v_comp, const Dictionary& channel_params )
 }
 
 void
-nest::Na::init_statevars( double v_init )
+Na::init_statevars( double v_init )
 {
   std::pair< double, double > sv( 0., 0. );
 
@@ -68,14 +70,14 @@ nest::Na::init_statevars( double v_init )
 }
 
 void
-nest::Na::append_recordables( std::map< std::string, double* >* recordables, const long compartment_idx )
+Na::append_recordables( std::map< std::string, double* >* recordables, const long compartment_idx )
 {
   ( *recordables )[ "m_Na_" + std::to_string( compartment_idx ) ] = &m_Na_;
   ( *recordables )[ "h_Na_" + std::to_string( compartment_idx ) ] = &h_Na_;
 }
 
 std::pair< double, double >
-nest::Na::compute_statevar_m( const double v_comp )
+Na::compute_statevar_m( const double v_comp )
 {
   /**
    * Channel rate equations from the following .mod file:
@@ -110,7 +112,7 @@ nest::Na::compute_statevar_m( const double v_comp )
 }
 
 std::pair< double, double >
-nest::Na::compute_statevar_h( const double v_comp )
+Na::compute_statevar_h( const double v_comp )
 {
   /**
    * Channel rate equations from the following .mod file:
@@ -147,7 +149,7 @@ nest::Na::compute_statevar_h( const double v_comp )
 }
 
 std::pair< double, double >
-nest::Na::f_numstep( const double v_comp )
+Na::f_numstep( const double v_comp )
 {
   const double dt = Time::get_resolution().get_ms();
   double g_val = 0., i_val = 0.;
@@ -186,7 +188,7 @@ nest::Na::f_numstep( const double v_comp )
 }
 
 
-nest::K::K( double v_comp )
+K::K( double v_comp )
   // state variables
   : n_K_( 0.0 )
   // parameters
@@ -197,7 +199,7 @@ nest::K::K( double v_comp )
   init_statevars( v_comp );
 }
 
-nest::K::K( double v_comp, const Dictionary& channel_params )
+K::K( double v_comp, const Dictionary& channel_params )
   // state variables
   : n_K_( 0.0 )
   // parameters
@@ -220,7 +222,7 @@ nest::K::K( double v_comp, const Dictionary& channel_params )
 }
 
 void
-nest::K::init_statevars( double v_init )
+K::init_statevars( double v_init )
 {
   std::pair< double, double > sv( 0., 0. );
   sv = compute_statevar_n( v_init );
@@ -228,13 +230,13 @@ nest::K::init_statevars( double v_init )
 }
 
 void
-nest::K::append_recordables( std::map< std::string, double* >* recordables, const long compartment_idx )
+K::append_recordables( std::map< std::string, double* >* recordables, const long compartment_idx )
 {
   ( *recordables )[ "n_K_" + std::to_string( compartment_idx ) ] = &n_K_;
 }
 
 std::pair< double, double >
-nest::K::compute_statevar_n( const double v_comp )
+K::compute_statevar_n( const double v_comp )
 {
   /**
    * Channel rate equations from the following .mod file:
@@ -270,7 +272,7 @@ nest::K::compute_statevar_n( const double v_comp )
 }
 
 std::pair< double, double >
-nest::K::f_numstep( const double v_comp )
+K::f_numstep( const double v_comp )
 {
   const double dt = Time::get_resolution().get_ms();
   double g_val = 0., i_val = 0.;
@@ -299,7 +301,7 @@ nest::K::f_numstep( const double v_comp )
 }
 
 
-nest::AMPA::AMPA( const long syn_index )
+AMPA::AMPA( const long syn_index )
   // initialization state variables
   : g_r_AMPA_( 0.0 )
   , g_d_AMPA_( 0.0 )
@@ -318,7 +320,7 @@ nest::AMPA::AMPA( const long syn_index )
   g_norm_ = 1. / ( -std::exp( -tp / tau_r_ ) + std::exp( -tp / tau_d_ ) );
 }
 
-nest::AMPA::AMPA( const long syn_index, const Dictionary& receptor_params )
+AMPA::AMPA( const long syn_index, const Dictionary& receptor_params )
   // initialization state variables
   : g_r_AMPA_( 0.0 )
   , g_d_AMPA_( 0.0 )
@@ -352,14 +354,14 @@ nest::AMPA::AMPA( const long syn_index, const Dictionary& receptor_params )
 }
 
 void
-nest::AMPA::append_recordables( std::map< std::string, double* >* recordables )
+AMPA::append_recordables( std::map< std::string, double* >* recordables )
 {
   ( *recordables )[ "g_r_AMPA_" + std::to_string( syn_idx ) ] = &g_r_AMPA_;
   ( *recordables )[ "g_d_AMPA_" + std::to_string( syn_idx ) ] = &g_d_AMPA_;
 }
 
 std::pair< double, double >
-nest::AMPA::f_numstep( const double v_comp, const long lag )
+AMPA::f_numstep( const double v_comp, const long lag )
 {
   // update conductance
   g_r_AMPA_ *= prop_r_;
@@ -386,7 +388,7 @@ nest::AMPA::f_numstep( const double v_comp, const long lag )
 }
 
 
-nest::GABA::GABA( const long syn_index )
+GABA::GABA( const long syn_index )
   // initialization state variables
   : g_r_GABA_( 0.0 )
   , g_d_GABA_( 0.0 )
@@ -405,7 +407,7 @@ nest::GABA::GABA( const long syn_index )
   g_norm_ = 1. / ( -std::exp( -tp / tau_r_ ) + std::exp( -tp / tau_d_ ) );
 }
 
-nest::GABA::GABA( const long syn_index, const Dictionary& receptor_params )
+GABA::GABA( const long syn_index, const Dictionary& receptor_params )
   // initialization state variables
   : g_r_GABA_( 0.0 )
   , g_d_GABA_( 0.0 )
@@ -439,14 +441,14 @@ nest::GABA::GABA( const long syn_index, const Dictionary& receptor_params )
 }
 
 void
-nest::GABA::append_recordables( std::map< std::string, double* >* recordables )
+GABA::append_recordables( std::map< std::string, double* >* recordables )
 {
   ( *recordables )[ "g_r_GABA_" + std::to_string( syn_idx ) ] = &g_r_GABA_;
   ( *recordables )[ "g_d_GABA_" + std::to_string( syn_idx ) ] = &g_d_GABA_;
 }
 
 std::pair< double, double >
-nest::GABA::f_numstep( const double v_comp, const long lag )
+GABA::f_numstep( const double v_comp, const long lag )
 {
   // update conductance
   g_r_GABA_ *= prop_r_;
@@ -473,7 +475,7 @@ nest::GABA::f_numstep( const double v_comp, const long lag )
 }
 
 
-nest::NMDA::NMDA( const long syn_index )
+NMDA::NMDA( const long syn_index )
   // initialization state variables
   : g_r_NMDA_( 0.0 )
   , g_d_NMDA_( 0.0 )
@@ -492,7 +494,7 @@ nest::NMDA::NMDA( const long syn_index )
   g_norm_ = 1. / ( -std::exp( -tp / tau_r_ ) + std::exp( -tp / tau_d_ ) );
 }
 
-nest::NMDA::NMDA( const long syn_index, const Dictionary& receptor_params )
+NMDA::NMDA( const long syn_index, const Dictionary& receptor_params )
   // initialization state variables
   : g_r_NMDA_( 0.0 )
   , g_d_NMDA_( 0.0 )
@@ -526,14 +528,14 @@ nest::NMDA::NMDA( const long syn_index, const Dictionary& receptor_params )
 }
 
 void
-nest::NMDA::append_recordables( std::map< std::string, double* >* recordables )
+NMDA::append_recordables( std::map< std::string, double* >* recordables )
 {
   ( *recordables )[ "g_r_NMDA_" + std::to_string( syn_idx ) ] = &g_r_NMDA_;
   ( *recordables )[ "g_d_NMDA_" + std::to_string( syn_idx ) ] = &g_d_NMDA_;
 }
 
 std::pair< double, double >
-nest::NMDA::f_numstep( const double v_comp, const long lag )
+NMDA::f_numstep( const double v_comp, const long lag )
 {
   // update conductance
   g_r_NMDA_ *= prop_r_;
@@ -563,7 +565,7 @@ nest::NMDA::f_numstep( const double v_comp, const long lag )
 }
 
 
-nest::AMPA_NMDA::AMPA_NMDA( const long syn_index )
+AMPA_NMDA::AMPA_NMDA( const long syn_index )
   // initialization state variables
   : g_r_AN_AMPA_( 0.0 )
   , g_d_AN_AMPA_( 0.0 )
@@ -594,7 +596,7 @@ nest::AMPA_NMDA::AMPA_NMDA( const long syn_index )
   g_norm_NMDA_ = 1. / ( -std::exp( -tp / tau_r_NMDA_ ) + std::exp( -tp / tau_d_NMDA_ ) );
 }
 
-nest::AMPA_NMDA::AMPA_NMDA( const long syn_index, const Dictionary& receptor_params )
+AMPA_NMDA::AMPA_NMDA( const long syn_index, const Dictionary& receptor_params )
   // initialization state variables
   : g_r_AN_AMPA_( 0.0 )
   , g_d_AN_AMPA_( 0.0 )
@@ -652,7 +654,7 @@ nest::AMPA_NMDA::AMPA_NMDA( const long syn_index, const Dictionary& receptor_par
 }
 
 void
-nest::AMPA_NMDA::append_recordables( std::map< std::string, double* >* recordables )
+AMPA_NMDA::append_recordables( std::map< std::string, double* >* recordables )
 {
   ( *recordables )[ "g_r_AN_AMPA_" + std::to_string( syn_idx ) ] = &g_r_AN_AMPA_;
   ( *recordables )[ "g_d_AN_AMPA_" + std::to_string( syn_idx ) ] = &g_d_AN_AMPA_;
@@ -661,7 +663,7 @@ nest::AMPA_NMDA::append_recordables( std::map< std::string, double* >* recordabl
 }
 
 std::pair< double, double >
-nest::AMPA_NMDA::f_numstep( const double v_comp, const long lag )
+AMPA_NMDA::f_numstep( const double v_comp, const long lag )
 {
   // update conductance
   g_r_AN_AMPA_ *= prop_r_AMPA_;
@@ -699,14 +701,16 @@ nest::AMPA_NMDA::f_numstep( const double v_comp, const long lag )
 }
 
 
-nest::CompartmentCurrents::CompartmentCurrents( double v_comp )
+CompartmentCurrents::CompartmentCurrents( double v_comp )
   : Na_chan_( v_comp )
   , K_chan_( v_comp )
 {
 }
 
-nest::CompartmentCurrents::CompartmentCurrents( double v_comp, const Dictionary& channel_params )
+CompartmentCurrents::CompartmentCurrents( double v_comp, const Dictionary& channel_params )
   : Na_chan_( v_comp, channel_params )
   , K_chan_( v_comp, channel_params )
 {
 }
+
+}  // namespace nest

--- a/models/cm_default.cpp
+++ b/models/cm_default.cpp
@@ -25,6 +25,7 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -50,7 +51,7 @@ DynamicRecordablesMap< cm_default >::create( cm_default& host )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::cm_default::cm_default()
+cm_default::cm_default()
   : ArchivingNode()
   , c_tree_()
   , syn_buffers_( 0 )
@@ -61,7 +62,7 @@ nest::cm_default::cm_default()
   recordables_values.resize( 0 );
 }
 
-nest::cm_default::cm_default( const cm_default& n )
+cm_default::cm_default( const cm_default& n )
   : ArchivingNode( n )
   , c_tree_( n.c_tree_ )
   , syn_buffers_( n.syn_buffers_ )
@@ -107,7 +108,7 @@ cm_default::get_status( Dictionary& statusdict ) const
 }
 
 void
-nest::cm_default::set_status( const Dictionary& statusdict )
+cm_default::set_status( const Dictionary& statusdict )
 {
   statusdict.update_value( names::V_th, V_th_ );
   ArchivingNode::set_status( statusdict );
@@ -212,7 +213,7 @@ nest::cm_default::set_status( const Dictionary& statusdict )
 }
 
 void
-nest::cm_default::add_compartment_( const Dictionary& dd )
+cm_default::add_compartment_( const Dictionary& dd )
 {
   dd.init_access_flags();
 
@@ -229,7 +230,7 @@ nest::cm_default::add_compartment_( const Dictionary& dd )
 }
 
 void
-nest::cm_default::add_receptor_( const Dictionary& dd )
+cm_default::add_receptor_( const Dictionary& dd )
 {
   dd.init_access_flags();
 
@@ -258,7 +259,7 @@ nest::cm_default::add_receptor_( const Dictionary& dd )
 }
 
 void
-nest::cm_default::init_recordables_pointers_()
+cm_default::init_recordables_pointers_()
 {
   /**
    * Get the map of all recordables (i.e. all state variables of the model):
@@ -291,7 +292,7 @@ nest::cm_default::init_recordables_pointers_()
 }
 
 void
-nest::cm_default::pre_run_hook()
+cm_default::pre_run_hook()
 {
   logger_.init();
 
@@ -309,7 +310,7 @@ nest::cm_default::pre_run_hook()
  * Update and spike handling functions
  */
 void
-nest::cm_default::update( Time const& origin, const long from, const long to )
+cm_default::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -332,7 +333,7 @@ nest::cm_default::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::cm_default::handle( SpikeEvent& e )
+cm_default::handle( SpikeEvent& e )
 {
   if ( e.get_weight() < 0 )
   {
@@ -347,7 +348,7 @@ nest::cm_default::handle( SpikeEvent& e )
 }
 
 void
-nest::cm_default::handle( CurrentEvent& e )
+cm_default::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -359,9 +360,9 @@ nest::cm_default::handle( CurrentEvent& e )
 }
 
 void
-nest::cm_default::handle( DataLoggingRequest& e )
+cm_default::handle( DataLoggingRequest& e )
 {
   logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/cm_default.h
+++ b/models/cm_default.h
@@ -305,7 +305,7 @@ private:
 
 
 inline size_t
-nest::cm_default::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+cm_default::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -49,9 +49,7 @@ Compartment::Compartment( const long compartment_index, const long parent_index 
   compartment_currents = CompartmentCurrents( v_comp );
 }
 
-Compartment::Compartment( const long compartment_index,
-  const long parent_index,
-  const Dictionary& compartment_params )
+Compartment::Compartment( const long compartment_index, const long parent_index, const Dictionary& compartment_params )
   : xx_( 0.0 )
   , yy_( 0.0 )
   , comp_index( compartment_index )

--- a/models/cm_tree.cpp
+++ b/models/cm_tree.cpp
@@ -22,7 +22,9 @@
 #include "cm_tree.h"
 
 
-nest::Compartment::Compartment( const long compartment_index, const long parent_index )
+namespace nest
+{
+Compartment::Compartment( const long compartment_index, const long parent_index )
   : xx_( 0.0 )
   , yy_( 0.0 )
   , comp_index( compartment_index )
@@ -47,7 +49,7 @@ nest::Compartment::Compartment( const long compartment_index, const long parent_
   compartment_currents = CompartmentCurrents( v_comp );
 }
 
-nest::Compartment::Compartment( const long compartment_index,
+Compartment::Compartment( const long compartment_index,
   const long parent_index,
   const Dictionary& compartment_params )
   : xx_( 0.0 )
@@ -85,7 +87,7 @@ nest::Compartment::Compartment( const long compartment_index,
 }
 
 void
-nest::Compartment::pre_run_hook()
+Compartment::pre_run_hook()
 {
   compartment_currents.pre_run_hook();
 
@@ -101,7 +103,7 @@ nest::Compartment::pre_run_hook()
 }
 
 std::map< std::string, double* >
-nest::Compartment::get_recordables()
+Compartment::get_recordables()
 {
   std::map< std::string, double* > recordables = compartment_currents.get_recordables( comp_index );
 
@@ -113,7 +115,7 @@ nest::Compartment::get_recordables()
 
 // for matrix construction
 void
-nest::Compartment::construct_matrix_element( const long lag )
+Compartment::construct_matrix_element( const long lag )
 {
   // matrix diagonal element
   gg = gg0;
@@ -153,7 +155,7 @@ nest::Compartment::construct_matrix_element( const long lag )
 }
 
 
-nest::CompTree::CompTree()
+CompTree::CompTree()
   : root_( -1, -1 )
   , size_( 0 )
 {
@@ -167,21 +169,21 @@ nest::CompTree::CompTree()
  * Assumes parent of compartment is already added
  */
 void
-nest::CompTree::add_compartment( const long parent_index )
+CompTree::add_compartment( const long parent_index )
 {
   Compartment* compartment = new Compartment( size_, parent_index );
   add_compartment( compartment, parent_index );
 }
 
 void
-nest::CompTree::add_compartment( const long parent_index, const Dictionary& compartment_params )
+CompTree::add_compartment( const long parent_index, const Dictionary& compartment_params )
 {
   Compartment* compartment = new Compartment( size_, parent_index, compartment_params );
   add_compartment( compartment, parent_index );
 }
 
 void
-nest::CompTree::add_compartment( Compartment* compartment, const long parent_index )
+CompTree::add_compartment( Compartment* compartment, const long parent_index )
 {
   size_++;
 
@@ -226,14 +228,14 @@ nest::CompTree::add_compartment( Compartment* compartment, const long parent_ind
  * and also has the option to throw an error if no compartment corresponding to
  * `compartment_index` is found in the tree
  */
-nest::Compartment*
-nest::CompTree::get_compartment( const long compartment_index ) const
+Compartment*
+CompTree::get_compartment( const long compartment_index ) const
 {
   return get_compartment( compartment_index, get_root(), 1 );
 }
 
-nest::Compartment*
-nest::CompTree::get_compartment( const long compartment_index, Compartment* compartment, const long raise_flag ) const
+Compartment*
+CompTree::get_compartment( const long compartment_index, Compartment* compartment, const long raise_flag ) const
 {
   Compartment* r_compartment = nullptr;
 
@@ -266,8 +268,8 @@ nest::CompTree::get_compartment( const long compartment_index, Compartment* comp
  * function before CompTree::init_pointers() is called will result in a segmentation
  * fault
  */
-nest::Compartment*
-nest::CompTree::get_compartment_opt( const long compartment_idx ) const
+Compartment*
+CompTree::get_compartment_opt( const long compartment_idx ) const
 {
   return compartments_[ compartment_idx ];
 }
@@ -276,7 +278,7 @@ nest::CompTree::get_compartment_opt( const long compartment_idx ) const
  * Initialize all tree structure pointers
  */
 void
-nest::CompTree::init_pointers()
+CompTree::init_pointers()
 {
   set_parents();
   set_compartments();
@@ -287,7 +289,7 @@ nest::CompTree::init_pointers()
  * For each compartments, sets its pointer towards its parent compartment
  */
 void
-nest::CompTree::set_parents()
+CompTree::set_parents()
 {
   for ( auto compartment_idx_it = compartment_indices_.begin(); compartment_idx_it != compartment_indices_.end();
     ++compartment_idx_it )
@@ -304,7 +306,7 @@ nest::CompTree::set_parents()
  * added by `add_compartment()`
  */
 void
-nest::CompTree::set_compartments()
+CompTree::set_compartments()
 {
   compartments_.clear();
 
@@ -319,7 +321,7 @@ nest::CompTree::set_compartments()
  * Creates a vector of compartment pointers of compartments that are also leafs of the tree.
  */
 void
-nest::CompTree::set_leafs()
+CompTree::set_leafs()
 {
   leafs_.clear();
   for ( auto compartment_it = compartments_.begin(); compartment_it != compartments_.end(); ++compartment_it )
@@ -335,7 +337,7 @@ nest::CompTree::set_leafs()
  * Initializes pointers for the spike buffers for all synapse receptors
  */
 void
-nest::CompTree::set_syn_buffers( std::vector< RingBuffer >& syn_buffers )
+CompTree::set_syn_buffers( std::vector< RingBuffer >& syn_buffers )
 {
   for ( auto compartment_it = compartments_.begin(); compartment_it != compartments_.end(); ++compartment_it )
   {
@@ -347,7 +349,7 @@ nest::CompTree::set_syn_buffers( std::vector< RingBuffer >& syn_buffers )
  * Returns a map of variable names and pointers to the recordables
  */
 std::map< std::string, double* >
-nest::CompTree::get_recordables()
+CompTree::get_recordables()
 {
   std::map< std::string, double* > recordables;
 
@@ -367,7 +369,7 @@ nest::CompTree::get_recordables()
  * Initialize state variables
  */
 void
-nest::CompTree::pre_run_hook()
+CompTree::pre_run_hook()
 {
   if ( root_.comp_index < 0 )
   {
@@ -386,7 +388,7 @@ nest::CompTree::pre_run_hook()
  * Returns vector of voltage values, indices correspond to compartments in `compartments_`
  */
 std::vector< double >
-nest::CompTree::get_voltage() const
+CompTree::get_voltage() const
 {
   std::vector< double > v_comps;
   for ( auto compartment_it = compartments_.cbegin(); compartment_it != compartments_.cend(); ++compartment_it )
@@ -400,7 +402,7 @@ nest::CompTree::get_voltage() const
  * Return voltage of single compartment voltage, indicated by the compartment_index
  */
 double
-nest::CompTree::get_compartment_voltage( const long compartment_index )
+CompTree::get_compartment_voltage( const long compartment_index )
 {
   return compartments_[ compartment_index ]->v_comp;
 }
@@ -409,7 +411,7 @@ nest::CompTree::get_compartment_voltage( const long compartment_index )
  * Construct the matrix equation to be solved to advance the model one timestep
  */
 void
-nest::CompTree::construct_matrix( const long lag )
+CompTree::construct_matrix( const long lag )
 {
   for ( auto compartment_it = compartments_.begin(); compartment_it != compartments_.end(); ++compartment_it )
   {
@@ -421,7 +423,7 @@ nest::CompTree::construct_matrix( const long lag )
  * Solve matrix with O(n) algorithm
  */
 void
-nest::CompTree::solve_matrix()
+CompTree::solve_matrix()
 {
   std::vector< Compartment* >::iterator leaf_it = leafs_.begin();
 
@@ -433,7 +435,7 @@ nest::CompTree::solve_matrix()
 }
 
 void
-nest::CompTree::solve_matrix_downsweep( Compartment* compartment, std::vector< Compartment* >::iterator leaf_it )
+CompTree::solve_matrix_downsweep( Compartment* compartment, std::vector< Compartment* >::iterator leaf_it )
 {
   // compute the input output transformation at compartment
   std::pair< double, double > output = compartment->io();
@@ -465,7 +467,7 @@ nest::CompTree::solve_matrix_downsweep( Compartment* compartment, std::vector< C
 }
 
 void
-nest::CompTree::solve_matrix_upsweep( Compartment* compartment, double vv )
+CompTree::solve_matrix_upsweep( Compartment* compartment, double vv )
 {
   // compute compartment voltage
   vv = compartment->calc_v( vv );
@@ -480,7 +482,7 @@ nest::CompTree::solve_matrix_upsweep( Compartment* compartment, double vv )
  * Print the tree graph
  */
 void
-nest::CompTree::print_tree() const
+CompTree::print_tree() const
 {
   // loop over all compartments
   std::printf( ">>> CM tree with %d compartments <<<\n", int( compartments_.size() ) );
@@ -500,3 +502,5 @@ nest::CompTree::print_tree() const
   }
   std::cout << std::endl;
 }
+
+}  // namespace nest

--- a/models/cm_tree.h
+++ b/models/cm_tree.h
@@ -109,14 +109,14 @@ public:
 Short helper functions for solving the matrix equation. Can hopefully be inlined
 */
 inline void
-nest::Compartment::gather_input( const std::pair< double, double >& in )
+Compartment::gather_input( const std::pair< double, double >& in )
 {
   xx_ += in.first;
   yy_ += in.second;
 }
 
 inline std::pair< double, double >
-nest::Compartment::io()
+Compartment::io()
 {
   // include inputs from child compartments
   gg -= xx_;
@@ -130,7 +130,7 @@ nest::Compartment::io()
 }
 
 inline double
-nest::Compartment::calc_v( const double v_in )
+Compartment::calc_v( const double v_in )
 {
   // reset recursion variables
   xx_ = 0.0;

--- a/models/cont_delay_synapse.cpp
+++ b/models/cont_delay_synapse.cpp
@@ -26,8 +26,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_cont_delay_synapse( const std::string& name )
+register_cont_delay_synapse( const std::string& name )
 {
   register_connection_model< cont_delay_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/correlation_detector.cpp
+++ b/models/correlation_detector.cpp
@@ -35,8 +35,11 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_correlation_detector( const std::string& name )
+register_correlation_detector( const std::string& name )
 {
   register_node_model< correlation_detector >( name );
 }
@@ -45,7 +48,7 @@ nest::register_correlation_detector( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::correlation_detector::Parameters_::Parameters_()
+correlation_detector::Parameters_::Parameters_()
   : delta_tau_( get_default_delta_tau() )
   , tau_max_( 10 * delta_tau_ )
   , Tstart_( Time::ms( 0.0 ) )
@@ -53,7 +56,7 @@ nest::correlation_detector::Parameters_::Parameters_()
 {
 }
 
-nest::correlation_detector::Parameters_::Parameters_( const Parameters_& p )
+correlation_detector::Parameters_::Parameters_( const Parameters_& p )
   : delta_tau_( p.delta_tau_ )
   , tau_max_( p.tau_max_ )
   , Tstart_( p.Tstart_ )
@@ -73,8 +76,8 @@ nest::correlation_detector::Parameters_::Parameters_( const Parameters_& p )
   Tstop_.calibrate();
 }
 
-nest::correlation_detector::Parameters_&
-nest::correlation_detector::Parameters_::operator=( const Parameters_& p )
+correlation_detector::Parameters_&
+correlation_detector::Parameters_::operator=( const Parameters_& p )
 {
   delta_tau_ = p.delta_tau_;
   tau_max_ = p.tau_max_;
@@ -89,7 +92,7 @@ nest::correlation_detector::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::correlation_detector::State_::State_()
+correlation_detector::State_::State_()
   : n_events_( 2, 0 )
   , incoming_( 2 )
   , histogram_()
@@ -104,7 +107,7 @@ nest::correlation_detector::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::correlation_detector::Parameters_::get( Dictionary& d ) const
+correlation_detector::Parameters_::get( Dictionary& d ) const
 {
   d[ names::delta_tau ] = delta_tau_.get_ms();
   d[ names::tau_max ] = tau_max_.get_ms();
@@ -113,7 +116,7 @@ nest::correlation_detector::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::correlation_detector::State_::get( Dictionary& d ) const
+correlation_detector::State_::get( Dictionary& d ) const
 {
   d[ names::n_events ] = n_events_;
   d[ names::histogram ] = histogram_;
@@ -122,7 +125,7 @@ nest::correlation_detector::State_::get( Dictionary& d ) const
 }
 
 bool
-nest::correlation_detector::Parameters_::set( const Dictionary& d, const correlation_detector& n, Node* node )
+correlation_detector::Parameters_::set( const Dictionary& d, const correlation_detector& n, Node* node )
 {
   bool reset = false;
   double t;
@@ -164,7 +167,7 @@ nest::correlation_detector::Parameters_::set( const Dictionary& d, const correla
 }
 
 void
-nest::correlation_detector::State_::set( const Dictionary& d, const Parameters_& p, bool reset_required, Node* )
+correlation_detector::State_::set( const Dictionary& d, const Parameters_& p, bool reset_required, Node* )
 {
   std::vector< long > nev;
   if ( d.update_value( names::n_events, nev ) )
@@ -185,7 +188,7 @@ nest::correlation_detector::State_::set( const Dictionary& d, const Parameters_&
 }
 
 void
-nest::correlation_detector::State_::reset( const Parameters_& p )
+correlation_detector::State_::reset( const Parameters_& p )
 {
   n_events_.clear();
   n_events_.resize( 2, 0 );
@@ -208,7 +211,7 @@ nest::correlation_detector::State_::reset( const Parameters_& p )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::correlation_detector::correlation_detector()
+correlation_detector::correlation_detector()
   : Node()
   , device_()
   , P_()
@@ -216,7 +219,7 @@ nest::correlation_detector::correlation_detector()
 {
 }
 
-nest::correlation_detector::correlation_detector( const correlation_detector& n )
+correlation_detector::correlation_detector( const correlation_detector& n )
   : Node( n )
   , device_( n.device_ )
   , P_( n.P_ )
@@ -230,20 +233,20 @@ nest::correlation_detector::correlation_detector( const correlation_detector& n 
  * ---------------------------------------------------------------- */
 
 void
-nest::correlation_detector::init_state_()
+correlation_detector::init_state_()
 {
   device_.init_state();
 }
 
 void
-nest::correlation_detector::init_buffers_()
+correlation_detector::init_buffers_()
 {
   device_.init_buffers();
   S_.reset( P_ );
 }
 
 void
-nest::correlation_detector::pre_run_hook()
+correlation_detector::pre_run_hook()
 {
   device_.pre_run_hook();
 }
@@ -254,12 +257,12 @@ nest::correlation_detector::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::correlation_detector::update( Time const&, const long, const long )
+correlation_detector::update( Time const&, const long, const long )
 {
 }
 
 void
-nest::correlation_detector::handle( SpikeEvent& e )
+correlation_detector::handle( SpikeEvent& e )
 {
   // The receiver port identifies the sending node in our
   // sender list.
@@ -348,7 +351,7 @@ nest::correlation_detector::handle( SpikeEvent& e )
 }
 
 void
-nest::correlation_detector::calibrate_time( const TimeConverter& tc )
+correlation_detector::calibrate_time( const TimeConverter& tc )
 {
   if ( P_.delta_tau_.is_step() )
   {
@@ -366,3 +369,5 @@ nest::correlation_detector::calibrate_time( const TimeConverter& tc )
   P_.Tstart_ = tc.from_old_tics( P_.Tstart_.get_tics() );
   P_.Tstop_ = tc.from_old_tics( P_.Tstop_.get_tics() );
 }
+
+}  // namespace nest

--- a/models/correlomatrix_detector.cpp
+++ b/models/correlomatrix_detector.cpp
@@ -37,8 +37,10 @@
 #include "nest_impl.h"
 
 
+namespace nest
+{
 void
-nest::register_correlomatrix_detector( const std::string& name )
+register_correlomatrix_detector( const std::string& name )
 {
   register_node_model< correlomatrix_detector >( name );
 }
@@ -48,7 +50,7 @@ nest::register_correlomatrix_detector( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::correlomatrix_detector::Parameters_::Parameters_()
+correlomatrix_detector::Parameters_::Parameters_()
   : delta_tau_( get_default_delta_tau() )
   , tau_max_( 10 * delta_tau_ )
   , Tstart_( Time::ms( 0.0 ) )
@@ -57,7 +59,7 @@ nest::correlomatrix_detector::Parameters_::Parameters_()
 {
 }
 
-nest::correlomatrix_detector::Parameters_::Parameters_( const Parameters_& p )
+correlomatrix_detector::Parameters_::Parameters_( const Parameters_& p )
   : delta_tau_( p.delta_tau_ )
   , tau_max_( p.tau_max_ )
   , Tstart_( p.Tstart_ )
@@ -78,8 +80,8 @@ nest::correlomatrix_detector::Parameters_::Parameters_( const Parameters_& p )
   Tstop_.calibrate();
 }
 
-nest::correlomatrix_detector::Parameters_&
-nest::correlomatrix_detector::Parameters_::operator=( const Parameters_& p )
+correlomatrix_detector::Parameters_&
+correlomatrix_detector::Parameters_::operator=( const Parameters_& p )
 {
   delta_tau_ = p.delta_tau_;
   tau_max_ = p.tau_max_;
@@ -95,7 +97,7 @@ nest::correlomatrix_detector::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::correlomatrix_detector::State_::State_()
+correlomatrix_detector::State_::State_()
   : n_events_( 1, 0 )
   , incoming_()
   , covariance_( 1, std::vector< std::vector< double > >( 1, std::vector< double >() ) )
@@ -109,7 +111,7 @@ nest::correlomatrix_detector::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::correlomatrix_detector::Parameters_::get( Dictionary& d ) const
+correlomatrix_detector::Parameters_::get( Dictionary& d ) const
 {
   d[ names::delta_tau ] = delta_tau_.get_ms();
   d[ names::tau_max ] = tau_max_.get_ms();
@@ -119,7 +121,7 @@ nest::correlomatrix_detector::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::correlomatrix_detector::State_::get( Dictionary& d ) const
+correlomatrix_detector::State_::get( Dictionary& d ) const
 {
   d[ names::n_events ] = n_events_;
   d[ names::covariance ] = covariance_;
@@ -127,7 +129,7 @@ nest::correlomatrix_detector::State_::get( Dictionary& d ) const
 }
 
 bool
-nest::correlomatrix_detector::Parameters_::set( const Dictionary& d, const correlomatrix_detector& n, Node* node )
+correlomatrix_detector::Parameters_::set( const Dictionary& d, const correlomatrix_detector& n, Node* node )
 {
   bool reset = false;
   double t;
@@ -189,12 +191,12 @@ nest::correlomatrix_detector::Parameters_::set( const Dictionary& d, const corre
 }
 
 void
-nest::correlomatrix_detector::State_::set( const Dictionary&, const Parameters_&, bool, Node* )
+correlomatrix_detector::State_::set( const Dictionary&, const Parameters_&, bool, Node* )
 {
 }
 
 void
-nest::correlomatrix_detector::State_::reset( const Parameters_& p )
+correlomatrix_detector::State_::reset( const Parameters_& p )
 {
   n_events_.clear();
   n_events_.resize( p.N_channels_, 0 );
@@ -225,7 +227,7 @@ nest::correlomatrix_detector::State_::reset( const Parameters_& p )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::correlomatrix_detector::correlomatrix_detector()
+correlomatrix_detector::correlomatrix_detector()
   : Node()
   , device_()
   , P_()
@@ -233,7 +235,7 @@ nest::correlomatrix_detector::correlomatrix_detector()
 {
 }
 
-nest::correlomatrix_detector::correlomatrix_detector( const correlomatrix_detector& n )
+correlomatrix_detector::correlomatrix_detector( const correlomatrix_detector& n )
   : Node( n )
   , device_( n.device_ )
   , P_( n.P_ )
@@ -247,20 +249,20 @@ nest::correlomatrix_detector::correlomatrix_detector( const correlomatrix_detect
  * ---------------------------------------------------------------- */
 
 void
-nest::correlomatrix_detector::init_state_()
+correlomatrix_detector::init_state_()
 {
   device_.init_state();
 }
 
 void
-nest::correlomatrix_detector::init_buffers_()
+correlomatrix_detector::init_buffers_()
 {
   device_.init_buffers();
   S_.reset( P_ );
 }
 
 void
-nest::correlomatrix_detector::pre_run_hook()
+correlomatrix_detector::pre_run_hook()
 {
   device_.pre_run_hook();
 }
@@ -271,12 +273,12 @@ nest::correlomatrix_detector::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::correlomatrix_detector::update( Time const&, const long, const long )
+correlomatrix_detector::update( Time const&, const long, const long )
 {
 }
 
 void
-nest::correlomatrix_detector::handle( SpikeEvent& e )
+correlomatrix_detector::handle( SpikeEvent& e )
 {
   // The receiver port identifies the sending node in our
   // sender list.
@@ -381,7 +383,7 @@ nest::correlomatrix_detector::handle( SpikeEvent& e )
 }
 
 void
-nest::correlomatrix_detector::calibrate_time( const TimeConverter& tc )
+correlomatrix_detector::calibrate_time( const TimeConverter& tc )
 {
   if ( P_.delta_tau_.is_step() )
   {
@@ -399,3 +401,5 @@ nest::correlomatrix_detector::calibrate_time( const TimeConverter& tc )
   P_.Tstart_ = tc.from_old_tics( P_.Tstart_.get_tics() );
   P_.Tstop_ = tc.from_old_tics( P_.Tstop_.get_tics() );
 }
+
+}  // namespace nest

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -128,9 +128,7 @@ correlospinmatrix_detector::State_::get( Dictionary& d ) const
 }
 
 bool
-correlospinmatrix_detector::Parameters_::set( const Dictionary& d,
-  const correlospinmatrix_detector& n,
-  Node* node )
+correlospinmatrix_detector::Parameters_::set( const Dictionary& d, const correlospinmatrix_detector& n, Node* node )
 {
   bool reset = false;
   double t;

--- a/models/correlospinmatrix_detector.cpp
+++ b/models/correlospinmatrix_detector.cpp
@@ -36,8 +36,11 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_correlospinmatrix_detector( const std::string& name )
+register_correlospinmatrix_detector( const std::string& name )
 {
   register_node_model< correlospinmatrix_detector >( name );
 }
@@ -46,7 +49,7 @@ nest::register_correlospinmatrix_detector( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::correlospinmatrix_detector::Parameters_::Parameters_()
+correlospinmatrix_detector::Parameters_::Parameters_()
   : delta_tau_( get_default_delta_tau() )
   , tau_max_( 10 * delta_tau_ )
   , Tstart_( Time::ms( 0.0 ) )
@@ -55,7 +58,7 @@ nest::correlospinmatrix_detector::Parameters_::Parameters_()
 {
 }
 
-nest::correlospinmatrix_detector::Parameters_::Parameters_( const Parameters_& p )
+correlospinmatrix_detector::Parameters_::Parameters_( const Parameters_& p )
   : delta_tau_( p.delta_tau_ )
   , tau_max_( p.tau_max_ )
   , Tstart_( p.Tstart_ )
@@ -77,8 +80,8 @@ nest::correlospinmatrix_detector::Parameters_::Parameters_( const Parameters_& p
 }
 
 
-nest::correlospinmatrix_detector::Parameters_&
-nest::correlospinmatrix_detector::Parameters_::operator=( const Parameters_& p )
+correlospinmatrix_detector::Parameters_&
+correlospinmatrix_detector::Parameters_::operator=( const Parameters_& p )
 {
   delta_tau_ = p.delta_tau_;
   tau_max_ = p.tau_max_;
@@ -95,7 +98,7 @@ nest::correlospinmatrix_detector::Parameters_::operator=( const Parameters_& p )
 }
 
 
-nest::correlospinmatrix_detector::State_::State_()
+correlospinmatrix_detector::State_::State_()
   : incoming_()
   , last_i_( 0 )
   , t_last_in_spike_( Time::neg_inf() )
@@ -109,7 +112,7 @@ nest::correlospinmatrix_detector::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::correlospinmatrix_detector::Parameters_::get( Dictionary& d ) const
+correlospinmatrix_detector::Parameters_::get( Dictionary& d ) const
 {
   d[ names::delta_tau ] = delta_tau_.get_ms();
   d[ names::tau_max ] = tau_max_.get_ms();
@@ -119,13 +122,13 @@ nest::correlospinmatrix_detector::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::correlospinmatrix_detector::State_::get( Dictionary& d ) const
+correlospinmatrix_detector::State_::get( Dictionary& d ) const
 {
   d[ names::count_covariance ] = count_covariance_;
 }
 
 bool
-nest::correlospinmatrix_detector::Parameters_::set( const Dictionary& d,
+correlospinmatrix_detector::Parameters_::set( const Dictionary& d,
   const correlospinmatrix_detector& n,
   Node* node )
 {
@@ -199,12 +202,12 @@ nest::correlospinmatrix_detector::Parameters_::set( const Dictionary& d,
 }
 
 void
-nest::correlospinmatrix_detector::State_::set( const Dictionary&, const Parameters_&, bool, Node* )
+correlospinmatrix_detector::State_::set( const Dictionary&, const Parameters_&, bool, Node* )
 {
 }
 
 void
-nest::correlospinmatrix_detector::State_::reset( const Parameters_& p )
+correlospinmatrix_detector::State_::reset( const Parameters_& p )
 {
   last_i_ = 0;
   tentative_down_ = false;
@@ -237,7 +240,7 @@ nest::correlospinmatrix_detector::State_::reset( const Parameters_& p )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::correlospinmatrix_detector::correlospinmatrix_detector()
+correlospinmatrix_detector::correlospinmatrix_detector()
   : Node()
   , device_()
   , P_()
@@ -245,7 +248,7 @@ nest::correlospinmatrix_detector::correlospinmatrix_detector()
 {
 }
 
-nest::correlospinmatrix_detector::correlospinmatrix_detector( const correlospinmatrix_detector& n )
+correlospinmatrix_detector::correlospinmatrix_detector( const correlospinmatrix_detector& n )
   : Node( n )
   , device_( n.device_ )
   , P_( n.P_ )
@@ -259,20 +262,20 @@ nest::correlospinmatrix_detector::correlospinmatrix_detector( const correlospinm
  * ---------------------------------------------------------------- */
 
 void
-nest::correlospinmatrix_detector::init_state_()
+correlospinmatrix_detector::init_state_()
 {
   device_.init_state();
 }
 
 void
-nest::correlospinmatrix_detector::init_buffers_()
+correlospinmatrix_detector::init_buffers_()
 {
   device_.init_buffers();
   S_.reset( P_ );
 }
 
 void
-nest::correlospinmatrix_detector::pre_run_hook()
+correlospinmatrix_detector::pre_run_hook()
 {
   device_.pre_run_hook();
 }
@@ -283,12 +286,12 @@ nest::correlospinmatrix_detector::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::correlospinmatrix_detector::update( Time const&, const long, const long )
+correlospinmatrix_detector::update( Time const&, const long, const long )
 {
 }
 
 void
-nest::correlospinmatrix_detector::handle( SpikeEvent& e )
+correlospinmatrix_detector::handle( SpikeEvent& e )
 {
   // The receiver port identifies the sending node in our
   // sender list.
@@ -472,7 +475,7 @@ nest::correlospinmatrix_detector::handle( SpikeEvent& e )
 }
 
 void
-nest::correlospinmatrix_detector::calibrate_time( const TimeConverter& tc )
+correlospinmatrix_detector::calibrate_time( const TimeConverter& tc )
 {
   if ( P_.delta_tau_.is_step() )
   {
@@ -492,3 +495,5 @@ nest::correlospinmatrix_detector::calibrate_time( const TimeConverter& tc )
 
   S_.t_last_in_spike_ = tc.from_old_tics( S_.t_last_in_spike_.get_tics() );
 }
+
+}  // namespace nest

--- a/models/correlospinmatrix_detector.h
+++ b/models/correlospinmatrix_detector.h
@@ -311,7 +311,7 @@ correlospinmatrix_detector::handles_test_event( SpikeEvent&, size_t receptor_typ
 }
 
 inline void
-nest::correlospinmatrix_detector::get_status( Dictionary& d ) const
+correlospinmatrix_detector::get_status( Dictionary& d ) const
 {
   device_.get_status( d );
   P_.get( d );
@@ -319,7 +319,7 @@ nest::correlospinmatrix_detector::get_status( Dictionary& d ) const
 }
 
 inline void
-nest::correlospinmatrix_detector::set_status( const Dictionary& d )
+correlospinmatrix_detector::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;
   const bool reset_required = ptmp.set( d, *this, this );

--- a/models/dc_generator.cpp
+++ b/models/dc_generator.cpp
@@ -31,6 +31,7 @@
 // Includes from libnestutil:
 #include "dict_util.h"
 
+
 namespace nest
 {
 void
@@ -47,24 +48,23 @@ RecordablesMap< dc_generator >::create()
 {
   insert_( names::I, &dc_generator::get_I_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::dc_generator::Parameters_::Parameters_()
+dc_generator::Parameters_::Parameters_()
   : amp_( 0.0 )  // pA
 {
 }
 
-nest::dc_generator::Parameters_::Parameters_( const Parameters_& p )
+dc_generator::Parameters_::Parameters_( const Parameters_& p )
   : amp_( p.amp_ )
 {
 }
 
-nest::dc_generator::Parameters_&
-nest::dc_generator::Parameters_::operator=( const Parameters_& p )
+dc_generator::Parameters_&
+dc_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -76,18 +76,18 @@ nest::dc_generator::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::dc_generator::State_::State_()
+dc_generator::State_::State_()
   : I_( 0.0 )  // pA
 {
 }
 
 
-nest::dc_generator::Buffers_::Buffers_( dc_generator& n )
+dc_generator::Buffers_::Buffers_( dc_generator& n )
   : logger_( n )
 {
 }
 
-nest::dc_generator::Buffers_::Buffers_( const Buffers_&, dc_generator& n )
+dc_generator::Buffers_::Buffers_( const Buffers_&, dc_generator& n )
   : logger_( n )
 {
 }
@@ -97,13 +97,13 @@ nest::dc_generator::Buffers_::Buffers_( const Buffers_&, dc_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::dc_generator::Parameters_::get( Dictionary& d ) const
+dc_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::amplitude ] = amp_;
 }
 
 void
-nest::dc_generator::Parameters_::set( const Dictionary& d, Node* node )
+dc_generator::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::amplitude, amp_, node );
 }
@@ -113,7 +113,7 @@ nest::dc_generator::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::dc_generator::dc_generator()
+dc_generator::dc_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -122,7 +122,7 @@ nest::dc_generator::dc_generator()
   recordablesMap_.create();
 }
 
-nest::dc_generator::dc_generator( const dc_generator& n )
+dc_generator::dc_generator( const dc_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -135,20 +135,20 @@ nest::dc_generator::dc_generator( const dc_generator& n )
  * Node initialization functions
  * ---------------------------------------------------------------- */
 void
-nest::dc_generator::init_state_()
+dc_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::dc_generator::init_buffers_()
+dc_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
 }
 
 void
-nest::dc_generator::pre_run_hook()
+dc_generator::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -161,7 +161,7 @@ nest::dc_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::dc_generator::update( Time const& origin, const long from, const long to )
+dc_generator::update( Time const& origin, const long from, const long to )
 {
   long start = origin.get_steps();
 
@@ -180,13 +180,13 @@ nest::dc_generator::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::dc_generator::handle( DataLoggingRequest& e )
+dc_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
 void
-nest::dc_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+dc_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -205,3 +205,5 @@ nest::dc_generator::set_data_from_stimulation_backend( std::vector< double >& in
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/diffusion_connection.cpp
+++ b/models/diffusion_connection.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_diffusion_connection( const std::string& name )
+register_diffusion_connection( const std::string& name )
 {
   register_connection_model< diffusion_connection >( name );
 }
+
+}  // namespace nest

--- a/models/eprop_iaf.cpp
+++ b/models/eprop_iaf.cpp
@@ -37,9 +37,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_iaf( const std::string& name )
 {

--- a/models/eprop_iaf_adapt.cpp
+++ b/models/eprop_iaf_adapt.cpp
@@ -37,9 +37,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_iaf_adapt( const std::string& name )
 {

--- a/models/eprop_iaf_adapt_bsshslm_2020.cpp
+++ b/models/eprop_iaf_adapt_bsshslm_2020.cpp
@@ -37,9 +37,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_iaf_adapt_bsshslm_2020( const std::string& name )
 {

--- a/models/eprop_iaf_bsshslm_2020.cpp
+++ b/models/eprop_iaf_bsshslm_2020.cpp
@@ -37,9 +37,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_iaf_bsshslm_2020( const std::string& name )
 {

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -37,9 +37,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_iaf_psc_delta( const std::string& name )
 {

--- a/models/eprop_iaf_psc_delta_adapt.cpp
+++ b/models/eprop_iaf_psc_delta_adapt.cpp
@@ -37,9 +37,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_iaf_psc_delta_adapt( const std::string& name )
 {

--- a/models/eprop_learning_signal_connection.cpp
+++ b/models/eprop_learning_signal_connection.cpp
@@ -25,8 +25,13 @@
 // nestkernel
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_eprop_learning_signal_connection( const std::string& name )
+register_eprop_learning_signal_connection( const std::string& name )
 {
   register_connection_model< eprop_learning_signal_connection >( name );
 }
+
+}  // namespace nest

--- a/models/eprop_learning_signal_connection_bsshslm_2020.cpp
+++ b/models/eprop_learning_signal_connection_bsshslm_2020.cpp
@@ -25,8 +25,13 @@
 // nestkernel
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_eprop_learning_signal_connection_bsshslm_2020( const std::string& name )
+register_eprop_learning_signal_connection_bsshslm_2020( const std::string& name )
 {
   register_connection_model< eprop_learning_signal_connection_bsshslm_2020 >( name );
 }
+
+}  // namespace nest

--- a/models/eprop_readout.cpp
+++ b/models/eprop_readout.cpp
@@ -36,9 +36,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_readout( const std::string& name )
 {

--- a/models/eprop_readout_bsshslm_2020.cpp
+++ b/models/eprop_readout_bsshslm_2020.cpp
@@ -36,9 +36,9 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_readout_bsshslm_2020( const std::string& name )
 {

--- a/models/eprop_synapse.cpp
+++ b/models/eprop_synapse.cpp
@@ -25,9 +25,9 @@
 // nestkernel
 #include "nest_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_synapse( const std::string& name )
 {

--- a/models/eprop_synapse_bsshslm_2020.cpp
+++ b/models/eprop_synapse_bsshslm_2020.cpp
@@ -25,9 +25,9 @@
 // nestkernel
 #include "nest_impl.h"
 
+
 namespace nest
 {
-
 void
 register_eprop_synapse_bsshslm_2020( const std::string& name )
 {

--- a/models/erfc_neuron.cpp
+++ b/models/erfc_neuron.cpp
@@ -28,6 +28,7 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
 void
@@ -57,11 +58,11 @@ gainfunction_erfc::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::erfc_neuron >::create()
+RecordablesMap< erfc_neuron >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::S, &nest::erfc_neuron::get_output_state__ );
-  insert_( names::h, &nest::erfc_neuron::get_input__ );
+  insert_( names::S, &erfc_neuron::get_output_state__ );
+  insert_( names::h, &erfc_neuron::get_input__ );
 }
 
 }  // namespace nest

--- a/models/erfc_neuron.h
+++ b/models/erfc_neuron.h
@@ -151,7 +151,7 @@ gainfunction_erfc::operator()( RngPtr rng, double h )
   return rng->drand() < 0.5 * erfc( -( h - theta_ ) / ( sqrt( 2. ) * sigma_ ) );
 }
 
-typedef binary_neuron< nest::gainfunction_erfc > erfc_neuron;
+typedef binary_neuron< gainfunction_erfc > erfc_neuron;
 void register_erfc_neuron( const std::string& name );
 
 

--- a/models/gamma_sup_generator.cpp
+++ b/models/gamma_sup_generator.cpp
@@ -34,8 +34,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_gamma_sup_generator( const std::string& name )
+register_gamma_sup_generator( const std::string& name )
 {
   register_node_model< gamma_sup_generator >( name );
 }
@@ -44,7 +47,7 @@ nest::register_gamma_sup_generator( const std::string& name )
  * Constructor of internal states class
  * ---------------------------------------------------------------- */
 
-nest::gamma_sup_generator::Internal_states_::Internal_states_( size_t num_bins,
+gamma_sup_generator::Internal_states_::Internal_states_( size_t num_bins,
   unsigned long ini_occ_ref,
   unsigned long ini_occ_act )
 {
@@ -57,7 +60,7 @@ nest::gamma_sup_generator::Internal_states_::Internal_states_( size_t num_bins,
  * ---------------------------------------------------------------- */
 
 unsigned long
-nest::gamma_sup_generator::Internal_states_::update( double transition_prob, RngPtr rng )
+gamma_sup_generator::Internal_states_::update( double transition_prob, RngPtr rng )
 {
   std::vector< unsigned long > n_trans;  // only set from poisson_dist_, bino_dist_ or 0, thus >= 0
   n_trans.resize( occ_.size() );
@@ -122,7 +125,7 @@ nest::gamma_sup_generator::Internal_states_::update( double transition_prob, Rng
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::gamma_sup_generator::Parameters_::Parameters_()
+gamma_sup_generator::Parameters_::Parameters_()
   : rate_( 0.0 )  // Hz
   , gamma_shape_( 1 )
   , n_proc_( 1 )
@@ -135,7 +138,7 @@ nest::gamma_sup_generator::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::gamma_sup_generator::Parameters_::get( Dictionary& d ) const
+gamma_sup_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
   d[ names::gamma_shape ] = gamma_shape_;
@@ -143,7 +146,7 @@ nest::gamma_sup_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::gamma_sup_generator::Parameters_::set( const Dictionary& d, Node* node )
+gamma_sup_generator::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::gamma_shape, gamma_shape_, node );
   if ( gamma_shape_ < 1 )
@@ -169,13 +172,13 @@ nest::gamma_sup_generator::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::gamma_sup_generator::gamma_sup_generator()
+gamma_sup_generator::gamma_sup_generator()
   : StimulationDevice()
   , P_()
 {
 }
 
-nest::gamma_sup_generator::gamma_sup_generator( const gamma_sup_generator& n )
+gamma_sup_generator::gamma_sup_generator( const gamma_sup_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
 {
@@ -187,19 +190,19 @@ nest::gamma_sup_generator::gamma_sup_generator( const gamma_sup_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::gamma_sup_generator::init_state_()
+gamma_sup_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::gamma_sup_generator::init_buffers_()
+gamma_sup_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
 }
 
 void
-nest::gamma_sup_generator::pre_run_hook()
+gamma_sup_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
 
@@ -224,7 +227,7 @@ nest::gamma_sup_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::gamma_sup_generator::update( Time const& T, const long from, const long to )
+gamma_sup_generator::update( Time const& T, const long from, const long to )
 {
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {
@@ -247,7 +250,7 @@ nest::gamma_sup_generator::update( Time const& T, const long from, const long to
 
 
 void
-nest::gamma_sup_generator::event_hook( DSSpikeEvent& e )
+gamma_sup_generator::event_hook( DSSpikeEvent& e )
 {
   // get port number
   const size_t prt = e.get_port();
@@ -271,7 +274,7 @@ nest::gamma_sup_generator::event_hook( DSSpikeEvent& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::gamma_sup_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+gamma_sup_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -293,3 +296,5 @@ nest::gamma_sup_generator::set_data_from_stimulation_backend( std::vector< doubl
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/gap_junction.cpp
+++ b/models/gap_junction.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_gap_junction( const std::string& name )
+register_gap_junction( const std::string& name )
 {
   register_connection_model< gap_junction >( name );
 }
+
+}  // namespace nest

--- a/models/gauss_rate.cpp
+++ b/models/gauss_rate.cpp
@@ -27,6 +27,7 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -64,19 +65,19 @@ nonlinearities_gauss_rate::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::gauss_rate_ipn >::create()
+RecordablesMap< gauss_rate_ipn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::gauss_rate_ipn::get_rate_ );
-  insert_( names::noise, &nest::gauss_rate_ipn::get_noise_ );
+  insert_( names::rate, &gauss_rate_ipn::get_rate_ );
+  insert_( names::noise, &gauss_rate_ipn::get_noise_ );
 }
 
 template <>
 void
-RecordablesMap< nest::rate_transformer_gauss >::create()
+RecordablesMap< rate_transformer_gauss >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::rate_transformer_gauss::get_rate_ );
+  insert_( names::rate, &rate_transformer_gauss::get_rate_ );
 }
 
 }  // namespace nest

--- a/models/gauss_rate.h
+++ b/models/gauss_rate.h
@@ -169,10 +169,10 @@ nonlinearities_gauss_rate::mult_coupling_in( double )
   return 1.;
 }
 
-typedef rate_neuron_ipn< nest::nonlinearities_gauss_rate > gauss_rate_ipn;
+typedef rate_neuron_ipn< nonlinearities_gauss_rate > gauss_rate_ipn;
 void register_gauss_rate_ipn( const std::string& name );
 
-typedef rate_transformer_node< nest::nonlinearities_gauss_rate > rate_transformer_gauss;
+typedef rate_transformer_node< nonlinearities_gauss_rate > rate_transformer_gauss;
 void register_rate_transformer_gauss( const std::string& name );
 
 

--- a/models/gif_cond_exp.cpp
+++ b/models/gif_cond_exp.cpp
@@ -67,17 +67,16 @@ RecordablesMap< gif_cond_exp >::create()
   insert_( names::g_ex, &gif_cond_exp::get_y_elem_< gif_cond_exp::State_::G_EXC > );
   insert_( names::g_in, &gif_cond_exp::get_y_elem_< gif_cond_exp::State_::G_INH > );
 }
-}  // namespace
 
 extern "C" int
-nest::gif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
+gif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::gif_cond_exp::State_ S;
+  typedef gif_cond_exp::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::gif_cond_exp& node = *( reinterpret_cast< nest::gif_cond_exp* >( pnode ) );
+  const gif_cond_exp& node = *( reinterpret_cast< gif_cond_exp* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ref_ > 0;
 
@@ -108,7 +107,7 @@ nest::gif_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::gif_cond_exp::Parameters_::Parameters_()
+gif_cond_exp::Parameters_::Parameters_()
   : g_L_( 4.0 )         // nS
   , E_L_( -70.0 )       // mV
   , V_reset_( -55.0 )   // mV
@@ -130,7 +129,7 @@ nest::gif_cond_exp::Parameters_::Parameters_()
 {
 }
 
-nest::gif_cond_exp::State_::State_( const Parameters_& p )
+gif_cond_exp::State_::State_( const Parameters_& p )
   : I_stim_( 0.0 )
   , sfa_( 0.0 )
   , stc_( 0.0 )
@@ -142,7 +141,7 @@ nest::gif_cond_exp::State_::State_( const Parameters_& p )
   neuron_state_[ G_EXC ] = neuron_state_[ G_INH ] = 0;
 }
 
-nest::gif_cond_exp::State_::State_( const State_& s )
+gif_cond_exp::State_::State_( const State_& s )
   : I_stim_( s.I_stim_ )
   , sfa_( s.sfa_ )
   , stc_( s.stc_ )
@@ -167,8 +166,8 @@ nest::gif_cond_exp::State_::State_( const State_& s )
   }
 }
 
-nest::gif_cond_exp::State_&
-nest::gif_cond_exp::State_::operator=( const State_& s )
+gif_cond_exp::State_&
+gif_cond_exp::State_::operator=( const State_& s )
 {
   I_stim_ = s.I_stim_;
   sfa_ = s.sfa_;
@@ -198,7 +197,7 @@ nest::gif_cond_exp::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_cond_exp::Parameters_::get( Dictionary& d ) const
+gif_cond_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::I_e ] = I_e_;
   d[ names::E_L ] = E_L_;
@@ -221,7 +220,7 @@ nest::gif_cond_exp::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::gif_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
+gif_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::I_e, I_e_, node );
   update_value_param( d, names::E_L, E_L_, node );
@@ -308,7 +307,7 @@ nest::gif_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::gif_cond_exp::State_::get( Dictionary& d, const Parameters_& ) const
+gif_cond_exp::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::V_m ] = neuron_state_[ V_M ];  // Membrane potential
   d[ names::g_ex ] = neuron_state_[ G_EXC ];
@@ -318,14 +317,14 @@ nest::gif_cond_exp::State_::get( Dictionary& d, const Parameters_& ) const
 }
 
 void
-nest::gif_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+gif_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, neuron_state_[ V_M ], node );
   update_value_param( d, names::g_ex, neuron_state_[ G_EXC ], node );
   update_value_param( d, names::g_in, neuron_state_[ G_INH ], node );
 }
 
-nest::gif_cond_exp::Buffers_::Buffers_( gif_cond_exp& n )
+gif_cond_exp::Buffers_::Buffers_( gif_cond_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -335,7 +334,7 @@ nest::gif_cond_exp::Buffers_::Buffers_( gif_cond_exp& n )
   // init_buffers_().
 }
 
-nest::gif_cond_exp::Buffers_::Buffers_( const Buffers_&, gif_cond_exp& n )
+gif_cond_exp::Buffers_::Buffers_( const Buffers_&, gif_cond_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -349,7 +348,7 @@ nest::gif_cond_exp::Buffers_::Buffers_( const Buffers_&, gif_cond_exp& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::gif_cond_exp::gif_cond_exp()
+gif_cond_exp::gif_cond_exp()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -358,7 +357,7 @@ nest::gif_cond_exp::gif_cond_exp()
   recordablesMap_.create();
 }
 
-nest::gif_cond_exp::gif_cond_exp( const gif_cond_exp& n )
+gif_cond_exp::gif_cond_exp( const gif_cond_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -366,7 +365,7 @@ nest::gif_cond_exp::gif_cond_exp( const gif_cond_exp& n )
 {
 }
 
-nest::gif_cond_exp::~gif_cond_exp()
+gif_cond_exp::~gif_cond_exp()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -388,7 +387,7 @@ nest::gif_cond_exp::~gif_cond_exp()
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_cond_exp::init_buffers_()
+gif_cond_exp::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -433,7 +432,7 @@ nest::gif_cond_exp::init_buffers_()
 }
 
 void
-nest::gif_cond_exp::pre_run_hook()
+gif_cond_exp::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -464,7 +463,7 @@ nest::gif_cond_exp::pre_run_hook()
  */
 
 void
-nest::gif_cond_exp::update( Time const& origin, const long from, const long to )
+gif_cond_exp::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -565,7 +564,7 @@ nest::gif_cond_exp::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::gif_cond_exp::handle( SpikeEvent& e )
+gif_cond_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -586,7 +585,7 @@ nest::gif_cond_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::gif_cond_exp::handle( CurrentEvent& e )
+gif_cond_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -598,9 +597,11 @@ nest::gif_cond_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::gif_cond_exp::handle( DataLoggingRequest& e )
+gif_cond_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/gif_cond_exp_multisynapse.cpp
+++ b/models/gif_cond_exp_multisynapse.cpp
@@ -66,17 +66,16 @@ RecordablesMap< gif_cond_exp_multisynapse >::create()
   insert_( names::E_sfa, &gif_cond_exp_multisynapse::get_E_sfa_ );
   insert_( names::I_stc, &gif_cond_exp_multisynapse::get_I_stc_ );
 }
-}  // namespace
 
 extern "C" int
-nest::gif_cond_exp_multisynapse_dynamics( double, const double* y, double* f, void* pnode )
+gif_cond_exp_multisynapse_dynamics( double, const double* y, double* f, void* pnode )
 {
   // a shorthand
-  typedef nest::gif_cond_exp_multisynapse::State_ S;
+  typedef gif_cond_exp_multisynapse::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::gif_cond_exp_multisynapse& node = *( reinterpret_cast< nest::gif_cond_exp_multisynapse* >( pnode ) );
+  const gif_cond_exp_multisynapse& node = *( reinterpret_cast< gif_cond_exp_multisynapse* >( pnode ) );
 
   // The following code is verbose for the sake of clarity. We assume that a
   // good compiler will optimize the verbosity away ...
@@ -111,7 +110,7 @@ nest::gif_cond_exp_multisynapse_dynamics( double, const double* y, double* f, vo
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::gif_cond_exp_multisynapse::Parameters_::Parameters_()
+gif_cond_exp_multisynapse::Parameters_::Parameters_()
   : g_L_( 4.0 )         // nS
   , E_L_( -70.0 )       // mV
   , V_reset_( -55.0 )   // mV
@@ -132,7 +131,7 @@ nest::gif_cond_exp_multisynapse::Parameters_::Parameters_()
 {
 }
 
-nest::gif_cond_exp_multisynapse::State_::State_( const Parameters_& p )
+gif_cond_exp_multisynapse::State_::State_( const Parameters_& p )
   : y_( STATE_VEC_SIZE + NUM_STATE_ELEMENTS_PER_RECEPTOR, 0.0 )
   , I_stim_( 0.0 )
   , sfa_( 0.0 )
@@ -149,7 +148,7 @@ nest::gif_cond_exp_multisynapse::State_::State_( const Parameters_& p )
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_cond_exp_multisynapse::Parameters_::get( Dictionary& d ) const
+gif_cond_exp_multisynapse::Parameters_::get( Dictionary& d ) const
 {
   d[ names::I_e ] = I_e_;
   d[ names::E_L ] = E_L_;
@@ -172,7 +171,7 @@ nest::gif_cond_exp_multisynapse::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::gif_cond_exp_multisynapse::Parameters_::set( const Dictionary& d, Node* node )
+gif_cond_exp_multisynapse::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::I_e, I_e_, node );
   update_value_param( d, names::E_L, E_L_, node );
@@ -289,7 +288,7 @@ nest::gif_cond_exp_multisynapse::Parameters_::set( const Dictionary& d, Node* no
 }
 
 void
-nest::gif_cond_exp_multisynapse::State_::get( Dictionary& d, const Parameters_& ) const
+gif_cond_exp_multisynapse::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::V_m ] = y_[ V_M ];  // Membrane potential
   d[ names::E_sfa ] = sfa_;     // Adaptive threshold potential
@@ -306,7 +305,7 @@ nest::gif_cond_exp_multisynapse::State_::get( Dictionary& d, const Parameters_& 
 }
 
 void
-nest::gif_cond_exp_multisynapse::State_::set( const Dictionary& d, const Parameters_& p, Node* node )
+gif_cond_exp_multisynapse::State_::set( const Dictionary& d, const Parameters_& p, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   y_.resize( State_::NUMBER_OF_FIXED_STATES_ELEMENTS + State_::NUM_STATE_ELEMENTS_PER_RECEPTOR * p.n_receptors(), 0.0 );
@@ -315,7 +314,7 @@ nest::gif_cond_exp_multisynapse::State_::set( const Dictionary& d, const Paramet
   stc_elems_.resize( p.tau_stc_.size(), 0.0 );
 }
 
-nest::gif_cond_exp_multisynapse::Buffers_::Buffers_( gif_cond_exp_multisynapse& n )
+gif_cond_exp_multisynapse::Buffers_::Buffers_( gif_cond_exp_multisynapse& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -327,7 +326,7 @@ nest::gif_cond_exp_multisynapse::Buffers_::Buffers_( gif_cond_exp_multisynapse& 
   // init_buffers_().
 }
 
-nest::gif_cond_exp_multisynapse::Buffers_::Buffers_( const Buffers_& b, gif_cond_exp_multisynapse& n )
+gif_cond_exp_multisynapse::Buffers_::Buffers_( const Buffers_& b, gif_cond_exp_multisynapse& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -343,7 +342,7 @@ nest::gif_cond_exp_multisynapse::Buffers_::Buffers_( const Buffers_& b, gif_cond
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::gif_cond_exp_multisynapse::gif_cond_exp_multisynapse()
+gif_cond_exp_multisynapse::gif_cond_exp_multisynapse()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -352,7 +351,7 @@ nest::gif_cond_exp_multisynapse::gif_cond_exp_multisynapse()
   recordablesMap_.create();
 }
 
-nest::gif_cond_exp_multisynapse::gif_cond_exp_multisynapse( const gif_cond_exp_multisynapse& n )
+gif_cond_exp_multisynapse::gif_cond_exp_multisynapse( const gif_cond_exp_multisynapse& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -360,7 +359,7 @@ nest::gif_cond_exp_multisynapse::gif_cond_exp_multisynapse( const gif_cond_exp_m
 {
 }
 
-nest::gif_cond_exp_multisynapse::~gif_cond_exp_multisynapse()
+gif_cond_exp_multisynapse::~gif_cond_exp_multisynapse()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -382,7 +381,7 @@ nest::gif_cond_exp_multisynapse::~gif_cond_exp_multisynapse()
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_cond_exp_multisynapse::init_buffers_()
+gif_cond_exp_multisynapse::init_buffers_()
 {
   B_.spikes_.resize( P_.n_receptors() );
   for ( size_t i = 0; i < P_.n_receptors(); ++i )
@@ -433,7 +432,7 @@ nest::gif_cond_exp_multisynapse::init_buffers_()
 }
 
 void
-nest::gif_cond_exp_multisynapse::pre_run_hook()
+gif_cond_exp_multisynapse::pre_run_hook()
 {
   B_.sys_.dimension = S_.y_.size();
 
@@ -464,7 +463,7 @@ nest::gif_cond_exp_multisynapse::pre_run_hook()
  */
 
 void
-nest::gif_cond_exp_multisynapse::update( Time const& origin, const long from, const long to )
+gif_cond_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -569,7 +568,7 @@ nest::gif_cond_exp_multisynapse::update( Time const& origin, const long from, co
 }
 
 void
-nest::gif_cond_exp_multisynapse::handle( SpikeEvent& e )
+gif_cond_exp_multisynapse::handle( SpikeEvent& e )
 {
   if ( e.get_weight() < 0 )
   {
@@ -585,7 +584,7 @@ nest::gif_cond_exp_multisynapse::handle( SpikeEvent& e )
 }
 
 void
-nest::gif_cond_exp_multisynapse::handle( CurrentEvent& e )
+gif_cond_exp_multisynapse::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -597,9 +596,11 @@ nest::gif_cond_exp_multisynapse::handle( CurrentEvent& e )
 }
 
 void
-nest::gif_cond_exp_multisynapse::handle( DataLoggingRequest& e )
+gif_cond_exp_multisynapse::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -683,6 +683,6 @@ gif_pop_psc_exp::handle( DataLoggingRequest& e )
   B_.logger_.handle( e );
 }
 
-}  // namespace nest
-
 #endif /* HAVE_GSL */
+
+}  // namespace nest

--- a/models/gif_pop_psc_exp.cpp
+++ b/models/gif_pop_psc_exp.cpp
@@ -43,10 +43,10 @@
 #include "universal_data_logger_impl.h"
 
 
-#ifdef HAVE_GSL
-
 namespace nest
 {
+#ifdef HAVE_GSL
+
 void
 register_gif_pop_psc_exp( const std::string& name )
 {
@@ -78,7 +78,7 @@ RecordablesMap< gif_pop_psc_exp >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::gif_pop_psc_exp::Parameters_::Parameters_()
+gif_pop_psc_exp::Parameters_::Parameters_()
   : N_( 100 )           // 1
   , tau_m_( 20. )       // ms
   , c_m_( 250. )        // pF
@@ -100,7 +100,7 @@ nest::gif_pop_psc_exp::Parameters_::Parameters_()
   q_sfa_.push_back( 0.5 );      // mV
 }
 
-nest::gif_pop_psc_exp::State_::State_()
+gif_pop_psc_exp::State_::State_()
   : y0_( 0.0 )
   , I_syn_ex_( 0.0 )
   , I_syn_in_( 0.0 )
@@ -117,7 +117,7 @@ nest::gif_pop_psc_exp::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_pop_psc_exp::Parameters_::get( Dictionary& d ) const
+gif_pop_psc_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::N ] = N_;
   d[ names::tau_m ] = tau_m_;
@@ -138,7 +138,7 @@ nest::gif_pop_psc_exp::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::gif_pop_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
+gif_pop_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::N, N_, node );
   update_value_param( d, names::tau_m, tau_m_, node );
@@ -213,7 +213,7 @@ nest::gif_pop_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::gif_pop_psc_exp::State_::get( Dictionary& d, const Parameters_& ) const
+gif_pop_psc_exp::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::V_m ] = V_m_;            // Filtered version of input
   d[ names::n_events ] = n_spikes_;  // Number of generated spikes
@@ -224,7 +224,7 @@ nest::gif_pop_psc_exp::State_::get( Dictionary& d, const Parameters_& ) const
 }
 
 void
-nest::gif_pop_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+gif_pop_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, V_m_, node );
   update_value_param( d, names::I_syn_ex, I_syn_ex_, node );
@@ -232,12 +232,12 @@ nest::gif_pop_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Nod
   initialized_ = false;  // vectors of the state should be initialized with new parameter set.
 }
 
-nest::gif_pop_psc_exp::Buffers_::Buffers_( gif_pop_psc_exp& n )
+gif_pop_psc_exp::Buffers_::Buffers_( gif_pop_psc_exp& n )
   : logger_( n )
 {
 }
 
-nest::gif_pop_psc_exp::Buffers_::Buffers_( const Buffers_&, gif_pop_psc_exp& n )
+gif_pop_psc_exp::Buffers_::Buffers_( const Buffers_&, gif_pop_psc_exp& n )
   : logger_( n )
 {
 }
@@ -246,7 +246,7 @@ nest::gif_pop_psc_exp::Buffers_::Buffers_( const Buffers_&, gif_pop_psc_exp& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::gif_pop_psc_exp::gif_pop_psc_exp()
+gif_pop_psc_exp::gif_pop_psc_exp()
   : Node()
   , P_()
   , S_()
@@ -255,7 +255,7 @@ nest::gif_pop_psc_exp::gif_pop_psc_exp()
   recordablesMap_.create();
 }
 
-nest::gif_pop_psc_exp::gif_pop_psc_exp( const gif_pop_psc_exp& n )
+gif_pop_psc_exp::gif_pop_psc_exp( const gif_pop_psc_exp& n )
   : Node( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -268,7 +268,7 @@ nest::gif_pop_psc_exp::gif_pop_psc_exp( const gif_pop_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_pop_psc_exp::init_buffers_()
+gif_pop_psc_exp::init_buffers_()
 {
   B_.ex_spikes_.clear();  //!< includes resize
   B_.in_spikes_.clear();
@@ -278,7 +278,7 @@ nest::gif_pop_psc_exp::init_buffers_()
 
 
 void
-nest::gif_pop_psc_exp::pre_run_hook()
+gif_pop_psc_exp::pre_run_hook()
 {
   if ( P_.tau_sfa_.size() == 0 )
   {
@@ -380,14 +380,14 @@ nest::gif_pop_psc_exp::pre_run_hook()
 
 
 inline double
-nest::gif_pop_psc_exp::escrate( const double x )
+gif_pop_psc_exp::escrate( const double x )
 {
   return P_.lambda_0_ * std::exp( x / P_.Delta_V_ );
 }
 
 
 inline long
-nest::gif_pop_psc_exp::draw_poisson( const double n_expect_ )
+gif_pop_psc_exp::draw_poisson( const double n_expect_ )
 {
   // Draw Poisson random number of spikes
   // If n_expect_ is too large, the random numbers might get bad. So we use
@@ -434,7 +434,7 @@ nest::gif_pop_psc_exp::draw_poisson( const double n_expect_ )
 
 
 inline long
-nest::gif_pop_psc_exp::draw_binomial( const double n_expect_ )
+gif_pop_psc_exp::draw_binomial( const double n_expect_ )
 {
   double p_bino_ = n_expect_ / P_.N_;
   if ( p_bino_ >= 1. )
@@ -455,7 +455,7 @@ nest::gif_pop_psc_exp::draw_binomial( const double n_expect_ )
 
 
 inline double
-nest::gif_pop_psc_exp::adaptation_kernel( const int k )
+gif_pop_psc_exp::adaptation_kernel( const int k )
 {
   // this function computes the value of the sum of exponentials adaptation
   // kernel at a time lag given by k time steps.
@@ -471,7 +471,7 @@ nest::gif_pop_psc_exp::adaptation_kernel( const int k )
 
 
 inline int
-nest::gif_pop_psc_exp::get_history_size()
+gif_pop_psc_exp::get_history_size()
 {
   // This function automatically determines a suitable history kernel size,
   // see Schwalger et al. (2017), Eq. (86) and Fig 11, Procedure GetHistoryLength.
@@ -492,7 +492,7 @@ nest::gif_pop_psc_exp::get_history_size()
 
 
 void
-nest::gif_pop_psc_exp::update( Time const& origin, const long from, const long to )
+gif_pop_psc_exp::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -666,7 +666,7 @@ gif_pop_psc_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::gif_pop_psc_exp::handle( CurrentEvent& e )
+gif_pop_psc_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -678,11 +678,11 @@ nest::gif_pop_psc_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::gif_pop_psc_exp::handle( DataLoggingRequest& e )
+gif_pop_psc_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest
 
 #endif /* HAVE_GSL */

--- a/models/gif_psc_exp.cpp
+++ b/models/gif_psc_exp.cpp
@@ -34,6 +34,7 @@
 #include "iaf_propagator.h"
 #include "numerics.h"
 
+
 namespace nest
 {
 void
@@ -66,7 +67,7 @@ RecordablesMap< gif_psc_exp >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::gif_psc_exp::Parameters_::Parameters_()
+gif_psc_exp::Parameters_::Parameters_()
   : g_L_( 4.0 )         // nS
   , E_L_( -70.0 )       // mV
   , V_reset_( -55.0 )   // mV
@@ -86,7 +87,7 @@ nest::gif_psc_exp::Parameters_::Parameters_()
 }
 
 
-nest::gif_psc_exp::State_::State_()
+gif_psc_exp::State_::State_()
   : I_stim_( 0.0 )
   , V_( -70.0 )
   , sfa_( 0.0 )
@@ -104,7 +105,7 @@ nest::gif_psc_exp::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_psc_exp::Parameters_::get( Dictionary& d ) const
+gif_psc_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::I_e ] = I_e_;
   d[ names::E_L ] = E_L_;
@@ -124,7 +125,7 @@ nest::gif_psc_exp::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::gif_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
+gif_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::I_e, I_e_, node );
   update_value_param( d, names::E_L, E_L_, node );
@@ -208,7 +209,7 @@ nest::gif_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::gif_psc_exp::State_::get( Dictionary& d, const Parameters_& ) const
+gif_psc_exp::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::V_m ] = V_;      // Membrane potential
   d[ names::E_sfa ] = sfa_;  // Adaptive threshold potential
@@ -216,17 +217,17 @@ nest::gif_psc_exp::State_::get( Dictionary& d, const Parameters_& ) const
 }
 
 void
-nest::gif_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+gif_psc_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, V_, node );
 }
 
-nest::gif_psc_exp::Buffers_::Buffers_( gif_psc_exp& n )
+gif_psc_exp::Buffers_::Buffers_( gif_psc_exp& n )
   : logger_( n )
 {
 }
 
-nest::gif_psc_exp::Buffers_::Buffers_( const Buffers_&, gif_psc_exp& n )
+gif_psc_exp::Buffers_::Buffers_( const Buffers_&, gif_psc_exp& n )
   : logger_( n )
 {
 }
@@ -235,7 +236,7 @@ nest::gif_psc_exp::Buffers_::Buffers_( const Buffers_&, gif_psc_exp& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::gif_psc_exp::gif_psc_exp()
+gif_psc_exp::gif_psc_exp()
   : ArchivingNode()
   , P_()
   , S_()
@@ -244,7 +245,7 @@ nest::gif_psc_exp::gif_psc_exp()
   recordablesMap_.create();
 }
 
-nest::gif_psc_exp::gif_psc_exp( const gif_psc_exp& n )
+gif_psc_exp::gif_psc_exp( const gif_psc_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -257,7 +258,7 @@ nest::gif_psc_exp::gif_psc_exp( const gif_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_psc_exp::init_buffers_()
+gif_psc_exp::init_buffers_()
 {
   B_.spikes_ex_.clear();  // includes resize
   B_.spikes_in_.clear();  // includes resize
@@ -267,7 +268,7 @@ nest::gif_psc_exp::init_buffers_()
 }
 
 void
-nest::gif_psc_exp::pre_run_hook()
+gif_psc_exp::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -311,7 +312,7 @@ nest::gif_psc_exp::pre_run_hook()
  */
 
 void
-nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
+gif_psc_exp::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -388,7 +389,7 @@ nest::gif_psc_exp::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::gif_psc_exp::handle( SpikeEvent& e )
+gif_psc_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -409,7 +410,7 @@ nest::gif_psc_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::gif_psc_exp::handle( CurrentEvent& e )
+gif_psc_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -421,9 +422,9 @@ nest::gif_psc_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::gif_psc_exp::handle( DataLoggingRequest& e )
+gif_psc_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/gif_psc_exp_multisynapse.cpp
+++ b/models/gif_psc_exp_multisynapse.cpp
@@ -65,7 +65,7 @@ RecordablesMap< gif_psc_exp_multisynapse >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::gif_psc_exp_multisynapse::Parameters_::Parameters_()
+gif_psc_exp_multisynapse::Parameters_::Parameters_()
   : g_L_( 4.0 )         // nS
   , E_L_( -70.0 )       // mV
   , V_reset_( -55.0 )   // mV
@@ -85,7 +85,7 @@ nest::gif_psc_exp_multisynapse::Parameters_::Parameters_()
 }
 
 
-nest::gif_psc_exp_multisynapse::State_::State_()
+gif_psc_exp_multisynapse::State_::State_()
   : I_stim_( 0.0 )
   , V_( -70.0 )
   , sfa_( 0.0 )
@@ -102,7 +102,7 @@ nest::gif_psc_exp_multisynapse::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
+gif_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
 {
   d[ names::I_e ] = I_e_;
   d[ names::E_L ] = E_L_;
@@ -125,7 +125,7 @@ nest::gif_psc_exp_multisynapse::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::gif_psc_exp_multisynapse::Parameters_::set( const Dictionary& d, Node* node )
+gif_psc_exp_multisynapse::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::I_e, I_e_, node );
   update_value_param( d, names::E_L, E_L_, node );
@@ -224,7 +224,7 @@ nest::gif_psc_exp_multisynapse::Parameters_::set( const Dictionary& d, Node* nod
 }
 
 void
-nest::gif_psc_exp_multisynapse::State_::get( Dictionary& d, const Parameters_& ) const
+gif_psc_exp_multisynapse::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::V_m ] = V_;      // Membrane potential
   d[ names::E_sfa ] = sfa_;  // Adaptive threshold potential
@@ -232,17 +232,17 @@ nest::gif_psc_exp_multisynapse::State_::get( Dictionary& d, const Parameters_& )
 }
 
 void
-nest::gif_psc_exp_multisynapse::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+gif_psc_exp_multisynapse::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, V_, node );
 }
 
-nest::gif_psc_exp_multisynapse::Buffers_::Buffers_( gif_psc_exp_multisynapse& n )
+gif_psc_exp_multisynapse::Buffers_::Buffers_( gif_psc_exp_multisynapse& n )
   : logger_( n )
 {
 }
 
-nest::gif_psc_exp_multisynapse::Buffers_::Buffers_( const Buffers_&, gif_psc_exp_multisynapse& n )
+gif_psc_exp_multisynapse::Buffers_::Buffers_( const Buffers_&, gif_psc_exp_multisynapse& n )
   : logger_( n )
 {
 }
@@ -251,7 +251,7 @@ nest::gif_psc_exp_multisynapse::Buffers_::Buffers_( const Buffers_&, gif_psc_exp
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::gif_psc_exp_multisynapse::gif_psc_exp_multisynapse()
+gif_psc_exp_multisynapse::gif_psc_exp_multisynapse()
   : ArchivingNode()
   , P_()
   , S_()
@@ -260,7 +260,7 @@ nest::gif_psc_exp_multisynapse::gif_psc_exp_multisynapse()
   recordablesMap_.create();
 }
 
-nest::gif_psc_exp_multisynapse::gif_psc_exp_multisynapse( const gif_psc_exp_multisynapse& n )
+gif_psc_exp_multisynapse::gif_psc_exp_multisynapse( const gif_psc_exp_multisynapse& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -273,7 +273,7 @@ nest::gif_psc_exp_multisynapse::gif_psc_exp_multisynapse( const gif_psc_exp_mult
  * ---------------------------------------------------------------- */
 
 void
-nest::gif_psc_exp_multisynapse::init_buffers_()
+gif_psc_exp_multisynapse::init_buffers_()
 {
   B_.spikes_.clear();    //!< includes resize
   B_.currents_.clear();  //!< includes resize
@@ -282,7 +282,7 @@ nest::gif_psc_exp_multisynapse::init_buffers_()
 }
 
 void
-nest::gif_psc_exp_multisynapse::pre_run_hook()
+gif_psc_exp_multisynapse::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -335,7 +335,7 @@ nest::gif_psc_exp_multisynapse::pre_run_hook()
  */
 
 void
-nest::gif_psc_exp_multisynapse::update( Time const& origin, const long from, const long to )
+gif_psc_exp_multisynapse::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -424,7 +424,7 @@ gif_psc_exp_multisynapse::handle( SpikeEvent& e )
 }
 
 void
-nest::gif_psc_exp_multisynapse::handle( CurrentEvent& e )
+gif_psc_exp_multisynapse::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -436,9 +436,9 @@ nest::gif_psc_exp_multisynapse::handle( CurrentEvent& e )
 }
 
 void
-nest::gif_psc_exp_multisynapse::handle( DataLoggingRequest& e )
+gif_psc_exp_multisynapse::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/ginzburg_neuron.cpp
+++ b/models/ginzburg_neuron.cpp
@@ -28,6 +28,7 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
 void
@@ -61,11 +62,11 @@ gainfunction_ginzburg::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::ginzburg_neuron >::create()
+RecordablesMap< ginzburg_neuron >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::S, &nest::ginzburg_neuron::get_output_state__ );
-  insert_( names::h, &nest::ginzburg_neuron::get_input__ );
+  insert_( names::S, &ginzburg_neuron::get_output_state__ );
+  insert_( names::h, &ginzburg_neuron::get_input__ );
 }
 
 }  // namespace nest

--- a/models/ginzburg_neuron.h
+++ b/models/ginzburg_neuron.h
@@ -163,7 +163,7 @@ gainfunction_ginzburg::operator()( RngPtr rng, double h ) const
   return rng->drand() < c1_ * h + c2_ * 0.5 * ( 1.0 + tanh( c3_ * ( h - theta_ ) ) );
 }
 
-typedef binary_neuron< nest::gainfunction_ginzburg > ginzburg_neuron;
+typedef binary_neuron< gainfunction_ginzburg > ginzburg_neuron;
 void register_ginzburg_neuron( const std::string& name );
 
 

--- a/models/glif_cond.cpp
+++ b/models/glif_cond.cpp
@@ -38,7 +38,6 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-using namespace nest;
 
 namespace nest
 {
@@ -52,7 +51,7 @@ register_glif_cond( const std::string& name )
 // for each quantity to be recorded.
 template <>
 void
-DynamicRecordablesMap< nest::glif_cond >::create( glif_cond& host )
+DynamicRecordablesMap< glif_cond >::create( glif_cond& host )
 {
   insert( names::V_m, host.get_data_access_functor( glif_cond::State_::V_M ) );
   insert( names::I, host.get_data_access_functor( glif_cond::State_::I ) );
@@ -87,20 +86,19 @@ glif_cond::get_data_access_functor( size_t elem )
 {
   return DataAccessFunctor< glif_cond >( *this, elem );
 }
-}
 
 /* ----------------------------------------------------------------
  * Iteration function
  * ---------------------------------------------------------------- */
 extern "C" inline int
-nest::glif_cond_dynamics( double, const double y[], double f[], void* pnode )
+glif_cond_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::glif_cond::State_ S;
+  typedef glif_cond::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::glif_cond& node = *( reinterpret_cast< nest::glif_cond* >( pnode ) );
+  const glif_cond& node = *( reinterpret_cast< glif_cond* >( pnode ) );
 
   const bool is_refractory = node.S_.refractory_steps_ > 0;
 
@@ -144,7 +142,7 @@ nest::glif_cond_dynamics( double, const double y[], double f[], void* pnode )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::glif_cond::Parameters_::Parameters_()
+glif_cond::Parameters_::Parameters_()
   : G_( 9.43 )                // in nS
   , E_L_( -78.85 )            // in mV
   , th_inf_( -51.68 - E_L_ )  // in mv, rel to E_L_, - 51.68 - E_L_, i.e., 27.17
@@ -170,7 +168,7 @@ nest::glif_cond::Parameters_::Parameters_()
 {
 }
 
-nest::glif_cond::State_::State_( const Parameters_& p )
+glif_cond::State_::State_( const Parameters_& p )
   : threshold_( p.th_inf_ )     // in mV
   , threshold_spike_( 0.0 )     // in mV
   , threshold_voltage_( 0.0 )   // in mV
@@ -192,7 +190,7 @@ nest::glif_cond::State_::State_( const Parameters_& p )
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_cond::Parameters_::get( Dictionary& d ) const
+glif_cond::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = th_inf_ + E_L_;
   d[ names::g_m ] = G_;
@@ -222,7 +220,7 @@ nest::glif_cond::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::glif_cond::Parameters_::set( const Dictionary& d, Node* node )
+glif_cond::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -390,7 +388,7 @@ nest::glif_cond::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::glif_cond::State_::get( Dictionary& d, const Parameters_& p ) const
+glif_cond::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = y_[ V_M ] + p.E_L_;
   d[ names::ASCurrents ] = ASCurrents_;
@@ -413,7 +411,7 @@ nest::glif_cond::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::glif_cond::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+glif_cond::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, y_[ V_M ], node ) )
   {
@@ -451,7 +449,7 @@ nest::glif_cond::State_::set( const Dictionary& d, const Parameters_& p, double 
   }
 }
 
-nest::glif_cond::Buffers_::Buffers_( glif_cond& n )
+glif_cond::Buffers_::Buffers_( glif_cond& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -462,7 +460,7 @@ nest::glif_cond::Buffers_::Buffers_( glif_cond& n )
 {
 }
 
-nest::glif_cond::Buffers_::Buffers_( const Buffers_& b, glif_cond& n )
+glif_cond::Buffers_::Buffers_( const Buffers_& b, glif_cond& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -478,7 +476,7 @@ nest::glif_cond::Buffers_::Buffers_( const Buffers_& b, glif_cond& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::glif_cond::glif_cond()
+glif_cond::glif_cond()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -487,7 +485,7 @@ nest::glif_cond::glif_cond()
   recordablesMap_.create( *this );
 }
 
-nest::glif_cond::glif_cond( const glif_cond& n )
+glif_cond::glif_cond( const glif_cond& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -496,7 +494,7 @@ nest::glif_cond::glif_cond( const glif_cond& n )
   recordablesMap_.create( *this );
 }
 
-nest::glif_cond::~glif_cond()
+glif_cond::~glif_cond()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -519,7 +517,7 @@ nest::glif_cond::~glif_cond()
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_cond::init_buffers_()
+glif_cond::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // include resize
@@ -547,7 +545,7 @@ nest::glif_cond::init_buffers_()
 }
 
 void
-nest::glif_cond::pre_run_hook()
+glif_cond::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -618,7 +616,7 @@ nest::glif_cond::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_cond::update( Time const& origin, const long from, const long to )
+glif_cond::update( Time const& origin, const long from, const long to )
 {
   // initial values
   double v_old = S_.y_[ State_::V_M ];
@@ -765,7 +763,7 @@ nest::glif_cond::update( Time const& origin, const long from, const long to )
 }
 
 size_t
-nest::glif_cond::handles_test_event( SpikeEvent&, size_t receptor_type )
+glif_cond::handles_test_event( SpikeEvent&, size_t receptor_type )
 {
   if ( receptor_type <= 0 or receptor_type > P_.n_receptors_() )
   {
@@ -777,7 +775,7 @@ nest::glif_cond::handles_test_event( SpikeEvent&, size_t receptor_type )
 }
 
 void
-nest::glif_cond::handle( SpikeEvent& e )
+glif_cond::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -786,7 +784,7 @@ nest::glif_cond::handle( SpikeEvent& e )
 }
 
 void
-nest::glif_cond::handle( CurrentEvent& e )
+glif_cond::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -797,9 +795,11 @@ nest::glif_cond::handle( CurrentEvent& e )
 // Do not move this function as inline to h-file. It depends on
 // universal_data_logger_impl.h being included here.
 void
-nest::glif_cond::handle( DataLoggingRequest& e )
+glif_cond::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );  // the logger does this for us
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/glif_cond.h
+++ b/models/glif_cond.h
@@ -212,18 +212,18 @@ public:
 
   ~glif_cond() override;
 
-  using nest::Node::handle;
-  using nest::Node::handles_test_event;
+  using Node::handle;
+  using Node::handles_test_event;
 
-  size_t send_test_event( nest::Node&, size_t, nest::synindex, bool ) override;
+  size_t send_test_event( Node&, size_t, synindex, bool ) override;
 
-  void handle( nest::SpikeEvent& ) override;
-  void handle( nest::CurrentEvent& ) override;
-  void handle( nest::DataLoggingRequest& ) override;
+  void handle( SpikeEvent& ) override;
+  void handle( CurrentEvent& ) override;
+  void handle( DataLoggingRequest& ) override;
 
-  size_t handles_test_event( nest::SpikeEvent&, size_t ) override;
-  size_t handles_test_event( nest::CurrentEvent&, size_t ) override;
-  size_t handles_test_event( nest::DataLoggingRequest&, size_t ) override;
+  size_t handles_test_event( SpikeEvent&, size_t ) override;
+  size_t handles_test_event( CurrentEvent&, size_t ) override;
+  size_t handles_test_event( DataLoggingRequest&, size_t ) override;
 
   void get_status( Dictionary& ) const override;
   void set_status( const Dictionary& ) override;
@@ -236,7 +236,7 @@ private:
   void pre_run_hook() override;
 
   //! Take neuron through given time interval
-  void update( nest::Time const&, const long, const long ) override;
+  void update( Time const&, const long, const long ) override;
 
   // make dynamics function quasi-member
   friend int glif_cond_dynamics( double, const double*, double*, void* );
@@ -337,8 +337,8 @@ private:
     Buffers_( glif_cond& );
     Buffers_( const Buffers_&, glif_cond& );
 
-    std::vector< nest::RingBuffer > spikes_;  //!< Buffer incoming spikes through delay, as sum
-    nest::RingBuffer currents_;               //!< Buffer incoming currents through delay,
+    std::vector< RingBuffer > spikes_;  //!< Buffer incoming spikes through delay, as sum
+    RingBuffer currents_;               //!< Buffer incoming currents through delay,
 
     //! Logger for all analog data
     DynamicUniversalDataLogger< glif_cond > logger_;
@@ -399,33 +399,33 @@ private:
   inline double
   get_state_element( size_t elem )
   {
-    if ( elem == nest::glif_cond::State_::V_M )
+    if ( elem == glif_cond::State_::V_M )
     {
       return S_.y_[ elem ] + P_.E_L_;
     }
-    else if ( elem == nest::glif_cond::State_::I )
+    else if ( elem == glif_cond::State_::I )
     {
       return B_.I_;
     }
-    else if ( elem == nest::glif_cond::State_::ASC_SUM )
+    else if ( elem == glif_cond::State_::ASC_SUM )
     {
       return S_.ASCurrents_sum_;
     }
-    else if ( elem == nest::glif_cond::State_::TH )
+    else if ( elem == glif_cond::State_::TH )
     {
       return S_.threshold_ + P_.E_L_;
     }
-    else if ( elem == nest::glif_cond::State_::TH_SPK )
+    else if ( elem == glif_cond::State_::TH_SPK )
     {
       return S_.threshold_spike_;
     }
-    else if ( elem == nest::glif_cond::State_::TH_VLT )
+    else if ( elem == glif_cond::State_::TH_VLT )
     {
       return S_.threshold_voltage_;
     }
     else
     {
-      return S_.y_[ elem - nest::glif_cond::State_::NUMBER_OF_RECORDABLES_ELEMENTS ];
+      return S_.y_[ elem - glif_cond::State_::NUMBER_OF_RECORDABLES_ELEMENTS ];
     }
   };
 
@@ -438,36 +438,36 @@ private:
 
 
 inline size_t
-nest::glif_cond::Parameters_::n_receptors_() const
+glif_cond::Parameters_::n_receptors_() const
 {
   return tau_syn_.size();
 }
 
 
 inline size_t
-nest::glif_cond::send_test_event( nest::Node& target, size_t receptor_type, nest::synindex, bool )
+glif_cond::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
-  nest::SpikeEvent e;
+  SpikeEvent e;
   e.set_sender( *this );
   return target.handles_test_event( e, receptor_type );
 }
 
 inline size_t
-nest::glif_cond::handles_test_event( nest::CurrentEvent&, size_t receptor_type )
+glif_cond::handles_test_event( CurrentEvent&, size_t receptor_type )
 {
   if ( receptor_type != 0 )
   {
-    throw nest::UnknownReceptorType( receptor_type, get_name() );
+    throw UnknownReceptorType( receptor_type, get_name() );
   }
   return 0;
 }
 
 inline size_t
-nest::glif_cond::handles_test_event( nest::DataLoggingRequest& dlr, size_t receptor_type )
+glif_cond::handles_test_event( DataLoggingRequest& dlr, size_t receptor_type )
 {
   if ( receptor_type != 0 )
   {
-    throw nest::UnknownReceptorType( receptor_type, get_name() );
+    throw UnknownReceptorType( receptor_type, get_name() );
   }
 
   return B_.logger_.connect_logging_device( dlr, recordablesMap_ );
@@ -483,7 +483,7 @@ glif_cond::get_status( Dictionary& d ) const
   // get information managed by parent class
   ArchivingNode::get_status( d );
 
-  d[ nest::names::recordables ] = recordablesMap_.get_list();
+  d[ names::recordables ] = recordablesMap_.get_list();
 }
 
 inline void

--- a/models/glif_psc.cpp
+++ b/models/glif_psc.cpp
@@ -34,12 +34,11 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-using namespace nest;
-
-nest::RecordablesMap< nest::glif_psc > nest::glif_psc::recordablesMap_;
 
 namespace nest
 {
+RecordablesMap< glif_psc > glif_psc::recordablesMap_;
+
 void
 register_glif_psc( const std::string& name )
 {
@@ -50,23 +49,22 @@ register_glif_psc( const std::string& name )
 // for each quantity to be recorded.
 template <>
 void
-RecordablesMap< nest::glif_psc >::create()
+RecordablesMap< glif_psc >::create()
 {
-  insert_( names::V_m, &nest::glif_psc::get_V_m_ );
-  insert_( names::ASCurrents_sum, &nest::glif_psc::get_ASCurrents_sum_ );
-  insert_( names::I, &nest::glif_psc::get_I_ );
-  insert_( names::I_syn, &nest::glif_psc::get_I_syn_ );
-  insert_( names::threshold, &nest::glif_psc::get_threshold_ );
-  insert_( names::threshold_spike, &nest::glif_psc::get_threshold_spike_ );
-  insert_( names::threshold_voltage, &nest::glif_psc::get_threshold_voltage_ );
-}
+  insert_( names::V_m, &glif_psc::get_V_m_ );
+  insert_( names::ASCurrents_sum, &glif_psc::get_ASCurrents_sum_ );
+  insert_( names::I, &glif_psc::get_I_ );
+  insert_( names::I_syn, &glif_psc::get_I_syn_ );
+  insert_( names::threshold, &glif_psc::get_threshold_ );
+  insert_( names::threshold_spike, &glif_psc::get_threshold_spike_ );
+  insert_( names::threshold_voltage, &glif_psc::get_threshold_voltage_ );
 }
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::glif_psc::Parameters_::Parameters_()
+glif_psc::Parameters_::Parameters_()
   : G_( 9.43 )                // in nS
   , E_L_( -78.85 )            // in mV
   , th_inf_( -51.68 - E_L_ )  // in mv, rel to E_L_, - 51.68 - E_L_, i.e., 27.17
@@ -91,7 +89,7 @@ nest::glif_psc::Parameters_::Parameters_()
 {
 }
 
-nest::glif_psc::State_::State_( const Parameters_& p )
+glif_psc::State_::State_( const Parameters_& p )
   : U_( 0.0 )                   // in mV
   , threshold_( p.th_inf_ )     // in mV
   , threshold_spike_( 0.0 )     // in mV
@@ -115,7 +113,7 @@ nest::glif_psc::State_::State_( const Parameters_& p )
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc::Parameters_::get( Dictionary& d ) const
+glif_psc::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = th_inf_ + E_L_;
   d[ names::g ] = G_;
@@ -144,7 +142,7 @@ nest::glif_psc::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::glif_psc::Parameters_::set( const Dictionary& d, Node* node )
+glif_psc::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -298,7 +296,7 @@ nest::glif_psc::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::glif_psc::State_::get( Dictionary& d, const Parameters_& p ) const
+glif_psc::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = U_ + p.E_L_;
   d[ names::ASCurrents ] = ASCurrents_;
@@ -307,7 +305,7 @@ nest::glif_psc::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::glif_psc::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+glif_psc::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, U_, node ) )
   {
@@ -345,12 +343,12 @@ nest::glif_psc::State_::set( const Dictionary& d, const Parameters_& p, double d
   }
 }
 
-nest::glif_psc::Buffers_::Buffers_( glif_psc& n )
+glif_psc::Buffers_::Buffers_( glif_psc& n )
   : logger_( n )
 {
 }
 
-nest::glif_psc::Buffers_::Buffers_( const Buffers_&, glif_psc& n )
+glif_psc::Buffers_::Buffers_( const Buffers_&, glif_psc& n )
   : logger_( n )
 {
 }
@@ -359,7 +357,7 @@ nest::glif_psc::Buffers_::Buffers_( const Buffers_&, glif_psc& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::glif_psc::glif_psc()
+glif_psc::glif_psc()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -368,7 +366,7 @@ nest::glif_psc::glif_psc()
   recordablesMap_.create();
 }
 
-nest::glif_psc::glif_psc( const glif_psc& n )
+glif_psc::glif_psc( const glif_psc& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -381,7 +379,7 @@ nest::glif_psc::glif_psc( const glif_psc& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc::init_buffers_()
+glif_psc::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // include resize
@@ -389,7 +387,7 @@ nest::glif_psc::init_buffers_()
 }
 
 void
-nest::glif_psc::pre_run_hook()
+glif_psc::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -463,7 +461,7 @@ nest::glif_psc::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc::update( Time const& origin, const long from, const long to )
+glif_psc::update( Time const& origin, const long from, const long to )
 {
   double v_old = S_.U_;
 
@@ -593,7 +591,7 @@ nest::glif_psc::update( Time const& origin, const long from, const long to )
 }
 
 size_t
-nest::glif_psc::handles_test_event( SpikeEvent&, size_t receptor_type )
+glif_psc::handles_test_event( SpikeEvent&, size_t receptor_type )
 {
   if ( receptor_type <= 0 or receptor_type > P_.n_receptors_() )
   {
@@ -605,7 +603,7 @@ nest::glif_psc::handles_test_event( SpikeEvent&, size_t receptor_type )
 }
 
 void
-nest::glif_psc::handle( SpikeEvent& e )
+glif_psc::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -614,7 +612,7 @@ nest::glif_psc::handle( SpikeEvent& e )
 }
 
 void
-nest::glif_psc::handle( CurrentEvent& e )
+glif_psc::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -625,7 +623,9 @@ nest::glif_psc::handle( CurrentEvent& e )
 // Do not move this function as inline to h-file. It depends on
 // universal_data_logger_impl.h being included here.
 void
-nest::glif_psc::handle( DataLoggingRequest& e )
+glif_psc::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );  // the logger does this for us
 }
+
+}  // namespace nest

--- a/models/glif_psc.h
+++ b/models/glif_psc.h
@@ -208,18 +208,18 @@ public:
 
   glif_psc( const glif_psc& );
 
-  using nest::Node::handle;
-  using nest::Node::handles_test_event;
+  using Node::handle;
+  using Node::handles_test_event;
 
-  size_t send_test_event( nest::Node&, size_t, nest::synindex, bool ) override;
+  size_t send_test_event( Node&, size_t, synindex, bool ) override;
 
-  void handle( nest::SpikeEvent& ) override;
-  void handle( nest::CurrentEvent& ) override;
-  void handle( nest::DataLoggingRequest& ) override;
+  void handle( SpikeEvent& ) override;
+  void handle( CurrentEvent& ) override;
+  void handle( DataLoggingRequest& ) override;
 
-  size_t handles_test_event( nest::SpikeEvent&, size_t ) override;
-  size_t handles_test_event( nest::CurrentEvent&, size_t ) override;
-  size_t handles_test_event( nest::DataLoggingRequest&, size_t ) override;
+  size_t handles_test_event( SpikeEvent&, size_t ) override;
+  size_t handles_test_event( CurrentEvent&, size_t ) override;
+  size_t handles_test_event( DataLoggingRequest&, size_t ) override;
 
   void get_status( Dictionary& ) const override;
   void set_status( const Dictionary& ) override;
@@ -232,11 +232,11 @@ private:
   void pre_run_hook() override;
 
   //! Take neuron through given time interval
-  void update( nest::Time const&, const long, const long ) override;
+  void update( Time const&, const long, const long ) override;
 
   // The next two classes need to be friends to access the State_ class/member
-  friend class nest::RecordablesMap< glif_psc >;
-  friend class nest::UniversalDataLogger< glif_psc >;
+  friend class RecordablesMap< glif_psc >;
+  friend class UniversalDataLogger< glif_psc >;
 
   struct Parameters_
   {
@@ -306,11 +306,11 @@ private:
     Buffers_( glif_psc& );
     Buffers_( const Buffers_&, glif_psc& );
 
-    std::vector< nest::RingBuffer > spikes_;  //!< Buffer incoming spikes through delay, as sum
-    nest::RingBuffer currents_;               //!< Buffer incoming currents through delay,
+    std::vector< RingBuffer > spikes_;  //!< Buffer incoming spikes through delay, as sum
+    RingBuffer currents_;               //!< Buffer incoming currents through delay,
 
     //! Logger for all analog data
-    nest::UniversalDataLogger< glif_psc > logger_;
+    UniversalDataLogger< glif_psc > logger_;
   };
 
   struct Variables_
@@ -389,40 +389,40 @@ private:
   Buffers_ B_;
 
   //! Mapping of recordables names to access functions
-  static nest::RecordablesMap< glif_psc > recordablesMap_;
+  static RecordablesMap< glif_psc > recordablesMap_;
 };
 
 
 inline size_t
-nest::glif_psc::Parameters_::n_receptors_() const
+glif_psc::Parameters_::n_receptors_() const
 {
   return tau_syn_.size();
 }
 
 inline size_t
-nest::glif_psc::send_test_event( nest::Node& target, size_t receptor_type, nest::synindex, bool )
+glif_psc::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
-  nest::SpikeEvent e;
+  SpikeEvent e;
   e.set_sender( *this );
   return target.handles_test_event( e, receptor_type );
 }
 
 inline size_t
-nest::glif_psc::handles_test_event( nest::CurrentEvent&, size_t receptor_type )
+glif_psc::handles_test_event( CurrentEvent&, size_t receptor_type )
 {
   if ( receptor_type != 0 )
   {
-    throw nest::UnknownReceptorType( receptor_type, get_name() );
+    throw UnknownReceptorType( receptor_type, get_name() );
   }
   return 0;
 }
 
 inline size_t
-nest::glif_psc::handles_test_event( nest::DataLoggingRequest& dlr, size_t receptor_type )
+glif_psc::handles_test_event( DataLoggingRequest& dlr, size_t receptor_type )
 {
   if ( receptor_type != 0 )
   {
-    throw nest::UnknownReceptorType( receptor_type, get_name() );
+    throw UnknownReceptorType( receptor_type, get_name() );
   }
   return B_.logger_.connect_logging_device( dlr, recordablesMap_ );
 }
@@ -437,7 +437,7 @@ glif_psc::get_status( Dictionary& d ) const
   // get information managed by parent class
   ArchivingNode::get_status( d );
 
-  d[ nest::names::recordables ] = recordablesMap_.get_list();
+  d[ names::recordables ] = recordablesMap_.get_list();
 }
 
 inline void

--- a/models/glif_psc_double_alpha.cpp
+++ b/models/glif_psc_double_alpha.cpp
@@ -34,12 +34,11 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-using namespace nest;
-
-nest::RecordablesMap< nest::glif_psc_double_alpha > nest::glif_psc_double_alpha::recordablesMap_;
 
 namespace nest
 {
+RecordablesMap< glif_psc_double_alpha > glif_psc_double_alpha::recordablesMap_;
+
 void
 register_glif_psc_double_alpha( const std::string& name )
 {
@@ -50,23 +49,22 @@ register_glif_psc_double_alpha( const std::string& name )
 // for each quantity to be recorded.
 template <>
 void
-RecordablesMap< nest::glif_psc_double_alpha >::create()
+RecordablesMap< glif_psc_double_alpha >::create()
 {
-  insert_( names::V_m, &nest::glif_psc_double_alpha::get_V_m_ );
-  insert_( names::ASCurrents_sum, &nest::glif_psc_double_alpha::get_ASCurrents_sum_ );
-  insert_( names::I, &nest::glif_psc_double_alpha::get_I_ );
-  insert_( names::I_syn, &nest::glif_psc_double_alpha::get_I_syn_ );
-  insert_( names::threshold, &nest::glif_psc_double_alpha::get_threshold_ );
-  insert_( names::threshold_spike, &nest::glif_psc_double_alpha::get_threshold_spike_ );
-  insert_( names::threshold_voltage, &nest::glif_psc_double_alpha::get_threshold_voltage_ );
-}
+  insert_( names::V_m, &glif_psc_double_alpha::get_V_m_ );
+  insert_( names::ASCurrents_sum, &glif_psc_double_alpha::get_ASCurrents_sum_ );
+  insert_( names::I, &glif_psc_double_alpha::get_I_ );
+  insert_( names::I_syn, &glif_psc_double_alpha::get_I_syn_ );
+  insert_( names::threshold, &glif_psc_double_alpha::get_threshold_ );
+  insert_( names::threshold_spike, &glif_psc_double_alpha::get_threshold_spike_ );
+  insert_( names::threshold_voltage, &glif_psc_double_alpha::get_threshold_voltage_ );
 }
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::glif_psc_double_alpha::Parameters_::Parameters_()
+glif_psc_double_alpha::Parameters_::Parameters_()
   : G_( 9.43 )                // in nS
   , E_L_( -78.85 )            // in mV
   , th_inf_( -51.68 - E_L_ )  // in mv, rel to E_L_, - 51.68 - E_L_, i.e., 27.17
@@ -93,7 +91,7 @@ nest::glif_psc_double_alpha::Parameters_::Parameters_()
 {
 }
 
-nest::glif_psc_double_alpha::State_::State_( const Parameters_& p )
+glif_psc_double_alpha::State_::State_( const Parameters_& p )
   : U_( 0.0 )                   // in mV
   , threshold_( p.th_inf_ )     // in mV
   , threshold_spike_( 0.0 )     // in mV
@@ -121,7 +119,7 @@ nest::glif_psc_double_alpha::State_::State_( const Parameters_& p )
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc_double_alpha::Parameters_::get( Dictionary& d ) const
+glif_psc_double_alpha::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = th_inf_ + E_L_;
   d[ names::g ] = G_;
@@ -154,7 +152,7 @@ nest::glif_psc_double_alpha::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::glif_psc_double_alpha::Parameters_::set( const Dictionary& d, Node* node )
+glif_psc_double_alpha::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to E_L_
   const double ELold = E_L_;
@@ -329,7 +327,7 @@ nest::glif_psc_double_alpha::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::glif_psc_double_alpha::State_::get( Dictionary& d, const Parameters_& p ) const
+glif_psc_double_alpha::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = U_ + p.E_L_;
   d[ names::ASCurrents ] = ASCurrents_;
@@ -338,7 +336,7 @@ nest::glif_psc_double_alpha::State_::get( Dictionary& d, const Parameters_& p ) 
 }
 
 void
-nest::glif_psc_double_alpha::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+glif_psc_double_alpha::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, U_, node ) )
   {
@@ -376,12 +374,12 @@ nest::glif_psc_double_alpha::State_::set( const Dictionary& d, const Parameters_
   }
 }
 
-nest::glif_psc_double_alpha::Buffers_::Buffers_( glif_psc_double_alpha& n )
+glif_psc_double_alpha::Buffers_::Buffers_( glif_psc_double_alpha& n )
   : logger_( n )
 {
 }
 
-nest::glif_psc_double_alpha::Buffers_::Buffers_( const Buffers_&, glif_psc_double_alpha& n )
+glif_psc_double_alpha::Buffers_::Buffers_( const Buffers_&, glif_psc_double_alpha& n )
   : logger_( n )
 {
 }
@@ -390,7 +388,7 @@ nest::glif_psc_double_alpha::Buffers_::Buffers_( const Buffers_&, glif_psc_doubl
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::glif_psc_double_alpha::glif_psc_double_alpha()
+glif_psc_double_alpha::glif_psc_double_alpha()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -399,7 +397,7 @@ nest::glif_psc_double_alpha::glif_psc_double_alpha()
   recordablesMap_.create();
 }
 
-nest::glif_psc_double_alpha::glif_psc_double_alpha( const glif_psc_double_alpha& n )
+glif_psc_double_alpha::glif_psc_double_alpha( const glif_psc_double_alpha& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -412,7 +410,7 @@ nest::glif_psc_double_alpha::glif_psc_double_alpha( const glif_psc_double_alpha&
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc_double_alpha::init_buffers_()
+glif_psc_double_alpha::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // include resize
@@ -420,7 +418,7 @@ nest::glif_psc_double_alpha::init_buffers_()
 }
 
 void
-nest::glif_psc_double_alpha::pre_run_hook()
+glif_psc_double_alpha::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -513,7 +511,7 @@ nest::glif_psc_double_alpha::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::glif_psc_double_alpha::update( Time const& origin, const long from, const long to )
+glif_psc_double_alpha::update( Time const& origin, const long from, const long to )
 {
 
   double v_old = S_.U_;
@@ -659,7 +657,7 @@ nest::glif_psc_double_alpha::update( Time const& origin, const long from, const 
 }
 
 size_t
-nest::glif_psc_double_alpha::handles_test_event( SpikeEvent&, size_t receptor_type )
+glif_psc_double_alpha::handles_test_event( SpikeEvent&, size_t receptor_type )
 {
   if ( receptor_type <= 0 or receptor_type > P_.n_receptors_() )
   {
@@ -671,7 +669,7 @@ nest::glif_psc_double_alpha::handles_test_event( SpikeEvent&, size_t receptor_ty
 }
 
 void
-nest::glif_psc_double_alpha::handle( SpikeEvent& e )
+glif_psc_double_alpha::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -680,7 +678,7 @@ nest::glif_psc_double_alpha::handle( SpikeEvent& e )
 }
 
 void
-nest::glif_psc_double_alpha::handle( CurrentEvent& e )
+glif_psc_double_alpha::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -691,7 +689,9 @@ nest::glif_psc_double_alpha::handle( CurrentEvent& e )
 // Do not move this function as inline to h-file. It depends on
 // universal_data_logger_impl.h being included here.
 void
-nest::glif_psc_double_alpha::handle( DataLoggingRequest& e )
+glif_psc_double_alpha::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );  // the logger does this for us
 }
+
+}  // namespace nest

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -45,10 +45,10 @@
 #include "universal_data_logger_impl.h"
 
 
-nest::RecordablesMap< nest::hh_cond_beta_gap_traub > nest::hh_cond_beta_gap_traub::recordablesMap_;
-
 namespace nest
 {
+RecordablesMap< hh_cond_beta_gap_traub > hh_cond_beta_gap_traub::recordablesMap_;
+
 void
 register_hh_cond_beta_gap_traub( const std::string& name )
 {
@@ -74,11 +74,11 @@ extern "C" int
 hh_cond_beta_gap_traub_dynamics( double time, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::hh_cond_beta_gap_traub::State_ S;
+  typedef hh_cond_beta_gap_traub::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::hh_cond_beta_gap_traub& node = *( reinterpret_cast< nest::hh_cond_beta_gap_traub* >( pnode ) );
+  const hh_cond_beta_gap_traub& node = *( reinterpret_cast< hh_cond_beta_gap_traub* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -160,7 +160,7 @@ hh_cond_beta_gap_traub_dynamics( double time, const double y[], double f[], void
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::hh_cond_beta_gap_traub::Parameters_::Parameters_()
+hh_cond_beta_gap_traub::Parameters_::Parameters_()
   : g_Na( 20000.0 )       // Sodium Conductance                      (nS)
   , g_K( 6000.0 )         // Potassium Conductance                   (nS)
   , g_L( 10.0 )           // Leak Conductance                        (nS)
@@ -180,7 +180,7 @@ nest::hh_cond_beta_gap_traub::Parameters_::Parameters_()
 {
 }
 
-nest::hh_cond_beta_gap_traub::State_::State_( const Parameters_& p )
+hh_cond_beta_gap_traub::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -202,7 +202,7 @@ nest::hh_cond_beta_gap_traub::State_::State_( const Parameters_& p )
   y_[ HH_M ] = alpha_m / ( alpha_m + beta_m );
 }
 
-nest::hh_cond_beta_gap_traub::State_::State_( const State_& s )
+hh_cond_beta_gap_traub::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -211,8 +211,8 @@ nest::hh_cond_beta_gap_traub::State_::State_( const State_& s )
   }
 }
 
-nest::hh_cond_beta_gap_traub::State_&
-nest::hh_cond_beta_gap_traub::State_::operator=( const State_& s )
+hh_cond_beta_gap_traub::State_&
+hh_cond_beta_gap_traub::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -227,7 +227,7 @@ nest::hh_cond_beta_gap_traub::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_cond_beta_gap_traub::Parameters_::get( Dictionary& d ) const
+hh_cond_beta_gap_traub::Parameters_::get( Dictionary& d ) const
 {
   d[ names::g_Na ] = g_Na;
   d[ names::g_K ] = g_K;
@@ -248,7 +248,7 @@ nest::hh_cond_beta_gap_traub::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_cond_beta_gap_traub::Parameters_::set( const Dictionary& d, Node* node )
+hh_cond_beta_gap_traub::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::g_Na, g_Na, node );
   update_value_param( d, names::g_K, g_K, node );
@@ -289,7 +289,7 @@ nest::hh_cond_beta_gap_traub::Parameters_::set( const Dictionary& d, Node* node 
 }
 
 void
-nest::hh_cond_beta_gap_traub::State_::get( Dictionary& d ) const
+hh_cond_beta_gap_traub::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];  // Membrane potential
   d[ names::Act_m ] = y_[ HH_M ];
@@ -298,7 +298,7 @@ nest::hh_cond_beta_gap_traub::State_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_cond_beta_gap_traub::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+hh_cond_beta_gap_traub::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::Act_m, y_[ HH_M ], node );
@@ -310,7 +310,7 @@ nest::hh_cond_beta_gap_traub::State_::set( const Dictionary& d, const Parameters
   }
 }
 
-nest::hh_cond_beta_gap_traub::Buffers_::Buffers_( hh_cond_beta_gap_traub& n )
+hh_cond_beta_gap_traub::Buffers_::Buffers_( hh_cond_beta_gap_traub& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -320,7 +320,7 @@ nest::hh_cond_beta_gap_traub::Buffers_::Buffers_( hh_cond_beta_gap_traub& n )
   // init_buffers_().
 }
 
-nest::hh_cond_beta_gap_traub::Buffers_::Buffers_( const Buffers_&, hh_cond_beta_gap_traub& n )
+hh_cond_beta_gap_traub::Buffers_::Buffers_( const Buffers_&, hh_cond_beta_gap_traub& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -334,7 +334,7 @@ nest::hh_cond_beta_gap_traub::Buffers_::Buffers_( const Buffers_&, hh_cond_beta_
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::hh_cond_beta_gap_traub::hh_cond_beta_gap_traub()
+hh_cond_beta_gap_traub::hh_cond_beta_gap_traub()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -344,7 +344,7 @@ nest::hh_cond_beta_gap_traub::hh_cond_beta_gap_traub()
   Node::set_node_uses_wfr( kernel().simulation_manager.use_wfr() );
 }
 
-nest::hh_cond_beta_gap_traub::hh_cond_beta_gap_traub( const hh_cond_beta_gap_traub& n )
+hh_cond_beta_gap_traub::hh_cond_beta_gap_traub( const hh_cond_beta_gap_traub& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -353,7 +353,7 @@ nest::hh_cond_beta_gap_traub::hh_cond_beta_gap_traub( const hh_cond_beta_gap_tra
   Node::set_node_uses_wfr( kernel().simulation_manager.use_wfr() );
 }
 
-nest::hh_cond_beta_gap_traub::~hh_cond_beta_gap_traub()
+hh_cond_beta_gap_traub::~hh_cond_beta_gap_traub()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -375,7 +375,7 @@ nest::hh_cond_beta_gap_traub::~hh_cond_beta_gap_traub()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_cond_beta_gap_traub::init_buffers_()
+hh_cond_beta_gap_traub::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -443,19 +443,19 @@ nest::hh_cond_beta_gap_traub::init_buffers_()
 }
 
 double
-nest::hh_cond_beta_gap_traub::get_normalisation_factor( double tau_rise, double tau_decay )
+hh_cond_beta_gap_traub::get_normalisation_factor( double tau_rise, double tau_decay )
 {
-  return nest::beta_normalization_factor( tau_rise, tau_decay );
+  return beta_normalization_factor( tau_rise, tau_decay );
 }
 
 void
-nest::hh_cond_beta_gap_traub::pre_run_hook()
+hh_cond_beta_gap_traub::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 
-  V_.PSConInit_E = nest::hh_cond_beta_gap_traub::get_normalisation_factor( P_.tau_rise_ex, P_.tau_decay_ex );
-  V_.PSConInit_I = nest::hh_cond_beta_gap_traub::get_normalisation_factor( P_.tau_rise_in, P_.tau_decay_in );
+  V_.PSConInit_E = hh_cond_beta_gap_traub::get_normalisation_factor( P_.tau_rise_ex, P_.tau_decay_ex );
+  V_.PSConInit_I = hh_cond_beta_gap_traub::get_normalisation_factor( P_.tau_rise_in, P_.tau_decay_in );
 
   V_.refractory_counts_ = Time( Time::ms( P_.t_ref_ ) ).get_steps();
   V_.U_old_ = S_.y_[ State_::V_M ];
@@ -469,7 +469,7 @@ nest::hh_cond_beta_gap_traub::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 bool
-nest::hh_cond_beta_gap_traub::update_( Time const& origin,
+hh_cond_beta_gap_traub::update_( Time const& origin,
   const long from,
   const long to,
   const bool called_from_wfr_update )
@@ -629,7 +629,7 @@ nest::hh_cond_beta_gap_traub::update_( Time const& origin,
 }
 
 void
-nest::hh_cond_beta_gap_traub::handle( SpikeEvent& e )
+hh_cond_beta_gap_traub::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -648,7 +648,7 @@ nest::hh_cond_beta_gap_traub::handle( SpikeEvent& e )
 }
 
 void
-nest::hh_cond_beta_gap_traub::handle( CurrentEvent& e )
+hh_cond_beta_gap_traub::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -660,13 +660,13 @@ nest::hh_cond_beta_gap_traub::handle( CurrentEvent& e )
 }
 
 void
-nest::hh_cond_beta_gap_traub::handle( DataLoggingRequest& e )
+hh_cond_beta_gap_traub::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
 void
-nest::hh_cond_beta_gap_traub::handle( GapJunctionEvent& e )
+hh_cond_beta_gap_traub::handle( GapJunctionEvent& e )
 {
   const double weight = e.get_weight();
 

--- a/models/hh_cond_beta_gap_traub.cpp
+++ b/models/hh_cond_beta_gap_traub.cpp
@@ -469,10 +469,7 @@ hh_cond_beta_gap_traub::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 bool
-hh_cond_beta_gap_traub::update_( Time const& origin,
-  const long from,
-  const long to,
-  const bool called_from_wfr_update )
+hh_cond_beta_gap_traub::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();

--- a/models/hh_cond_exp_traub.cpp
+++ b/models/hh_cond_exp_traub.cpp
@@ -42,10 +42,10 @@
 #include "universal_data_logger_impl.h"
 
 
-nest::RecordablesMap< nest::hh_cond_exp_traub > nest::hh_cond_exp_traub::recordablesMap_;
-
 namespace nest
 {
+RecordablesMap< hh_cond_exp_traub > hh_cond_exp_traub::recordablesMap_;
+
 void
 register_hh_cond_exp_traub( const std::string& name )
 {
@@ -71,11 +71,11 @@ extern "C" int
 hh_cond_exp_traub_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::hh_cond_exp_traub::State_ S;
+  typedef hh_cond_exp_traub::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::hh_cond_exp_traub& node = *( reinterpret_cast< nest::hh_cond_exp_traub* >( pnode ) );
+  const hh_cond_exp_traub& node = *( reinterpret_cast< hh_cond_exp_traub* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -121,7 +121,7 @@ hh_cond_exp_traub_dynamics( double, const double y[], double f[], void* pnode )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::hh_cond_exp_traub::Parameters_::Parameters_()
+hh_cond_exp_traub::Parameters_::Parameters_()
   : g_Na( 20000.0 )  // Sodium Conductance (nS)
   , g_K( 6000.0 )    // K Conductance      (nS)
   , g_L( 10.0 )      // Leak Conductance   (nS)
@@ -139,7 +139,7 @@ nest::hh_cond_exp_traub::Parameters_::Parameters_()
 {
 }
 
-nest::hh_cond_exp_traub::State_::State_( const Parameters_& p )
+hh_cond_exp_traub::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ 0 ] = p.E_L;
@@ -161,7 +161,7 @@ nest::hh_cond_exp_traub::State_::State_( const Parameters_& p )
   y_[ HH_M ] = alpha_m / ( alpha_m + beta_m );
 }
 
-nest::hh_cond_exp_traub::State_::State_( const State_& s )
+hh_cond_exp_traub::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -170,8 +170,8 @@ nest::hh_cond_exp_traub::State_::State_( const State_& s )
   }
 }
 
-nest::hh_cond_exp_traub::State_&
-nest::hh_cond_exp_traub::State_::operator=( const State_& s )
+hh_cond_exp_traub::State_&
+hh_cond_exp_traub::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -186,7 +186,7 @@ nest::hh_cond_exp_traub::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_cond_exp_traub::Parameters_::get( Dictionary& d ) const
+hh_cond_exp_traub::Parameters_::get( Dictionary& d ) const
 {
   d[ names::g_Na ] = g_Na;
   d[ names::g_K ] = g_K;
@@ -205,7 +205,7 @@ nest::hh_cond_exp_traub::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_cond_exp_traub::Parameters_::set( const Dictionary& d, Node* node )
+hh_cond_exp_traub::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::g_Na, g_Na, node );
   update_value_param( d, names::g_K, g_K, node );
@@ -239,7 +239,7 @@ nest::hh_cond_exp_traub::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::hh_cond_exp_traub::State_::get( Dictionary& d ) const
+hh_cond_exp_traub::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];  // Membrane potential
   d[ names::Act_m ] = y_[ HH_M ];
@@ -248,7 +248,7 @@ nest::hh_cond_exp_traub::State_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_cond_exp_traub::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+hh_cond_exp_traub::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::Act_m, y_[ HH_M ], node );
@@ -260,7 +260,7 @@ nest::hh_cond_exp_traub::State_::set( const Dictionary& d, const Parameters_&, N
   }
 }
 
-nest::hh_cond_exp_traub::Buffers_::Buffers_( hh_cond_exp_traub& n )
+hh_cond_exp_traub::Buffers_::Buffers_( hh_cond_exp_traub& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -270,7 +270,7 @@ nest::hh_cond_exp_traub::Buffers_::Buffers_( hh_cond_exp_traub& n )
   // init_buffers_().
 }
 
-nest::hh_cond_exp_traub::Buffers_::Buffers_( const Buffers_&, hh_cond_exp_traub& n )
+hh_cond_exp_traub::Buffers_::Buffers_( const Buffers_&, hh_cond_exp_traub& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -284,7 +284,7 @@ nest::hh_cond_exp_traub::Buffers_::Buffers_( const Buffers_&, hh_cond_exp_traub&
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::hh_cond_exp_traub::hh_cond_exp_traub()
+hh_cond_exp_traub::hh_cond_exp_traub()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -293,7 +293,7 @@ nest::hh_cond_exp_traub::hh_cond_exp_traub()
   recordablesMap_.create();
 }
 
-nest::hh_cond_exp_traub::hh_cond_exp_traub( const hh_cond_exp_traub& n )
+hh_cond_exp_traub::hh_cond_exp_traub( const hh_cond_exp_traub& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -301,7 +301,7 @@ nest::hh_cond_exp_traub::hh_cond_exp_traub( const hh_cond_exp_traub& n )
 {
 }
 
-nest::hh_cond_exp_traub::~hh_cond_exp_traub()
+hh_cond_exp_traub::~hh_cond_exp_traub()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -323,7 +323,7 @@ nest::hh_cond_exp_traub::~hh_cond_exp_traub()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_cond_exp_traub::init_buffers_()
+hh_cond_exp_traub::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -371,7 +371,7 @@ nest::hh_cond_exp_traub::init_buffers_()
 }
 
 void
-nest::hh_cond_exp_traub::pre_run_hook()
+hh_cond_exp_traub::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -383,7 +383,7 @@ nest::hh_cond_exp_traub::pre_run_hook()
  * Update and spike handling functions
  * ---------------------------------------------------------------- */
 void
-nest::hh_cond_exp_traub::update( Time const& origin, const long from, const long to )
+hh_cond_exp_traub::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -437,7 +437,7 @@ nest::hh_cond_exp_traub::update( Time const& origin, const long from, const long
 }
 
 void
-nest::hh_cond_exp_traub::handle( SpikeEvent& e )
+hh_cond_exp_traub::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -456,7 +456,7 @@ nest::hh_cond_exp_traub::handle( SpikeEvent& e )
 }
 
 void
-nest::hh_cond_exp_traub::handle( CurrentEvent& e )
+hh_cond_exp_traub::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -468,7 +468,7 @@ nest::hh_cond_exp_traub::handle( CurrentEvent& e )
 }
 
 void
-nest::hh_cond_exp_traub::handle( DataLoggingRequest& e )
+hh_cond_exp_traub::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }

--- a/models/hh_psc_alpha.cpp
+++ b/models/hh_psc_alpha.cpp
@@ -40,10 +40,10 @@
 #include "universal_data_logger_impl.h"
 
 
-nest::RecordablesMap< nest::hh_psc_alpha > nest::hh_psc_alpha::recordablesMap_;
-
 namespace nest
 {
+RecordablesMap< hh_psc_alpha > hh_psc_alpha::recordablesMap_;
+
 void
 register_hh_psc_alpha( const std::string& name )
 {
@@ -69,11 +69,11 @@ extern "C" int
 hh_psc_alpha_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::hh_psc_alpha::State_ S;
+  typedef hh_psc_alpha::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::hh_psc_alpha& node = *( reinterpret_cast< nest::hh_psc_alpha* >( pnode ) );
+  const hh_psc_alpha& node = *( reinterpret_cast< hh_psc_alpha* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -118,13 +118,12 @@ hh_psc_alpha_dynamics( double, const double y[], double f[], void* pnode )
 
   return GSL_SUCCESS;
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::hh_psc_alpha::Parameters_::Parameters_()
+hh_psc_alpha::Parameters_::Parameters_()
   : t_ref_( 2.0 )    // ms
   , g_Na( 12000.0 )  // nS
   , g_K( 3600.0 )    // nS
@@ -139,7 +138,7 @@ nest::hh_psc_alpha::Parameters_::Parameters_()
 {
 }
 
-nest::hh_psc_alpha::State_::State_( const Parameters_& )
+hh_psc_alpha::State_::State_( const Parameters_& )
   : r_( 0 )
 {
   y_[ 0 ] = -65;  // p.E_L;
@@ -161,7 +160,7 @@ nest::hh_psc_alpha::State_::State_( const Parameters_& )
   y_[ HH_M ] = alpha_m / ( alpha_m + beta_m );
 }
 
-nest::hh_psc_alpha::State_::State_( const State_& s )
+hh_psc_alpha::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -170,8 +169,8 @@ nest::hh_psc_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::hh_psc_alpha::State_&
-nest::hh_psc_alpha::State_::operator=( const State_& s )
+hh_psc_alpha::State_&
+hh_psc_alpha::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -186,7 +185,7 @@ nest::hh_psc_alpha::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha::Parameters_::get( Dictionary& d ) const
+hh_psc_alpha::Parameters_::get( Dictionary& d ) const
 {
   d[ names::t_ref ] = t_ref_;
   d[ names::g_Na ] = g_Na;
@@ -202,7 +201,7 @@ nest::hh_psc_alpha::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_psc_alpha::Parameters_::set( const Dictionary& d, Node* node )
+hh_psc_alpha::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::t_ref, t_ref_, node );
   update_value_param( d, names::C_m, C_m, node );
@@ -236,7 +235,7 @@ nest::hh_psc_alpha::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::hh_psc_alpha::State_::get( Dictionary& d ) const
+hh_psc_alpha::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::Act_m ] = y_[ HH_M ];
@@ -245,7 +244,7 @@ nest::hh_psc_alpha::State_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_psc_alpha::State_::set( const Dictionary& d, Node* node )
+hh_psc_alpha::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::Act_m, y_[ HH_M ], node );
@@ -257,7 +256,7 @@ nest::hh_psc_alpha::State_::set( const Dictionary& d, Node* node )
   }
 }
 
-nest::hh_psc_alpha::Buffers_::Buffers_( hh_psc_alpha& n )
+hh_psc_alpha::Buffers_::Buffers_( hh_psc_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -267,7 +266,7 @@ nest::hh_psc_alpha::Buffers_::Buffers_( hh_psc_alpha& n )
   // init_buffers_().
 }
 
-nest::hh_psc_alpha::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha& n )
+hh_psc_alpha::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -281,7 +280,7 @@ nest::hh_psc_alpha::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::hh_psc_alpha::hh_psc_alpha()
+hh_psc_alpha::hh_psc_alpha()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -290,7 +289,7 @@ nest::hh_psc_alpha::hh_psc_alpha()
   recordablesMap_.create();
 }
 
-nest::hh_psc_alpha::hh_psc_alpha( const hh_psc_alpha& n )
+hh_psc_alpha::hh_psc_alpha( const hh_psc_alpha& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -298,7 +297,7 @@ nest::hh_psc_alpha::hh_psc_alpha( const hh_psc_alpha& n )
 {
 }
 
-nest::hh_psc_alpha::~hh_psc_alpha()
+hh_psc_alpha::~hh_psc_alpha()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -320,7 +319,7 @@ nest::hh_psc_alpha::~hh_psc_alpha()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha::init_buffers_()
+hh_psc_alpha::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -368,7 +367,7 @@ nest::hh_psc_alpha::init_buffers_()
 }
 
 void
-nest::hh_psc_alpha::pre_run_hook()
+hh_psc_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -385,7 +384,7 @@ nest::hh_psc_alpha::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha::update( Time const& origin, const long from, const long to )
+hh_psc_alpha::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -449,7 +448,7 @@ nest::hh_psc_alpha::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::hh_psc_alpha::handle( SpikeEvent& e )
+hh_psc_alpha::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -466,7 +465,7 @@ nest::hh_psc_alpha::handle( SpikeEvent& e )
 }
 
 void
-nest::hh_psc_alpha::handle( CurrentEvent& e )
+hh_psc_alpha::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -477,9 +476,11 @@ nest::hh_psc_alpha::handle( CurrentEvent& e )
 }
 
 void
-nest::hh_psc_alpha::handle( DataLoggingRequest& e )
+hh_psc_alpha::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/hh_psc_alpha_clopath.cpp
+++ b/models/hh_psc_alpha_clopath.cpp
@@ -40,10 +40,10 @@
 #include "universal_data_logger_impl.h"
 
 
-nest::RecordablesMap< nest::hh_psc_alpha_clopath > nest::hh_psc_alpha_clopath::recordablesMap_;
-
 namespace nest
 {
+RecordablesMap< hh_psc_alpha_clopath > hh_psc_alpha_clopath::recordablesMap_;
+
 void
 register_hh_psc_alpha_clopath( const std::string& name )
 {
@@ -72,11 +72,11 @@ extern "C" int
 hh_psc_alpha_clopath_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::hh_psc_alpha_clopath::State_ S;
+  typedef hh_psc_alpha_clopath::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::hh_psc_alpha_clopath& node = *( reinterpret_cast< nest::hh_psc_alpha_clopath* >( pnode ) );
+  const hh_psc_alpha_clopath& node = *( reinterpret_cast< hh_psc_alpha_clopath* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -129,13 +129,12 @@ hh_psc_alpha_clopath_dynamics( double, const double y[], double f[], void* pnode
 
   return GSL_SUCCESS;
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::hh_psc_alpha_clopath::Parameters_::Parameters_()
+hh_psc_alpha_clopath::Parameters_::Parameters_()
   : t_ref_( 2.0 )            // ms
   , g_Na( 12000.0 )          // nS
   , g_K( 3600.0 )            // nS
@@ -153,7 +152,7 @@ nest::hh_psc_alpha_clopath::Parameters_::Parameters_()
 {
 }
 
-nest::hh_psc_alpha_clopath::State_::State_( const Parameters_& )
+hh_psc_alpha_clopath::State_::State_( const Parameters_& )
   : r_( 0 )
 {
   y_[ 0 ] = -65;  // p.E_L;
@@ -175,7 +174,7 @@ nest::hh_psc_alpha_clopath::State_::State_( const Parameters_& )
   y_[ HH_M ] = alpha_m / ( alpha_m + beta_m );
 }
 
-nest::hh_psc_alpha_clopath::State_::State_( const State_& s )
+hh_psc_alpha_clopath::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -184,8 +183,8 @@ nest::hh_psc_alpha_clopath::State_::State_( const State_& s )
   }
 }
 
-nest::hh_psc_alpha_clopath::State_&
-nest::hh_psc_alpha_clopath::State_::operator=( const State_& s )
+hh_psc_alpha_clopath::State_&
+hh_psc_alpha_clopath::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -200,7 +199,7 @@ nest::hh_psc_alpha_clopath::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha_clopath::Parameters_::get( Dictionary& d ) const
+hh_psc_alpha_clopath::Parameters_::get( Dictionary& d ) const
 {
   d[ names::t_ref ] = t_ref_;
   d[ names::g_Na ] = g_Na;
@@ -219,7 +218,7 @@ nest::hh_psc_alpha_clopath::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_psc_alpha_clopath::Parameters_::set( const Dictionary& d, Node* node )
+hh_psc_alpha_clopath::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::t_ref, t_ref_, node );
   update_value_param( d, names::C_m, C_m, node );
@@ -256,7 +255,7 @@ nest::hh_psc_alpha_clopath::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::hh_psc_alpha_clopath::State_::get( Dictionary& d ) const
+hh_psc_alpha_clopath::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::Act_m ] = y_[ HH_M ];
@@ -268,7 +267,7 @@ nest::hh_psc_alpha_clopath::State_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_psc_alpha_clopath::State_::set( const Dictionary& d, Node* node )
+hh_psc_alpha_clopath::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::Act_m, y_[ HH_M ], node );
@@ -283,7 +282,7 @@ nest::hh_psc_alpha_clopath::State_::set( const Dictionary& d, Node* node )
   }
 }
 
-nest::hh_psc_alpha_clopath::Buffers_::Buffers_( hh_psc_alpha_clopath& n )
+hh_psc_alpha_clopath::Buffers_::Buffers_( hh_psc_alpha_clopath& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -293,7 +292,7 @@ nest::hh_psc_alpha_clopath::Buffers_::Buffers_( hh_psc_alpha_clopath& n )
   // init_buffers_().
 }
 
-nest::hh_psc_alpha_clopath::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha_clopath& n )
+hh_psc_alpha_clopath::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha_clopath& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -307,7 +306,7 @@ nest::hh_psc_alpha_clopath::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha_cl
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::hh_psc_alpha_clopath::hh_psc_alpha_clopath()
+hh_psc_alpha_clopath::hh_psc_alpha_clopath()
   : ClopathArchivingNode()
   , P_()
   , S_( P_ )
@@ -316,7 +315,7 @@ nest::hh_psc_alpha_clopath::hh_psc_alpha_clopath()
   recordablesMap_.create();
 }
 
-nest::hh_psc_alpha_clopath::hh_psc_alpha_clopath( const hh_psc_alpha_clopath& n )
+hh_psc_alpha_clopath::hh_psc_alpha_clopath( const hh_psc_alpha_clopath& n )
   : ClopathArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -324,7 +323,7 @@ nest::hh_psc_alpha_clopath::hh_psc_alpha_clopath( const hh_psc_alpha_clopath& n 
 {
 }
 
-nest::hh_psc_alpha_clopath::~hh_psc_alpha_clopath()
+hh_psc_alpha_clopath::~hh_psc_alpha_clopath()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -346,7 +345,7 @@ nest::hh_psc_alpha_clopath::~hh_psc_alpha_clopath()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha_clopath::init_buffers_()
+hh_psc_alpha_clopath::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -396,7 +395,7 @@ nest::hh_psc_alpha_clopath::init_buffers_()
 }
 
 void
-nest::hh_psc_alpha_clopath::pre_run_hook()
+hh_psc_alpha_clopath::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -413,7 +412,7 @@ nest::hh_psc_alpha_clopath::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha_clopath::update( Time const& origin, const long from, const long to )
+hh_psc_alpha_clopath::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -484,7 +483,7 @@ nest::hh_psc_alpha_clopath::update( Time const& origin, const long from, const l
 }
 
 void
-nest::hh_psc_alpha_clopath::handle( SpikeEvent& e )
+hh_psc_alpha_clopath::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -501,7 +500,7 @@ nest::hh_psc_alpha_clopath::handle( SpikeEvent& e )
 }
 
 void
-nest::hh_psc_alpha_clopath::handle( CurrentEvent& e )
+hh_psc_alpha_clopath::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -513,9 +512,11 @@ nest::hh_psc_alpha_clopath::handle( CurrentEvent& e )
 }
 
 void
-nest::hh_psc_alpha_clopath::handle( DataLoggingRequest& e )
+hh_psc_alpha_clopath::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/hh_psc_alpha_gap.cpp
+++ b/models/hh_psc_alpha_gap.cpp
@@ -41,10 +41,10 @@
 #include "universal_data_logger_impl.h"
 
 
-nest::RecordablesMap< nest::hh_psc_alpha_gap > nest::hh_psc_alpha_gap::recordablesMap_;
-
 namespace nest
 {
+RecordablesMap< hh_psc_alpha_gap > hh_psc_alpha_gap::recordablesMap_;
+
 void
 register_hh_psc_alpha_gap( const std::string& name )
 {
@@ -71,11 +71,11 @@ extern "C" int
 hh_psc_alpha_gap_dynamics( double time, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::hh_psc_alpha_gap::State_ S;
+  typedef hh_psc_alpha_gap::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::hh_psc_alpha_gap& node = *( reinterpret_cast< nest::hh_psc_alpha_gap* >( pnode ) );
+  const hh_psc_alpha_gap& node = *( reinterpret_cast< hh_psc_alpha_gap* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -152,13 +152,12 @@ hh_psc_alpha_gap_dynamics( double time, const double y[], double f[], void* pnod
 
   return GSL_SUCCESS;
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::hh_psc_alpha_gap::Parameters_::Parameters_()
+hh_psc_alpha_gap::Parameters_::Parameters_()
   : t_ref_( 2.0 )    // ms
   , g_Na( 4500. )    // nS
   , g_Kv1( 9.0 )     // nS
@@ -174,7 +173,7 @@ nest::hh_psc_alpha_gap::Parameters_::Parameters_()
 {
 }
 
-nest::hh_psc_alpha_gap::State_::State_( const Parameters_& )
+hh_psc_alpha_gap::State_::State_( const Parameters_& )
   : r_( 0 )
 {
   y_[ 0 ] = -69.60401191631222;  // p.E_L;
@@ -201,7 +200,7 @@ nest::hh_psc_alpha_gap::State_::State_( const Parameters_& )
   y_[ HH_P ] = alpha_p / ( alpha_p + beta_p );
 }
 
-nest::hh_psc_alpha_gap::State_::State_( const State_& s )
+hh_psc_alpha_gap::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -210,8 +209,8 @@ nest::hh_psc_alpha_gap::State_::State_( const State_& s )
   }
 }
 
-nest::hh_psc_alpha_gap::State_&
-nest::hh_psc_alpha_gap::State_::operator=( const State_& s )
+hh_psc_alpha_gap::State_&
+hh_psc_alpha_gap::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -226,7 +225,7 @@ nest::hh_psc_alpha_gap::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha_gap::Parameters_::get( Dictionary& d ) const
+hh_psc_alpha_gap::Parameters_::get( Dictionary& d ) const
 {
   d[ names::t_ref ] = t_ref_;
   d[ names::g_Na ] = g_Na;
@@ -243,7 +242,7 @@ nest::hh_psc_alpha_gap::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_psc_alpha_gap::Parameters_::set( const Dictionary& d, Node* node )
+hh_psc_alpha_gap::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::t_ref, t_ref_, node );
   update_value_param( d, names::C_m, C_m, node );
@@ -278,7 +277,7 @@ nest::hh_psc_alpha_gap::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::hh_psc_alpha_gap::State_::get( Dictionary& d ) const
+hh_psc_alpha_gap::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];
   d[ names::Act_m ] = y_[ HH_M ];
@@ -288,7 +287,7 @@ nest::hh_psc_alpha_gap::State_::get( Dictionary& d ) const
 }
 
 void
-nest::hh_psc_alpha_gap::State_::set( const Dictionary& d, Node* node )
+hh_psc_alpha_gap::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::Act_m, y_[ HH_M ], node );
@@ -301,7 +300,7 @@ nest::hh_psc_alpha_gap::State_::set( const Dictionary& d, Node* node )
   }
 }
 
-nest::hh_psc_alpha_gap::Buffers_::Buffers_( hh_psc_alpha_gap& n )
+hh_psc_alpha_gap::Buffers_::Buffers_( hh_psc_alpha_gap& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -311,7 +310,7 @@ nest::hh_psc_alpha_gap::Buffers_::Buffers_( hh_psc_alpha_gap& n )
   // init_buffers_().
 }
 
-nest::hh_psc_alpha_gap::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha_gap& n )
+hh_psc_alpha_gap::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha_gap& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -325,7 +324,7 @@ nest::hh_psc_alpha_gap::Buffers_::Buffers_( const Buffers_&, hh_psc_alpha_gap& n
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::hh_psc_alpha_gap::hh_psc_alpha_gap()
+hh_psc_alpha_gap::hh_psc_alpha_gap()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -335,7 +334,7 @@ nest::hh_psc_alpha_gap::hh_psc_alpha_gap()
   Node::set_node_uses_wfr( kernel().simulation_manager.use_wfr() );
 }
 
-nest::hh_psc_alpha_gap::hh_psc_alpha_gap( const hh_psc_alpha_gap& n )
+hh_psc_alpha_gap::hh_psc_alpha_gap( const hh_psc_alpha_gap& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -344,7 +343,7 @@ nest::hh_psc_alpha_gap::hh_psc_alpha_gap( const hh_psc_alpha_gap& n )
   Node::set_node_uses_wfr( kernel().simulation_manager.use_wfr() );
 }
 
-nest::hh_psc_alpha_gap::~hh_psc_alpha_gap()
+hh_psc_alpha_gap::~hh_psc_alpha_gap()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -366,7 +365,7 @@ nest::hh_psc_alpha_gap::~hh_psc_alpha_gap()
  * ---------------------------------------------------------------- */
 
 void
-nest::hh_psc_alpha_gap::init_buffers_()
+hh_psc_alpha_gap::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -434,7 +433,7 @@ nest::hh_psc_alpha_gap::init_buffers_()
 }
 
 void
-nest::hh_psc_alpha_gap::pre_run_hook()
+hh_psc_alpha_gap::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -451,7 +450,7 @@ nest::hh_psc_alpha_gap::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 bool
-nest::hh_psc_alpha_gap::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
+hh_psc_alpha_gap::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
   const size_t interpolation_order = kernel().simulation_manager.get_wfr_interpolation_order();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
@@ -608,7 +607,7 @@ nest::hh_psc_alpha_gap::update_( Time const& origin, const long from, const long
 }
 
 void
-nest::hh_psc_alpha_gap::handle( SpikeEvent& e )
+hh_psc_alpha_gap::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -625,7 +624,7 @@ nest::hh_psc_alpha_gap::handle( SpikeEvent& e )
 }
 
 void
-nest::hh_psc_alpha_gap::handle( CurrentEvent& e )
+hh_psc_alpha_gap::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -636,13 +635,13 @@ nest::hh_psc_alpha_gap::handle( CurrentEvent& e )
 }
 
 void
-nest::hh_psc_alpha_gap::handle( DataLoggingRequest& e )
+hh_psc_alpha_gap::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
 void
-nest::hh_psc_alpha_gap::handle( GapJunctionEvent& e )
+hh_psc_alpha_gap::handle( GapJunctionEvent& e )
 {
   const double weight = e.get_weight();
 
@@ -657,5 +656,7 @@ nest::hh_psc_alpha_gap::handle( GapJunctionEvent& e )
     ++i;
   }
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/ht_neuron.cpp
+++ b/models/ht_neuron.cpp
@@ -36,6 +36,7 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
 void
@@ -71,11 +72,11 @@ extern "C" inline int
 ht_neuron_dynamics( double, const double y[], double f[], void* pnode )
 {
   // shorthand
-  typedef nest::ht_neuron::State_ S;
+  typedef ht_neuron::State_ S;
 
   // get access to node so we can almost work as in a member class
   assert( pnode );
-  nest::ht_neuron& node = *( reinterpret_cast< nest::ht_neuron* >( pnode ) );
+  ht_neuron& node = *( reinterpret_cast< ht_neuron* >( pnode ) );
 
   // easier access to membrane potential, clamp if requested
   const double& V = node.P_.voltage_clamp ? node.V_.V_clamp_ : y[ S::V_M ];
@@ -174,26 +175,26 @@ ht_neuron_dynamics( double, const double y[], double f[], void* pnode )
 }
 
 inline double
-nest::ht_neuron::m_eq_h_( double V ) const
+ht_neuron::m_eq_h_( double V ) const
 {
   const double I_h_Vthreshold = -75.0;
   return 1.0 / ( 1.0 + std::exp( ( V - I_h_Vthreshold ) / 5.5 ) );
 }
 
 inline double
-nest::ht_neuron::h_eq_T_( double V ) const
+ht_neuron::h_eq_T_( double V ) const
 {
   return 1.0 / ( 1.0 + std::exp( ( V + 83.0 ) / 4 ) );
 }
 
 inline double
-nest::ht_neuron::m_eq_T_( double V ) const
+ht_neuron::m_eq_T_( double V ) const
 {
   return 1.0 / ( 1.0 + std::exp( -( V + 59.0 ) / 6.2 ) );
 }
 
 inline double
-nest::ht_neuron::D_eq_KNa_( double V ) const
+ht_neuron::D_eq_KNa_( double V ) const
 {
   const double D_influx_peak = 0.025;
   const double D_thresh = -10.0;
@@ -205,13 +206,13 @@ nest::ht_neuron::D_eq_KNa_( double V ) const
 }
 
 inline double
-nest::ht_neuron::m_eq_NMDA_( double V ) const
+ht_neuron::m_eq_NMDA_( double V ) const
 {
   return 1.0 / ( 1.0 + std::exp( -P_.S_act_NMDA * ( V - P_.V_act_NMDA ) ) );
 }
 
 inline double
-nest::ht_neuron::m_NMDA_( double V, double m_eq, double m_fast, double m_slow ) const
+ht_neuron::m_NMDA_( double V, double m_eq, double m_fast, double m_slow ) const
 {
   const double A1 = 0.51 - 0.0028 * V;
   const double A2 = 1 - A1;
@@ -219,7 +220,7 @@ nest::ht_neuron::m_NMDA_( double V, double m_eq, double m_fast, double m_slow ) 
 }
 
 inline double
-nest::ht_neuron::get_g_NMDA_() const
+ht_neuron::get_g_NMDA_() const
 {
   return S_.y_[ State_::G_NMDA_TIMECOURSE ]
     * m_NMDA_( S_.y_[ State_::V_M ],
@@ -232,7 +233,7 @@ nest::ht_neuron::get_g_NMDA_() const
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::ht_neuron::Parameters_::Parameters_()
+ht_neuron::Parameters_::Parameters_()
   : E_Na( 30.0 )  // mV
   , E_K( -90.0 )  // mV
   , g_NaL( 0.2 )
@@ -278,7 +279,7 @@ nest::ht_neuron::Parameters_::Parameters_()
 {
 }
 
-nest::ht_neuron::State_::State_( const ht_neuron& node, const Parameters_& p )
+ht_neuron::State_::State_( const ht_neuron& node, const Parameters_& p )
   : ref_steps_( 0 )
   , I_NaP_( 0.0 )
   , I_KNa_( 0.0 )
@@ -302,7 +303,7 @@ nest::ht_neuron::State_::State_( const ht_neuron& node, const Parameters_& p )
   y_[ h_IT ] = node.h_eq_T_( y_[ V_M ] );
 }
 
-nest::ht_neuron::State_::State_( const State_& s )
+ht_neuron::State_::State_( const State_& s )
   : ref_steps_( s.ref_steps_ )
   , I_NaP_( s.I_NaP_ )
   , I_KNa_( s.I_KNa_ )
@@ -315,8 +316,8 @@ nest::ht_neuron::State_::State_( const State_& s )
   }
 }
 
-nest::ht_neuron::State_&
-nest::ht_neuron::State_::operator=( const State_& s )
+ht_neuron::State_&
+ht_neuron::State_::operator=( const State_& s )
 {
   ref_steps_ = s.ref_steps_;
   I_NaP_ = s.I_NaP_;
@@ -330,7 +331,7 @@ nest::ht_neuron::State_::operator=( const State_& s )
   return *this;
 }
 
-nest::ht_neuron::State_::~State_()
+ht_neuron::State_::~State_()
 {
 }
 
@@ -339,7 +340,7 @@ nest::ht_neuron::State_::~State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::ht_neuron::Parameters_::get( Dictionary& d ) const
+ht_neuron::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_Na ] = E_Na;
   d[ names::E_K ] = E_K;
@@ -386,7 +387,7 @@ nest::ht_neuron::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::ht_neuron::Parameters_::set( const Dictionary& d, Node* node )
+ht_neuron::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::E_Na, E_Na, node );
   update_value_param( d, names::E_K, E_K, node );
@@ -561,14 +562,14 @@ nest::ht_neuron::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::ht_neuron::State_::get( Dictionary& d ) const
+ht_neuron::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];      // Membrane potential
   d[ names::theta ] = y_[ THETA ];  // Threshold
 }
 
 void
-nest::ht_neuron::State_::set( const Dictionary& d, const ht_neuron& node, Node* nodeptr )
+ht_neuron::State_::set( const Dictionary& d, const ht_neuron& node, Node* nodeptr )
 {
   update_value_param( d, names::V_m, y_[ V_M ], nodeptr );
   update_value_param( d, names::theta, y_[ THETA ], nodeptr );
@@ -586,7 +587,7 @@ nest::ht_neuron::State_::set( const Dictionary& d, const ht_neuron& node, Node* 
   }
 }
 
-nest::ht_neuron::Buffers_::Buffers_( ht_neuron& n )
+ht_neuron::Buffers_::Buffers_( ht_neuron& n )
   : logger_( n )
   , spike_inputs_( std::vector< RingBuffer >( SUP_SPIKE_RECEPTOR - 1 ) )
   , s_( nullptr )
@@ -598,7 +599,7 @@ nest::ht_neuron::Buffers_::Buffers_( ht_neuron& n )
 {
 }
 
-nest::ht_neuron::Buffers_::Buffers_( const Buffers_&, ht_neuron& n )
+ht_neuron::Buffers_::Buffers_( const Buffers_&, ht_neuron& n )
   : logger_( n )
   , spike_inputs_( std::vector< RingBuffer >( SUP_SPIKE_RECEPTOR - 1 ) )
   , s_( nullptr )
@@ -614,7 +615,7 @@ nest::ht_neuron::Buffers_::Buffers_( const Buffers_&, ht_neuron& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::ht_neuron::ht_neuron()
+ht_neuron::ht_neuron()
   : ArchivingNode()
   , P_()
   , S_( *this, P_ )
@@ -623,7 +624,7 @@ nest::ht_neuron::ht_neuron()
   recordablesMap_.create();
 }
 
-nest::ht_neuron::ht_neuron( const ht_neuron& n )
+ht_neuron::ht_neuron( const ht_neuron& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -631,7 +632,7 @@ nest::ht_neuron::ht_neuron( const ht_neuron& n )
 {
 }
 
-nest::ht_neuron::~ht_neuron()
+ht_neuron::~ht_neuron()
 {
   // GSL structs may not be initialized, so we need to protect destruction.
   if ( B_.e_ )
@@ -653,7 +654,7 @@ nest::ht_neuron::~ht_neuron()
  * ---------------------------------------------------------------- */
 
 void
-nest::ht_neuron::init_buffers_()
+ht_neuron::init_buffers_()
 {
   // Reset spike buffers.
   for ( std::vector< RingBuffer >::iterator it = B_.spike_inputs_.begin(); it != B_.spike_inputs_.end(); ++it )
@@ -706,13 +707,13 @@ nest::ht_neuron::init_buffers_()
 }
 
 double
-nest::ht_neuron::get_synapse_constant( double tau_1, double tau_2, double g_peak )
+ht_neuron::get_synapse_constant( double tau_1, double tau_2, double g_peak )
 {
   return g_peak * beta_normalization_factor( tau_1, tau_2 );
 }
 
 void
-nest::ht_neuron::pre_run_hook()
+ht_neuron::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -734,7 +735,7 @@ nest::ht_neuron::pre_run_hook()
 }
 
 void
-nest::ht_neuron::get_status( Dictionary& d ) const
+ht_neuron::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -752,7 +753,7 @@ nest::ht_neuron::get_status( Dictionary& d ) const
 }
 
 void
-nest::ht_neuron::set_status( const Dictionary& d )
+ht_neuron::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;       // temporary copy in case of errors
   ptmp.set( d, this );         // throws if BadProperty
@@ -851,7 +852,7 @@ ht_neuron::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::ht_neuron::handle( SpikeEvent& e )
+ht_neuron::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   assert( e.get_rport() < B_.spike_inputs_.size() );
@@ -861,7 +862,7 @@ nest::ht_neuron::handle( SpikeEvent& e )
 }
 
 void
-nest::ht_neuron::handle( CurrentEvent& e )
+ht_neuron::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -873,10 +874,11 @@ nest::ht_neuron::handle( CurrentEvent& e )
 }
 
 void
-nest::ht_neuron::handle( DataLoggingRequest& e )
+ht_neuron::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
-}
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/ht_synapse.cpp
+++ b/models/ht_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_ht_synapse( const std::string& name )
+register_ht_synapse( const std::string& name )
 {
   register_connection_model< ht_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/iaf_bw_2001.cpp
+++ b/models/iaf_bw_2001.cpp
@@ -40,13 +40,14 @@
 #include <boost/math/special_functions/gamma.hpp>
 #include <typeinfo>
 
-/* ---------------------------------------------------------------------------
- * Recordables map
- * --------------------------------------------------------------------------- */
-nest::RecordablesMap< nest::iaf_bw_2001 > nest::iaf_bw_2001::recordablesMap_;
 
 namespace nest
 {
+/* ---------------------------------------------------------------------------
+ * Recordables map
+ * --------------------------------------------------------------------------- */
+RecordablesMap< iaf_bw_2001 > iaf_bw_2001::recordablesMap_;
+
 void
 register_iaf_bw_2001( const std::string& name )
 {
@@ -69,17 +70,16 @@ RecordablesMap< iaf_bw_2001 >::create()
   insert_( names::I_AMPA, &iaf_bw_2001::get_I_AMPA_ );
   insert_( names::I_GABA, &iaf_bw_2001::get_I_GABA_ );
 }
-}
 
 extern "C" inline int
-nest::iaf_bw_2001_dynamics( double, const double y[], double f[], void* pnode )
+iaf_bw_2001_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_bw_2001::State_ S;
+  typedef iaf_bw_2001::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  nest::iaf_bw_2001& node = *( reinterpret_cast< nest::iaf_bw_2001* >( pnode ) );
+  iaf_bw_2001& node = *( reinterpret_cast< iaf_bw_2001* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -106,7 +106,7 @@ nest::iaf_bw_2001_dynamics( double, const double y[], double f[], void* pnode )
  * Default constructors defining default parameters and state
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001::Parameters_::Parameters_()
+iaf_bw_2001::Parameters_::Parameters_()
   : E_L( -70.0 )           // mV
   , E_ex( 0.0 )            // mV
   , E_in( -70.0 )          // mV
@@ -125,7 +125,7 @@ nest::iaf_bw_2001::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_bw_2001::State_::State_( const Parameters_& p )
+iaf_bw_2001::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ V_m ] = p.E_L;  // initialize to reversal potential
@@ -138,7 +138,7 @@ nest::iaf_bw_2001::State_::State_( const Parameters_& p )
   I_GABA_ = 0.0;
 }
 
-nest::iaf_bw_2001::State_::State_( const State_& s )
+iaf_bw_2001::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   y_[ V_m ] = s.y_[ V_m ];
@@ -151,7 +151,7 @@ nest::iaf_bw_2001::State_::State_( const State_& s )
   I_GABA_ = s.I_GABA_;
 }
 
-nest::iaf_bw_2001::Buffers_::Buffers_( iaf_bw_2001& n )
+iaf_bw_2001::Buffers_::Buffers_( iaf_bw_2001& n )
   : logger_( n )
   , spikes_()
   , s_( nullptr )
@@ -163,7 +163,7 @@ nest::iaf_bw_2001::Buffers_::Buffers_( iaf_bw_2001& n )
   // Initialization of the remaining members is deferred to init_buffers_().
 }
 
-nest::iaf_bw_2001::Buffers_::Buffers_( const Buffers_&, iaf_bw_2001& n )
+iaf_bw_2001::Buffers_::Buffers_( const Buffers_&, iaf_bw_2001& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -177,7 +177,7 @@ nest::iaf_bw_2001::Buffers_::Buffers_( const Buffers_&, iaf_bw_2001& n )
  * --------------------------------------------------------------------------- */
 
 void
-nest::iaf_bw_2001::Parameters_::get( Dictionary& d ) const
+iaf_bw_2001::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L;
   d[ names::E_ex ] = E_ex;
@@ -197,7 +197,7 @@ nest::iaf_bw_2001::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_bw_2001::Parameters_::set( const Dictionary& d, Node* node )
+iaf_bw_2001::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::E_L, E_L, node );
@@ -247,7 +247,7 @@ nest::iaf_bw_2001::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_bw_2001::State_::get( Dictionary& d ) const
+iaf_bw_2001::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_m ];  // Membrane potential
   d[ names::s_AMPA ] = y_[ s_AMPA ];
@@ -259,7 +259,7 @@ nest::iaf_bw_2001::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_bw_2001::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_bw_2001::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_m ], node );
   update_value_param( d, names::s_AMPA, y_[ s_AMPA ], node );
@@ -271,7 +271,7 @@ nest::iaf_bw_2001::State_::set( const Dictionary& d, const Parameters_&, Node* n
  * Default constructor for node
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001::iaf_bw_2001()
+iaf_bw_2001::iaf_bw_2001()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -284,7 +284,7 @@ nest::iaf_bw_2001::iaf_bw_2001()
  * Copy constructor for node
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001::iaf_bw_2001( const iaf_bw_2001& n_ )
+iaf_bw_2001::iaf_bw_2001( const iaf_bw_2001& n_ )
   : ArchivingNode( n_ )
   , P_( n_.P_ )
   , S_( n_.S_ )
@@ -296,7 +296,7 @@ nest::iaf_bw_2001::iaf_bw_2001( const iaf_bw_2001& n_ )
  * Destructor for node
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001::~iaf_bw_2001()
+iaf_bw_2001::~iaf_bw_2001()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
 
@@ -321,12 +321,12 @@ nest::iaf_bw_2001::~iaf_bw_2001()
  * --------------------------------------------------------------------------- */
 
 void
-nest::iaf_bw_2001::init_state_()
+iaf_bw_2001::init_state_()
 {
 }
 
 void
-nest::iaf_bw_2001::init_buffers_()
+iaf_bw_2001::init_buffers_()
 {
   B_.spikes_.resize( 3 );
   for ( auto& sb : B_.spikes_ )
@@ -377,7 +377,7 @@ nest::iaf_bw_2001::init_buffers_()
 }
 
 void
-nest::iaf_bw_2001::pre_run_hook()
+iaf_bw_2001::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -399,7 +399,7 @@ nest::iaf_bw_2001::pre_run_hook()
  * --------------------------------------------------------------------------- */
 
 void
-nest::iaf_bw_2001::update( Time const& origin, const long from, const long to )
+iaf_bw_2001::update( Time const& origin, const long from, const long to )
 {
   std::vector< double > s_vals( kernel().connection_manager.get_min_delay(), 0.0 );
   for ( long lag = from; lag < to; ++lag )
@@ -481,13 +481,13 @@ nest::iaf_bw_2001::update( Time const& origin, const long from, const long to )
 // Do not move this function as inline to h-file. It depends on
 // universal_data_logger_impl.h being included here.
 void
-nest::iaf_bw_2001::handle( DataLoggingRequest& e )
+iaf_bw_2001::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
 void
-nest::iaf_bw_2001::handle( SpikeEvent& e )
+iaf_bw_2001::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -506,7 +506,7 @@ nest::iaf_bw_2001::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_bw_2001::handle( CurrentEvent& e )
+iaf_bw_2001::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -515,4 +515,7 @@ nest::iaf_bw_2001::handle( CurrentEvent& e )
 }
 
 #endif  // HAVE_BOOST
+
+}  // namespace nest
+
 #endif  // HAVE_GSL

--- a/models/iaf_bw_2001.cpp
+++ b/models/iaf_bw_2001.cpp
@@ -514,8 +514,7 @@ iaf_bw_2001::handle( CurrentEvent& e )
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), e.get_weight() * e.get_current() );
 }
 
-#endif  // HAVE_BOOST
-
 }  // namespace nest
 
+#endif  // HAVE_BOOST
 #endif  // HAVE_GSL

--- a/models/iaf_bw_2001_exact.cpp
+++ b/models/iaf_bw_2001_exact.cpp
@@ -34,13 +34,14 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-/* ---------------------------------------------------------------------------
- * Recordables map
- * --------------------------------------------------------------------------- */
-nest::RecordablesMap< nest::iaf_bw_2001_exact > nest::iaf_bw_2001_exact::recordablesMap_;
 
 namespace nest
 {
+/* ---------------------------------------------------------------------------
+ * Recordables map
+ * --------------------------------------------------------------------------- */
+RecordablesMap< iaf_bw_2001_exact > iaf_bw_2001_exact::recordablesMap_;
+
 void
 register_iaf_bw_2001_exact( const std::string& name )
 {
@@ -63,12 +64,11 @@ RecordablesMap< iaf_bw_2001_exact >::create()
   insert_( names::I_AMPA, &iaf_bw_2001_exact::get_I_AMPA_ );
   insert_( names::I_GABA, &iaf_bw_2001_exact::get_I_GABA_ );
 }
-}
 /* ---------------------------------------------------------------------------
  * Default constructors defining default parameters and state
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001_exact::Parameters_::Parameters_()
+iaf_bw_2001_exact::Parameters_::Parameters_()
   : E_L( -70.0 )           // mV
   , E_ex( 0.0 )            // mV
   , E_in( -70.0 )          // mV
@@ -87,7 +87,7 @@ nest::iaf_bw_2001_exact::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_bw_2001_exact::State_::State_( const Parameters_& p )
+iaf_bw_2001_exact::State_::State_( const Parameters_& p )
   : state_vec_size( 0 )
   , ode_state_( nullptr )
   , num_ports_( SynapseTypes::GABA )  // only AMPA/GABA for now, add NMDA later
@@ -103,7 +103,7 @@ nest::iaf_bw_2001_exact::State_::State_( const Parameters_& p )
   state_vec_size = s_NMDA_base;
 }
 
-nest::iaf_bw_2001_exact::State_::State_( const State_& s )
+iaf_bw_2001_exact::State_::State_( const State_& s )
   : state_vec_size( s.state_vec_size )
   , ode_state_( nullptr )
   , num_ports_( s.num_ports_ )
@@ -120,7 +120,7 @@ nest::iaf_bw_2001_exact::State_::State_( const State_& s )
   ode_state_[ s_GABA ] = s.ode_state_[ s_GABA ];
 }
 
-nest::iaf_bw_2001_exact::Buffers_::Buffers_( iaf_bw_2001_exact& n )
+iaf_bw_2001_exact::Buffers_::Buffers_( iaf_bw_2001_exact& n )
   : logger_( n )
   , spikes_()
   , weights_()
@@ -133,7 +133,7 @@ nest::iaf_bw_2001_exact::Buffers_::Buffers_( iaf_bw_2001_exact& n )
   // Initialization of the remaining members is deferred to init_buffers_().
 }
 
-nest::iaf_bw_2001_exact::Buffers_::Buffers_( const Buffers_&, iaf_bw_2001_exact& n )
+iaf_bw_2001_exact::Buffers_::Buffers_( const Buffers_&, iaf_bw_2001_exact& n )
   : logger_( n )
   , spikes_()
   , weights_()
@@ -151,7 +151,7 @@ nest::iaf_bw_2001_exact::Buffers_::Buffers_( const Buffers_&, iaf_bw_2001_exact&
  * --------------------------------------------------------------------------- */
 
 void
-nest::iaf_bw_2001_exact::Parameters_::get( Dictionary& d ) const
+iaf_bw_2001_exact::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L;
   d[ names::E_ex ] = E_ex;
@@ -171,7 +171,7 @@ nest::iaf_bw_2001_exact::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_bw_2001_exact::Parameters_::set( const Dictionary& d, Node* node )
+iaf_bw_2001_exact::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th, node );
@@ -221,7 +221,7 @@ nest::iaf_bw_2001_exact::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_bw_2001_exact::State_::get( Dictionary& d ) const
+iaf_bw_2001_exact::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = ode_state_[ V_m ];  // Membrane potential
   d[ names::s_AMPA ] = ode_state_[ s_AMPA ];
@@ -229,7 +229,7 @@ nest::iaf_bw_2001_exact::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_bw_2001_exact::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_bw_2001_exact::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, ode_state_[ V_m ], node );
   update_value_param( d, names::s_AMPA, ode_state_[ s_AMPA ], node );
@@ -240,7 +240,7 @@ nest::iaf_bw_2001_exact::State_::set( const Dictionary& d, const Parameters_&, N
  * Default constructor for node
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001_exact::iaf_bw_2001_exact()
+iaf_bw_2001_exact::iaf_bw_2001_exact()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -253,7 +253,7 @@ nest::iaf_bw_2001_exact::iaf_bw_2001_exact()
  * Copy constructor for node
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001_exact::iaf_bw_2001_exact( const iaf_bw_2001_exact& n_ )
+iaf_bw_2001_exact::iaf_bw_2001_exact( const iaf_bw_2001_exact& n_ )
   : ArchivingNode( n_ )
   , P_( n_.P_ )
   , S_( n_.S_ )
@@ -265,7 +265,7 @@ nest::iaf_bw_2001_exact::iaf_bw_2001_exact( const iaf_bw_2001_exact& n_ )
  * Destructor for node
  * --------------------------------------------------------------------------- */
 
-nest::iaf_bw_2001_exact::~iaf_bw_2001_exact()
+iaf_bw_2001_exact::~iaf_bw_2001_exact()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
 
@@ -295,7 +295,7 @@ nest::iaf_bw_2001_exact::~iaf_bw_2001_exact()
  * --------------------------------------------------------------------------- */
 
 void
-nest::iaf_bw_2001_exact::init_state_()
+iaf_bw_2001_exact::init_state_()
 {
   assert( S_.state_vec_size == State_::s_NMDA_base );
 
@@ -318,7 +318,7 @@ nest::iaf_bw_2001_exact::init_state_()
 }
 
 void
-nest::iaf_bw_2001_exact::init_buffers_()
+iaf_bw_2001_exact::init_buffers_()
 {
   B_.spikes_.resize( S_.num_ports_ );
 
@@ -372,7 +372,7 @@ nest::iaf_bw_2001_exact::init_buffers_()
 }
 
 void
-nest::iaf_bw_2001_exact::pre_run_hook()
+iaf_bw_2001_exact::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -387,14 +387,14 @@ nest::iaf_bw_2001_exact::pre_run_hook()
  * --------------------------------------------------------------------------- */
 
 extern "C" inline int
-nest::iaf_bw_2001_exact_dynamics( double, const double ode_state[], double f[], void* pnode )
+iaf_bw_2001_exact_dynamics( double, const double ode_state[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_bw_2001_exact::State_ State_;
+  typedef iaf_bw_2001_exact::State_ State_;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  nest::iaf_bw_2001_exact& node = *( reinterpret_cast< nest::iaf_bw_2001_exact* >( pnode ) );
+  iaf_bw_2001_exact& node = *( reinterpret_cast< iaf_bw_2001_exact* >( pnode ) );
 
   // ode_state[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.ode_state[].
@@ -431,7 +431,7 @@ nest::iaf_bw_2001_exact_dynamics( double, const double ode_state[], double f[], 
 }
 
 void
-nest::iaf_bw_2001_exact::update( Time const& origin, const long from, const long to )
+iaf_bw_2001_exact::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -511,13 +511,13 @@ nest::iaf_bw_2001_exact::update( Time const& origin, const long from, const long
 // Do not move this function as inline to h-file. It depends on
 // universal_data_logger_impl.h being included here.
 void
-nest::iaf_bw_2001_exact::handle( DataLoggingRequest& e )
+iaf_bw_2001_exact::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
 void
-nest::iaf_bw_2001_exact::handle( SpikeEvent& e )
+iaf_bw_2001_exact::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   assert( e.get_rport() <= B_.spikes_.size() );
@@ -549,12 +549,14 @@ nest::iaf_bw_2001_exact::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_bw_2001_exact::handle( CurrentEvent& e )
+iaf_bw_2001_exact::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), e.get_weight() * e.get_current() );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/iaf_chs_2007.cpp
+++ b/models/iaf_chs_2007.cpp
@@ -33,14 +33,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_chs_2007 > nest::iaf_chs_2007::recordablesMap_;
+RecordablesMap< iaf_chs_2007 > iaf_chs_2007::recordablesMap_;
 
-namespace nest
-{
 void
 register_iaf_chs_2007( const std::string& name )
 {
@@ -56,13 +56,12 @@ RecordablesMap< iaf_chs_2007 >::create()
   // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_chs_2007::get_V_m_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_chs_2007::Parameters_::Parameters_()
+iaf_chs_2007::Parameters_::Parameters_()
   : tau_epsp_( 8.5 )    // in ms
   , tau_reset_( 15.4 )  // in ms
   , E_L_( 0.0 )         // normalized
@@ -77,7 +76,7 @@ nest::iaf_chs_2007::Parameters_::Parameters_()
 }
 
 
-nest::iaf_chs_2007::State_::State_()
+iaf_chs_2007::State_::State_()
   : i_syn_ex_( 0.0 )
   , V_syn_( 0.0 )
   , V_spike_( 0.0 )
@@ -90,7 +89,7 @@ nest::iaf_chs_2007::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_chs_2007::Parameters_::get( Dictionary& d ) const
+iaf_chs_2007::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_reset ] = U_reset_;
   d[ names::V_epsp ] = U_epsp_;
@@ -101,7 +100,7 @@ nest::iaf_chs_2007::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_chs_2007::Parameters_::set( const Dictionary& d, State_& s, Node* node )
+iaf_chs_2007::Parameters_::set( const Dictionary& d, State_& s, Node* node )
 {
   update_value_param( d, names::V_reset, U_reset_, node );
   update_value_param( d, names::V_epsp, U_epsp_, node );
@@ -137,23 +136,23 @@ nest::iaf_chs_2007::Parameters_::set( const Dictionary& d, State_& s, Node* node
 }
 
 void
-nest::iaf_chs_2007::State_::get( Dictionary& d ) const
+iaf_chs_2007::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = V_m_;  // Membrane potential
 }
 
 void
-nest::iaf_chs_2007::State_::set( Dictionary const& d, Node* node )
+iaf_chs_2007::State_::set( Dictionary const& d, Node* node )
 {
   update_value_param( d, names::V_m, V_m_, node );
 }
 
-nest::iaf_chs_2007::Buffers_::Buffers_( iaf_chs_2007& n )
+iaf_chs_2007::Buffers_::Buffers_( iaf_chs_2007& n )
   : logger_( n )
 {
 }
 
-nest::iaf_chs_2007::Buffers_::Buffers_( const Buffers_&, iaf_chs_2007& n )
+iaf_chs_2007::Buffers_::Buffers_( const Buffers_&, iaf_chs_2007& n )
   : logger_( n )
 {
 }
@@ -162,7 +161,7 @@ nest::iaf_chs_2007::Buffers_::Buffers_( const Buffers_&, iaf_chs_2007& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_chs_2007::iaf_chs_2007()
+iaf_chs_2007::iaf_chs_2007()
   : ArchivingNode()
   , P_()
   , S_()
@@ -171,7 +170,7 @@ nest::iaf_chs_2007::iaf_chs_2007()
   recordablesMap_.create();
 }
 
-nest::iaf_chs_2007::iaf_chs_2007( const iaf_chs_2007& n )
+iaf_chs_2007::iaf_chs_2007( const iaf_chs_2007& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -184,7 +183,7 @@ nest::iaf_chs_2007::iaf_chs_2007( const iaf_chs_2007& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_chs_2007::init_buffers_()
+iaf_chs_2007::init_buffers_()
 {
   B_.spikes_ex_.clear();  // includes resize
   B_.currents_.clear();   // includes resize
@@ -193,7 +192,7 @@ nest::iaf_chs_2007::init_buffers_()
 }
 
 void
-nest::iaf_chs_2007::pre_run_hook()
+iaf_chs_2007::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -219,7 +218,7 @@ nest::iaf_chs_2007::pre_run_hook()
 }
 
 void
-nest::iaf_chs_2007::update( const Time& origin, const long from, const long to )
+iaf_chs_2007::update( const Time& origin, const long from, const long to )
 {
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
@@ -259,7 +258,7 @@ nest::iaf_chs_2007::update( const Time& origin, const long from, const long to )
 }
 
 void
-nest::iaf_chs_2007::handle( SpikeEvent& e )
+iaf_chs_2007::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -271,7 +270,9 @@ nest::iaf_chs_2007::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_chs_2007::handle( DataLoggingRequest& e )
+iaf_chs_2007::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/iaf_chxk_2008.cpp
+++ b/models/iaf_chxk_2008.cpp
@@ -38,14 +38,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_chxk_2008 > nest::iaf_chxk_2008::recordablesMap_;
+RecordablesMap< iaf_chxk_2008 > iaf_chxk_2008::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_iaf_chxk_2008( const std::string& name )
 {
@@ -69,21 +69,20 @@ RecordablesMap< iaf_chxk_2008 >::create()
   insert_( names::I_syn_in, &iaf_chxk_2008::get_I_syn_inh_ );
   insert_( names::I_ahp, &iaf_chxk_2008::get_I_ahp_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Iteration function
  * ---------------------------------------------------------------- */
 
 extern "C" inline int
-nest::iaf_chxk_2008_dynamics( double, const double y[], double f[], void* pnode )
+iaf_chxk_2008_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_chxk_2008::State_ S;
+  typedef iaf_chxk_2008::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::iaf_chxk_2008& node = *( reinterpret_cast< nest::iaf_chxk_2008* >( pnode ) );
+  const iaf_chxk_2008& node = *( reinterpret_cast< iaf_chxk_2008* >( pnode ) );
 
   // y[] here is---and must be---the state vector supplied by the integrator,
   // not the state vector in the node, node.S_.y[].
@@ -117,7 +116,7 @@ nest::iaf_chxk_2008_dynamics( double, const double y[], double f[], void* pnode 
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_chxk_2008::Parameters_::Parameters_()
+iaf_chxk_2008::Parameters_::Parameters_()
   :  // Default values chosen based on values found in
   // Alex Casti's simulator
   V_th( -45.0 )      // mV
@@ -138,7 +137,7 @@ nest::iaf_chxk_2008::Parameters_::Parameters_()
   recordablesMap_.create();
 }
 
-nest::iaf_chxk_2008::State_::State_( const Parameters_& p )
+iaf_chxk_2008::State_::State_( const Parameters_& p )
   : r( 0 )
 {
   y[ V_M ] = p.E_L;  // initialize to reversal potential
@@ -148,7 +147,7 @@ nest::iaf_chxk_2008::State_::State_( const Parameters_& p )
   }
 }
 
-nest::iaf_chxk_2008::State_::State_( const State_& s )
+iaf_chxk_2008::State_::State_( const State_& s )
   : r( s.r )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -157,8 +156,8 @@ nest::iaf_chxk_2008::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_chxk_2008::State_&
-nest::iaf_chxk_2008::State_::operator=( const State_& s )
+iaf_chxk_2008::State_&
+iaf_chxk_2008::State_::operator=( const State_& s )
 {
   r = s.r;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -168,7 +167,7 @@ nest::iaf_chxk_2008::State_::operator=( const State_& s )
   return *this;
 }
 
-nest::iaf_chxk_2008::Buffers_::Buffers_( iaf_chxk_2008& n )
+iaf_chxk_2008::Buffers_::Buffers_( iaf_chxk_2008& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -178,7 +177,7 @@ nest::iaf_chxk_2008::Buffers_::Buffers_( iaf_chxk_2008& n )
   // init_buffers_().
 }
 
-nest::iaf_chxk_2008::Buffers_::Buffers_( const Buffers_&, iaf_chxk_2008& n )
+iaf_chxk_2008::Buffers_::Buffers_( const Buffers_&, iaf_chxk_2008& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -193,7 +192,7 @@ nest::iaf_chxk_2008::Buffers_::Buffers_( const Buffers_&, iaf_chxk_2008& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_chxk_2008::Parameters_::get( Dictionary& d ) const
+iaf_chxk_2008::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = V_th;
   d[ names::g_L ] = g_L;
@@ -211,7 +210,7 @@ nest::iaf_chxk_2008::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_chxk_2008::Parameters_::set( const Dictionary& d, Node* node )
+iaf_chxk_2008::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th, node );
@@ -238,13 +237,13 @@ nest::iaf_chxk_2008::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_chxk_2008::State_::get( Dictionary& d ) const
+iaf_chxk_2008::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y[ V_M ];  // Membrane potential
 }
 
 void
-nest::iaf_chxk_2008::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_chxk_2008::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y[ V_M ], node );
 }
@@ -253,7 +252,7 @@ nest::iaf_chxk_2008::State_::set( const Dictionary& d, const Parameters_&, Node*
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::iaf_chxk_2008::iaf_chxk_2008()
+iaf_chxk_2008::iaf_chxk_2008()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -261,7 +260,7 @@ nest::iaf_chxk_2008::iaf_chxk_2008()
 {
 }
 
-nest::iaf_chxk_2008::iaf_chxk_2008( const iaf_chxk_2008& n )
+iaf_chxk_2008::iaf_chxk_2008( const iaf_chxk_2008& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -269,7 +268,7 @@ nest::iaf_chxk_2008::iaf_chxk_2008( const iaf_chxk_2008& n )
 {
 }
 
-nest::iaf_chxk_2008::~iaf_chxk_2008()
+iaf_chxk_2008::~iaf_chxk_2008()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -291,7 +290,7 @@ nest::iaf_chxk_2008::~iaf_chxk_2008()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_chxk_2008::init_buffers_()
+iaf_chxk_2008::init_buffers_()
 {
   ArchivingNode::clear_history();
 
@@ -340,7 +339,7 @@ nest::iaf_chxk_2008::init_buffers_()
 }
 
 void
-nest::iaf_chxk_2008::pre_run_hook()
+iaf_chxk_2008::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -355,7 +354,7 @@ nest::iaf_chxk_2008::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_chxk_2008::update( Time const& origin, const long from, const long to )
+iaf_chxk_2008::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -440,7 +439,7 @@ nest::iaf_chxk_2008::update( Time const& origin, const long from, const long to 
 }
 
 void
-nest::iaf_chxk_2008::handle( SpikeEvent& e )
+iaf_chxk_2008::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -457,7 +456,7 @@ nest::iaf_chxk_2008::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_chxk_2008::handle( CurrentEvent& e )
+iaf_chxk_2008::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -466,8 +465,11 @@ nest::iaf_chxk_2008::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_chxk_2008::handle( DataLoggingRequest& e )
+iaf_chxk_2008::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
+
 #endif  // HAVE_GSL

--- a/models/iaf_cond_alpha.cpp
+++ b/models/iaf_cond_alpha.cpp
@@ -40,14 +40,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_cond_alpha > nest::iaf_cond_alpha::recordablesMap_;
+RecordablesMap< iaf_cond_alpha > iaf_cond_alpha::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_iaf_cond_alpha( const std::string& name )
 {
@@ -69,21 +69,20 @@ RecordablesMap< iaf_cond_alpha >::create()
 
   insert_( names::t_ref_remaining, &iaf_cond_alpha::get_r_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Iteration function
  * ---------------------------------------------------------------- */
 
 extern "C" inline int
-nest::iaf_cond_alpha_dynamics( double, const double y[], double f[], void* pnode )
+iaf_cond_alpha_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_cond_alpha::State_ S;
+  typedef iaf_cond_alpha::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::iaf_cond_alpha& node = *( reinterpret_cast< nest::iaf_cond_alpha* >( pnode ) );
+  const iaf_cond_alpha& node = *( reinterpret_cast< iaf_cond_alpha* >( pnode ) );
 
   const bool is_refractory = node.S_.r > 0;
 
@@ -119,7 +118,7 @@ nest::iaf_cond_alpha_dynamics( double, const double y[], double f[], void* pnode
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_alpha::Parameters_::Parameters_()
+iaf_cond_alpha::Parameters_::Parameters_()
   : V_th( -55.0 )     // mV
   , V_reset( -60.0 )  // mV
   , t_ref( 2.0 )      // ms
@@ -134,7 +133,7 @@ nest::iaf_cond_alpha::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_cond_alpha::State_::State_( const Parameters_& p )
+iaf_cond_alpha::State_::State_( const Parameters_& p )
   : r( 0 )
 {
   y[ V_M ] = p.E_L;  // initialize to reversal potential
@@ -144,7 +143,7 @@ nest::iaf_cond_alpha::State_::State_( const Parameters_& p )
   }
 }
 
-nest::iaf_cond_alpha::State_::State_( const State_& s )
+iaf_cond_alpha::State_::State_( const State_& s )
   : r( s.r )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -153,8 +152,8 @@ nest::iaf_cond_alpha::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_alpha::State_&
-nest::iaf_cond_alpha::State_::operator=( const State_& s )
+iaf_cond_alpha::State_&
+iaf_cond_alpha::State_::operator=( const State_& s )
 {
   r = s.r;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -164,7 +163,7 @@ nest::iaf_cond_alpha::State_::operator=( const State_& s )
   return *this;
 }
 
-nest::iaf_cond_alpha::Buffers_::Buffers_( iaf_cond_alpha& n )
+iaf_cond_alpha::Buffers_::Buffers_( iaf_cond_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -174,7 +173,7 @@ nest::iaf_cond_alpha::Buffers_::Buffers_( iaf_cond_alpha& n )
   // init_buffers_().
 }
 
-nest::iaf_cond_alpha::Buffers_::Buffers_( const Buffers_&, iaf_cond_alpha& n )
+iaf_cond_alpha::Buffers_::Buffers_( const Buffers_&, iaf_cond_alpha& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -189,7 +188,7 @@ nest::iaf_cond_alpha::Buffers_::Buffers_( const Buffers_&, iaf_cond_alpha& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_alpha::Parameters_::get( Dictionary& d ) const
+iaf_cond_alpha::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = V_th;
   d[ names::V_reset ] = V_reset;
@@ -205,7 +204,7 @@ nest::iaf_cond_alpha::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_alpha::Parameters_::set( const Dictionary& d, Node* node )
+iaf_cond_alpha::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th, node );
@@ -242,7 +241,7 @@ nest::iaf_cond_alpha::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_cond_alpha::State_::get( Dictionary& d ) const
+iaf_cond_alpha::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y[ V_M ];  // Membrane potential
   d[ names::g_ex ] = y[ G_EXC ];
@@ -252,7 +251,7 @@ nest::iaf_cond_alpha::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_alpha::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_cond_alpha::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y[ V_M ], node );
   update_value_param( d, names::g_ex, y[ G_EXC ], node );
@@ -266,7 +265,7 @@ nest::iaf_cond_alpha::State_::set( const Dictionary& d, const Parameters_&, Node
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_alpha::iaf_cond_alpha()
+iaf_cond_alpha::iaf_cond_alpha()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -275,7 +274,7 @@ nest::iaf_cond_alpha::iaf_cond_alpha()
   recordablesMap_.create();
 }
 
-nest::iaf_cond_alpha::iaf_cond_alpha( const iaf_cond_alpha& n )
+iaf_cond_alpha::iaf_cond_alpha( const iaf_cond_alpha& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -283,7 +282,7 @@ nest::iaf_cond_alpha::iaf_cond_alpha( const iaf_cond_alpha& n )
 {
 }
 
-nest::iaf_cond_alpha::~iaf_cond_alpha()
+iaf_cond_alpha::~iaf_cond_alpha()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -305,7 +304,7 @@ nest::iaf_cond_alpha::~iaf_cond_alpha()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_alpha::init_buffers_()
+iaf_cond_alpha::init_buffers_()
 {
   ArchivingNode::clear_history();
 
@@ -354,7 +353,7 @@ nest::iaf_cond_alpha::init_buffers_()
 }
 
 void
-nest::iaf_cond_alpha::pre_run_hook()
+iaf_cond_alpha::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -372,7 +371,7 @@ nest::iaf_cond_alpha::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_alpha::update( Time const& origin, const long from, const long to )
+iaf_cond_alpha::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -440,7 +439,7 @@ nest::iaf_cond_alpha::update( Time const& origin, const long from, const long to
 }
 
 void
-nest::iaf_cond_alpha::handle( SpikeEvent& e )
+iaf_cond_alpha::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -457,7 +456,7 @@ nest::iaf_cond_alpha::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_cond_alpha::handle( CurrentEvent& e )
+iaf_cond_alpha::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -466,9 +465,11 @@ nest::iaf_cond_alpha::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_cond_alpha::handle( DataLoggingRequest& e )
+iaf_cond_alpha::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/iaf_cond_alpha_mc.cpp
+++ b/models/iaf_cond_alpha_mc.cpp
@@ -39,12 +39,13 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
-std::vector< std::string > nest::iaf_cond_alpha_mc::comp_names_( NCOMP );
-nest::RecordablesMap< nest::iaf_cond_alpha_mc > nest::iaf_cond_alpha_mc::recordablesMap_;
-
 
 namespace nest
 {
+std::vector< std::string > iaf_cond_alpha_mc::comp_names_( NCOMP );
+RecordablesMap< iaf_cond_alpha_mc > iaf_cond_alpha_mc::recordablesMap_;
+
+
 void
 register_iaf_cond_alpha_mc( const std::string& name )
 {
@@ -70,22 +71,21 @@ RecordablesMap< iaf_cond_alpha_mc >::create()
 
   insert_( names::t_ref_remaining, &iaf_cond_alpha_mc::get_r_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Iteration function
  * ---------------------------------------------------------------- */
 
 extern "C" int
-nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pnode )
+iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pnode )
 {
   // some shorthands
-  typedef nest::iaf_cond_alpha_mc N;
-  typedef nest::iaf_cond_alpha_mc::State_ S;
+  typedef iaf_cond_alpha_mc N;
+  typedef iaf_cond_alpha_mc::State_ S;
 
   // get access to node so we can work almost as in a member function
   assert( pnode );
-  const nest::iaf_cond_alpha_mc& node = *( reinterpret_cast< nest::iaf_cond_alpha_mc* >( pnode ) );
+  const iaf_cond_alpha_mc& node = *( reinterpret_cast< iaf_cond_alpha_mc* >( pnode ) );
 
   bool is_refractory = false;
 
@@ -152,7 +152,7 @@ nest::iaf_cond_alpha_mc_dynamics( double, const double y[], double f[], void* pn
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_alpha_mc::Parameters_::Parameters_()
+iaf_cond_alpha_mc::Parameters_::Parameters_()
   : V_th( -55.0 )     // mV
   , V_reset( -60.0 )  // mV
   , t_ref( 2.0 )      // ms
@@ -192,7 +192,7 @@ nest::iaf_cond_alpha_mc::Parameters_::Parameters_()
   I_e[ DIST ] = 0.0;       // pA
 }
 
-nest::iaf_cond_alpha_mc::Parameters_::Parameters_( const Parameters_& p )
+iaf_cond_alpha_mc::Parameters_::Parameters_( const Parameters_& p )
   : V_th( p.V_th )
   , V_reset( p.V_reset )
   , t_ref( p.t_ref )
@@ -216,8 +216,8 @@ nest::iaf_cond_alpha_mc::Parameters_::Parameters_( const Parameters_& p )
   }
 }
 
-nest::iaf_cond_alpha_mc::Parameters_&
-nest::iaf_cond_alpha_mc::Parameters_::operator=( const Parameters_& p )
+iaf_cond_alpha_mc::Parameters_&
+iaf_cond_alpha_mc::Parameters_::operator=( const Parameters_& p )
 {
   assert( this != &p );  // would be bad logical error in program
 
@@ -247,7 +247,7 @@ nest::iaf_cond_alpha_mc::Parameters_::operator=( const Parameters_& p )
 }
 
 
-nest::iaf_cond_alpha_mc::State_::State_( const Parameters_& p )
+iaf_cond_alpha_mc::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   // for simplicity, we first initialize all values to 0,
@@ -262,7 +262,7 @@ nest::iaf_cond_alpha_mc::State_::State_( const Parameters_& p )
   }
 }
 
-nest::iaf_cond_alpha_mc::State_::State_( const State_& s )
+iaf_cond_alpha_mc::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -271,8 +271,8 @@ nest::iaf_cond_alpha_mc::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_alpha_mc::State_&
-nest::iaf_cond_alpha_mc::State_::operator=( const State_& s )
+iaf_cond_alpha_mc::State_&
+iaf_cond_alpha_mc::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -282,7 +282,7 @@ nest::iaf_cond_alpha_mc::State_::operator=( const State_& s )
   return *this;
 }
 
-nest::iaf_cond_alpha_mc::Buffers_::Buffers_( iaf_cond_alpha_mc& n )
+iaf_cond_alpha_mc::Buffers_::Buffers_( iaf_cond_alpha_mc& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -292,7 +292,7 @@ nest::iaf_cond_alpha_mc::Buffers_::Buffers_( iaf_cond_alpha_mc& n )
   // init_buffers_().
 }
 
-nest::iaf_cond_alpha_mc::Buffers_::Buffers_( const Buffers_&, iaf_cond_alpha_mc& n )
+iaf_cond_alpha_mc::Buffers_::Buffers_( const Buffers_&, iaf_cond_alpha_mc& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -307,7 +307,7 @@ nest::iaf_cond_alpha_mc::Buffers_::Buffers_( const Buffers_&, iaf_cond_alpha_mc&
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_alpha_mc::Parameters_::get( Dictionary& d ) const
+iaf_cond_alpha_mc::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = V_th;
   d[ names::V_reset ] = V_reset;
@@ -335,7 +335,7 @@ nest::iaf_cond_alpha_mc::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_alpha_mc::Parameters_::set( const Dictionary& d, Node* node )
+iaf_cond_alpha_mc::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th, node );
@@ -386,7 +386,7 @@ nest::iaf_cond_alpha_mc::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_cond_alpha_mc::State_::get( Dictionary& d ) const
+iaf_cond_alpha_mc::State_::get( Dictionary& d ) const
 {
   // we assume here that State_::get() always is called after
   // Parameters_::get(), so that the per-compartment dictionaries exist
@@ -400,7 +400,7 @@ nest::iaf_cond_alpha_mc::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_alpha_mc::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_cond_alpha_mc::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   // extract from sub-dictionaries
   for ( size_t n = 0; n < NCOMP; ++n )
@@ -418,7 +418,7 @@ nest::iaf_cond_alpha_mc::State_::set( const Dictionary& d, const Parameters_&, N
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_alpha_mc::iaf_cond_alpha_mc()
+iaf_cond_alpha_mc::iaf_cond_alpha_mc()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -433,7 +433,7 @@ nest::iaf_cond_alpha_mc::iaf_cond_alpha_mc()
   comp_names_[ DIST ] = "distal";
 }
 
-nest::iaf_cond_alpha_mc::iaf_cond_alpha_mc( const iaf_cond_alpha_mc& n )
+iaf_cond_alpha_mc::iaf_cond_alpha_mc( const iaf_cond_alpha_mc& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -441,7 +441,7 @@ nest::iaf_cond_alpha_mc::iaf_cond_alpha_mc( const iaf_cond_alpha_mc& n )
 {
 }
 
-nest::iaf_cond_alpha_mc::~iaf_cond_alpha_mc()
+iaf_cond_alpha_mc::~iaf_cond_alpha_mc()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -463,7 +463,7 @@ nest::iaf_cond_alpha_mc::~iaf_cond_alpha_mc()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_alpha_mc::init_buffers_()
+iaf_cond_alpha_mc::init_buffers_()
 {
   B_.spikes_.resize( NUM_SPIKE_RECEPTORS );
   for ( size_t n = 0; n < NUM_SPIKE_RECEPTORS; ++n )
@@ -523,7 +523,7 @@ nest::iaf_cond_alpha_mc::init_buffers_()
 }
 
 void
-nest::iaf_cond_alpha_mc::pre_run_hook()
+iaf_cond_alpha_mc::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -546,7 +546,7 @@ nest::iaf_cond_alpha_mc::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_alpha_mc::update( Time const& origin, const long from, const long to )
+iaf_cond_alpha_mc::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -622,7 +622,7 @@ nest::iaf_cond_alpha_mc::update( Time const& origin, const long from, const long
 }
 
 void
-nest::iaf_cond_alpha_mc::handle( SpikeEvent& e )
+iaf_cond_alpha_mc::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   assert( e.get_rport() < 2 * NCOMP );
@@ -632,7 +632,7 @@ nest::iaf_cond_alpha_mc::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_cond_alpha_mc::handle( CurrentEvent& e )
+iaf_cond_alpha_mc::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   // not 100% clean, should look at MIN, SUP
@@ -644,9 +644,11 @@ nest::iaf_cond_alpha_mc::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_cond_alpha_mc::handle( DataLoggingRequest& e )
+iaf_cond_alpha_mc::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/iaf_cond_beta.cpp
+++ b/models/iaf_cond_beta.cpp
@@ -41,14 +41,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_cond_beta > nest::iaf_cond_beta::recordablesMap_;
+RecordablesMap< iaf_cond_beta > iaf_cond_beta::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_iaf_cond_beta( const std::string& name )
 {
@@ -70,21 +70,20 @@ RecordablesMap< iaf_cond_beta >::create()
 
   insert_( names::t_ref_remaining, &iaf_cond_beta::get_r_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Iteration function
  * ---------------------------------------------------------------- */
 
 extern "C" inline int
-nest::iaf_cond_beta_dynamics( double, const double y[], double f[], void* pnode )
+iaf_cond_beta_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_cond_beta::State_ S;
+  typedef iaf_cond_beta::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::iaf_cond_beta& node = *( reinterpret_cast< nest::iaf_cond_beta* >( pnode ) );
+  const iaf_cond_beta& node = *( reinterpret_cast< iaf_cond_beta* >( pnode ) );
 
   const bool is_refractory = node.S_.r > 0;
 
@@ -120,7 +119,7 @@ nest::iaf_cond_beta_dynamics( double, const double y[], double f[], void* pnode 
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_beta::Parameters_::Parameters_()
+iaf_cond_beta::Parameters_::Parameters_()
   : V_th( -55.0 )        // mV
   , V_reset( -60.0 )     // mV
   , t_ref( 2.0 )         // ms
@@ -137,7 +136,7 @@ nest::iaf_cond_beta::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_cond_beta::State_::State_( const Parameters_& p )
+iaf_cond_beta::State_::State_( const Parameters_& p )
   : r( 0 )
 {
   y[ V_M ] = p.E_L;  // initialize to reversal potential
@@ -147,7 +146,7 @@ nest::iaf_cond_beta::State_::State_( const Parameters_& p )
   }
 }
 
-nest::iaf_cond_beta::State_::State_( const State_& s )
+iaf_cond_beta::State_::State_( const State_& s )
   : r( s.r )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -156,8 +155,8 @@ nest::iaf_cond_beta::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_beta::State_&
-nest::iaf_cond_beta::State_::operator=( const State_& s )
+iaf_cond_beta::State_&
+iaf_cond_beta::State_::operator=( const State_& s )
 {
   r = s.r;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -167,7 +166,7 @@ nest::iaf_cond_beta::State_::operator=( const State_& s )
   return *this;
 }
 
-nest::iaf_cond_beta::Buffers_::Buffers_( iaf_cond_beta& n )
+iaf_cond_beta::Buffers_::Buffers_( iaf_cond_beta& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -177,7 +176,7 @@ nest::iaf_cond_beta::Buffers_::Buffers_( iaf_cond_beta& n )
   // init_buffers_().
 }
 
-nest::iaf_cond_beta::Buffers_::Buffers_( const Buffers_&, iaf_cond_beta& n )
+iaf_cond_beta::Buffers_::Buffers_( const Buffers_&, iaf_cond_beta& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -192,7 +191,7 @@ nest::iaf_cond_beta::Buffers_::Buffers_( const Buffers_&, iaf_cond_beta& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_beta::Parameters_::get( Dictionary& d ) const
+iaf_cond_beta::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = V_th;
   d[ names::V_reset ] = V_reset;
@@ -210,7 +209,7 @@ nest::iaf_cond_beta::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_beta::Parameters_::set( const Dictionary& d, Node* node )
+iaf_cond_beta::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th, node );
@@ -249,7 +248,7 @@ nest::iaf_cond_beta::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_cond_beta::State_::get( Dictionary& d ) const
+iaf_cond_beta::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y[ V_M ];  // Membrane potential
   d[ names::g_ex ] = y[ G_EXC ];
@@ -259,7 +258,7 @@ nest::iaf_cond_beta::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_beta::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_cond_beta::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y[ V_M ], node );
   update_value_param( d, names::g_ex, y[ G_EXC ], node );
@@ -273,7 +272,7 @@ nest::iaf_cond_beta::State_::set( const Dictionary& d, const Parameters_&, Node*
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_beta::iaf_cond_beta()
+iaf_cond_beta::iaf_cond_beta()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -282,7 +281,7 @@ nest::iaf_cond_beta::iaf_cond_beta()
   recordablesMap_.create();
 }
 
-nest::iaf_cond_beta::iaf_cond_beta( const iaf_cond_beta& n )
+iaf_cond_beta::iaf_cond_beta( const iaf_cond_beta& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -290,7 +289,7 @@ nest::iaf_cond_beta::iaf_cond_beta( const iaf_cond_beta& n )
 {
 }
 
-nest::iaf_cond_beta::~iaf_cond_beta()
+iaf_cond_beta::~iaf_cond_beta()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -312,7 +311,7 @@ nest::iaf_cond_beta::~iaf_cond_beta()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_beta::init_buffers_()
+iaf_cond_beta::init_buffers_()
 {
   ArchivingNode::clear_history();
 
@@ -361,19 +360,19 @@ nest::iaf_cond_beta::init_buffers_()
 }
 
 double
-nest::iaf_cond_beta::get_normalisation_factor( double tau_rise, double tau_decay )
+iaf_cond_beta::get_normalisation_factor( double tau_rise, double tau_decay )
 {
-  return nest::beta_normalization_factor( tau_rise, tau_decay );
+  return beta_normalization_factor( tau_rise, tau_decay );
 }
 
 void
-nest::iaf_cond_beta::pre_run_hook()
+iaf_cond_beta::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
 
-  V_.PSConInit_E = nest::iaf_cond_beta::get_normalisation_factor( P_.tau_rise_ex, P_.tau_decay_ex );
-  V_.PSConInit_I = nest::iaf_cond_beta::get_normalisation_factor( P_.tau_rise_in, P_.tau_decay_in );
+  V_.PSConInit_E = iaf_cond_beta::get_normalisation_factor( P_.tau_rise_ex, P_.tau_decay_ex );
+  V_.PSConInit_I = iaf_cond_beta::get_normalisation_factor( P_.tau_rise_in, P_.tau_decay_in );
   V_.RefractoryCounts = Time( Time::ms( P_.t_ref ) ).get_steps();
 
   // since t_ref >= 0, this can only fail in error
@@ -385,7 +384,7 @@ nest::iaf_cond_beta::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_beta::update( Time const& origin, const long from, const long to )
+iaf_cond_beta::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -453,7 +452,7 @@ nest::iaf_cond_beta::update( Time const& origin, const long from, const long to 
 }
 
 void
-nest::iaf_cond_beta::handle( SpikeEvent& e )
+iaf_cond_beta::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -470,7 +469,7 @@ nest::iaf_cond_beta::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_cond_beta::handle( CurrentEvent& e )
+iaf_cond_beta::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -480,9 +479,11 @@ nest::iaf_cond_beta::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_cond_beta::handle( DataLoggingRequest& e )
+iaf_cond_beta::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/iaf_cond_exp.cpp
+++ b/models/iaf_cond_exp.cpp
@@ -40,14 +40,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_cond_exp > nest::iaf_cond_exp::recordablesMap_;
+RecordablesMap< iaf_cond_exp > iaf_cond_exp::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_iaf_cond_exp( const std::string& name )
 {
@@ -65,17 +65,16 @@ RecordablesMap< iaf_cond_exp >::create()
   insert_( names::g_ex, &iaf_cond_exp::get_y_elem_< iaf_cond_exp::State_::G_EXC > );
   insert_( names::g_in, &iaf_cond_exp::get_y_elem_< iaf_cond_exp::State_::G_INH > );
 }
-}
 
 extern "C" inline int
-nest::iaf_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
+iaf_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_cond_exp::State_ S;
+  typedef iaf_cond_exp::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::iaf_cond_exp& node = *( reinterpret_cast< nest::iaf_cond_exp* >( pnode ) );
+  const iaf_cond_exp& node = *( reinterpret_cast< iaf_cond_exp* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -106,7 +105,7 @@ nest::iaf_cond_exp_dynamics( double, const double y[], double f[], void* pnode )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_exp::Parameters_::Parameters_()
+iaf_cond_exp::Parameters_::Parameters_()
   : V_th_( -55.0 )     // mV
   , V_reset_( -60.0 )  // mV
   , t_ref_( 2.0 )      // ms
@@ -121,14 +120,14 @@ nest::iaf_cond_exp::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_cond_exp::State_::State_( const Parameters_& p )
+iaf_cond_exp::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ V_M ] = p.E_L;
   y_[ G_EXC ] = y_[ G_INH ] = 0;
 }
 
-nest::iaf_cond_exp::State_::State_( const State_& s )
+iaf_cond_exp::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -137,8 +136,8 @@ nest::iaf_cond_exp::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_exp::State_&
-nest::iaf_cond_exp::State_::operator=( const State_& s )
+iaf_cond_exp::State_&
+iaf_cond_exp::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -153,7 +152,7 @@ nest::iaf_cond_exp::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_exp::Parameters_::get( Dictionary& d ) const
+iaf_cond_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = V_th_;
   d[ names::V_reset ] = V_reset_;
@@ -169,7 +168,7 @@ nest::iaf_cond_exp::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
+iaf_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th_, node );
@@ -206,7 +205,7 @@ nest::iaf_cond_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_cond_exp::State_::get( Dictionary& d ) const
+iaf_cond_exp::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];  // Membrane potential
   d[ names::g_ex ] = y_[ G_EXC ];
@@ -214,14 +213,14 @@ nest::iaf_cond_exp::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_cond_exp::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::g_ex, y_[ G_EXC ], node );
   update_value_param( d, names::g_in, y_[ G_INH ], node );
 }
 
-nest::iaf_cond_exp::Buffers_::Buffers_( iaf_cond_exp& n )
+iaf_cond_exp::Buffers_::Buffers_( iaf_cond_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -231,7 +230,7 @@ nest::iaf_cond_exp::Buffers_::Buffers_( iaf_cond_exp& n )
   // init_buffers_().
 }
 
-nest::iaf_cond_exp::Buffers_::Buffers_( const Buffers_&, iaf_cond_exp& n )
+iaf_cond_exp::Buffers_::Buffers_( const Buffers_&, iaf_cond_exp& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -245,7 +244,7 @@ nest::iaf_cond_exp::Buffers_::Buffers_( const Buffers_&, iaf_cond_exp& n )
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_exp::iaf_cond_exp()
+iaf_cond_exp::iaf_cond_exp()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -254,7 +253,7 @@ nest::iaf_cond_exp::iaf_cond_exp()
   recordablesMap_.create();
 }
 
-nest::iaf_cond_exp::iaf_cond_exp( const iaf_cond_exp& n )
+iaf_cond_exp::iaf_cond_exp( const iaf_cond_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -262,7 +261,7 @@ nest::iaf_cond_exp::iaf_cond_exp( const iaf_cond_exp& n )
 {
 }
 
-nest::iaf_cond_exp::~iaf_cond_exp()
+iaf_cond_exp::~iaf_cond_exp()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -284,7 +283,7 @@ nest::iaf_cond_exp::~iaf_cond_exp()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_exp::init_buffers_()
+iaf_cond_exp::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -332,7 +331,7 @@ nest::iaf_cond_exp::init_buffers_()
 }
 
 void
-nest::iaf_cond_exp::pre_run_hook()
+iaf_cond_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -347,7 +346,7 @@ nest::iaf_cond_exp::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_exp::update( Time const& origin, const long from, const long to )
+iaf_cond_exp::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -413,7 +412,7 @@ nest::iaf_cond_exp::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::iaf_cond_exp::handle( SpikeEvent& e )
+iaf_cond_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -430,7 +429,7 @@ nest::iaf_cond_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_cond_exp::handle( CurrentEvent& e )
+iaf_cond_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -441,9 +440,11 @@ nest::iaf_cond_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_cond_exp::handle( DataLoggingRequest& e )
+iaf_cond_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/iaf_cond_exp.h
+++ b/models/iaf_cond_exp.h
@@ -368,7 +368,7 @@ private:
 
 
 inline size_t
-nest::iaf_cond_exp::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_cond_exp::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_cond_exp_sfa_rr.cpp
+++ b/models/iaf_cond_exp_sfa_rr.cpp
@@ -40,14 +40,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_cond_exp_sfa_rr > nest::iaf_cond_exp_sfa_rr::recordablesMap_;
+RecordablesMap< iaf_cond_exp_sfa_rr > iaf_cond_exp_sfa_rr::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_iaf_cond_exp_sfa_rr( const std::string& name )
 {
@@ -67,17 +67,16 @@ RecordablesMap< iaf_cond_exp_sfa_rr >::create()
   insert_( names::g_sfa, &iaf_cond_exp_sfa_rr::get_y_elem_< iaf_cond_exp_sfa_rr::State_::G_SFA > );
   insert_( names::g_rr, &iaf_cond_exp_sfa_rr::get_y_elem_< iaf_cond_exp_sfa_rr::State_::G_RR > );
 }
-}
 
 extern "C" inline int
-nest::iaf_cond_exp_sfa_rr_dynamics( double, const double y[], double f[], void* pnode )
+iaf_cond_exp_sfa_rr_dynamics( double, const double y[], double f[], void* pnode )
 {
   // a shorthand
-  typedef nest::iaf_cond_exp_sfa_rr::State_ S;
+  typedef iaf_cond_exp_sfa_rr::State_ S;
 
   // get access to node so we can almost work as in a member function
   assert( pnode );
-  const nest::iaf_cond_exp_sfa_rr& node = *( reinterpret_cast< nest::iaf_cond_exp_sfa_rr* >( pnode ) );
+  const iaf_cond_exp_sfa_rr& node = *( reinterpret_cast< iaf_cond_exp_sfa_rr* >( pnode ) );
 
   const bool is_refractory = node.S_.r_ > 0;
 
@@ -115,7 +114,7 @@ nest::iaf_cond_exp_sfa_rr_dynamics( double, const double y[], double f[], void* 
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_exp_sfa_rr::Parameters_::Parameters_()
+iaf_cond_exp_sfa_rr::Parameters_::Parameters_()
   : V_th_( -57.0 )     // mV
   , V_reset_( -70.0 )  // mV
   , t_ref_( 0.5 )      // ms
@@ -136,7 +135,7 @@ nest::iaf_cond_exp_sfa_rr::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_cond_exp_sfa_rr::State_::State_( const Parameters_& p )
+iaf_cond_exp_sfa_rr::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   y_[ V_M ] = p.E_L;
@@ -146,7 +145,7 @@ nest::iaf_cond_exp_sfa_rr::State_::State_( const Parameters_& p )
   }
 }
 
-nest::iaf_cond_exp_sfa_rr::State_::State_( const State_& s )
+iaf_cond_exp_sfa_rr::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -155,8 +154,8 @@ nest::iaf_cond_exp_sfa_rr::State_::State_( const State_& s )
   }
 }
 
-nest::iaf_cond_exp_sfa_rr::State_&
-nest::iaf_cond_exp_sfa_rr::State_::operator=( const State_& s )
+iaf_cond_exp_sfa_rr::State_&
+iaf_cond_exp_sfa_rr::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -171,7 +170,7 @@ nest::iaf_cond_exp_sfa_rr::State_::operator=( const State_& s )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_exp_sfa_rr::Parameters_::get( Dictionary& d ) const
+iaf_cond_exp_sfa_rr::Parameters_::get( Dictionary& d ) const
 {
   d[ names::V_th ] = V_th_;
   d[ names::V_reset ] = V_reset_;
@@ -194,7 +193,7 @@ nest::iaf_cond_exp_sfa_rr::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::Parameters_::set( const Dictionary& d, Node* node )
+iaf_cond_exp_sfa_rr::Parameters_::set( const Dictionary& d, Node* node )
 {
   // allow setting the membrane potential
   update_value_param( d, names::V_th, V_th_, node );
@@ -238,7 +237,7 @@ nest::iaf_cond_exp_sfa_rr::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::State_::get( Dictionary& d ) const
+iaf_cond_exp_sfa_rr::State_::get( Dictionary& d ) const
 {
   d[ names::V_m ] = y_[ V_M ];  // Membrane potential
   d[ names::g_ex ] = y_[ G_EXC ];
@@ -248,7 +247,7 @@ nest::iaf_cond_exp_sfa_rr::State_::get( Dictionary& d ) const
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+iaf_cond_exp_sfa_rr::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y_[ V_M ], node );
   update_value_param( d, names::g_ex, y_[ G_EXC ], node );
@@ -257,7 +256,7 @@ nest::iaf_cond_exp_sfa_rr::State_::set( const Dictionary& d, const Parameters_&,
   update_value_param( d, names::g_rr, y_[ G_RR ], node );
 }
 
-nest::iaf_cond_exp_sfa_rr::Buffers_::Buffers_( iaf_cond_exp_sfa_rr& n )
+iaf_cond_exp_sfa_rr::Buffers_::Buffers_( iaf_cond_exp_sfa_rr& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -267,7 +266,7 @@ nest::iaf_cond_exp_sfa_rr::Buffers_::Buffers_( iaf_cond_exp_sfa_rr& n )
   // init_buffers_().
 }
 
-nest::iaf_cond_exp_sfa_rr::Buffers_::Buffers_( const Buffers_&, iaf_cond_exp_sfa_rr& n )
+iaf_cond_exp_sfa_rr::Buffers_::Buffers_( const Buffers_&, iaf_cond_exp_sfa_rr& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -281,7 +280,7 @@ nest::iaf_cond_exp_sfa_rr::Buffers_::Buffers_( const Buffers_&, iaf_cond_exp_sfa
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::iaf_cond_exp_sfa_rr::iaf_cond_exp_sfa_rr()
+iaf_cond_exp_sfa_rr::iaf_cond_exp_sfa_rr()
   : ArchivingNode()
   , P_()
   , S_( P_ )
@@ -290,7 +289,7 @@ nest::iaf_cond_exp_sfa_rr::iaf_cond_exp_sfa_rr()
   recordablesMap_.create();
 }
 
-nest::iaf_cond_exp_sfa_rr::iaf_cond_exp_sfa_rr( const iaf_cond_exp_sfa_rr& n )
+iaf_cond_exp_sfa_rr::iaf_cond_exp_sfa_rr( const iaf_cond_exp_sfa_rr& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -298,7 +297,7 @@ nest::iaf_cond_exp_sfa_rr::iaf_cond_exp_sfa_rr( const iaf_cond_exp_sfa_rr& n )
 {
 }
 
-nest::iaf_cond_exp_sfa_rr::~iaf_cond_exp_sfa_rr()
+iaf_cond_exp_sfa_rr::~iaf_cond_exp_sfa_rr()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -320,7 +319,7 @@ nest::iaf_cond_exp_sfa_rr::~iaf_cond_exp_sfa_rr()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_exp_sfa_rr::init_buffers_()
+iaf_cond_exp_sfa_rr::init_buffers_()
 {
   B_.spike_exc_.clear();  // includes resize
   B_.spike_inh_.clear();  // includes resize
@@ -368,7 +367,7 @@ nest::iaf_cond_exp_sfa_rr::init_buffers_()
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::pre_run_hook()
+iaf_cond_exp_sfa_rr::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -383,7 +382,7 @@ nest::iaf_cond_exp_sfa_rr::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_cond_exp_sfa_rr::update( Time const& origin, const long from, const long to )
+iaf_cond_exp_sfa_rr::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -452,7 +451,7 @@ nest::iaf_cond_exp_sfa_rr::update( Time const& origin, const long from, const lo
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::handle( SpikeEvent& e )
+iaf_cond_exp_sfa_rr::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -469,7 +468,7 @@ nest::iaf_cond_exp_sfa_rr::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::handle( CurrentEvent& e )
+iaf_cond_exp_sfa_rr::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -480,9 +479,11 @@ nest::iaf_cond_exp_sfa_rr::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_cond_exp_sfa_rr::handle( DataLoggingRequest& e )
+iaf_cond_exp_sfa_rr::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/iaf_cond_exp_sfa_rr.h
+++ b/models/iaf_cond_exp_sfa_rr.h
@@ -330,7 +330,7 @@ private:
 
 
 inline size_t
-nest::iaf_cond_exp_sfa_rr::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_cond_exp_sfa_rr::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_alpha.cpp
+++ b/models/iaf_psc_alpha.cpp
@@ -36,10 +36,10 @@
 #include "universal_data_logger_impl.h"
 
 
-nest::RecordablesMap< nest::iaf_psc_alpha > nest::iaf_psc_alpha::recordablesMap_;
-
 namespace nest
 {
+RecordablesMap< iaf_psc_alpha > iaf_psc_alpha::recordablesMap_;
+
 void
 register_iaf_psc_alpha( const std::string& name )
 {
@@ -403,4 +403,4 @@ iaf_psc_alpha::handle( DataLoggingRequest& e )
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/iaf_psc_alpha.h
+++ b/models/iaf_psc_alpha.h
@@ -404,7 +404,7 @@ private:
 };
 
 inline size_t
-nest::iaf_psc_alpha::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_psc_alpha::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_alpha_multisynapse.cpp
+++ b/models/iaf_psc_alpha_multisynapse.cpp
@@ -34,12 +34,13 @@
 #include "numerics.h"
 #include "universal_data_logger_impl.h"
 
+
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-namespace nest
-{
 void
 register_iaf_psc_alpha_multisynapse( const std::string& name )
 {
@@ -452,4 +453,4 @@ iaf_psc_alpha_multisynapse::set_status( const Dictionary& d )
   S_ = stmp;
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/iaf_psc_alpha_ps.cpp
+++ b/models/iaf_psc_alpha_ps.cpp
@@ -38,14 +38,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_psc_alpha_ps > nest::iaf_psc_alpha_ps::recordablesMap_;
+RecordablesMap< iaf_psc_alpha_ps > iaf_psc_alpha_ps::recordablesMap_;
 
-namespace nest
-{
 void
 register_iaf_psc_alpha_ps( const std::string& name )
 {
@@ -65,13 +65,12 @@ RecordablesMap< iaf_psc_alpha_ps >::create()
   insert_( names::I_syn_ex, &iaf_psc_alpha_ps::get_I_ex_ );
   insert_( names::I_syn_in, &iaf_psc_alpha_ps::get_I_in_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_alpha_ps::Parameters_::Parameters_()
+iaf_psc_alpha_ps::Parameters_::Parameters_()
   : tau_m_( 10.0 )                                        // ms
   , tau_syn_ex_( 2.0 )                                    // ms
   , tau_syn_in_( 2.0 )                                    // ms
@@ -85,7 +84,7 @@ nest::iaf_psc_alpha_ps::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_alpha_ps::State_::State_()
+iaf_psc_alpha_ps::State_::State_()
   : y_input_( 0.0 )
   , I_ex_( 0.0 )
   , dI_ex_( 0.0 )
@@ -103,7 +102,7 @@ nest::iaf_psc_alpha_ps::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_alpha_ps::Parameters_::get( Dictionary& d ) const
+iaf_psc_alpha_ps::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;
   d[ names::I_e ] = I_e_;
@@ -118,7 +117,7 @@ nest::iaf_psc_alpha_ps::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_alpha_ps::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_alpha_ps::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -189,7 +188,7 @@ nest::iaf_psc_alpha_ps::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_psc_alpha_ps::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_alpha_ps::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = V_m_ + p.E_L_;  // Membrane potential
   d[ names::I_syn_ex ] = I_ex_;     // Excitatory synaptic current
@@ -200,7 +199,7 @@ nest::iaf_psc_alpha_ps::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::iaf_psc_alpha_ps::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_alpha_ps::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, V_m_, node ) )
   {
@@ -212,12 +211,12 @@ nest::iaf_psc_alpha_ps::State_::set( const Dictionary& d, const Parameters_& p, 
   }
 }
 
-nest::iaf_psc_alpha_ps::Buffers_::Buffers_( iaf_psc_alpha_ps& n )
+iaf_psc_alpha_ps::Buffers_::Buffers_( iaf_psc_alpha_ps& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_alpha_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_alpha_ps& n )
+iaf_psc_alpha_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_alpha_ps& n )
   : logger_( n )
 {
 }
@@ -227,7 +226,7 @@ nest::iaf_psc_alpha_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_alpha_ps& n
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_alpha_ps::iaf_psc_alpha_ps()
+iaf_psc_alpha_ps::iaf_psc_alpha_ps()
   : ArchivingNode()
   , P_()
   , S_()
@@ -236,7 +235,7 @@ nest::iaf_psc_alpha_ps::iaf_psc_alpha_ps()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_alpha_ps::iaf_psc_alpha_ps( const iaf_psc_alpha_ps& n )
+iaf_psc_alpha_ps::iaf_psc_alpha_ps( const iaf_psc_alpha_ps& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -249,7 +248,7 @@ nest::iaf_psc_alpha_ps::iaf_psc_alpha_ps( const iaf_psc_alpha_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_alpha_ps::init_buffers_()
+iaf_psc_alpha_ps::init_buffers_()
 {
   B_.events_.resize();
   B_.events_.clear();
@@ -260,7 +259,7 @@ nest::iaf_psc_alpha_ps::init_buffers_()
 }
 
 void
-nest::iaf_psc_alpha_ps::pre_run_hook()
+iaf_psc_alpha_ps::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -301,13 +300,13 @@ nest::iaf_psc_alpha_ps::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 bool
-nest::iaf_psc_alpha_ps::get_next_event_( const long T, double& ev_offset, double& ev_weight, bool& end_of_refract )
+iaf_psc_alpha_ps::get_next_event_( const long T, double& ev_offset, double& ev_weight, bool& end_of_refract )
 {
   return B_.events_.get_next_spike( T, false, ev_offset, ev_weight, end_of_refract );
 }
 
 void
-nest::iaf_psc_alpha_ps::update( Time const& origin, const long from, const long to )
+iaf_psc_alpha_ps::update( Time const& origin, const long from, const long to )
 {
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
@@ -462,7 +461,7 @@ nest::iaf_psc_alpha_ps::update( Time const& origin, const long from, const long 
 
 // function handles exact spike times
 void
-nest::iaf_psc_alpha_ps::handle( SpikeEvent& e )
+iaf_psc_alpha_ps::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -472,14 +471,14 @@ nest::iaf_psc_alpha_ps::handle( SpikeEvent& e )
   */
   const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
-  B_.events_.add_spike( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ),
+  B_.events_.add_spike( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     Tdeliver,
     e.get_offset(),
     e.get_weight() * e.get_multiplicity() );
 }
 
 void
-nest::iaf_psc_alpha_ps::handle( CurrentEvent& e )
+iaf_psc_alpha_ps::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -487,11 +486,11 @@ nest::iaf_psc_alpha_ps::handle( CurrentEvent& e )
   const double w = e.get_weight();
 
   // add weighted current; HEP 2002-10-04
-  B_.currents_.add_value( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ), w * c );
+  B_.currents_.add_value( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), w * c );
 }
 
 void
-nest::iaf_psc_alpha_ps::handle( DataLoggingRequest& e )
+iaf_psc_alpha_ps::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -499,7 +498,7 @@ nest::iaf_psc_alpha_ps::handle( DataLoggingRequest& e )
 // auxiliary functions ---------------------------------------------
 
 void
-nest::iaf_psc_alpha_ps::propagate_( const double dt )
+iaf_psc_alpha_ps::propagate_( const double dt )
 {
   // V_m_ remains unchanged at 0.0 while neuron is refractory
   if ( not S_.is_refractory_ )
@@ -534,7 +533,7 @@ nest::iaf_psc_alpha_ps::propagate_( const double dt )
 }
 
 void
-nest::iaf_psc_alpha_ps::emit_spike_( Time const& origin, const long lag, const double t0, const double dt )
+iaf_psc_alpha_ps::emit_spike_( Time const& origin, const long lag, const double t0, const double dt )
 {
   // we know that the potential is subthreshold at t0, super at t0+dt
 
@@ -558,7 +557,7 @@ nest::iaf_psc_alpha_ps::emit_spike_( Time const& origin, const long lag, const d
 }
 
 void
-nest::iaf_psc_alpha_ps::emit_instant_spike_( Time const& origin, const long lag, const double spike_offs )
+iaf_psc_alpha_ps::emit_instant_spike_( Time const& origin, const long lag, const double spike_offs )
 {
   assert( S_.V_m_ >= P_.U_th_ );  // ensure we are superthreshold
 
@@ -580,7 +579,7 @@ nest::iaf_psc_alpha_ps::emit_instant_spike_( Time const& origin, const long lag,
 }
 
 double
-nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
+iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 {
   const double expm1_tau_m = numerics::expm1( -t_step * V_.inv_tau_m_ );
 
@@ -599,3 +598,5 @@ nest::iaf_psc_alpha_ps::threshold_distance( double t_step ) const
 
   return V_m_root - P_.U_th_;
 }
+
+}  // namespace nest

--- a/models/iaf_psc_alpha_ps.h
+++ b/models/iaf_psc_alpha_ps.h
@@ -461,7 +461,7 @@ private:
 };
 
 inline size_t
-nest::iaf_psc_alpha_ps::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_psc_alpha_ps::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_delta.cpp
+++ b/models/iaf_psc_delta.cpp
@@ -37,6 +37,7 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
 void
@@ -66,7 +67,7 @@ RecordablesMap< iaf_psc_delta >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_delta::Parameters_::Parameters_()
+iaf_psc_delta::Parameters_::Parameters_()
   : tau_m_( 10.0 )                                   // ms
   , c_m_( 250.0 )                                    // pF
   , t_ref_( 2.0 )                                    // ms
@@ -79,7 +80,7 @@ nest::iaf_psc_delta::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_delta::State_::State_()
+iaf_psc_delta::State_::State_()
   : y0_( 0.0 )
   , y3_( 0.0 )
   , r_( 0 )
@@ -92,7 +93,7 @@ nest::iaf_psc_delta::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_delta::Parameters_::get( Dictionary& d ) const
+iaf_psc_delta::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;  // Resting potential
   d[ names::I_e ] = I_e_;
@@ -106,7 +107,7 @@ nest::iaf_psc_delta::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -168,13 +169,13 @@ nest::iaf_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_psc_delta::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_delta::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = y3_ + p.E_L_;  // Membrane potential
 }
 
 void
-nest::iaf_psc_delta::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_delta::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, y3_, node ) )
   {
@@ -186,12 +187,12 @@ nest::iaf_psc_delta::State_::set( const Dictionary& d, const Parameters_& p, dou
   }
 }
 
-nest::iaf_psc_delta::Buffers_::Buffers_( iaf_psc_delta& n )
+iaf_psc_delta::Buffers_::Buffers_( iaf_psc_delta& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_delta::Buffers_::Buffers_( const Buffers_&, iaf_psc_delta& n )
+iaf_psc_delta::Buffers_::Buffers_( const Buffers_&, iaf_psc_delta& n )
   : logger_( n )
 {
 }
@@ -200,7 +201,7 @@ nest::iaf_psc_delta::Buffers_::Buffers_( const Buffers_&, iaf_psc_delta& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_delta::iaf_psc_delta()
+iaf_psc_delta::iaf_psc_delta()
   : ArchivingNode()
   , P_()
   , S_()
@@ -209,7 +210,7 @@ nest::iaf_psc_delta::iaf_psc_delta()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_delta::iaf_psc_delta( const iaf_psc_delta& n )
+iaf_psc_delta::iaf_psc_delta( const iaf_psc_delta& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -222,7 +223,7 @@ nest::iaf_psc_delta::iaf_psc_delta( const iaf_psc_delta& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_delta::init_buffers_()
+iaf_psc_delta::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // includes resize
@@ -231,7 +232,7 @@ nest::iaf_psc_delta::init_buffers_()
 }
 
 void
-nest::iaf_psc_delta::pre_run_hook()
+iaf_psc_delta::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -269,7 +270,7 @@ nest::iaf_psc_delta::pre_run_hook()
  */
 
 void
-nest::iaf_psc_delta::update( Time const& origin, const long from, const long to )
+iaf_psc_delta::update( Time const& origin, const long from, const long to )
 {
   const double h = Time::get_resolution().get_ms();
   for ( long lag = from; lag < to; ++lag )
@@ -329,7 +330,7 @@ nest::iaf_psc_delta::update( Time const& origin, const long from, const long to 
 }
 
 void
-nest::iaf_psc_delta::handle( SpikeEvent& e )
+iaf_psc_delta::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -342,7 +343,7 @@ nest::iaf_psc_delta::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_psc_delta::handle( CurrentEvent& e )
+iaf_psc_delta::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -354,9 +355,9 @@ nest::iaf_psc_delta::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_psc_delta::handle( DataLoggingRequest& e )
+iaf_psc_delta::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/iaf_psc_delta.h
+++ b/models/iaf_psc_delta.h
@@ -370,7 +370,7 @@ private:
 
 
 inline size_t
-nest::iaf_psc_delta::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_psc_delta::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_delta_ps.cpp
+++ b/models/iaf_psc_delta_ps.cpp
@@ -69,7 +69,7 @@ RecordablesMap< iaf_psc_delta_ps >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_delta_ps::Parameters_::Parameters_()
+iaf_psc_delta_ps::Parameters_::Parameters_()
   : tau_m_( 10.0 )                                   // ms
   , c_m_( 250.0 )                                    // pF
   , t_ref_( 2.0 )                                    // ms
@@ -81,7 +81,7 @@ nest::iaf_psc_delta_ps::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_delta_ps::State_::State_()
+iaf_psc_delta_ps::State_::State_()
   : U_( 0.0 )  //  or U_ = U_reset_;
   , I_( 0. )
   , last_spike_step_( -1 )
@@ -96,7 +96,7 @@ nest::iaf_psc_delta_ps::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_delta_ps::Parameters_::get( Dictionary& d ) const
+iaf_psc_delta_ps::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;
   d[ names::I_e ] = I_e_;
@@ -109,7 +109,7 @@ nest::iaf_psc_delta_ps::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_delta_ps::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_delta_ps::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -174,7 +174,7 @@ nest::iaf_psc_delta_ps::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_psc_delta_ps::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_delta_ps::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = U_ + p.E_L_;  // Membrane potential
   d[ names::is_refractory ] = is_refractory_;
@@ -182,7 +182,7 @@ nest::iaf_psc_delta_ps::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::iaf_psc_delta_ps::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_delta_ps::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, U_, node ) )
   {
@@ -194,12 +194,12 @@ nest::iaf_psc_delta_ps::State_::set( const Dictionary& d, const Parameters_& p, 
   }
 }
 
-nest::iaf_psc_delta_ps::Buffers_::Buffers_( iaf_psc_delta_ps& n )
+iaf_psc_delta_ps::Buffers_::Buffers_( iaf_psc_delta_ps& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_delta_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_delta_ps& n )
+iaf_psc_delta_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_delta_ps& n )
   : logger_( n )
 {
 }
@@ -208,7 +208,7 @@ nest::iaf_psc_delta_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_delta_ps& n
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_delta_ps::iaf_psc_delta_ps()
+iaf_psc_delta_ps::iaf_psc_delta_ps()
   : ArchivingNode()
   , P_()
   , S_()
@@ -217,7 +217,7 @@ nest::iaf_psc_delta_ps::iaf_psc_delta_ps()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_delta_ps::iaf_psc_delta_ps( const iaf_psc_delta_ps& n )
+iaf_psc_delta_ps::iaf_psc_delta_ps( const iaf_psc_delta_ps& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -230,7 +230,7 @@ nest::iaf_psc_delta_ps::iaf_psc_delta_ps( const iaf_psc_delta_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_delta_ps::init_buffers_()
+iaf_psc_delta_ps::init_buffers_()
 {
   B_.events_.resize();
   B_.events_.clear();
@@ -447,7 +447,7 @@ iaf_psc_delta_ps::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::iaf_psc_delta_ps::propagate_( const double dt )
+iaf_psc_delta_ps::propagate_( const double dt )
 {
   assert( not S_.is_refractory_ );  // should not be called if neuron is
                                     // refractory
@@ -459,7 +459,7 @@ nest::iaf_psc_delta_ps::propagate_( const double dt )
 }
 
 void
-nest::iaf_psc_delta_ps::emit_spike_( Time const& origin, const long lag, const double offset_U )
+iaf_psc_delta_ps::emit_spike_( Time const& origin, const long lag, const double offset_U )
 {
   assert( S_.U_ >= P_.U_th_ );  // ensure we are superthreshold
 
@@ -483,7 +483,7 @@ nest::iaf_psc_delta_ps::emit_spike_( Time const& origin, const long lag, const d
 }
 
 void
-nest::iaf_psc_delta_ps::emit_instant_spike_( Time const& origin, const long lag, const double spike_offs )
+iaf_psc_delta_ps::emit_instant_spike_( Time const& origin, const long lag, const double spike_offs )
 {
   assert( S_.U_ >= P_.U_th_ );  // ensure we are superthreshold
 
@@ -532,9 +532,9 @@ iaf_psc_delta_ps::handle( CurrentEvent& e )
 
 
 void
-nest::iaf_psc_delta_ps::handle( DataLoggingRequest& e )
+iaf_psc_delta_ps::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/iaf_psc_delta_ps.h
+++ b/models/iaf_psc_delta_ps.h
@@ -394,7 +394,7 @@ private:
 
 
 inline size_t
-nest::iaf_psc_delta_ps::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_psc_delta_ps::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_exp.cpp
+++ b/models/iaf_psc_exp.cpp
@@ -37,14 +37,15 @@
 #include "ring_buffer_impl.h"
 #include "universal_data_logger_impl.h"
 
+
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_psc_exp > nest::iaf_psc_exp::recordablesMap_;
+RecordablesMap< iaf_psc_exp > iaf_psc_exp::recordablesMap_;
 
-namespace nest
-{
 void
 register_iaf_psc_exp( const std::string& name )
 {
@@ -62,13 +63,12 @@ RecordablesMap< iaf_psc_exp >::create()
   insert_( names::I_syn_ex, &iaf_psc_exp::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_psc_exp::get_I_syn_in_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp::Parameters_::Parameters_()
+iaf_psc_exp::Parameters_::Parameters_()
   : Tau_( 10.0 )              // in ms
   , C_( 250.0 )               // in pF
   , t_ref_( 2.0 )             // in ms
@@ -83,7 +83,7 @@ nest::iaf_psc_exp::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_exp::State_::State_()
+iaf_psc_exp::State_::State_()
   : i_0_( 0.0 )
   , i_1_( 0.0 )
   , i_syn_ex_( 0.0 )
@@ -98,7 +98,7 @@ nest::iaf_psc_exp::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp::Parameters_::get( Dictionary& d ) const
+iaf_psc_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;  // resting potential
   d[ names::I_e ] = I_e_;
@@ -114,7 +114,7 @@ nest::iaf_psc_exp::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -179,13 +179,13 @@ nest::iaf_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = V_m_ + p.E_L_;  // Membrane potential
 }
 
 void
-nest::iaf_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, V_m_, node ) )
   {
@@ -197,12 +197,12 @@ nest::iaf_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, doubl
   }
 }
 
-nest::iaf_psc_exp::Buffers_::Buffers_( iaf_psc_exp& n )
+iaf_psc_exp::Buffers_::Buffers_( iaf_psc_exp& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_exp::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp& n )
+iaf_psc_exp::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp& n )
   : logger_( n )
 {
 }
@@ -211,7 +211,7 @@ nest::iaf_psc_exp::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp::iaf_psc_exp()
+iaf_psc_exp::iaf_psc_exp()
   : ArchivingNode()
   , P_()
   , S_()
@@ -220,7 +220,7 @@ nest::iaf_psc_exp::iaf_psc_exp()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_exp::iaf_psc_exp( const iaf_psc_exp& n )
+iaf_psc_exp::iaf_psc_exp( const iaf_psc_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -233,7 +233,7 @@ nest::iaf_psc_exp::iaf_psc_exp( const iaf_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp::init_buffers_()
+iaf_psc_exp::init_buffers_()
 {
   B_.input_buffer_.clear();  // includes resize
   B_.logger_.reset();
@@ -241,7 +241,7 @@ nest::iaf_psc_exp::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp::pre_run_hook()
+iaf_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -285,7 +285,7 @@ nest::iaf_psc_exp::pre_run_hook()
 }
 
 void
-nest::iaf_psc_exp::update( const Time& origin, const long from, const long to )
+iaf_psc_exp::update( const Time& origin, const long from, const long to )
 {
   const double h = Time::get_resolution().get_ms();
 
@@ -348,7 +348,7 @@ nest::iaf_psc_exp::update( const Time& origin, const long from, const long to )
 }
 
 void
-nest::iaf_psc_exp::handle( SpikeEvent& e )
+iaf_psc_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -362,7 +362,7 @@ nest::iaf_psc_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_psc_exp::handle( CurrentEvent& e )
+iaf_psc_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -383,7 +383,9 @@ nest::iaf_psc_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_psc_exp::handle( DataLoggingRequest& e )
+iaf_psc_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/iaf_psc_exp.h
+++ b/models/iaf_psc_exp.h
@@ -457,7 +457,7 @@ private:
 
 
 inline size_t
-nest::iaf_psc_exp::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_psc_exp::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_exp_htum.cpp
+++ b/models/iaf_psc_exp_htum.cpp
@@ -33,14 +33,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_psc_exp_htum > nest::iaf_psc_exp_htum::recordablesMap_;
+RecordablesMap< iaf_psc_exp_htum > iaf_psc_exp_htum::recordablesMap_;
 
-namespace nest
-{
 void
 register_iaf_psc_exp_htum( const std::string& name )
 {
@@ -58,13 +58,12 @@ RecordablesMap< iaf_psc_exp_htum >::create()
   insert_( names::I_syn_ex, &iaf_psc_exp_htum::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_psc_exp_htum::get_I_syn_in_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp_htum::Parameters_::Parameters_()
+iaf_psc_exp_htum::Parameters_::Parameters_()
   : Tau_( 10.0 )              // in ms
   , C_( 250.0 )               // in pF
   , tau_ref_tot_( 2.0 )       // in ms
@@ -78,7 +77,7 @@ nest::iaf_psc_exp_htum::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_exp_htum::State_::State_()
+iaf_psc_exp_htum::State_::State_()
   : i_0_( 0.0 )
   , i_syn_ex_( 0.0 )
   , i_syn_in_( 0.0 )
@@ -93,7 +92,7 @@ nest::iaf_psc_exp_htum::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_htum::Parameters_::get( Dictionary& d ) const
+iaf_psc_exp_htum::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;  // Resting potential
   d[ names::I_e ] = I_e_;
@@ -108,7 +107,7 @@ nest::iaf_psc_exp_htum::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_exp_htum::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_exp_htum::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -164,13 +163,13 @@ nest::iaf_psc_exp_htum::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_psc_exp_htum::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_exp_htum::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = V_m_ + p.E_L_;  // Membrane potential
 }
 
 void
-nest::iaf_psc_exp_htum::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_exp_htum::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, V_m_, node ) )
   {
@@ -182,12 +181,12 @@ nest::iaf_psc_exp_htum::State_::set( const Dictionary& d, const Parameters_& p, 
   }
 }
 
-nest::iaf_psc_exp_htum::Buffers_::Buffers_( iaf_psc_exp_htum& n )
+iaf_psc_exp_htum::Buffers_::Buffers_( iaf_psc_exp_htum& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_exp_htum::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_htum& n )
+iaf_psc_exp_htum::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_htum& n )
   : logger_( n )
 {
 }
@@ -196,7 +195,7 @@ nest::iaf_psc_exp_htum::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_htum& n
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp_htum::iaf_psc_exp_htum()
+iaf_psc_exp_htum::iaf_psc_exp_htum()
   : ArchivingNode()
   , P_()
   , S_()
@@ -205,7 +204,7 @@ nest::iaf_psc_exp_htum::iaf_psc_exp_htum()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_exp_htum::iaf_psc_exp_htum( const iaf_psc_exp_htum& n )
+iaf_psc_exp_htum::iaf_psc_exp_htum( const iaf_psc_exp_htum& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -218,7 +217,7 @@ nest::iaf_psc_exp_htum::iaf_psc_exp_htum( const iaf_psc_exp_htum& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_htum::init_buffers_()
+iaf_psc_exp_htum::init_buffers_()
 {
   B_.spikes_ex_.clear();  // includes resize
   B_.spikes_in_.clear();  // includes resize
@@ -228,7 +227,7 @@ nest::iaf_psc_exp_htum::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_htum::pre_run_hook()
+iaf_psc_exp_htum::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -294,7 +293,7 @@ nest::iaf_psc_exp_htum::pre_run_hook()
 }
 
 void
-nest::iaf_psc_exp_htum::update( Time const& origin, const long from, const long to )
+iaf_psc_exp_htum::update( Time const& origin, const long from, const long to )
 {
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
@@ -349,7 +348,7 @@ nest::iaf_psc_exp_htum::update( Time const& origin, const long from, const long 
 }
 
 void
-nest::iaf_psc_exp_htum::handle( SpikeEvent& e )
+iaf_psc_exp_htum::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -366,7 +365,7 @@ nest::iaf_psc_exp_htum::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_psc_exp_htum::handle( CurrentEvent& e )
+iaf_psc_exp_htum::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -378,7 +377,9 @@ nest::iaf_psc_exp_htum::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_psc_exp_htum::handle( DataLoggingRequest& e )
+iaf_psc_exp_htum::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/iaf_psc_exp_multisynapse.cpp
+++ b/models/iaf_psc_exp_multisynapse.cpp
@@ -32,12 +32,12 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-namespace nest
-{
 void
 register_iaf_psc_exp_multisynapse( const std::string& name )
 {
@@ -267,7 +267,7 @@ iaf_psc_exp_multisynapse::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_multisynapse::pre_run_hook()
+iaf_psc_exp_multisynapse::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -422,4 +422,4 @@ iaf_psc_exp_multisynapse::set_status( const Dictionary& d )
   S_ = stmp;
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/iaf_psc_exp_ps.cpp
+++ b/models/iaf_psc_exp_ps.cpp
@@ -38,14 +38,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_psc_exp_ps > nest::iaf_psc_exp_ps::recordablesMap_;
+RecordablesMap< iaf_psc_exp_ps > iaf_psc_exp_ps::recordablesMap_;
 
-namespace nest
-{
 void
 register_iaf_psc_exp_ps( const std::string& name )
 {
@@ -61,13 +61,12 @@ RecordablesMap< iaf_psc_exp_ps >::create()
   // use standard names wherever you can for consistency!
   insert_( names::V_m, &iaf_psc_exp_ps::get_V_m_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp_ps::Parameters_::Parameters_()
+iaf_psc_exp_ps::Parameters_::Parameters_()
   : tau_m_( 10.0 )                                        // ms
   , tau_ex_( 2.0 )                                        // ms
   , tau_in_( 2.0 )                                        // ms
@@ -81,7 +80,7 @@ nest::iaf_psc_exp_ps::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_exp_ps::State_::State_()
+iaf_psc_exp_ps::State_::State_()
   : y0_( 0.0 )
   , y1_ex_( 0.0 )
   , y1_in_( 0.0 )
@@ -92,12 +91,12 @@ nest::iaf_psc_exp_ps::State_::State_()
 {
 }
 
-nest::iaf_psc_exp_ps::Buffers_::Buffers_( iaf_psc_exp_ps& n )
+iaf_psc_exp_ps::Buffers_::Buffers_( iaf_psc_exp_ps& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_exp_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_ps& n )
+iaf_psc_exp_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_ps& n )
   : logger_( n )
 {
 }
@@ -107,7 +106,7 @@ nest::iaf_psc_exp_ps::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps::Parameters_::get( Dictionary& d ) const
+iaf_psc_exp_ps::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;
   d[ names::I_e ] = I_e_;
@@ -122,7 +121,7 @@ nest::iaf_psc_exp_ps::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_exp_ps::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_exp_ps::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -189,7 +188,7 @@ nest::iaf_psc_exp_ps::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_psc_exp_ps::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_exp_ps::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = y2_ + p.E_L_;  // Membrane potential
   d[ names::I_syn_ex ] = y1_ex_;   // Excitatory synaptic current
@@ -198,7 +197,7 @@ nest::iaf_psc_exp_ps::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::iaf_psc_exp_ps::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_exp_ps::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, y2_, node ) )
   {
@@ -216,7 +215,7 @@ nest::iaf_psc_exp_ps::State_::set( const Dictionary& d, const Parameters_& p, do
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp_ps::iaf_psc_exp_ps()
+iaf_psc_exp_ps::iaf_psc_exp_ps()
   : ArchivingNode()
   , P_()
   , S_()
@@ -225,7 +224,7 @@ nest::iaf_psc_exp_ps::iaf_psc_exp_ps()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_exp_ps::iaf_psc_exp_ps( const iaf_psc_exp_ps& n )
+iaf_psc_exp_ps::iaf_psc_exp_ps( const iaf_psc_exp_ps& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -238,7 +237,7 @@ nest::iaf_psc_exp_ps::iaf_psc_exp_ps( const iaf_psc_exp_ps& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps::init_buffers_()
+iaf_psc_exp_ps::init_buffers_()
 {
   B_.events_.resize();
   B_.events_.clear();
@@ -249,7 +248,7 @@ nest::iaf_psc_exp_ps::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_ps::pre_run_hook()
+iaf_psc_exp_ps::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -277,7 +276,7 @@ nest::iaf_psc_exp_ps::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps::update( const Time& origin, const long from, const long to )
+iaf_psc_exp_ps::update( const Time& origin, const long from, const long to )
 {
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
@@ -431,7 +430,7 @@ nest::iaf_psc_exp_ps::update( const Time& origin, const long from, const long to
 
 // function handles exact spike times
 void
-nest::iaf_psc_exp_ps::handle( SpikeEvent& e )
+iaf_psc_exp_ps::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -441,14 +440,14 @@ nest::iaf_psc_exp_ps::handle( SpikeEvent& e )
   */
   const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
-  B_.events_.add_spike( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ),
+  B_.events_.add_spike( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     Tdeliver,
     e.get_offset(),
     e.get_weight() * e.get_multiplicity() );
 }
 
 void
-nest::iaf_psc_exp_ps::handle( CurrentEvent& e )
+iaf_psc_exp_ps::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -456,11 +455,11 @@ nest::iaf_psc_exp_ps::handle( CurrentEvent& e )
   const double w = e.get_weight();
 
   // add weighted current; HEP 2002-10-04
-  B_.currents_.add_value( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ), w * c );
+  B_.currents_.add_value( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), w * c );
 }
 
 void
-nest::iaf_psc_exp_ps::handle( DataLoggingRequest& e )
+iaf_psc_exp_ps::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -468,7 +467,7 @@ nest::iaf_psc_exp_ps::handle( DataLoggingRequest& e )
 // auxiliary functions ---------------------------------------------
 
 void
-nest::iaf_psc_exp_ps::propagate_( const double dt )
+iaf_psc_exp_ps::propagate_( const double dt )
 {
   // dt == 0 may occur if two spikes arrive simultaneously;
   // propagate_() shall not be called then; see #368.
@@ -493,7 +492,7 @@ nest::iaf_psc_exp_ps::propagate_( const double dt )
 }
 
 void
-nest::iaf_psc_exp_ps::emit_spike_( const Time& origin, const long lag, const double t0, const double dt )
+iaf_psc_exp_ps::emit_spike_( const Time& origin, const long lag, const double t0, const double dt )
 {
   // dt == 0 if two input spikes arrived simultaneously,
   // but threshold cannot be crossed during empty interval,
@@ -519,7 +518,7 @@ nest::iaf_psc_exp_ps::emit_spike_( const Time& origin, const long lag, const dou
 }
 
 void
-nest::iaf_psc_exp_ps::emit_instant_spike_( const Time& origin, const long lag, const double spike_offs )
+iaf_psc_exp_ps::emit_instant_spike_( const Time& origin, const long lag, const double spike_offs )
 {
   assert( S_.y2_ >= P_.U_th_ );  // ensure we are superthreshold
 
@@ -540,7 +539,7 @@ nest::iaf_psc_exp_ps::emit_instant_spike_( const Time& origin, const long lag, c
 }
 
 double
-nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
+iaf_psc_exp_ps::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
@@ -552,3 +551,5 @@ nest::iaf_psc_exp_ps::threshold_distance( double t_step ) const
 
   return y2_root - P_.U_th_;
 }
+
+}  // namespace nest

--- a/models/iaf_psc_exp_ps.h
+++ b/models/iaf_psc_exp_ps.h
@@ -414,7 +414,7 @@ private:
 };
 
 inline size_t
-nest::iaf_psc_exp_ps::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_psc_exp_ps::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/iaf_psc_exp_ps_lossless.cpp
+++ b/models/iaf_psc_exp_ps_lossless.cpp
@@ -36,14 +36,14 @@
 #include "regula_falsi.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_psc_exp_ps_lossless > nest::iaf_psc_exp_ps_lossless::recordablesMap_;
+RecordablesMap< iaf_psc_exp_ps_lossless > iaf_psc_exp_ps_lossless::recordablesMap_;
 
-namespace nest
-{
 void
 register_iaf_psc_exp_ps_lossless( const std::string& name )
 {
@@ -62,13 +62,12 @@ RecordablesMap< iaf_psc_exp_ps_lossless >::create()
   insert_( names::I_syn_ex, &iaf_psc_exp_ps_lossless::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_psc_exp_ps_lossless::get_I_syn_in_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp_ps_lossless::Parameters_::Parameters_()
+iaf_psc_exp_ps_lossless::Parameters_::Parameters_()
   : tau_m_( 10.0 )                                        // ms
   , tau_ex_( 2.0 )                                        // ms
   , tau_in_( 2.0 )                                        // ms
@@ -82,7 +81,7 @@ nest::iaf_psc_exp_ps_lossless::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_psc_exp_ps_lossless::State_::State_()
+iaf_psc_exp_ps_lossless::State_::State_()
   : y0_( 0.0 )
   , I_syn_ex_( 0.0 )
   , I_syn_in_( 0.0 )
@@ -93,12 +92,12 @@ nest::iaf_psc_exp_ps_lossless::State_::State_()
 {
 }
 
-nest::iaf_psc_exp_ps_lossless::Buffers_::Buffers_( iaf_psc_exp_ps_lossless& n )
+iaf_psc_exp_ps_lossless::Buffers_::Buffers_( iaf_psc_exp_ps_lossless& n )
   : logger_( n )
 {
 }
 
-nest::iaf_psc_exp_ps_lossless::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_ps_lossless& n )
+iaf_psc_exp_ps_lossless::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_ps_lossless& n )
   : logger_( n )
 {
 }
@@ -107,7 +106,7 @@ nest::iaf_psc_exp_ps_lossless::Buffers_::Buffers_( const Buffers_&, iaf_psc_exp_
  * Parameter and state extractions and manipulation functions
  * ---------------------------------------------------------------- */
 void
-nest::iaf_psc_exp_ps_lossless::Parameters_::get( Dictionary& d ) const
+iaf_psc_exp_ps_lossless::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;
   d[ names::I_e ] = I_e_;
@@ -122,7 +121,7 @@ nest::iaf_psc_exp_ps_lossless::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_psc_exp_ps_lossless::Parameters_::set( const Dictionary& d, Node* node )
+iaf_psc_exp_ps_lossless::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -208,7 +207,7 @@ nest::iaf_psc_exp_ps_lossless::Parameters_::set( const Dictionary& d, Node* node
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_psc_exp_ps_lossless::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = y2_ + p.E_L_;  // Membrane potential
   d[ names::is_refractory ] = is_refractory_;
@@ -220,7 +219,7 @@ nest::iaf_psc_exp_ps_lossless::State_::get( Dictionary& d, const Parameters_& p 
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_psc_exp_ps_lossless::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, y2_, node ) )
   {
@@ -239,7 +238,7 @@ nest::iaf_psc_exp_ps_lossless::State_::set( const Dictionary& d, const Parameter
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless()
+iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless()
   : ArchivingNode()
   , P_()
   , S_()
@@ -248,7 +247,7 @@ nest::iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless()
   recordablesMap_.create();
 }
 
-nest::iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless( const iaf_psc_exp_ps_lossless& n )
+iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless( const iaf_psc_exp_ps_lossless& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -261,7 +260,7 @@ nest::iaf_psc_exp_ps_lossless::iaf_psc_exp_ps_lossless( const iaf_psc_exp_ps_los
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps_lossless::init_buffers_()
+iaf_psc_exp_ps_lossless::init_buffers_()
 {
   B_.events_.resize();
   B_.events_.clear();
@@ -270,7 +269,7 @@ nest::iaf_psc_exp_ps_lossless::init_buffers_()
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::pre_run_hook()
+iaf_psc_exp_ps_lossless::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -314,7 +313,7 @@ nest::iaf_psc_exp_ps_lossless::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_psc_exp_ps_lossless::update( const Time& origin, const long from, const long to )
+iaf_psc_exp_ps_lossless::update( const Time& origin, const long from, const long to )
 {
   // at start of slice, tell input queue to prepare for delivery
   if ( from == 0 )
@@ -471,7 +470,7 @@ nest::iaf_psc_exp_ps_lossless::update( const Time& origin, const long from, cons
 
 // function handles exact spike times
 void
-nest::iaf_psc_exp_ps_lossless::handle( SpikeEvent& e )
+iaf_psc_exp_ps_lossless::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -481,14 +480,14 @@ nest::iaf_psc_exp_ps_lossless::handle( SpikeEvent& e )
   */
   const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
-  B_.events_.add_spike( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ),
+  B_.events_.add_spike( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     Tdeliver,
     e.get_offset(),
     e.get_weight() * e.get_multiplicity() );
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::handle( CurrentEvent& e )
+iaf_psc_exp_ps_lossless::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -496,11 +495,11 @@ nest::iaf_psc_exp_ps_lossless::handle( CurrentEvent& e )
   const double w = e.get_weight();
 
   // add weighted current; HEP 2002-10-04
-  B_.currents_.add_value( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ), w * c );
+  B_.currents_.add_value( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ), w * c );
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::handle( DataLoggingRequest& e )
+iaf_psc_exp_ps_lossless::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -508,7 +507,7 @@ nest::iaf_psc_exp_ps_lossless::handle( DataLoggingRequest& e )
 // auxiliary functions ---------------------------------------------
 
 void
-nest::iaf_psc_exp_ps_lossless::propagate_( const double dt )
+iaf_psc_exp_ps_lossless::propagate_( const double dt )
 {
   // dt == 0 may occur if two spikes arrive simultaneously;
   // propagate_() shall not be called then; see #368.
@@ -533,7 +532,7 @@ nest::iaf_psc_exp_ps_lossless::propagate_( const double dt )
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::emit_spike_( const Time& origin, const long lag, const double t0, const double dt )
+iaf_psc_exp_ps_lossless::emit_spike_( const Time& origin, const long lag, const double t0, const double dt )
 {
   // dt == 0 may occur if two spikes arrive simultaneously;
   // emit_spike_() shall not be called then; see #368.
@@ -558,7 +557,7 @@ nest::iaf_psc_exp_ps_lossless::emit_spike_( const Time& origin, const long lag, 
 }
 
 void
-nest::iaf_psc_exp_ps_lossless::emit_instant_spike_( const Time& origin, const long lag, const double spike_offs )
+iaf_psc_exp_ps_lossless::emit_instant_spike_( const Time& origin, const long lag, const double spike_offs )
 {
   assert( S_.y2_ >= P_.U_th_ );  // ensure we are superthreshold
 
@@ -579,7 +578,7 @@ nest::iaf_psc_exp_ps_lossless::emit_instant_spike_( const Time& origin, const lo
 }
 
 double
-nest::iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
+iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
 {
   const double P20 = -P_.tau_m_ / P_.c_m_ * numerics::expm1( -t_step / P_.tau_m_ );
 
@@ -593,7 +592,7 @@ nest::iaf_psc_exp_ps_lossless::threshold_distance( double t_step ) const
 }
 
 double
-nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
+iaf_psc_exp_ps_lossless::is_spike_( const double dt )
 {
   // dt == 0 may occur if two spikes arrive simultaneously;
   // is_spike_() shall not be called then; see #368.
@@ -648,3 +647,5 @@ nest::iaf_psc_exp_ps_lossless::is_spike_( const double dt )
       * std::log( V_.b1_ * I_0 / ( V_.a2_ * I_e - V_.a1_ * I_0 - V_.a4_ * V_0 ) );
   }
 }
+
+}  // namespace nest

--- a/models/iaf_tum_2000.cpp
+++ b/models/iaf_tum_2000.cpp
@@ -36,14 +36,15 @@
 #include "ring_buffer_impl.h"
 #include "universal_data_logger_impl.h"
 
+
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::iaf_tum_2000 > nest::iaf_tum_2000::recordablesMap_;
+RecordablesMap< iaf_tum_2000 > iaf_tum_2000::recordablesMap_;
 
-namespace nest
-{
 
 void
 register_iaf_tum_2000( const std::string& name )
@@ -62,13 +63,12 @@ RecordablesMap< iaf_tum_2000 >::create()
   insert_( names::I_syn_ex, &iaf_tum_2000::get_I_syn_ex_ );
   insert_( names::I_syn_in, &iaf_tum_2000::get_I_syn_in_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::iaf_tum_2000::Parameters_::Parameters_()
+iaf_tum_2000::Parameters_::Parameters_()
   : Tau_( 10.0 )              // in ms
   , C_( 250.0 )               // in pF
   , t_ref_( 2.0 )             // in ms
@@ -87,7 +87,7 @@ nest::iaf_tum_2000::Parameters_::Parameters_()
 {
 }
 
-nest::iaf_tum_2000::State_::State_()
+iaf_tum_2000::State_::State_()
   : i_0_( 0.0 )
   , i_1_( 0.0 )
   , i_syn_ex_( 0.0 )
@@ -105,7 +105,7 @@ nest::iaf_tum_2000::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_tum_2000::Parameters_::get( Dictionary& d ) const
+iaf_tum_2000::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;  // resting potential
   d[ names::I_e ] = I_e_;
@@ -125,7 +125,7 @@ nest::iaf_tum_2000::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::iaf_tum_2000::Parameters_::set( const Dictionary& d, Node* node )
+iaf_tum_2000::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -202,7 +202,7 @@ nest::iaf_tum_2000::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::iaf_tum_2000::State_::get( Dictionary& d, const Parameters_& p ) const
+iaf_tum_2000::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = V_m_ + p.E_L_;  // Membrane potential
   d[ names::x ] = x_;
@@ -211,7 +211,7 @@ nest::iaf_tum_2000::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::iaf_tum_2000::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+iaf_tum_2000::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
 
   double x = x_;
@@ -244,18 +244,18 @@ nest::iaf_tum_2000::State_::set( const Dictionary& d, const Parameters_& p, doub
   }
 }
 
-nest::iaf_tum_2000::Buffers_::Buffers_( iaf_tum_2000& n )
+iaf_tum_2000::Buffers_::Buffers_( iaf_tum_2000& n )
   : logger_( n )
 {
 }
 
-nest::iaf_tum_2000::Buffers_::Buffers_( const Buffers_&, iaf_tum_2000& n )
+iaf_tum_2000::Buffers_::Buffers_( const Buffers_&, iaf_tum_2000& n )
   : logger_( n )
 {
 }
 
 inline double
-nest::iaf_tum_2000::phi_() const
+iaf_tum_2000::phi_() const
 {
   assert( P_.delta_ > 0. );
   return P_.rho_ * std::exp( 1. / P_.delta_ * ( S_.V_m_ - P_.Theta_ ) );
@@ -265,7 +265,7 @@ nest::iaf_tum_2000::phi_() const
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::iaf_tum_2000::iaf_tum_2000()
+iaf_tum_2000::iaf_tum_2000()
   : ArchivingNode()
   , P_()
   , S_()
@@ -274,7 +274,7 @@ nest::iaf_tum_2000::iaf_tum_2000()
   recordablesMap_.create();
 }
 
-nest::iaf_tum_2000::iaf_tum_2000( const iaf_tum_2000& n )
+iaf_tum_2000::iaf_tum_2000( const iaf_tum_2000& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -287,7 +287,7 @@ nest::iaf_tum_2000::iaf_tum_2000( const iaf_tum_2000& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::iaf_tum_2000::init_buffers_()
+iaf_tum_2000::init_buffers_()
 {
   B_.input_buffer_.clear();  // includes resize
   B_.logger_.reset();
@@ -295,7 +295,7 @@ nest::iaf_tum_2000::init_buffers_()
 }
 
 void
-nest::iaf_tum_2000::pre_run_hook()
+iaf_tum_2000::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -338,7 +338,7 @@ nest::iaf_tum_2000::pre_run_hook()
 }
 
 void
-nest::iaf_tum_2000::update( const Time& origin, const long from, const long to )
+iaf_tum_2000::update( const Time& origin, const long from, const long to )
 {
   const double h = Time::get_resolution().get_ms();
 
@@ -443,7 +443,7 @@ nest::iaf_tum_2000::update( const Time& origin, const long from, const long to )
 }
 
 void
-nest::iaf_tum_2000::handle( SpikeEvent& e )
+iaf_tum_2000::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -463,7 +463,7 @@ nest::iaf_tum_2000::handle( SpikeEvent& e )
 }
 
 void
-nest::iaf_tum_2000::handle( CurrentEvent& e )
+iaf_tum_2000::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -484,7 +484,9 @@ nest::iaf_tum_2000::handle( CurrentEvent& e )
 }
 
 void
-nest::iaf_tum_2000::handle( DataLoggingRequest& e )
+iaf_tum_2000::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/iaf_tum_2000.h
+++ b/models/iaf_tum_2000.h
@@ -386,7 +386,7 @@ private:
 
 
 inline size_t
-nest::iaf_tum_2000::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+iaf_tum_2000::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   if ( target.get_model_id() != this->get_model_id() and target.is_off_grid() )
   {

--- a/models/ignore_and_fire.cpp
+++ b/models/ignore_and_fire.cpp
@@ -37,10 +37,11 @@
 #include "numerics.h"
 #include "ring_buffer_impl.h"
 
-nest::RecordablesMap< nest::ignore_and_fire > nest::ignore_and_fire::recordablesMap_;
 
 namespace nest
 {
+RecordablesMap< ignore_and_fire > ignore_and_fire::recordablesMap_;
+
 void
 register_ignore_and_fire( const std::string& name )
 {
@@ -227,4 +228,4 @@ ignore_and_fire::handle( DataLoggingRequest& e )
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/ignore_and_fire.h
+++ b/models/ignore_and_fire.h
@@ -247,7 +247,7 @@ private:
 };
 
 inline size_t
-nest::ignore_and_fire::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+ignore_and_fire::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   SpikeEvent e;
   e.set_sender( *this );

--- a/models/inhomogeneous_poisson_generator.cpp
+++ b/models/inhomogeneous_poisson_generator.cpp
@@ -35,8 +35,11 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_inhomogeneous_poisson_generator( const std::string& name )
+register_inhomogeneous_poisson_generator( const std::string& name )
 {
   register_node_model< inhomogeneous_poisson_generator >( name );
 }
@@ -45,7 +48,7 @@ nest::register_inhomogeneous_poisson_generator( const std::string& name )
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::inhomogeneous_poisson_generator::Parameters_::Parameters_()
+inhomogeneous_poisson_generator::Parameters_::Parameters_()
   : rate_times_()   // ms
   , rate_values_()  // spikes/ms,
   , allow_offgrid_times_( false )
@@ -58,7 +61,7 @@ nest::inhomogeneous_poisson_generator::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::inhomogeneous_poisson_generator::Parameters_::get( Dictionary& d ) const
+inhomogeneous_poisson_generator::Parameters_::get( Dictionary& d ) const
 {
   const size_t n_rates = rate_times_.size();
   std::vector< double > times_ms;
@@ -74,7 +77,7 @@ nest::inhomogeneous_poisson_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::inhomogeneous_poisson_generator::Parameters_::assert_valid_rate_time_and_insert( const double t )
+inhomogeneous_poisson_generator::Parameters_::assert_valid_rate_time_and_insert( const double t )
 {
   Time t_rate;
 
@@ -110,7 +113,7 @@ nest::inhomogeneous_poisson_generator::Parameters_::assert_valid_rate_time_and_i
 }
 
 void
-nest::inhomogeneous_poisson_generator::Parameters_::set( const Dictionary& d, Buffers_& b, Node* )
+inhomogeneous_poisson_generator::Parameters_::set( const Dictionary& d, Buffers_& b, Node* )
 {
   const bool times = d.known( names::rate_times );
   const bool rates = d.update_value( names::rate_values, rate_values_ );
@@ -189,7 +192,7 @@ nest::inhomogeneous_poisson_generator::Parameters_::set( const Dictionary& d, Bu
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::inhomogeneous_poisson_generator::inhomogeneous_poisson_generator()
+inhomogeneous_poisson_generator::inhomogeneous_poisson_generator()
   : StimulationDevice()
   , P_()
   , B_()
@@ -197,7 +200,7 @@ nest::inhomogeneous_poisson_generator::inhomogeneous_poisson_generator()
 {
 }
 
-nest::inhomogeneous_poisson_generator::inhomogeneous_poisson_generator( const inhomogeneous_poisson_generator& n )
+inhomogeneous_poisson_generator::inhomogeneous_poisson_generator( const inhomogeneous_poisson_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , B_( n.B_ )
@@ -209,13 +212,13 @@ nest::inhomogeneous_poisson_generator::inhomogeneous_poisson_generator( const in
  * Node initialization functions
  * ---------------------------------------------------------------- */
 void
-nest::inhomogeneous_poisson_generator::init_state_()
+inhomogeneous_poisson_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::inhomogeneous_poisson_generator::init_buffers_()
+inhomogeneous_poisson_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.idx_ = 0;
@@ -223,7 +226,7 @@ nest::inhomogeneous_poisson_generator::init_buffers_()
 }
 
 void
-nest::inhomogeneous_poisson_generator::pre_run_hook()
+inhomogeneous_poisson_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
   V_.h_ = Time::get_resolution().get_ms();
@@ -234,7 +237,7 @@ nest::inhomogeneous_poisson_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::inhomogeneous_poisson_generator::update( Time const& origin, const long from, const long to )
+inhomogeneous_poisson_generator::update( Time const& origin, const long from, const long to )
 {
   assert( P_.rate_times_.size() == P_.rate_values_.size() );
 
@@ -271,7 +274,7 @@ nest::inhomogeneous_poisson_generator::update( Time const& origin, const long fr
 }
 
 void
-nest::inhomogeneous_poisson_generator::event_hook( DSSpikeEvent& e )
+inhomogeneous_poisson_generator::event_hook( DSSpikeEvent& e )
 {
   poisson_distribution::param_type param( B_.rate_ * V_.h_ );
   long n_spikes = V_.poisson_dist_( get_vp_specific_rng( get_thread() ), param );
@@ -288,7 +291,7 @@ nest::inhomogeneous_poisson_generator::event_hook( DSSpikeEvent& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::inhomogeneous_poisson_generator::set_data_from_stimulation_backend( std::vector< double >& rate_time_update )
+inhomogeneous_poisson_generator::set_data_from_stimulation_backend( std::vector< double >& rate_time_update )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   // For the input backend
@@ -322,3 +325,5 @@ nest::inhomogeneous_poisson_generator::set_data_from_stimulation_backend( std::v
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/izhikevich.cpp
+++ b/models/izhikevich.cpp
@@ -37,14 +37,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::izhikevich > nest::izhikevich::recordablesMap_;
+RecordablesMap< izhikevich > izhikevich::recordablesMap_;
 
-namespace nest
-{
 void
 register_izhikevich( const std::string& name )
 {
@@ -61,13 +61,12 @@ RecordablesMap< izhikevich >::create()
   insert_( names::V_m, &izhikevich::get_V_m_ );
   insert_( names::U_m, &izhikevich::get_U_m_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::izhikevich::Parameters_::Parameters_()
+izhikevich::Parameters_::Parameters_()
   : a_( 0.02 )                                       // a
   , b_( 0.2 )                                        // b
   , c_( -65.0 )                                      // c without unit
@@ -79,7 +78,7 @@ nest::izhikevich::Parameters_::Parameters_()
 {
 }
 
-nest::izhikevich::State_::State_()
+izhikevich::State_::State_()
   : v_( -65.0 )        // membrane potential
   , u_( 0.2 * -65.0 )  // membrane recovery variable (b * V_m_init)
   , I_( 0.0 )          // input current
@@ -91,7 +90,7 @@ nest::izhikevich::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::izhikevich::Parameters_::get( Dictionary& d ) const
+izhikevich::Parameters_::get( Dictionary& d ) const
 {
   d[ names::I_e ] = I_e_;
   d[ names::V_th ] = V_th_;  // threshold value
@@ -104,7 +103,7 @@ nest::izhikevich::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::izhikevich::Parameters_::set( const Dictionary& d, Node* node )
+izhikevich::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::V_th, V_th_, node );
   update_value_param( d, names::V_min, V_min_, node );
@@ -124,25 +123,25 @@ nest::izhikevich::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::izhikevich::State_::get( Dictionary& d, const Parameters_& ) const
+izhikevich::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::U_m ] = u_;  // Membrane potential recovery variable
   d[ names::V_m ] = v_;  // Membrane potential
 }
 
 void
-nest::izhikevich::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+izhikevich::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::U_m, u_, node );
   update_value_param( d, names::V_m, v_, node );
 }
 
-nest::izhikevich::Buffers_::Buffers_( izhikevich& n )
+izhikevich::Buffers_::Buffers_( izhikevich& n )
   : logger_( n )
 {
 }
 
-nest::izhikevich::Buffers_::Buffers_( const Buffers_&, izhikevich& n )
+izhikevich::Buffers_::Buffers_( const Buffers_&, izhikevich& n )
   : logger_( n )
 {
 }
@@ -151,7 +150,7 @@ nest::izhikevich::Buffers_::Buffers_( const Buffers_&, izhikevich& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::izhikevich::izhikevich()
+izhikevich::izhikevich()
   : ArchivingNode()
   , P_()
   , S_()
@@ -160,7 +159,7 @@ nest::izhikevich::izhikevich()
   recordablesMap_.create();
 }
 
-nest::izhikevich::izhikevich( const izhikevich& n )
+izhikevich::izhikevich( const izhikevich& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -173,7 +172,7 @@ nest::izhikevich::izhikevich( const izhikevich& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::izhikevich::init_buffers_()
+izhikevich::init_buffers_()
 {
   B_.spikes_.clear();    // includes resize
   B_.currents_.clear();  // includes resize
@@ -182,7 +181,7 @@ nest::izhikevich::init_buffers_()
 }
 
 void
-nest::izhikevich::pre_run_hook()
+izhikevich::pre_run_hook()
 {
   B_.logger_.init();
 }
@@ -192,7 +191,7 @@ nest::izhikevich::pre_run_hook()
  */
 
 void
-nest::izhikevich::update( Time const& origin, const long from, const long to )
+izhikevich::update( Time const& origin, const long from, const long to )
 {
   const double h = Time::get_resolution().get_ms();
   double v_old, u_old;
@@ -244,7 +243,7 @@ nest::izhikevich::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::izhikevich::handle( SpikeEvent& e )
+izhikevich::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   B_.spikes_.add_value(
@@ -252,7 +251,7 @@ nest::izhikevich::handle( SpikeEvent& e )
 }
 
 void
-nest::izhikevich::handle( CurrentEvent& e )
+izhikevich::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -262,7 +261,9 @@ nest::izhikevich::handle( CurrentEvent& e )
 }
 
 void
-nest::izhikevich::handle( DataLoggingRequest& e )
+izhikevich::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/jonke_synapse.cpp
+++ b/models/jonke_synapse.cpp
@@ -25,14 +25,15 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_jonke_synapse( const std::string& name )
+register_jonke_synapse( const std::string& name )
 {
   register_connection_model< jonke_synapse >( name );
 }
 
-namespace nest
-{
 
 JonkeCommonProperties::JonkeCommonProperties()
   : CommonSynapseProperties()
@@ -74,5 +75,4 @@ JonkeCommonProperties::set_status( const Dictionary& d, ConnectorModel& cm )
   d.update_value( names::Wmax, Wmax_ );
 }
 
-
-}
+}  // namespace nest

--- a/models/lin_rate.cpp
+++ b/models/lin_rate.cpp
@@ -27,6 +27,7 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -74,29 +75,29 @@ nonlinearities_lin_rate::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::lin_rate_ipn >::create()
+RecordablesMap< lin_rate_ipn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::lin_rate_ipn::get_rate_ );
-  insert_( names::noise, &nest::lin_rate_ipn::get_noise_ );
+  insert_( names::rate, &lin_rate_ipn::get_rate_ );
+  insert_( names::noise, &lin_rate_ipn::get_noise_ );
 }
 
 template <>
 void
-RecordablesMap< nest::lin_rate_opn >::create()
+RecordablesMap< lin_rate_opn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::lin_rate_opn::get_rate_ );
-  insert_( names::noise, &nest::lin_rate_opn::get_noise_ );
-  insert_( names::noisy_rate, &nest::lin_rate_opn::get_noisy_rate_ );
+  insert_( names::rate, &lin_rate_opn::get_rate_ );
+  insert_( names::noise, &lin_rate_opn::get_noise_ );
+  insert_( names::noisy_rate, &lin_rate_opn::get_noisy_rate_ );
 }
 
 template <>
 void
-RecordablesMap< nest::rate_transformer_lin >::create()
+RecordablesMap< rate_transformer_lin >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::rate_transformer_lin::get_rate_ );
+  insert_( names::rate, &rate_transformer_lin::get_rate_ );
 }
 
 }  // namespace nest

--- a/models/lin_rate.h
+++ b/models/lin_rate.h
@@ -172,13 +172,13 @@ nonlinearities_lin_rate::mult_coupling_in( double rate )
   return g_in_ * ( theta_in_ + rate );
 }
 
-typedef rate_neuron_ipn< nest::nonlinearities_lin_rate > lin_rate_ipn;
+typedef rate_neuron_ipn< nonlinearities_lin_rate > lin_rate_ipn;
 void register_lin_rate_ipn( const std::string& name );
 
-typedef rate_neuron_opn< nest::nonlinearities_lin_rate > lin_rate_opn;
+typedef rate_neuron_opn< nonlinearities_lin_rate > lin_rate_opn;
 void register_lin_rate_opn( const std::string& name );
 
-typedef rate_transformer_node< nest::nonlinearities_lin_rate > rate_transformer_lin;
+typedef rate_transformer_node< nonlinearities_lin_rate > rate_transformer_lin;
 void register_rate_transformer_lin( const std::string& name );
 
 

--- a/models/mat2_psc_exp.cpp
+++ b/models/mat2_psc_exp.cpp
@@ -34,14 +34,14 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Recordables map
  * ---------------------------------------------------------------- */
 
-nest::RecordablesMap< nest::mat2_psc_exp > nest::mat2_psc_exp::recordablesMap_;
+RecordablesMap< mat2_psc_exp > mat2_psc_exp::recordablesMap_;
 
-namespace nest  // template specialization must be placed in namespace
-{
 void
 register_mat2_psc_exp( const std::string& name )
 {
@@ -60,13 +60,12 @@ RecordablesMap< mat2_psc_exp >::create()
   insert_( names::V_m, &mat2_psc_exp::get_V_m_ );
   insert_( names::V_th, &mat2_psc_exp::get_V_th_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::mat2_psc_exp::Parameters_::Parameters_()
+mat2_psc_exp::Parameters_::Parameters_()
   : Tau_( 5.0 )       // in ms
   , C_( 100.0 )       // in pF
   , tau_ref_( 2.0 )   // in ms
@@ -84,7 +83,7 @@ nest::mat2_psc_exp::Parameters_::Parameters_()
 {
 }
 
-nest::mat2_psc_exp::State_::State_()
+mat2_psc_exp::State_::State_()
   : i_0_( 0.0 )
   , i_syn_ex_( 0.0 )
   , i_syn_in_( 0.0 )
@@ -100,7 +99,7 @@ nest::mat2_psc_exp::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::mat2_psc_exp::Parameters_::get( Dictionary& d ) const
+mat2_psc_exp::Parameters_::get( Dictionary& d ) const
 {
   d[ names::E_L ] = E_L_;  // Resting potential
   d[ names::I_e ] = I_e_;
@@ -117,7 +116,7 @@ nest::mat2_psc_exp::Parameters_::get( Dictionary& d ) const
 }
 
 double
-nest::mat2_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
+mat2_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 {
   // if E_L_ is changed, we need to adjust all variables defined relative to
   // E_L_
@@ -163,7 +162,7 @@ nest::mat2_psc_exp::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::mat2_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
+mat2_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
 {
   d[ names::V_m ] = V_m_ + p.E_L_;                           // Membrane potential
   d[ names::V_th ] = p.E_L_ + p.omega_ + V_th_1_ + V_th_2_;  // Adaptive threshold
@@ -172,7 +171,7 @@ nest::mat2_psc_exp::State_::get( Dictionary& d, const Parameters_& p ) const
 }
 
 void
-nest::mat2_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
+mat2_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, double delta_EL, Node* node )
 {
   if ( update_value_param( d, names::V_m, V_m_, node ) )
   {
@@ -187,14 +186,14 @@ nest::mat2_psc_exp::State_::set( const Dictionary& d, const Parameters_& p, doub
   update_value_param( d, names::V_th_alpha_2, V_th_2_, node );
 }
 
-nest::mat2_psc_exp::Buffers_::Buffers_( mat2_psc_exp& n )
+mat2_psc_exp::Buffers_::Buffers_( mat2_psc_exp& n )
   : logger_( n )
 {
   // The other member variables are left uninitialised or are
   // automatically initialised by their default constructor.
 }
 
-nest::mat2_psc_exp::Buffers_::Buffers_( const Buffers_&, mat2_psc_exp& n )
+mat2_psc_exp::Buffers_::Buffers_( const Buffers_&, mat2_psc_exp& n )
   : logger_( n )
 {
   // The other member variables are left uninitialised or are
@@ -205,7 +204,7 @@ nest::mat2_psc_exp::Buffers_::Buffers_( const Buffers_&, mat2_psc_exp& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::mat2_psc_exp::mat2_psc_exp()
+mat2_psc_exp::mat2_psc_exp()
   : ArchivingNode()
   , P_()
   , S_()
@@ -214,7 +213,7 @@ nest::mat2_psc_exp::mat2_psc_exp()
   recordablesMap_.create();
 }
 
-nest::mat2_psc_exp::mat2_psc_exp( const mat2_psc_exp& n )
+mat2_psc_exp::mat2_psc_exp( const mat2_psc_exp& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -227,7 +226,7 @@ nest::mat2_psc_exp::mat2_psc_exp( const mat2_psc_exp& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::mat2_psc_exp::init_buffers_()
+mat2_psc_exp::init_buffers_()
 {
   ArchivingNode::clear_history();
 
@@ -239,7 +238,7 @@ nest::mat2_psc_exp::init_buffers_()
 }
 
 void
-nest::mat2_psc_exp::pre_run_hook()
+mat2_psc_exp::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -305,7 +304,7 @@ nest::mat2_psc_exp::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::mat2_psc_exp::update( Time const& origin, const long from, const long to )
+mat2_psc_exp::update( Time const& origin, const long from, const long to )
 {
   // evolve from timestep 'from' to timestep 'to' with steps of h each
   for ( long lag = from; lag < to; ++lag )
@@ -358,7 +357,7 @@ nest::mat2_psc_exp::update( Time const& origin, const long from, const long to )
 
 
 void
-nest::mat2_psc_exp::handle( SpikeEvent& e )
+mat2_psc_exp::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -375,7 +374,7 @@ nest::mat2_psc_exp::handle( SpikeEvent& e )
 }
 
 void
-nest::mat2_psc_exp::handle( CurrentEvent& e )
+mat2_psc_exp::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -387,7 +386,9 @@ nest::mat2_psc_exp::handle( CurrentEvent& e )
 }
 
 void
-nest::mat2_psc_exp::handle( DataLoggingRequest& e )
+mat2_psc_exp::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest

--- a/models/mcculloch_pitts_neuron.cpp
+++ b/models/mcculloch_pitts_neuron.cpp
@@ -28,6 +28,7 @@
 #include "nest_impl.h"
 #include "universal_data_logger_impl.h"
 
+
 namespace nest
 {
 void
@@ -55,11 +56,11 @@ gainfunction_mcculloch_pitts::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::mcculloch_pitts_neuron >::create()
+RecordablesMap< mcculloch_pitts_neuron >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::S, &nest::mcculloch_pitts_neuron::get_output_state__ );
-  insert_( names::h, &nest::mcculloch_pitts_neuron::get_input__ );
+  insert_( names::S, &mcculloch_pitts_neuron::get_output_state__ );
+  insert_( names::h, &mcculloch_pitts_neuron::get_input__ );
 }
 
 }  // namespace nest

--- a/models/mip_generator.cpp
+++ b/models/mip_generator.cpp
@@ -32,8 +32,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_mip_generator( const std::string& name )
+register_mip_generator( const std::string& name )
 {
   register_node_model< mip_generator >( name );
 }
@@ -43,7 +46,7 @@ nest::register_mip_generator( const std::string& name )
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::mip_generator::Parameters_::Parameters_()
+mip_generator::Parameters_::Parameters_()
   : rate_( 0.0 )  // spks/s
   , p_copy_( 1.0 )
 {
@@ -54,14 +57,14 @@ nest::mip_generator::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::mip_generator::Parameters_::get( Dictionary& d ) const
+mip_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
   d[ names::p_copy ] = p_copy_;
 }
 
 void
-nest::mip_generator::Parameters_::set( const Dictionary& d, Node* node )
+mip_generator::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::rate, rate_, node );
   update_value_param( d, names::p_copy, p_copy_, node );
@@ -81,13 +84,13 @@ nest::mip_generator::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::mip_generator::mip_generator()
+mip_generator::mip_generator()
   : StimulationDevice()
   , P_()
 {
 }
 
-nest::mip_generator::mip_generator( const mip_generator& n )
+mip_generator::mip_generator( const mip_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )  // also causes deep copy of random nnumber generator
 {
@@ -98,19 +101,19 @@ nest::mip_generator::mip_generator( const mip_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::mip_generator::init_state_()
+mip_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::mip_generator::init_buffers_()
+mip_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
 }
 
 void
-nest::mip_generator::pre_run_hook()
+mip_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
 
@@ -125,7 +128,7 @@ nest::mip_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::mip_generator::update( Time const& T, const long from, const long to )
+mip_generator::update( Time const& T, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -148,7 +151,7 @@ nest::mip_generator::update( Time const& T, const long from, const long to )
 }
 
 void
-nest::mip_generator::event_hook( DSSpikeEvent& e )
+mip_generator::event_hook( DSSpikeEvent& e )
 {
   /*
      We temporarily set the spike multiplicity here to the number of
@@ -186,7 +189,7 @@ nest::mip_generator::event_hook( DSSpikeEvent& e )
  * Other functions
  * ---------------------------------------------------------------- */
 void
-nest::mip_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+mip_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -209,3 +212,5 @@ nest::mip_generator::set_data_from_stimulation_backend( std::vector< double >& i
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/multimeter.cpp
+++ b/models/multimeter.cpp
@@ -30,6 +30,7 @@
 // Includes from libnestutil:
 #include "dict_util.h"
 
+
 namespace nest
 {
 void
@@ -72,14 +73,14 @@ multimeter::send_test_event( Node& target, size_t receptor_type, synindex, bool 
   return p;
 }
 
-nest::multimeter::Parameters_::Parameters_()
+multimeter::Parameters_::Parameters_()
   : interval_( Time::ms( 1.0 ) )
   , offset_( Time::ms( 0. ) )
   , record_from_()
 {
 }
 
-nest::multimeter::Parameters_::Parameters_( const Parameters_& p )
+multimeter::Parameters_::Parameters_( const Parameters_& p )
   : interval_( p.interval_ )
   , offset_( p.offset_ )
   , record_from_( p.record_from_ )
@@ -87,8 +88,8 @@ nest::multimeter::Parameters_::Parameters_( const Parameters_& p )
   interval_.calibrate();
 }
 
-nest::multimeter::Parameters_&
-nest::multimeter::Parameters_::operator=( const Parameters_& p )
+multimeter::Parameters_&
+multimeter::Parameters_::operator=( const Parameters_& p )
 {
   interval_ = p.interval_;
   offset_ = p.offset_;
@@ -99,13 +100,13 @@ nest::multimeter::Parameters_::operator=( const Parameters_& p )
 }
 
 
-nest::multimeter::Buffers_::Buffers_()
+multimeter::Buffers_::Buffers_()
   : has_targets_( false )
 {
 }
 
 void
-nest::multimeter::Parameters_::get( Dictionary& d ) const
+multimeter::Parameters_::get( Dictionary& d ) const
 {
   d[ names::interval ] = interval_.get_ms();
   d[ names::offset ] = offset_.get_ms();
@@ -113,7 +114,7 @@ nest::multimeter::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::multimeter::Parameters_::set( const Dictionary& d, const Buffers_& b, Node* node )
+multimeter::Parameters_::set( const Dictionary& d, const Buffers_& b, Node* node )
 {
   if ( b.has_targets_ and ( d.known( names::interval ) or d.known( names::offset ) or d.known( names::record_from ) ) )
   {

--- a/models/multimeter.h
+++ b/models/multimeter.h
@@ -231,7 +231,7 @@ private:
 
 
 inline void
-nest::multimeter::get_status( Dictionary& d ) const
+multimeter::get_status( Dictionary& d ) const
 {
   RecordingDevice::get_status( d );
   P_.get( d );
@@ -255,7 +255,7 @@ nest::multimeter::get_status( Dictionary& d ) const
 }
 
 inline void
-nest::multimeter::set_status( const Dictionary& d )
+multimeter::set_status( const Dictionary& d )
 {
   // protect multimeter from being frozen
   bool freeze = false;
@@ -272,13 +272,13 @@ nest::multimeter::set_status( const Dictionary& d )
 }
 
 inline SignalType
-nest::multimeter::sends_signal() const
+multimeter::sends_signal() const
 {
   return ALL;
 }
 
 inline void
-nest::multimeter::calibrate_time( const TimeConverter& tc )
+multimeter::calibrate_time( const TimeConverter& tc )
 {
   P_.interval_ = tc.from_old_tics( P_.interval_.get_tics() );
   P_.offset_ = tc.from_old_tics( P_.offset_.get_tics() );

--- a/models/music_cont_in_proxy.cpp
+++ b/models/music_cont_in_proxy.cpp
@@ -33,8 +33,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_music_cont_in_proxy( const std::string& name )
+register_music_cont_in_proxy( const std::string& name )
 {
   register_node_model< music_cont_in_proxy >( name );
 }
@@ -44,12 +47,12 @@ nest::register_music_cont_in_proxy( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::music_cont_in_proxy::Parameters_::Parameters_()
+music_cont_in_proxy::Parameters_::Parameters_()
   : port_name_( "cont_in" )
 {
 }
 
-nest::music_cont_in_proxy::State_::State_()
+music_cont_in_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )
 {
@@ -60,13 +63,13 @@ nest::music_cont_in_proxy::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::music_cont_in_proxy::Parameters_::get( Dictionary& d ) const
+music_cont_in_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::port_name ] = port_name_;
 }
 
 void
-nest::music_cont_in_proxy::Parameters_::set( const Dictionary& d, State_& s, Node* node )
+music_cont_in_proxy::Parameters_::set( const Dictionary& d, State_& s, Node* node )
 {
   if ( d.known( names::port_name ) and s.published_ )
   {
@@ -80,14 +83,14 @@ nest::music_cont_in_proxy::Parameters_::set( const Dictionary& d, State_& s, Nod
 }
 
 void
-nest::music_cont_in_proxy::State_::get( Dictionary& d ) const
+music_cont_in_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
   d[ names::port_width ] = port_width_;
 }
 
 void
-nest::music_cont_in_proxy::State_::set( const Dictionary&, const Parameters_& )
+music_cont_in_proxy::State_::set( const Dictionary&, const Parameters_& )
 {
 }
 
@@ -96,14 +99,14 @@ nest::music_cont_in_proxy::State_::set( const Dictionary&, const Parameters_& )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_cont_in_proxy::music_cont_in_proxy()
+music_cont_in_proxy::music_cont_in_proxy()
   : DeviceNode()
   , P_()
   , S_()
 {
 }
 
-nest::music_cont_in_proxy::music_cont_in_proxy( const music_cont_in_proxy& n )
+music_cont_in_proxy::music_cont_in_proxy( const music_cont_in_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -116,12 +119,12 @@ nest::music_cont_in_proxy::music_cont_in_proxy( const music_cont_in_proxy& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::music_cont_in_proxy::init_buffers_()
+music_cont_in_proxy::init_buffers_()
 {
 }
 
 void
-nest::music_cont_in_proxy::pre_run_hook()
+music_cont_in_proxy::pre_run_hook()
 {
   // only publish the port once
   if ( not S_.published_ )
@@ -158,7 +161,7 @@ nest::music_cont_in_proxy::pre_run_hook()
 }
 
 void
-nest::music_cont_in_proxy::get_status( Dictionary& d ) const
+music_cont_in_proxy::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -167,7 +170,7 @@ nest::music_cont_in_proxy::get_status( Dictionary& d ) const
 }
 
 void
-nest::music_cont_in_proxy::set_status( const Dictionary& d )
+music_cont_in_proxy::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;    // temporary copy in case of errors
   ptmp.set( d, S_, this );  // throws if BadProperty
@@ -179,5 +182,7 @@ nest::music_cont_in_proxy::set_status( const Dictionary& d )
   P_ = ptmp;
   S_ = stmp;
 }
+
+}  // namespace nest
 
 #endif

--- a/models/music_cont_out_proxy.cpp
+++ b/models/music_cont_out_proxy.cpp
@@ -37,8 +37,11 @@
 #include "compose.hpp"
 #include "logging.h"
 
+
+namespace nest
+{
 void
-nest::register_music_cont_out_proxy( const std::string& name )
+register_music_cont_out_proxy( const std::string& name )
 {
   register_node_model< music_cont_out_proxy >( name );
 }
@@ -48,7 +51,7 @@ nest::register_music_cont_out_proxy( const std::string& name )
  * ----------------------------------------------------------------
  */
 
-nest::music_cont_out_proxy::Parameters_::Parameters_()
+music_cont_out_proxy::Parameters_::Parameters_()
   : interval_( Time::ms( 1.0 ) )
   , port_name_( "cont_out" )
   , record_from_()
@@ -56,7 +59,7 @@ nest::music_cont_out_proxy::Parameters_::Parameters_()
 {
 }
 
-nest::music_cont_out_proxy::Parameters_::Parameters_( const Parameters_& p )
+music_cont_out_proxy::Parameters_::Parameters_( const Parameters_& p )
   : interval_( p.interval_ )
   , port_name_( p.port_name_ )
   , record_from_( p.record_from_ )
@@ -65,25 +68,25 @@ nest::music_cont_out_proxy::Parameters_::Parameters_( const Parameters_& p )
   interval_.calibrate();
 }
 
-nest::music_cont_out_proxy::State_::State_()
+music_cont_out_proxy::State_::State_()
   : published_( false )
   , port_width_( 0 )
 {
 }
 
-nest::music_cont_out_proxy::State_::State_( const State_& s )
+music_cont_out_proxy::State_::State_( const State_& s )
   : published_( s.published_ )
   , port_width_( s.port_width_ )
 {
 }
 
-nest::music_cont_out_proxy::Buffers_::Buffers_()
+music_cont_out_proxy::Buffers_::Buffers_()
   : has_targets_( false )
   , data_()
 {
 }
 
-nest::music_cont_out_proxy::Buffers_::Buffers_( const Buffers_& b )
+music_cont_out_proxy::Buffers_::Buffers_( const Buffers_& b )
   : has_targets_( b.has_targets_ )
   , data_( b.data_ )
 {
@@ -94,7 +97,7 @@ nest::music_cont_out_proxy::Buffers_::Buffers_( const Buffers_& b )
  * ---------------------------------------------------------------- */
 
 void
-nest::music_cont_out_proxy::Parameters_::get( Dictionary& d ) const
+music_cont_out_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::port_name ] = port_name_;
   d[ names::interval ] = interval_.get_ms();
@@ -103,7 +106,7 @@ nest::music_cont_out_proxy::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::music_cont_out_proxy::Parameters_::set( const Dictionary& d,
+music_cont_out_proxy::Parameters_::set( const Dictionary& d,
   const Node& self,
   const State_& state,
   const Buffers_& buffers )
@@ -161,7 +164,7 @@ nest::music_cont_out_proxy::Parameters_::set( const Dictionary& d,
 }
 
 void
-nest::music_cont_out_proxy::State_::get( Dictionary& d ) const
+music_cont_out_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
   d[ names::port_width ] = static_cast< long >( port_width_ );
@@ -171,7 +174,7 @@ nest::music_cont_out_proxy::State_::get( Dictionary& d ) const
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_cont_out_proxy::music_cont_out_proxy()
+music_cont_out_proxy::music_cont_out_proxy()
   : DeviceNode()
   , P_()
   , S_()
@@ -179,7 +182,7 @@ nest::music_cont_out_proxy::music_cont_out_proxy()
 {
 }
 
-nest::music_cont_out_proxy::music_cont_out_proxy( const music_cont_out_proxy& n )
+music_cont_out_proxy::music_cont_out_proxy( const music_cont_out_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -188,18 +191,18 @@ nest::music_cont_out_proxy::music_cont_out_proxy( const music_cont_out_proxy& n 
 }
 
 void
-nest::music_cont_out_proxy::init_buffers_()
+music_cont_out_proxy::init_buffers_()
 {
   B_.data_.clear();
 }
 
 void
-nest::music_cont_out_proxy::finalize()
+music_cont_out_proxy::finalize()
 {
 }
 
 size_t
-nest::music_cont_out_proxy::send_test_event( Node& target, size_t receptor_type, synindex, bool )
+music_cont_out_proxy::send_test_event( Node& target, size_t receptor_type, synindex, bool )
 {
   DataLoggingRequest e( P_.interval_, P_.record_from_ );
   e.set_sender( *this );
@@ -213,7 +216,7 @@ nest::music_cont_out_proxy::send_test_event( Node& target, size_t receptor_type,
 }
 
 void
-nest::music_cont_out_proxy::pre_run_hook()
+music_cont_out_proxy::pre_run_hook()
 {
   // only publish the output port once,
   if ( S_.published_ == false )
@@ -285,7 +288,7 @@ nest::music_cont_out_proxy::pre_run_hook()
 }
 
 void
-nest::music_cont_out_proxy::get_status( Dictionary& d ) const
+music_cont_out_proxy::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -309,13 +312,13 @@ nest::music_cont_out_proxy::get_status( Dictionary& d ) const
 }
 
 void
-nest::music_cont_out_proxy::set_status( const Dictionary& d )
+music_cont_out_proxy::set_status( const Dictionary& d )
 {
   P_.set( d, *this, S_, B_ );  // throws if BadProperty
 }
 
 void
-nest::music_cont_out_proxy::update( Time const& origin, const long from, const long )
+music_cont_out_proxy::update( Time const& origin, const long from, const long )
 {
   /* There is nothing to request during the first time slice. For
      each subsequent slice, we collect all data generated during
@@ -339,7 +342,7 @@ nest::music_cont_out_proxy::update( Time const& origin, const long from, const l
 }
 
 void
-nest::music_cont_out_proxy::handle( DataLoggingReply& reply )
+music_cont_out_proxy::handle( DataLoggingReply& reply )
 {
   // easy access to relevant information
   DataLoggingReply::Container const& info = reply.get_info();
@@ -356,5 +359,7 @@ nest::music_cont_out_proxy::handle( DataLoggingReply& reply )
     }
   }
 }
+
+}  // namespace nest
 
 #endif

--- a/models/music_cont_out_proxy.h
+++ b/models/music_cont_out_proxy.h
@@ -218,13 +218,13 @@ private:
 };
 
 inline SignalType
-nest::music_cont_out_proxy::sends_signal() const
+music_cont_out_proxy::sends_signal() const
 {
   return ALL;
 }
 
 inline void
-nest::music_cont_out_proxy::calibrate_time( const TimeConverter& tc )
+music_cont_out_proxy::calibrate_time( const TimeConverter& tc )
 {
   P_.interval_ = tc.from_old_tics( P_.interval_.get_tics() );
 }

--- a/models/music_event_in_proxy.cpp
+++ b/models/music_event_in_proxy.cpp
@@ -36,8 +36,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_music_event_in_proxy( const std::string& name )
+register_music_event_in_proxy( const std::string& name )
 {
   register_node_model< music_event_in_proxy >( name );
 }
@@ -47,13 +50,13 @@ nest::register_music_event_in_proxy( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::music_event_in_proxy::Parameters_::Parameters_()
+music_event_in_proxy::Parameters_::Parameters_()
   : port_name_( "event_in" )
   , channel_( 0 )
 {
 }
 
-nest::music_event_in_proxy::State_::State_()
+music_event_in_proxy::State_::State_()
   : registered_( false )
 {
 }
@@ -64,14 +67,14 @@ nest::music_event_in_proxy::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::music_event_in_proxy::Parameters_::get( Dictionary& d ) const
+music_event_in_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::music_channel ] = channel_;
   d[ names::port_name ] = port_name_;
 }
 
 void
-nest::music_event_in_proxy::Parameters_::set( const Dictionary& d, State_& s )
+music_event_in_proxy::Parameters_::set( const Dictionary& d, State_& s )
 {
   if ( not s.registered_ )
   {
@@ -81,13 +84,13 @@ nest::music_event_in_proxy::Parameters_::set( const Dictionary& d, State_& s )
 }
 
 void
-nest::music_event_in_proxy::State_::get( Dictionary& d ) const
+music_event_in_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::registered ] = registered_;
 }
 
 void
-nest::music_event_in_proxy::State_::set( const Dictionary&, const Parameters_& )
+music_event_in_proxy::State_::set( const Dictionary&, const Parameters_& )
 {
 }
 
@@ -96,7 +99,7 @@ nest::music_event_in_proxy::State_::set( const Dictionary&, const Parameters_& )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_event_in_proxy::music_event_in_proxy()
+music_event_in_proxy::music_event_in_proxy()
   : DeviceNode()
   , P_()
   , S_()
@@ -105,7 +108,7 @@ nest::music_event_in_proxy::music_event_in_proxy()
   kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 
-nest::music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n )
+music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -120,12 +123,12 @@ nest::music_event_in_proxy::music_event_in_proxy( const music_event_in_proxy& n 
  * ---------------------------------------------------------------- */
 
 void
-nest::music_event_in_proxy::init_buffers_()
+music_event_in_proxy::init_buffers_()
 {
 }
 
 void
-nest::music_event_in_proxy::pre_run_hook()
+music_event_in_proxy::pre_run_hook()
 {
   // register my port and my channel at the scheduler
   if ( not S_.registered_ )
@@ -136,14 +139,14 @@ nest::music_event_in_proxy::pre_run_hook()
 }
 
 void
-nest::music_event_in_proxy::get_status( Dictionary& d ) const
+music_event_in_proxy::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
 }
 
 void
-nest::music_event_in_proxy::set_status( const Dictionary& d )
+music_event_in_proxy::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.set( d, S_ );      // throws if BadProperty
@@ -160,7 +163,7 @@ nest::music_event_in_proxy::set_status( const Dictionary& d )
 }
 
 void
-nest::music_event_in_proxy::handle( SpikeEvent& e )
+music_event_in_proxy::handle( SpikeEvent& e )
 {
   e.set_sender( *this );
 
@@ -169,5 +172,7 @@ nest::music_event_in_proxy::handle( SpikeEvent& e )
     kernel().connection_manager.send_from_device( t, local_device_id_, e );
   }
 }
+
+}  // namespace nest
 
 #endif

--- a/models/music_event_out_proxy.cpp
+++ b/models/music_event_out_proxy.cpp
@@ -35,8 +35,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_music_event_out_proxy( const std::string& name )
+register_music_event_out_proxy( const std::string& name )
 {
   register_node_model< music_event_out_proxy >( name );
 }
@@ -45,12 +48,12 @@ nest::register_music_event_out_proxy( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::music_event_out_proxy::Parameters_::Parameters_()
+music_event_out_proxy::Parameters_::Parameters_()
   : port_name_( "event_out" )
 {
 }
 
-nest::music_event_out_proxy::State_::State_()
+music_event_out_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )
 {
@@ -61,13 +64,13 @@ nest::music_event_out_proxy::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::music_event_out_proxy::Parameters_::get( Dictionary& d ) const
+music_event_out_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::port_name ] = port_name_;
 }
 
 void
-nest::music_event_out_proxy::Parameters_::set( const Dictionary& d, State_& s )
+music_event_out_proxy::Parameters_::set( const Dictionary& d, State_& s )
 {
   // TODO: This is not possible, as P_ does not know about get_name()
   //  if(d.known(names::port_name) and s.published_)
@@ -80,14 +83,14 @@ nest::music_event_out_proxy::Parameters_::set( const Dictionary& d, State_& s )
 }
 
 void
-nest::music_event_out_proxy::State_::get( Dictionary& d ) const
+music_event_out_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
   d[ names::port_width ] = port_width_;
 }
 
 void
-nest::music_event_out_proxy::State_::set( const Dictionary&, const Parameters_& )
+music_event_out_proxy::State_::set( const Dictionary&, const Parameters_& )
 {
 }
 
@@ -96,21 +99,21 @@ nest::music_event_out_proxy::State_::set( const Dictionary&, const Parameters_& 
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_event_out_proxy::music_event_out_proxy()
+music_event_out_proxy::music_event_out_proxy()
   : DeviceNode()
   , P_()
   , S_()
 {
 }
 
-nest::music_event_out_proxy::music_event_out_proxy( const music_event_out_proxy& n )
+music_event_out_proxy::music_event_out_proxy( const music_event_out_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
 {
 }
 
-nest::music_event_out_proxy::~music_event_out_proxy()
+music_event_out_proxy::~music_event_out_proxy()
 {
   if ( S_.published_ )
   {
@@ -120,12 +123,12 @@ nest::music_event_out_proxy::~music_event_out_proxy()
 }
 
 void
-nest::music_event_out_proxy::init_buffers_()
+music_event_out_proxy::init_buffers_()
 {
 }
 
 void
-nest::music_event_out_proxy::pre_run_hook()
+music_event_out_proxy::pre_run_hook()
 {
   // only publish the output port once,
   if ( not S_.published_ )
@@ -175,7 +178,7 @@ nest::music_event_out_proxy::pre_run_hook()
 }
 
 void
-nest::music_event_out_proxy::get_status( Dictionary& d ) const
+music_event_out_proxy::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -191,7 +194,7 @@ nest::music_event_out_proxy::get_status( Dictionary& d ) const
 }
 
 void
-nest::music_event_out_proxy::set_status( const Dictionary& d )
+music_event_out_proxy::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.set( d, S_ );      // throws if BadProperty
@@ -205,7 +208,7 @@ nest::music_event_out_proxy::set_status( const Dictionary& d )
 }
 
 void
-nest::music_event_out_proxy::handle( SpikeEvent& e )
+music_event_out_proxy::handle( SpikeEvent& e )
 {
   assert( e.get_multiplicity() > 0 );
 
@@ -225,5 +228,7 @@ nest::music_event_out_proxy::handle( SpikeEvent& e )
   }
 #endif
 }
+
+}  // namespace nest
 
 #endif

--- a/models/music_message_in_proxy.cpp
+++ b/models/music_message_in_proxy.cpp
@@ -35,8 +35,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_music_message_in_proxy( const std::string& name )
+register_music_message_in_proxy( const std::string& name )
 {
   register_node_model< music_message_in_proxy >( name );
 }
@@ -45,13 +48,13 @@ nest::register_music_message_in_proxy( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::music_message_in_proxy::Parameters_::Parameters_()
+music_message_in_proxy::Parameters_::Parameters_()
   : port_name_( "message_in" )
   , acceptable_latency_( 0.0 )
 {
 }
 
-nest::music_message_in_proxy::State_::State_()
+music_message_in_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )
 {
@@ -63,14 +66,14 @@ nest::music_message_in_proxy::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::music_message_in_proxy::Parameters_::get( Dictionary& d ) const
+music_message_in_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::port_name ] = port_name_;
   d[ names::acceptable_latency ] = acceptable_latency_;
 }
 
 void
-nest::music_message_in_proxy::Parameters_::set( const Dictionary& d, State_& s, Node* node )
+music_message_in_proxy::Parameters_::set( const Dictionary& d, State_& s, Node* node )
 {
   if ( not s.published_ )
   {
@@ -80,14 +83,14 @@ nest::music_message_in_proxy::Parameters_::set( const Dictionary& d, State_& s, 
 }
 
 void
-nest::music_message_in_proxy::State_::get( Dictionary& d ) const
+music_message_in_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
   d[ names::port_width ] = port_width_;
 }
 
 void
-nest::music_message_in_proxy::State_::set( const Dictionary&, const Parameters_&, Node* )
+music_message_in_proxy::State_::set( const Dictionary&, const Parameters_&, Node* )
 {
 }
 
@@ -96,14 +99,14 @@ nest::music_message_in_proxy::State_::set( const Dictionary&, const Parameters_&
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_message_in_proxy::music_message_in_proxy()
+music_message_in_proxy::music_message_in_proxy()
   : DeviceNode()
   , P_()
   , S_()
 {
 }
 
-nest::music_message_in_proxy::music_message_in_proxy( const music_message_in_proxy& n )
+music_message_in_proxy::music_message_in_proxy( const music_message_in_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -116,12 +119,12 @@ nest::music_message_in_proxy::music_message_in_proxy( const music_message_in_pro
  * ---------------------------------------------------------------- */
 
 void
-nest::music_message_in_proxy::init_buffers_()
+music_message_in_proxy::init_buffers_()
 {
 }
 
 void
-nest::music_message_in_proxy::pre_run_hook()
+music_message_in_proxy::pre_run_hook()
 {
   // only publish the port once,
   if ( not S_.published_ )
@@ -161,5 +164,7 @@ nest::music_message_in_proxy::pre_run_hook()
     LOG( VerbosityLevel::INFO, "music_message_in_proxy::pre_run_hook()", msg.c_str() );
   }
 }
+
+}  // namespace nest
 
 #endif

--- a/models/music_rate_in_proxy.cpp
+++ b/models/music_rate_in_proxy.cpp
@@ -33,8 +33,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_music_rate_in_proxy( const std::string& name )
+register_music_rate_in_proxy( const std::string& name )
 {
   register_node_model< music_rate_in_proxy >( name );
 }
@@ -44,13 +47,13 @@ nest::register_music_rate_in_proxy( const std::string& name )
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::music_rate_in_proxy::Parameters_::Parameters_()
+music_rate_in_proxy::Parameters_::Parameters_()
   : port_name_( "rate_in" )
   , channel_( 0 )
 {
 }
 
-nest::music_rate_in_proxy::State_::State_()
+music_rate_in_proxy::State_::State_()
   : registered_( false )
 {
 }
@@ -60,13 +63,13 @@ nest::music_rate_in_proxy::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::music_rate_in_proxy::Parameters_::get( Dictionary& d ) const
+music_rate_in_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::port_name ] = port_name_;
 }
 
 void
-nest::music_rate_in_proxy::Parameters_::set( const Dictionary& d, State_& s )
+music_rate_in_proxy::Parameters_::set( const Dictionary& d, State_& s )
 {
   // TODO: This is not possible, as P_ does not know about get_name()
   //  if(d.known(names::port_name) and s.registered_)
@@ -80,13 +83,13 @@ nest::music_rate_in_proxy::Parameters_::set( const Dictionary& d, State_& s )
 }
 
 void
-nest::music_rate_in_proxy::State_::get( Dictionary& d ) const
+music_rate_in_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::registered ] = registered_;
 }
 
 void
-nest::music_rate_in_proxy::State_::set( const Dictionary&, const Parameters_& )
+music_rate_in_proxy::State_::set( const Dictionary&, const Parameters_& )
 {
 }
 
@@ -95,7 +98,7 @@ nest::music_rate_in_proxy::State_::set( const Dictionary&, const Parameters_& )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_rate_in_proxy::music_rate_in_proxy()
+music_rate_in_proxy::music_rate_in_proxy()
   : DeviceNode()
   , P_()
   , S_()
@@ -104,7 +107,7 @@ nest::music_rate_in_proxy::music_rate_in_proxy()
   kernel().music_manager.register_music_in_port( P_.port_name_ );
 }
 
-nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
+music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -119,12 +122,12 @@ nest::music_rate_in_proxy::music_rate_in_proxy( const music_rate_in_proxy& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::music_rate_in_proxy::init_buffers_()
+music_rate_in_proxy::init_buffers_()
 {
 }
 
 void
-nest::music_rate_in_proxy::pre_run_hook()
+music_rate_in_proxy::pre_run_hook()
 {
   // only publish the port once
   if ( not S_.registered_ )
@@ -135,7 +138,7 @@ nest::music_rate_in_proxy::pre_run_hook()
 }
 
 void
-nest::music_rate_in_proxy::get_status( Dictionary& d ) const
+music_rate_in_proxy::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -144,7 +147,7 @@ nest::music_rate_in_proxy::get_status( Dictionary& d ) const
 }
 
 void
-nest::music_rate_in_proxy::set_status( const Dictionary& d )
+music_rate_in_proxy::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.set( d, S_ );      // throws if BadProperty
@@ -160,15 +163,16 @@ nest::music_rate_in_proxy::set_status( const Dictionary& d )
 }
 
 void
-nest::music_rate_in_proxy::update( Time const&, const long, const long )
+music_rate_in_proxy::update( Time const&, const long, const long )
 {
 }
 
 void
-nest::music_rate_in_proxy::handle( InstantaneousRateConnectionEvent& e )
+music_rate_in_proxy::handle( InstantaneousRateConnectionEvent& e )
 {
   kernel().event_delivery_manager.send_secondary( *this, e );
 }
 
+}  // namespace nest
 
 #endif

--- a/models/music_rate_out_proxy.cpp
+++ b/models/music_rate_out_proxy.cpp
@@ -35,33 +35,36 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
 void
-nest::register_music_rate_out_proxy( const std::string& name )
+register_music_rate_out_proxy( const std::string& name )
 {
   register_node_model< music_rate_out_proxy >( name );
 }
 
-nest::music_rate_out_proxy::Parameters_::Parameters_()
+music_rate_out_proxy::Parameters_::Parameters_()
   : port_name_( "rate_out" )
 {
 }
 
-nest::music_rate_out_proxy::State_::State_()
+music_rate_out_proxy::State_::State_()
   : published_( false )
   , port_width_( -1 )
 {
 }
 
-nest::music_rate_out_proxy::Buffers_::Buffers_()
+music_rate_out_proxy::Buffers_::Buffers_()
   : data_()
 {
 }
 
-nest::music_rate_out_proxy::Buffers_::Buffers_( const Buffers_& b )
+music_rate_out_proxy::Buffers_::Buffers_( const Buffers_& b )
   : data_( b.data_ )
 {
 }
@@ -71,13 +74,13 @@ nest::music_rate_out_proxy::Buffers_::Buffers_( const Buffers_& b )
  * ---------------------------------------------------------------- */
 
 void
-nest::music_rate_out_proxy::Parameters_::get( Dictionary& d ) const
+music_rate_out_proxy::Parameters_::get( Dictionary& d ) const
 {
   d[ names::port_name ] = port_name_;
 }
 
 void
-nest::music_rate_out_proxy::Parameters_::set( const Dictionary& d, State_& s )
+music_rate_out_proxy::Parameters_::set( const Dictionary& d, State_& s )
 {
   // TODO: This is not possible, as P_ does not know about get_name()
   //  if(d.known(names::port_name) and s.published_)
@@ -90,14 +93,14 @@ nest::music_rate_out_proxy::Parameters_::set( const Dictionary& d, State_& s )
 }
 
 void
-nest::music_rate_out_proxy::State_::get( Dictionary& d ) const
+music_rate_out_proxy::State_::get( Dictionary& d ) const
 {
   d[ names::published ] = published_;
   d[ names::port_width ] = port_width_;
 }
 
 void
-nest::music_rate_out_proxy::State_::set( const Dictionary&, const Parameters_& )
+music_rate_out_proxy::State_::set( const Dictionary&, const Parameters_& )
 {
 }
 
@@ -106,21 +109,21 @@ nest::music_rate_out_proxy::State_::set( const Dictionary&, const Parameters_& )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::music_rate_out_proxy::music_rate_out_proxy()
+music_rate_out_proxy::music_rate_out_proxy()
   : DeviceNode()
   , P_()
   , S_()
 {
 }
 
-nest::music_rate_out_proxy::music_rate_out_proxy( const music_rate_out_proxy& n )
+music_rate_out_proxy::music_rate_out_proxy( const music_rate_out_proxy& n )
   : DeviceNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
 {
 }
 
-nest::music_rate_out_proxy::~music_rate_out_proxy()
+music_rate_out_proxy::~music_rate_out_proxy()
 {
   if ( S_.published_ )
   {
@@ -129,12 +132,12 @@ nest::music_rate_out_proxy::~music_rate_out_proxy()
 }
 
 void
-nest::music_rate_out_proxy::init_buffers_()
+music_rate_out_proxy::init_buffers_()
 {
 }
 
 void
-nest::music_rate_out_proxy::pre_run_hook()
+music_rate_out_proxy::pre_run_hook()
 {
   // only publish the output port once,
   if ( not S_.published_ )
@@ -191,7 +194,7 @@ nest::music_rate_out_proxy::pre_run_hook()
 }
 
 void
-nest::music_rate_out_proxy::get_status( Dictionary& d ) const
+music_rate_out_proxy::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -207,7 +210,7 @@ nest::music_rate_out_proxy::get_status( Dictionary& d ) const
 }
 
 void
-nest::music_rate_out_proxy::set_status( const Dictionary& d )
+music_rate_out_proxy::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.set( d, S_ );      // throws if BadProperty
@@ -221,7 +224,7 @@ nest::music_rate_out_proxy::set_status( const Dictionary& d )
 }
 
 void
-nest::music_rate_out_proxy::handle( InstantaneousRateConnectionEvent& e )
+music_rate_out_proxy::handle( InstantaneousRateConnectionEvent& e )
 {
   // propagate last rate in min delay interval to MUSIC port; we can not use
   // e.end() - 1 since the iterator is defined in terms of unsigned ints, not
@@ -236,5 +239,7 @@ nest::music_rate_out_proxy::handle( InstantaneousRateConnectionEvent& e )
     B_.data_[ receiver_port ] = e.get_coeffvalue( it );
   }
 }
+
+}  // namespace nest
 
 #endif

--- a/models/noise_generator.cpp
+++ b/models/noise_generator.cpp
@@ -51,13 +51,12 @@ RecordablesMap< noise_generator >::create()
 {
   insert_( names::I, &noise_generator::get_I_avg_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::noise_generator::Parameters_::Parameters_()
+noise_generator::Parameters_::Parameters_()
   : mean_( 0.0 )     // pA
   , std_( 0.0 )      // pA / sqrt(s)
   , std_mod_( 0.0 )  // pA / sqrt(s)
@@ -68,7 +67,7 @@ nest::noise_generator::Parameters_::Parameters_()
 {
 }
 
-nest::noise_generator::Parameters_::Parameters_( const Parameters_& p )
+noise_generator::Parameters_::Parameters_( const Parameters_& p )
   : mean_( p.mean_ )
   , std_( p.std_ )
   , std_mod_( p.std_mod_ )
@@ -87,8 +86,8 @@ nest::noise_generator::Parameters_::Parameters_( const Parameters_& p )
   }
 }
 
-nest::noise_generator::Parameters_&
-nest::noise_generator::Parameters_::operator=( const Parameters_& p )
+noise_generator::Parameters_&
+noise_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -105,20 +104,20 @@ nest::noise_generator::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::noise_generator::State_::State_()
+noise_generator::State_::State_()
   : y_0_( 0.0 )
   , y_1_( 0.0 )    // pA
   , I_avg_( 0.0 )  // pA
 {
 }
 
-nest::noise_generator::Buffers_::Buffers_( noise_generator& n )
+noise_generator::Buffers_::Buffers_( noise_generator& n )
   : next_step_( 0 )
   , logger_( n )
 {
 }
 
-nest::noise_generator::Buffers_::Buffers_( const Buffers_& b, noise_generator& n )
+noise_generator::Buffers_::Buffers_( const Buffers_& b, noise_generator& n )
   : next_step_( b.next_step_ )
   , logger_( n )
 {
@@ -129,7 +128,7 @@ nest::noise_generator::Buffers_::Buffers_( const Buffers_& b, noise_generator& n
  * ---------------------------------------------------------------- */
 
 void
-nest::noise_generator::Parameters_::get( Dictionary& d ) const
+noise_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::mean ] = mean_;
   d[ names::std ] = std_;
@@ -140,14 +139,14 @@ nest::noise_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::noise_generator::State_::get( Dictionary& d ) const
+noise_generator::State_::get( Dictionary& d ) const
 {
   d[ names::y_0 ] = y_0_;
   d[ names::y_1 ] = y_1_;
 }
 
 void
-nest::noise_generator::Parameters_::set( const Dictionary& d, const noise_generator& n, Node* node )
+noise_generator::Parameters_::set( const Dictionary& d, const noise_generator& n, Node* node )
 {
   update_value_param( d, names::mean, mean_, node );
   update_value_param( d, names::std, std_, node );
@@ -185,7 +184,7 @@ nest::noise_generator::Parameters_::set( const Dictionary& d, const noise_genera
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::noise_generator::noise_generator()
+noise_generator::noise_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -194,7 +193,7 @@ nest::noise_generator::noise_generator()
   recordablesMap_.create();
 }
 
-nest::noise_generator::noise_generator( const noise_generator& n )
+noise_generator::noise_generator( const noise_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -208,13 +207,13 @@ nest::noise_generator::noise_generator( const noise_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::noise_generator::init_state_()
+noise_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::noise_generator::init_buffers_()
+noise_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
@@ -225,7 +224,7 @@ nest::noise_generator::init_buffers_()
 }
 
 void
-nest::noise_generator::pre_run_hook()
+noise_generator::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -264,7 +263,7 @@ nest::noise_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 size_t
-nest::noise_generator::send_test_event( Node& target, size_t receptor_type, synindex syn_id, bool dummy_target )
+noise_generator::send_test_event( Node& target, size_t receptor_type, synindex syn_id, bool dummy_target )
 {
   StimulationDevice::enforce_single_syn_type( syn_id );
 
@@ -291,7 +290,7 @@ nest::noise_generator::send_test_event( Node& target, size_t receptor_type, syni
 // Time Evolution Operator
 //
 void
-nest::noise_generator::update( Time const& origin, const long from, const long to )
+noise_generator::update( Time const& origin, const long from, const long to )
 {
   const long start = origin.get_steps();
 
@@ -342,7 +341,7 @@ nest::noise_generator::update( Time const& origin, const long from, const long t
 }
 
 void
-nest::noise_generator::event_hook( DSCurrentEvent& e )
+noise_generator::event_hook( DSCurrentEvent& e )
 {
   // get port number
   const size_t prt = e.get_port();
@@ -355,7 +354,7 @@ nest::noise_generator::event_hook( DSCurrentEvent& e )
 }
 
 void
-nest::noise_generator::handle( DataLoggingRequest& e )
+noise_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -365,7 +364,7 @@ nest::noise_generator::handle( DataLoggingRequest& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::noise_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+noise_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.num_targets_ = P_.num_targets_;
@@ -393,7 +392,7 @@ nest::noise_generator::set_data_from_stimulation_backend( std::vector< double >&
 }
 
 void
-nest::noise_generator::calibrate_time( const TimeConverter& tc )
+noise_generator::calibrate_time( const TimeConverter& tc )
 {
   if ( P_.dt_.is_step() )
   {
@@ -407,3 +406,5 @@ nest::noise_generator::calibrate_time( const TimeConverter& tc )
     LOG( VerbosityLevel::INFO, get_name(), msg );
   }
 }
+
+}  // namespace nest

--- a/models/parrot_neuron.cpp
+++ b/models/parrot_neuron.cpp
@@ -111,4 +111,4 @@ parrot_neuron::handle( SpikeEvent& e )
   }
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/parrot_neuron_ps.cpp
+++ b/models/parrot_neuron_ps.cpp
@@ -117,11 +117,11 @@ parrot_neuron_ps::handle( SpikeEvent& e )
     const long Tdeliver = e.get_stamp().get_steps() + e.get_delay_steps() - 1;
 
     // parrot ignores weight of incoming connection, store multiplicity
-    B_.events_.add_spike( e.get_rel_delivery_steps( nest::kernel().simulation_manager.get_slice_origin() ),
+    B_.events_.add_spike( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
       Tdeliver,
       e.get_offset(),
       static_cast< double >( e.get_multiplicity() ) );
   }
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/poisson_generator.cpp
+++ b/models/poisson_generator.cpp
@@ -31,8 +31,11 @@
 // Includes from libnestutil:
 #include "dict_util.h"
 
+
+namespace nest
+{
 void
-nest::register_poisson_generator( const std::string& name )
+register_poisson_generator( const std::string& name )
 {
   register_node_model< poisson_generator >( name );
 }
@@ -41,7 +44,7 @@ nest::register_poisson_generator( const std::string& name )
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::poisson_generator::Parameters_::Parameters_()
+poisson_generator::Parameters_::Parameters_()
   : rate_( 0.0 )  // spks/s
 {
 }
@@ -52,13 +55,13 @@ nest::poisson_generator::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator::Parameters_::get( Dictionary& d ) const
+poisson_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
 }
 
 void
-nest::poisson_generator::Parameters_::set( const Dictionary& d, Node* node )
+poisson_generator::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::rate, rate_, node );
   if ( rate_ < 0 )
@@ -72,13 +75,13 @@ nest::poisson_generator::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::poisson_generator::poisson_generator()
+poisson_generator::poisson_generator()
   : StimulationDevice()
   , P_()
 {
 }
 
-nest::poisson_generator::poisson_generator( const poisson_generator& n )
+poisson_generator::poisson_generator( const poisson_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
 {
@@ -90,19 +93,19 @@ nest::poisson_generator::poisson_generator( const poisson_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator::init_state_()
+poisson_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::poisson_generator::init_buffers_()
+poisson_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
 }
 
 void
-nest::poisson_generator::pre_run_hook()
+poisson_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
 
@@ -117,7 +120,7 @@ nest::poisson_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator::update( Time const& T, const long from, const long to )
+poisson_generator::update( Time const& T, const long from, const long to )
 {
   if ( P_.rate_ <= 0 )
   {
@@ -137,7 +140,7 @@ nest::poisson_generator::update( Time const& T, const long from, const long to )
 }
 
 void
-nest::poisson_generator::event_hook( DSSpikeEvent& e )
+poisson_generator::event_hook( DSSpikeEvent& e )
 {
   long n_spikes = V_.poisson_dist_( get_vp_specific_rng( get_thread() ) );
 
@@ -153,7 +156,7 @@ nest::poisson_generator::event_hook( DSSpikeEvent& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+poisson_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -172,3 +175,5 @@ nest::poisson_generator::set_data_from_stimulation_backend( std::vector< double 
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/poisson_generator_ps.cpp
+++ b/models/poisson_generator_ps.cpp
@@ -34,8 +34,11 @@
 // Includes from libnestutil:
 #include "dict_util.h"
 
+
+namespace nest
+{
 void
-nest::register_poisson_generator_ps( const std::string& name )
+register_poisson_generator_ps( const std::string& name )
 {
   register_node_model< poisson_generator_ps >( name );
 }
@@ -44,7 +47,7 @@ nest::register_poisson_generator_ps( const std::string& name )
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::poisson_generator_ps::Parameters_::Parameters_()
+poisson_generator_ps::Parameters_::Parameters_()
   : rate_( 0.0 )       // spks/s
   , dead_time_( 0.0 )  // ms
   , num_targets_( 0 )
@@ -56,14 +59,14 @@ nest::poisson_generator_ps::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator_ps::Parameters_::get( Dictionary& d ) const
+poisson_generator_ps::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
   d[ names::dead_time ] = dead_time_;
 }
 
 void
-nest::poisson_generator_ps::Parameters_::set( const Dictionary& d, Node* node )
+poisson_generator_ps::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::dead_time, dead_time_, node );
   if ( dead_time_ < 0 )
@@ -89,13 +92,13 @@ nest::poisson_generator_ps::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::poisson_generator_ps::poisson_generator_ps()
+poisson_generator_ps::poisson_generator_ps()
   : StimulationDevice()
   , P_()
 {
 }
 
-nest::poisson_generator_ps::poisson_generator_ps( const poisson_generator_ps& n )
+poisson_generator_ps::poisson_generator_ps( const poisson_generator_ps& n )
   : StimulationDevice( n )
   , P_( n.P_ )
 {
@@ -107,15 +110,15 @@ nest::poisson_generator_ps::poisson_generator_ps( const poisson_generator_ps& n 
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator_ps::init_state_()
+poisson_generator_ps::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::poisson_generator_ps::init_buffers_()
+poisson_generator_ps::init_buffers_()
 {
-  nest::Device::init_buffers();
+  Device::init_buffers();
 
   // forget all about past, but do not discard connection information
   B_.next_spike_.clear();
@@ -123,7 +126,7 @@ nest::poisson_generator_ps::init_buffers_()
 }
 
 void
-nest::poisson_generator_ps::pre_run_hook()
+poisson_generator_ps::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
   if ( P_.rate_ > 0 )
@@ -176,7 +179,7 @@ nest::poisson_generator_ps::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::poisson_generator_ps::update( Time const& T, const long from, const long to )
+poisson_generator_ps::update( Time const& T, const long from, const long to )
 {
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {
@@ -204,7 +207,7 @@ nest::poisson_generator_ps::update( Time const& T, const long from, const long t
 }
 
 void
-nest::poisson_generator_ps::event_hook( DSSpikeEvent& e )
+poisson_generator_ps::event_hook( DSSpikeEvent& e )
 {
   // get port number
   const size_t prt = e.get_port();
@@ -278,7 +281,7 @@ nest::poisson_generator_ps::event_hook( DSSpikeEvent& e )
 }
 
 void
-nest::poisson_generator_ps::set_data_from_stimulation_backend( std::vector< double >& input_param )
+poisson_generator_ps::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -298,3 +301,5 @@ nest::poisson_generator_ps::set_data_from_stimulation_backend( std::vector< doub
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/pp_cond_exp_mc_urbanczik.cpp
+++ b/models/pp_cond_exp_mc_urbanczik.cpp
@@ -40,11 +40,11 @@
 #include "universal_data_logger_impl.h"
 
 
-std::vector< std::string > nest::pp_cond_exp_mc_urbanczik::comp_names_( NCOMP );
-nest::RecordablesMap< nest::pp_cond_exp_mc_urbanczik > nest::pp_cond_exp_mc_urbanczik::recordablesMap_;
-
 namespace nest
 {
+std::vector< std::string > pp_cond_exp_mc_urbanczik::comp_names_( NCOMP );
+RecordablesMap< pp_cond_exp_mc_urbanczik > pp_cond_exp_mc_urbanczik::recordablesMap_;
+
 void
 register_pp_cond_exp_mc_urbanczik( const std::string& name )
 {
@@ -70,22 +70,21 @@ RecordablesMap< pp_cond_exp_mc_urbanczik >::create()
   insert_( "I_in.p",
     &pp_cond_exp_mc_urbanczik::get_y_elem_< pp_cond_exp_mc_urbanczik::State_::I_INH, pp_cond_exp_mc_urbanczik::DEND > );
 }
-}
 
 /* ----------------------------------------------------------------
  * Iteration function
  * ---------------------------------------------------------------- */
 
 extern "C" int
-nest::pp_cond_exp_mc_urbanczik_dynamics( double, const double y[], double f[], void* pnode )
+pp_cond_exp_mc_urbanczik_dynamics( double, const double y[], double f[], void* pnode )
 {
   // some shorthands
-  typedef nest::pp_cond_exp_mc_urbanczik N;
-  typedef nest::pp_cond_exp_mc_urbanczik::State_ S;
+  typedef pp_cond_exp_mc_urbanczik N;
+  typedef pp_cond_exp_mc_urbanczik::State_ S;
 
   // get access to node so we can work almost as in a member function
   assert( pnode );
-  const nest::pp_cond_exp_mc_urbanczik& node = *( reinterpret_cast< nest::pp_cond_exp_mc_urbanczik* >( pnode ) );
+  const pp_cond_exp_mc_urbanczik& node = *( reinterpret_cast< pp_cond_exp_mc_urbanczik* >( pnode ) );
 
   // computations written quite explicitly for clarity, assume compile
   // will optimized most stuff away ...
@@ -166,7 +165,7 @@ nest::pp_cond_exp_mc_urbanczik_dynamics( double, const double y[], double f[], v
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::pp_cond_exp_mc_urbanczik::Parameters_::Parameters_()
+pp_cond_exp_mc_urbanczik::Parameters_::Parameters_()
   : t_ref( 3.0 )  // ms
 {
   urbanczik_params.phi_max = 0.15;
@@ -198,7 +197,7 @@ nest::pp_cond_exp_mc_urbanczik::Parameters_::Parameters_()
   I_e[ DEND ] = 0.0;  // pA
 }
 
-nest::pp_cond_exp_mc_urbanczik::Parameters_::Parameters_( const Parameters_& p )
+pp_cond_exp_mc_urbanczik::Parameters_::Parameters_( const Parameters_& p )
   : t_ref( p.t_ref )
 {
   urbanczik_params.phi_max = p.urbanczik_params.phi_max;
@@ -220,8 +219,8 @@ nest::pp_cond_exp_mc_urbanczik::Parameters_::Parameters_( const Parameters_& p )
   }
 }
 
-nest::pp_cond_exp_mc_urbanczik::Parameters_&
-nest::pp_cond_exp_mc_urbanczik::Parameters_::operator=( const Parameters_& p )
+pp_cond_exp_mc_urbanczik::Parameters_&
+pp_cond_exp_mc_urbanczik::Parameters_::operator=( const Parameters_& p )
 {
   assert( this != &p );  // would be bad logical error in program
 
@@ -248,7 +247,7 @@ nest::pp_cond_exp_mc_urbanczik::Parameters_::operator=( const Parameters_& p )
 }
 
 
-nest::pp_cond_exp_mc_urbanczik::State_::State_( const Parameters_& p )
+pp_cond_exp_mc_urbanczik::State_::State_( const Parameters_& p )
   : r_( 0 )
 {
   // for simplicity, we first initialize all values to 0,
@@ -263,7 +262,7 @@ nest::pp_cond_exp_mc_urbanczik::State_::State_( const Parameters_& p )
   }
 }
 
-nest::pp_cond_exp_mc_urbanczik::State_::State_( const State_& s )
+pp_cond_exp_mc_urbanczik::State_::State_( const State_& s )
   : r_( s.r_ )
 {
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -272,8 +271,8 @@ nest::pp_cond_exp_mc_urbanczik::State_::State_( const State_& s )
   }
 }
 
-nest::pp_cond_exp_mc_urbanczik::State_&
-nest::pp_cond_exp_mc_urbanczik::State_::operator=( const State_& s )
+pp_cond_exp_mc_urbanczik::State_&
+pp_cond_exp_mc_urbanczik::State_::operator=( const State_& s )
 {
   r_ = s.r_;
   for ( size_t i = 0; i < STATE_VEC_SIZE; ++i )
@@ -283,7 +282,7 @@ nest::pp_cond_exp_mc_urbanczik::State_::operator=( const State_& s )
   return *this;
 }
 
-nest::pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( pp_cond_exp_mc_urbanczik& n )
+pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( pp_cond_exp_mc_urbanczik& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -293,7 +292,7 @@ nest::pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( pp_cond_exp_mc_urbanczik& n 
   // init_buffers_().
 }
 
-nest::pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( const Buffers_&, pp_cond_exp_mc_urbanczik& n )
+pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( const Buffers_&, pp_cond_exp_mc_urbanczik& n )
   : logger_( n )
   , s_( nullptr )
   , c_( nullptr )
@@ -308,7 +307,7 @@ nest::pp_cond_exp_mc_urbanczik::Buffers_::Buffers_( const Buffers_&, pp_cond_exp
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_cond_exp_mc_urbanczik::Parameters_::get( Dictionary& d ) const
+pp_cond_exp_mc_urbanczik::Parameters_::get( Dictionary& d ) const
 {
   d[ names::t_ref ] = t_ref;
   d[ names::phi_max ] = urbanczik_params.phi_max;
@@ -338,7 +337,7 @@ nest::pp_cond_exp_mc_urbanczik::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::Parameters_::set( const Dictionary& d )
+pp_cond_exp_mc_urbanczik::Parameters_::set( const Dictionary& d )
 {
   // allow setting the membrane potential
   d.update_value( names::t_ref, t_ref );
@@ -398,7 +397,7 @@ nest::pp_cond_exp_mc_urbanczik::Parameters_::set( const Dictionary& d )
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::State_::get( Dictionary& d ) const
+pp_cond_exp_mc_urbanczik::State_::get( Dictionary& d ) const
 {
   // we assume here that State_::get() always is called after
   // Parameters_::get(), so that the per-compartment dictionaries exist
@@ -412,7 +411,7 @@ nest::pp_cond_exp_mc_urbanczik::State_::get( Dictionary& d ) const
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::State_::set( const Dictionary& d, const Parameters_& )
+pp_cond_exp_mc_urbanczik::State_::set( const Dictionary& d, const Parameters_& )
 {
   // extract from sub-dictionaries
   for ( size_t n = 0; n < NCOMP; ++n )
@@ -430,7 +429,7 @@ nest::pp_cond_exp_mc_urbanczik::State_::set( const Dictionary& d, const Paramete
  * Default and copy constructor for node, and destructor
  * ---------------------------------------------------------------- */
 
-nest::pp_cond_exp_mc_urbanczik::pp_cond_exp_mc_urbanczik()
+pp_cond_exp_mc_urbanczik::pp_cond_exp_mc_urbanczik()
   : UrbanczikArchivingNode< pp_cond_exp_mc_urbanczik_parameters >()
   , P_()
   , S_( P_ )
@@ -445,7 +444,7 @@ nest::pp_cond_exp_mc_urbanczik::pp_cond_exp_mc_urbanczik()
   UrbanczikArchivingNode< pp_cond_exp_mc_urbanczik_parameters >::urbanczik_params = &P_.urbanczik_params;
 }
 
-nest::pp_cond_exp_mc_urbanczik::pp_cond_exp_mc_urbanczik( const pp_cond_exp_mc_urbanczik& n )
+pp_cond_exp_mc_urbanczik::pp_cond_exp_mc_urbanczik( const pp_cond_exp_mc_urbanczik& n )
   : UrbanczikArchivingNode< pp_cond_exp_mc_urbanczik_parameters >( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -454,7 +453,7 @@ nest::pp_cond_exp_mc_urbanczik::pp_cond_exp_mc_urbanczik( const pp_cond_exp_mc_u
   UrbanczikArchivingNode< pp_cond_exp_mc_urbanczik_parameters >::urbanczik_params = &P_.urbanczik_params;
 }
 
-nest::pp_cond_exp_mc_urbanczik::~pp_cond_exp_mc_urbanczik()
+pp_cond_exp_mc_urbanczik::~pp_cond_exp_mc_urbanczik()
 {
   // GSL structs may not have been allocated, so we need to protect destruction
   if ( B_.s_ )
@@ -476,7 +475,7 @@ nest::pp_cond_exp_mc_urbanczik::~pp_cond_exp_mc_urbanczik()
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_cond_exp_mc_urbanczik::init_buffers_()
+pp_cond_exp_mc_urbanczik::init_buffers_()
 {
   B_.spikes_.resize( NUM_SPIKE_RECEPTORS );
   for ( size_t n = 0; n < NUM_SPIKE_RECEPTORS; ++n )
@@ -534,7 +533,7 @@ nest::pp_cond_exp_mc_urbanczik::init_buffers_()
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::pre_run_hook()
+pp_cond_exp_mc_urbanczik::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -555,7 +554,7 @@ nest::pp_cond_exp_mc_urbanczik::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_cond_exp_mc_urbanczik::update( Time const& origin, const long from, const long to )
+pp_cond_exp_mc_urbanczik::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -672,7 +671,7 @@ nest::pp_cond_exp_mc_urbanczik::update( Time const& origin, const long from, con
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::handle( SpikeEvent& e )
+pp_cond_exp_mc_urbanczik::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   assert( e.get_rport() < 2 * NCOMP );
@@ -682,7 +681,7 @@ nest::pp_cond_exp_mc_urbanczik::handle( SpikeEvent& e )
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::handle( CurrentEvent& e )
+pp_cond_exp_mc_urbanczik::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
   // not 100% clean, should look at MIN, SUP
@@ -694,9 +693,11 @@ nest::pp_cond_exp_mc_urbanczik::handle( CurrentEvent& e )
 }
 
 void
-nest::pp_cond_exp_mc_urbanczik::handle( DataLoggingRequest& e )
+pp_cond_exp_mc_urbanczik::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
+
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/pp_psc_delta.cpp
+++ b/models/pp_psc_delta.cpp
@@ -69,7 +69,7 @@ RecordablesMap< pp_psc_delta >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::pp_psc_delta::Parameters_::Parameters_()
+pp_psc_delta::Parameters_::Parameters_()
   : tau_m_( 10.0 )     // ms
   , c_m_( 250.0 )      // pF
   , dead_time_( 1.0 )  // ms
@@ -89,7 +89,7 @@ nest::pp_psc_delta::Parameters_::Parameters_()
   q_sfa_.clear();
 }
 
-nest::pp_psc_delta::State_::State_()
+pp_psc_delta::State_::State_()
   : y0_( 0.0 )
   , y3_( 0.0 )
   , q_( 0.0 )
@@ -104,7 +104,7 @@ nest::pp_psc_delta::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_psc_delta::Parameters_::get( Dictionary& d ) const
+pp_psc_delta::Parameters_::get( Dictionary& d ) const
 {
   d[ names::I_e ] = I_e_;
   d[ names::C_m ] = c_m_;
@@ -140,7 +140,7 @@ nest::pp_psc_delta::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::pp_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
+pp_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::I_e, I_e_, node );
   update_value_param( d, names::C_m, c_m_, node );
@@ -220,14 +220,14 @@ nest::pp_psc_delta::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::pp_psc_delta::State_::get( Dictionary& d, const Parameters_& ) const
+pp_psc_delta::State_::get( Dictionary& d, const Parameters_& ) const
 {
   d[ names::V_m ] = y3_;   // Membrane potential
   d[ names::E_sfa ] = q_;  // Adaptive threshold potential
 }
 
 void
-nest::pp_psc_delta::State_::set( const Dictionary& d, const Parameters_&, Node* node )
+pp_psc_delta::State_::set( const Dictionary& d, const Parameters_&, Node* node )
 {
   update_value_param( d, names::V_m, y3_, node );
   update_value_param( d, names::E_sfa, q_, node );
@@ -235,12 +235,12 @@ nest::pp_psc_delta::State_::set( const Dictionary& d, const Parameters_&, Node* 
   initialized_ = false;
 }
 
-nest::pp_psc_delta::Buffers_::Buffers_( pp_psc_delta& n )
+pp_psc_delta::Buffers_::Buffers_( pp_psc_delta& n )
   : logger_( n )
 {
 }
 
-nest::pp_psc_delta::Buffers_::Buffers_( const Buffers_&, pp_psc_delta& n )
+pp_psc_delta::Buffers_::Buffers_( const Buffers_&, pp_psc_delta& n )
   : logger_( n )
 {
 }
@@ -249,7 +249,7 @@ nest::pp_psc_delta::Buffers_::Buffers_( const Buffers_&, pp_psc_delta& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::pp_psc_delta::pp_psc_delta()
+pp_psc_delta::pp_psc_delta()
   : ArchivingNode()
   , P_()
   , S_()
@@ -258,7 +258,7 @@ nest::pp_psc_delta::pp_psc_delta()
   recordablesMap_.create();
 }
 
-nest::pp_psc_delta::pp_psc_delta( const pp_psc_delta& n )
+pp_psc_delta::pp_psc_delta( const pp_psc_delta& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -271,13 +271,13 @@ nest::pp_psc_delta::pp_psc_delta( const pp_psc_delta& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::pp_psc_delta::init_state_()
+pp_psc_delta::init_state_()
 {
   S_.r_ = Time( Time::ms( P_.t_ref_remaining_ ) ).get_steps();
 }
 
 void
-nest::pp_psc_delta::init_buffers_()
+pp_psc_delta::init_buffers_()
 {
   B_.spikes_.clear();    //!< includes resize
   B_.currents_.clear();  //!< includes resize
@@ -286,7 +286,7 @@ nest::pp_psc_delta::init_buffers_()
 }
 
 void
-nest::pp_psc_delta::pre_run_hook()
+pp_psc_delta::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -353,7 +353,7 @@ nest::pp_psc_delta::pre_run_hook()
  */
 
 void
-nest::pp_psc_delta::update( Time const& origin, const long from, const long to )
+pp_psc_delta::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -457,7 +457,7 @@ nest::pp_psc_delta::update( Time const& origin, const long from, const long to )
 }
 
 void
-nest::pp_psc_delta::handle( SpikeEvent& e )
+pp_psc_delta::handle( SpikeEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -470,7 +470,7 @@ nest::pp_psc_delta::handle( SpikeEvent& e )
 }
 
 void
-nest::pp_psc_delta::handle( CurrentEvent& e )
+pp_psc_delta::handle( CurrentEvent& e )
 {
   assert( e.get_delay_steps() > 0 );
 
@@ -482,9 +482,9 @@ nest::pp_psc_delta::handle( CurrentEvent& e )
 }
 
 void
-nest::pp_psc_delta::handle( DataLoggingRequest& e )
+pp_psc_delta::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest

--- a/models/ppd_sup_generator.cpp
+++ b/models/ppd_sup_generator.cpp
@@ -34,8 +34,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_ppd_sup_generator( const std::string& name )
+register_ppd_sup_generator( const std::string& name )
 {
   register_node_model< ppd_sup_generator >( name );
 }
@@ -44,7 +47,7 @@ nest::register_ppd_sup_generator( const std::string& name )
  * Constructor of age distribution class
  * ---------------------------------------------------------------- */
 
-nest::ppd_sup_generator::Age_distribution_::Age_distribution_( size_t num_age_bins,
+ppd_sup_generator::Age_distribution_::Age_distribution_( size_t num_age_bins,
   unsigned long ini_occ_ref,
   unsigned long ini_occ_act )
 {
@@ -58,7 +61,7 @@ nest::ppd_sup_generator::Age_distribution_::Age_distribution_( size_t num_age_bi
  * ---------------------------------------------------------------- */
 
 unsigned long
-nest::ppd_sup_generator::Age_distribution_::update( double hazard_step, RngPtr rng )
+ppd_sup_generator::Age_distribution_::update( double hazard_step, RngPtr rng )
 {
   unsigned long n_spikes;  // only set from poisson_dev, bino_dev or 0, thus >= 0
   if ( occ_active_ > 0 )
@@ -105,7 +108,7 @@ nest::ppd_sup_generator::Age_distribution_::update( double hazard_step, RngPtr r
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::ppd_sup_generator::Parameters_::Parameters_()
+ppd_sup_generator::Parameters_::Parameters_()
   : rate_( 0.0 )       // Hz
   , dead_time_( 0.0 )  // ms
   , n_proc_( 1 )
@@ -120,7 +123,7 @@ nest::ppd_sup_generator::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::ppd_sup_generator::Parameters_::get( Dictionary& d ) const
+ppd_sup_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;
   d[ names::dead_time ] = dead_time_;
@@ -130,7 +133,7 @@ nest::ppd_sup_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::ppd_sup_generator::Parameters_::set( const Dictionary& d, Node* node )
+ppd_sup_generator::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::dead_time, dead_time_, node );
   if ( dead_time_ < 0 )
@@ -169,13 +172,13 @@ nest::ppd_sup_generator::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::ppd_sup_generator::ppd_sup_generator()
+ppd_sup_generator::ppd_sup_generator()
   : StimulationDevice()
   , P_()
 {
 }
 
-nest::ppd_sup_generator::ppd_sup_generator( const ppd_sup_generator& n )
+ppd_sup_generator::ppd_sup_generator( const ppd_sup_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
 {
@@ -187,19 +190,19 @@ nest::ppd_sup_generator::ppd_sup_generator( const ppd_sup_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::ppd_sup_generator::init_state_()
+ppd_sup_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::ppd_sup_generator::init_buffers_()
+ppd_sup_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
 }
 
 void
-nest::ppd_sup_generator::pre_run_hook()
+ppd_sup_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
 
@@ -230,7 +233,7 @@ nest::ppd_sup_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::ppd_sup_generator::update( Time const& T, const long from, const long to )
+ppd_sup_generator::update( Time const& T, const long from, const long to )
 {
   if ( P_.rate_ <= 0 or P_.num_targets_ == 0 )
   {
@@ -264,7 +267,7 @@ nest::ppd_sup_generator::update( Time const& T, const long from, const long to )
 
 
 void
-nest::ppd_sup_generator::event_hook( DSSpikeEvent& e )
+ppd_sup_generator::event_hook( DSSpikeEvent& e )
 {
   // get port number
   const size_t prt = e.get_port();
@@ -289,7 +292,7 @@ nest::ppd_sup_generator::event_hook( DSSpikeEvent& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::ppd_sup_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+ppd_sup_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -314,3 +317,5 @@ nest::ppd_sup_generator::set_data_from_stimulation_backend( std::vector< double 
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/pulsepacket_generator.cpp
+++ b/models/pulsepacket_generator.cpp
@@ -35,8 +35,11 @@
 #include "kernel_manager.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_pulsepacket_generator( const std::string& name )
+register_pulsepacket_generator( const std::string& name )
 {
   register_node_model< pulsepacket_generator >( name );
 }
@@ -45,7 +48,7 @@ nest::register_pulsepacket_generator( const std::string& name )
  * Default constructors defining default parameters and variables
  * ---------------------------------------------------------------- */
 
-nest::pulsepacket_generator::Parameters_::Parameters_()
+pulsepacket_generator::Parameters_::Parameters_()
   : pulse_times_()
   , a_( 0 )
   , sdev_( 0.0 )
@@ -53,7 +56,7 @@ nest::pulsepacket_generator::Parameters_::Parameters_()
 {
 }
 
-nest::pulsepacket_generator::Variables_::Variables_()
+pulsepacket_generator::Variables_::Variables_()
   : start_center_idx_( 0 )
   , stop_center_idx_( 0 )
   , tolerance( 0.0 )
@@ -65,7 +68,7 @@ nest::pulsepacket_generator::Variables_::Variables_()
  * ---------------------------------------------------------------- */
 
 void
-nest::pulsepacket_generator::Parameters_::get( Dictionary& d ) const
+pulsepacket_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::pulse_times ] = pulse_times_;
   d[ names::activity ] = a_;
@@ -73,7 +76,7 @@ nest::pulsepacket_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::pulsepacket_generator::Parameters_::set( const Dictionary& d, pulsepacket_generator& ppg, Node* node )
+pulsepacket_generator::Parameters_::set( const Dictionary& d, pulsepacket_generator& ppg, Node* node )
 {
   // We cannot use a single line here since short-circuiting may stop evaluation
   // prematurely. Therefore, neednewpulse must be second arg on second line.
@@ -100,13 +103,13 @@ nest::pulsepacket_generator::Parameters_::set( const Dictionary& d, pulsepacket_
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::pulsepacket_generator::pulsepacket_generator()
+pulsepacket_generator::pulsepacket_generator()
   : StimulationDevice()
   , P_()
 {
 }
 
-nest::pulsepacket_generator::pulsepacket_generator( const pulsepacket_generator& ppg )
+pulsepacket_generator::pulsepacket_generator( const pulsepacket_generator& ppg )
   : StimulationDevice( ppg )
   , P_( ppg.P_ )
 {
@@ -117,19 +120,19 @@ nest::pulsepacket_generator::pulsepacket_generator( const pulsepacket_generator&
  * ---------------------------------------------------------------- */
 
 void
-nest::pulsepacket_generator::init_state_()
+pulsepacket_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::pulsepacket_generator::init_buffers_()
+pulsepacket_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
 }
 
 void
-nest::pulsepacket_generator::pre_run_hook()
+pulsepacket_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
   assert( V_.start_center_idx_ <= V_.stop_center_idx_ );
@@ -164,7 +167,7 @@ nest::pulsepacket_generator::pre_run_hook()
 
 
 void
-nest::pulsepacket_generator::update( Time const& T, const long, const long to )
+pulsepacket_generator::update( Time const& T, const long, const long to )
 {
   if ( ( V_.start_center_idx_ == P_.pulse_times_.size() and B_.spiketimes_.empty() )
     or ( not StimulationDevice::is_active( T ) ) )
@@ -232,7 +235,7 @@ nest::pulsepacket_generator::update( Time const& T, const long, const long to )
  * ---------------------------------------------------------------- */
 
 void
-nest::pulsepacket_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+pulsepacket_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -257,3 +260,5 @@ nest::pulsepacket_generator::set_data_from_stimulation_backend( std::vector< dou
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/quantal_stp_synapse.cpp
+++ b/models/quantal_stp_synapse.cpp
@@ -26,8 +26,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_quantal_stp_synapse( const std::string& name )
+register_quantal_stp_synapse( const std::string& name )
 {
   register_connection_model< quantal_stp_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/rate_connection_delayed.cpp
+++ b/models/rate_connection_delayed.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_rate_connection_delayed( const std::string& name )
+register_rate_connection_delayed( const std::string& name )
 {
   register_connection_model< rate_connection_delayed >( name );
 }
+
+}  // namespace nest

--- a/models/rate_connection_instantaneous.cpp
+++ b/models/rate_connection_instantaneous.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_rate_connection_instantaneous( const std::string& name )
+register_rate_connection_instantaneous( const std::string& name )
 {
   register_connection_model< rate_connection_instantaneous >( name );
 }
+
+}  // namespace nest

--- a/models/rate_neuron_ipn_impl.h
+++ b/models/rate_neuron_ipn_impl.h
@@ -58,7 +58,7 @@ RecordablesMap< rate_neuron_ipn< TNonlinearities > > rate_neuron_ipn< TNonlinear
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
-nest::rate_neuron_ipn< TNonlinearities >::Parameters_::Parameters_()
+rate_neuron_ipn< TNonlinearities >::Parameters_::Parameters_()
   : tau_( 10.0 )    // ms
   , lambda_( 1.0 )  // ms
   , sigma_( 1.0 )
@@ -72,7 +72,7 @@ nest::rate_neuron_ipn< TNonlinearities >::Parameters_::Parameters_()
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_ipn< TNonlinearities >::State_::State_()
+rate_neuron_ipn< TNonlinearities >::State_::State_()
   : rate_( 0.0 )
   , noise_( 0.0 )
 {
@@ -84,7 +84,7 @@ nest::rate_neuron_ipn< TNonlinearities >::State_::State_()
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::Parameters_::get( Dictionary& d ) const
+rate_neuron_ipn< TNonlinearities >::Parameters_::get( Dictionary& d ) const
 {
   d[ names::tau ] = tau_;
   d[ names::lambda ] = lambda_;
@@ -102,7 +102,7 @@ nest::rate_neuron_ipn< TNonlinearities >::Parameters_::get( Dictionary& d ) cons
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::Parameters_::set( const Dictionary& d, Node* node )
+rate_neuron_ipn< TNonlinearities >::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::tau, tau_, node );
   update_value_param( d, names::lambda, lambda_, node );
@@ -151,7 +151,7 @@ nest::rate_neuron_ipn< TNonlinearities >::Parameters_::set( const Dictionary& d,
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::State_::get( Dictionary& d ) const
+rate_neuron_ipn< TNonlinearities >::State_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;    // Rate
   d[ names::noise ] = noise_;  // Noise
@@ -159,19 +159,19 @@ nest::rate_neuron_ipn< TNonlinearities >::State_::get( Dictionary& d ) const
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::State_::set( const Dictionary& d, Node* node )
+rate_neuron_ipn< TNonlinearities >::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::rate, rate_, node );  // Rate
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_ipn< TNonlinearities >::Buffers_::Buffers_( rate_neuron_ipn< TNonlinearities >& n )
+rate_neuron_ipn< TNonlinearities >::Buffers_::Buffers_( rate_neuron_ipn< TNonlinearities >& n )
   : logger_( n )
 {
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_ipn< TNonlinearities >::Buffers_::Buffers_( const Buffers_&, rate_neuron_ipn< TNonlinearities >& n )
+rate_neuron_ipn< TNonlinearities >::Buffers_::Buffers_( const Buffers_&, rate_neuron_ipn< TNonlinearities >& n )
   : logger_( n )
 {
 }
@@ -181,7 +181,7 @@ nest::rate_neuron_ipn< TNonlinearities >::Buffers_::Buffers_( const Buffers_&, r
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
-nest::rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn()
+rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn()
   : ArchivingNode()
   , P_()
   , S_()
@@ -192,7 +192,7 @@ nest::rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn()
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn( const rate_neuron_ipn& n )
+rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn( const rate_neuron_ipn& n )
   : ArchivingNode( n )
   , nonlinearities_( n.nonlinearities_ )
   , P_( n.P_ )
@@ -208,7 +208,7 @@ nest::rate_neuron_ipn< TNonlinearities >::rate_neuron_ipn( const rate_neuron_ipn
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::init_buffers_()
+rate_neuron_ipn< TNonlinearities >::init_buffers_()
 {
   B_.delayed_rates_ex_.clear();  // includes resize
   B_.delayed_rates_in_.clear();  // includes resize
@@ -232,7 +232,7 @@ nest::rate_neuron_ipn< TNonlinearities >::init_buffers_()
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::pre_run_hook()
+rate_neuron_ipn< TNonlinearities >::pre_run_hook()
 {
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 
@@ -260,7 +260,7 @@ nest::rate_neuron_ipn< TNonlinearities >::pre_run_hook()
 
 template < class TNonlinearities >
 bool
-nest::rate_neuron_ipn< TNonlinearities >::update_( Time const& origin,
+rate_neuron_ipn< TNonlinearities >::update_( Time const& origin,
   const long from,
   const long to,
   const bool called_from_wfr_update )
@@ -389,7 +389,7 @@ nest::rate_neuron_ipn< TNonlinearities >::update_( Time const& origin,
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::handle( InstantaneousRateConnectionEvent& e )
+rate_neuron_ipn< TNonlinearities >::handle( InstantaneousRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
 
@@ -426,7 +426,7 @@ nest::rate_neuron_ipn< TNonlinearities >::handle( InstantaneousRateConnectionEve
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::handle( DelayedRateConnectionEvent& e )
+rate_neuron_ipn< TNonlinearities >::handle( DelayedRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
   const long delay = e.get_delay_steps() - kernel().connection_manager.get_min_delay();
@@ -464,7 +464,7 @@ nest::rate_neuron_ipn< TNonlinearities >::handle( DelayedRateConnectionEvent& e 
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_ipn< TNonlinearities >::handle( DataLoggingRequest& e )
+rate_neuron_ipn< TNonlinearities >::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }

--- a/models/rate_neuron_opn_impl.h
+++ b/models/rate_neuron_opn_impl.h
@@ -58,7 +58,7 @@ RecordablesMap< rate_neuron_opn< TNonlinearities > > rate_neuron_opn< TNonlinear
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
-nest::rate_neuron_opn< TNonlinearities >::Parameters_::Parameters_()
+rate_neuron_opn< TNonlinearities >::Parameters_::Parameters_()
   : tau_( 10.0 )  // ms
   , sigma_( 1.0 )
   , mu_( 0.0 )
@@ -69,7 +69,7 @@ nest::rate_neuron_opn< TNonlinearities >::Parameters_::Parameters_()
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_opn< TNonlinearities >::State_::State_()
+rate_neuron_opn< TNonlinearities >::State_::State_()
   : rate_( 0.0 )
   , noise_( 0.0 )
   , noisy_rate_( 0.0 )
@@ -82,7 +82,7 @@ nest::rate_neuron_opn< TNonlinearities >::State_::State_()
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::Parameters_::get( Dictionary& d ) const
+rate_neuron_opn< TNonlinearities >::Parameters_::get( Dictionary& d ) const
 {
   d[ names::tau ] = tau_;
   d[ names::sigma ] = sigma_;
@@ -97,7 +97,7 @@ nest::rate_neuron_opn< TNonlinearities >::Parameters_::get( Dictionary& d ) cons
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::Parameters_::set( const Dictionary& d, Node* node )
+rate_neuron_opn< TNonlinearities >::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::tau, tau_, node );
   update_value_param( d, names::mu, mu_, node );
@@ -135,7 +135,7 @@ nest::rate_neuron_opn< TNonlinearities >::Parameters_::set( const Dictionary& d,
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::State_::get( Dictionary& d ) const
+rate_neuron_opn< TNonlinearities >::State_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;              // Rate
   d[ names::noise ] = noise_;            // Noise
@@ -144,19 +144,19 @@ nest::rate_neuron_opn< TNonlinearities >::State_::get( Dictionary& d ) const
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::State_::set( const Dictionary& d, Node* node )
+rate_neuron_opn< TNonlinearities >::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::rate, rate_, node );  // Rate
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_opn< TNonlinearities >::Buffers_::Buffers_( rate_neuron_opn< TNonlinearities >& n )
+rate_neuron_opn< TNonlinearities >::Buffers_::Buffers_( rate_neuron_opn< TNonlinearities >& n )
   : logger_( n )
 {
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_opn< TNonlinearities >::Buffers_::Buffers_( const Buffers_&, rate_neuron_opn< TNonlinearities >& n )
+rate_neuron_opn< TNonlinearities >::Buffers_::Buffers_( const Buffers_&, rate_neuron_opn< TNonlinearities >& n )
   : logger_( n )
 {
 }
@@ -166,7 +166,7 @@ nest::rate_neuron_opn< TNonlinearities >::Buffers_::Buffers_( const Buffers_&, r
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
-nest::rate_neuron_opn< TNonlinearities >::rate_neuron_opn()
+rate_neuron_opn< TNonlinearities >::rate_neuron_opn()
   : ArchivingNode()
   , P_()
   , S_()
@@ -177,7 +177,7 @@ nest::rate_neuron_opn< TNonlinearities >::rate_neuron_opn()
 }
 
 template < class TNonlinearities >
-nest::rate_neuron_opn< TNonlinearities >::rate_neuron_opn( const rate_neuron_opn& n )
+rate_neuron_opn< TNonlinearities >::rate_neuron_opn( const rate_neuron_opn& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -192,7 +192,7 @@ nest::rate_neuron_opn< TNonlinearities >::rate_neuron_opn( const rate_neuron_opn
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::init_buffers_()
+rate_neuron_opn< TNonlinearities >::init_buffers_()
 {
   B_.delayed_rates_ex_.clear();  // includes resize
   B_.delayed_rates_in_.clear();  // includes resize
@@ -216,7 +216,7 @@ nest::rate_neuron_opn< TNonlinearities >::init_buffers_()
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::pre_run_hook()
+rate_neuron_opn< TNonlinearities >::pre_run_hook()
 {
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 
@@ -236,7 +236,7 @@ nest::rate_neuron_opn< TNonlinearities >::pre_run_hook()
 
 template < class TNonlinearities >
 bool
-nest::rate_neuron_opn< TNonlinearities >::update_( Time const& origin,
+rate_neuron_opn< TNonlinearities >::update_( Time const& origin,
   const long from,
   const long to,
   const bool called_from_wfr_update )
@@ -362,7 +362,7 @@ nest::rate_neuron_opn< TNonlinearities >::update_( Time const& origin,
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::handle( InstantaneousRateConnectionEvent& e )
+rate_neuron_opn< TNonlinearities >::handle( InstantaneousRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
 
@@ -399,7 +399,7 @@ nest::rate_neuron_opn< TNonlinearities >::handle( InstantaneousRateConnectionEve
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::handle( DelayedRateConnectionEvent& e )
+rate_neuron_opn< TNonlinearities >::handle( DelayedRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
   const long delay = e.get_delay_steps() - kernel().connection_manager.get_min_delay();
@@ -437,7 +437,7 @@ nest::rate_neuron_opn< TNonlinearities >::handle( DelayedRateConnectionEvent& e 
 
 template < class TNonlinearities >
 void
-nest::rate_neuron_opn< TNonlinearities >::handle( DataLoggingRequest& e )
+rate_neuron_opn< TNonlinearities >::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }

--- a/models/rate_transformer_node_impl.h
+++ b/models/rate_transformer_node_impl.h
@@ -59,13 +59,13 @@ RecordablesMap< rate_transformer_node< TNonlinearities > > rate_transformer_node
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
-nest::rate_transformer_node< TNonlinearities >::Parameters_::Parameters_()
+rate_transformer_node< TNonlinearities >::Parameters_::Parameters_()
   : linear_summation_( true )
 {
 }
 
 template < class TNonlinearities >
-nest::rate_transformer_node< TNonlinearities >::State_::State_()
+rate_transformer_node< TNonlinearities >::State_::State_()
   : rate_( 0.0 )
 {
 }
@@ -76,40 +76,40 @@ nest::rate_transformer_node< TNonlinearities >::State_::State_()
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::Parameters_::get( Dictionary& d ) const
+rate_transformer_node< TNonlinearities >::Parameters_::get( Dictionary& d ) const
 {
   d[ names::linear_summation ] = linear_summation_;
 }
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::Parameters_::set( const Dictionary& d, Node* node )
+rate_transformer_node< TNonlinearities >::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::linear_summation, linear_summation_, node );
 }
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::State_::get( Dictionary& d ) const
+rate_transformer_node< TNonlinearities >::State_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_;  // Rate
 }
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::State_::set( const Dictionary& d, Node* node )
+rate_transformer_node< TNonlinearities >::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::rate, rate_, node );  // Rate
 }
 
 template < class TNonlinearities >
-nest::rate_transformer_node< TNonlinearities >::Buffers_::Buffers_( rate_transformer_node< TNonlinearities >& n )
+rate_transformer_node< TNonlinearities >::Buffers_::Buffers_( rate_transformer_node< TNonlinearities >& n )
   : logger_( n )
 {
 }
 
 template < class TNonlinearities >
-nest::rate_transformer_node< TNonlinearities >::Buffers_::Buffers_( const Buffers_&,
+rate_transformer_node< TNonlinearities >::Buffers_::Buffers_( const Buffers_&,
   rate_transformer_node< TNonlinearities >& n )
   : logger_( n )
 {
@@ -120,7 +120,7 @@ nest::rate_transformer_node< TNonlinearities >::Buffers_::Buffers_( const Buffer
  * ---------------------------------------------------------------- */
 
 template < class TNonlinearities >
-nest::rate_transformer_node< TNonlinearities >::rate_transformer_node()
+rate_transformer_node< TNonlinearities >::rate_transformer_node()
   : ArchivingNode()
   , S_()
   , B_( *this )
@@ -130,7 +130,7 @@ nest::rate_transformer_node< TNonlinearities >::rate_transformer_node()
 }
 
 template < class TNonlinearities >
-nest::rate_transformer_node< TNonlinearities >::rate_transformer_node( const rate_transformer_node& n )
+rate_transformer_node< TNonlinearities >::rate_transformer_node( const rate_transformer_node& n )
   : ArchivingNode( n )
   , nonlinearities_( n.nonlinearities_ )
   , S_( n.S_ )
@@ -145,7 +145,7 @@ nest::rate_transformer_node< TNonlinearities >::rate_transformer_node( const rat
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::init_buffers_()
+rate_transformer_node< TNonlinearities >::init_buffers_()
 {
   B_.delayed_rates_.clear();  // includes resize
 
@@ -160,7 +160,7 @@ nest::rate_transformer_node< TNonlinearities >::init_buffers_()
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::pre_run_hook()
+rate_transformer_node< TNonlinearities >::pre_run_hook()
 {
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 }
@@ -171,7 +171,7 @@ nest::rate_transformer_node< TNonlinearities >::pre_run_hook()
 
 template < class TNonlinearities >
 bool
-nest::rate_transformer_node< TNonlinearities >::update_( Time const& origin,
+rate_transformer_node< TNonlinearities >::update_( Time const& origin,
   const long from,
   const long to,
   const bool called_from_wfr_update )
@@ -257,7 +257,7 @@ nest::rate_transformer_node< TNonlinearities >::update_( Time const& origin,
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::handle( InstantaneousRateConnectionEvent& e )
+rate_transformer_node< TNonlinearities >::handle( InstantaneousRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
 
@@ -280,7 +280,7 @@ nest::rate_transformer_node< TNonlinearities >::handle( InstantaneousRateConnect
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::handle( DelayedRateConnectionEvent& e )
+rate_transformer_node< TNonlinearities >::handle( DelayedRateConnectionEvent& e )
 {
   const double weight = e.get_weight();
   const long delay = e.get_delay_steps() - kernel().connection_manager.get_min_delay();
@@ -304,7 +304,7 @@ nest::rate_transformer_node< TNonlinearities >::handle( DelayedRateConnectionEve
 
 template < class TNonlinearities >
 void
-nest::rate_transformer_node< TNonlinearities >::handle( DataLoggingRequest& e )
+rate_transformer_node< TNonlinearities >::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }

--- a/models/sic_connection.cpp
+++ b/models/sic_connection.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_sic_connection( const std::string& name )
+register_sic_connection( const std::string& name )
 {
   register_connection_model< sic_connection >( name );
 }
+
+}  // namespace nest

--- a/models/siegert_neuron.cpp
+++ b/models/siegert_neuron.cpp
@@ -40,6 +40,8 @@
 #include "universal_data_logger_impl.h"
 
 
+namespace nest
+{
 struct my_params
 {
   double a;
@@ -57,8 +59,6 @@ erfcx( double x, void* p )
   return exp( scale * scale * x * x + gsl_sf_log_erfc( x ) );
 }
 
-namespace nest
-{
 void
 register_siegert_neuron( const std::string& name )
 {
@@ -85,7 +85,7 @@ RecordablesMap< siegert_neuron >::create()
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::siegert_neuron::Parameters_::Parameters_()
+siegert_neuron::Parameters_::Parameters_()
   : tau_( 1.0 )      // ms
   , tau_m_( 5.0 )    // ms
   , tau_syn_( 0.0 )  // ms
@@ -96,7 +96,7 @@ nest::siegert_neuron::Parameters_::Parameters_()
 {
 }
 
-nest::siegert_neuron::State_::State_()
+siegert_neuron::State_::State_()
   : r_( 0.0 )
 {
 }
@@ -107,7 +107,7 @@ nest::siegert_neuron::State_::State_()
  * ---------------------------------------------------------------- */
 
 void
-nest::siegert_neuron::Parameters_::get( Dictionary& d ) const
+siegert_neuron::Parameters_::get( Dictionary& d ) const
 {
   d[ names::mean ] = mean_;
   d[ names::theta ] = theta_;
@@ -119,7 +119,7 @@ nest::siegert_neuron::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::siegert_neuron::Parameters_::set( const Dictionary& d, Node* node )
+siegert_neuron::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::mean, mean_, node );
   update_value_param( d, names::theta, theta_, node );
@@ -156,23 +156,23 @@ nest::siegert_neuron::Parameters_::set( const Dictionary& d, Node* node )
 }
 
 void
-nest::siegert_neuron::State_::get( Dictionary& d ) const
+siegert_neuron::State_::get( Dictionary& d ) const
 {
   d[ names::rate ] = r_;  // Rate
 }
 
 void
-nest::siegert_neuron::State_::set( const Dictionary& d, Node* node )
+siegert_neuron::State_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::rate, r_, node );  // Rate
 }
 
-nest::siegert_neuron::Buffers_::Buffers_( siegert_neuron& n )
+siegert_neuron::Buffers_::Buffers_( siegert_neuron& n )
   : logger_( n )
 {
 }
 
-nest::siegert_neuron::Buffers_::Buffers_( const Buffers_&, siegert_neuron& n )
+siegert_neuron::Buffers_::Buffers_( const Buffers_&, siegert_neuron& n )
   : logger_( n )
 {
 }
@@ -181,7 +181,7 @@ nest::siegert_neuron::Buffers_::Buffers_( const Buffers_&, siegert_neuron& n )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::siegert_neuron::siegert_neuron()
+siegert_neuron::siegert_neuron()
   : ArchivingNode()
   , P_()
   , S_()
@@ -192,7 +192,7 @@ nest::siegert_neuron::siegert_neuron()
   gsl_w_ = gsl_integration_workspace_alloc( 1000 );
 }
 
-nest::siegert_neuron::siegert_neuron( const siegert_neuron& n )
+siegert_neuron::siegert_neuron( const siegert_neuron& n )
   : ArchivingNode( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -202,7 +202,7 @@ nest::siegert_neuron::siegert_neuron( const siegert_neuron& n )
   gsl_w_ = gsl_integration_workspace_alloc( 1000 );
 }
 
-nest::siegert_neuron::~siegert_neuron()
+siegert_neuron::~siegert_neuron()
 {
   gsl_integration_workspace_free( gsl_w_ );
 }
@@ -212,7 +212,7 @@ nest::siegert_neuron::~siegert_neuron()
  * ---------------------------------------------------------------- */
 
 double
-nest::siegert_neuron::siegert( double mu, double sigma_square )
+siegert_neuron::siegert( double mu, double sigma_square )
 {
   double sigma = std::sqrt( sigma_square );
 
@@ -278,7 +278,7 @@ nest::siegert_neuron::siegert( double mu, double sigma_square )
  * ---------------------------------------------------------------- */
 
 void
-nest::siegert_neuron::init_buffers_()
+siegert_neuron::init_buffers_()
 {
   // resize buffers
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
@@ -291,7 +291,7 @@ nest::siegert_neuron::init_buffers_()
 }
 
 void
-nest::siegert_neuron::pre_run_hook()
+siegert_neuron::pre_run_hook()
 {
   B_.logger_.init();  // ensures initialization in case mm connected after Simulate
 
@@ -307,7 +307,7 @@ nest::siegert_neuron::pre_run_hook()
  */
 
 bool
-nest::siegert_neuron::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
+siegert_neuron::update_( Time const& origin, const long from, const long to, const bool called_from_wfr_update )
 {
   const size_t buffer_size = kernel().connection_manager.get_min_delay();
   const double wfr_tol = kernel().simulation_manager.get_wfr_tol();
@@ -364,7 +364,7 @@ nest::siegert_neuron::update_( Time const& origin, const long from, const long t
 }
 
 void
-nest::siegert_neuron::handle( DiffusionConnectionEvent& e )
+siegert_neuron::handle( DiffusionConnectionEvent& e )
 {
   const double drift = e.get_drift_factor();
   const double diffusion = e.get_diffusion_factor();
@@ -382,11 +382,11 @@ nest::siegert_neuron::handle( DiffusionConnectionEvent& e )
 }
 
 void
-nest::siegert_neuron::handle( DataLoggingRequest& e )
+siegert_neuron::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
 
-}  // namespace
+}  // namespace nest
 
 #endif  // HAVE_GSL

--- a/models/sigmoid_rate.cpp
+++ b/models/sigmoid_rate.cpp
@@ -27,6 +27,7 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -64,19 +65,19 @@ nonlinearities_sigmoid_rate::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::sigmoid_rate_ipn >::create()
+RecordablesMap< sigmoid_rate_ipn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::sigmoid_rate_ipn::get_rate_ );
-  insert_( names::noise, &nest::sigmoid_rate_ipn::get_noise_ );
+  insert_( names::rate, &sigmoid_rate_ipn::get_rate_ );
+  insert_( names::noise, &sigmoid_rate_ipn::get_noise_ );
 }
 
 template <>
 void
-RecordablesMap< nest::rate_transformer_sigmoid >::create()
+RecordablesMap< rate_transformer_sigmoid >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::rate_transformer_sigmoid::get_rate_ );
+  insert_( names::rate, &rate_transformer_sigmoid::get_rate_ );
 }
 
 }  // namespace nest

--- a/models/sigmoid_rate.h
+++ b/models/sigmoid_rate.h
@@ -167,10 +167,10 @@ nonlinearities_sigmoid_rate::mult_coupling_in( double )
   return 1.;
 }
 
-typedef rate_neuron_ipn< nest::nonlinearities_sigmoid_rate > sigmoid_rate_ipn;
+typedef rate_neuron_ipn< nonlinearities_sigmoid_rate > sigmoid_rate_ipn;
 void register_sigmoid_rate_ipn( const std::string& name );
 
-typedef rate_transformer_node< nest::nonlinearities_sigmoid_rate > rate_transformer_sigmoid;
+typedef rate_transformer_node< nonlinearities_sigmoid_rate > rate_transformer_sigmoid;
 void register_rate_transformer_sigmoid( const std::string& name );
 
 

--- a/models/sigmoid_rate_gg_1998.cpp
+++ b/models/sigmoid_rate_gg_1998.cpp
@@ -27,6 +27,7 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -60,19 +61,19 @@ nonlinearities_sigmoid_rate_gg_1998::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::sigmoid_rate_gg_1998_ipn >::create()
+RecordablesMap< sigmoid_rate_gg_1998_ipn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::sigmoid_rate_gg_1998_ipn::get_rate_ );
-  insert_( names::noise, &nest::sigmoid_rate_gg_1998_ipn::get_noise_ );
+  insert_( names::rate, &sigmoid_rate_gg_1998_ipn::get_rate_ );
+  insert_( names::noise, &sigmoid_rate_gg_1998_ipn::get_noise_ );
 }
 
 template <>
 void
-RecordablesMap< nest::rate_transformer_sigmoid_gg_1998 >::create()
+RecordablesMap< rate_transformer_sigmoid_gg_1998 >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::rate_transformer_sigmoid_gg_1998::get_rate_ );
+  insert_( names::rate, &rate_transformer_sigmoid_gg_1998::get_rate_ );
 }
 
 }  // namespace nest

--- a/models/sigmoid_rate_gg_1998.h
+++ b/models/sigmoid_rate_gg_1998.h
@@ -158,10 +158,10 @@ nonlinearities_sigmoid_rate_gg_1998::mult_coupling_in( double )
   return 1.;
 }
 
-typedef rate_neuron_ipn< nest::nonlinearities_sigmoid_rate_gg_1998 > sigmoid_rate_gg_1998_ipn;
+typedef rate_neuron_ipn< nonlinearities_sigmoid_rate_gg_1998 > sigmoid_rate_gg_1998_ipn;
 void register_sigmoid_rate_gg_1998_ipn( const std::string& name );
 
-typedef rate_transformer_node< nest::nonlinearities_sigmoid_rate_gg_1998 > rate_transformer_sigmoid_gg_1998;
+typedef rate_transformer_node< nonlinearities_sigmoid_rate_gg_1998 > rate_transformer_sigmoid_gg_1998;
 void register_rate_transformer_sigmoid_gg_1998( const std::string& name );
 
 

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -58,10 +58,9 @@ RecordablesMap< sinusoidal_gamma_generator >::create()
 {
   insert_( names::rate, &sinusoidal_gamma_generator::get_rate_ );
 }
-}
 
 
-nest::sinusoidal_gamma_generator::Parameters_::Parameters_()
+sinusoidal_gamma_generator::Parameters_::Parameters_()
   : om_( 0.0 )   // radian/ms
   , phi_( 0.0 )  // radian
   , order_( 1.0 )
@@ -72,7 +71,7 @@ nest::sinusoidal_gamma_generator::Parameters_::Parameters_()
 {
 }
 
-nest::sinusoidal_gamma_generator::Parameters_::Parameters_( const Parameters_& p )
+sinusoidal_gamma_generator::Parameters_::Parameters_( const Parameters_& p )
   : om_( p.om_ )
   , phi_( p.phi_ )
   , order_( p.order_ )
@@ -83,8 +82,8 @@ nest::sinusoidal_gamma_generator::Parameters_::Parameters_( const Parameters_& p
 {
 }
 
-nest::sinusoidal_gamma_generator::Parameters_&
-nest::sinusoidal_gamma_generator::Parameters_::operator=( const Parameters_& p )
+sinusoidal_gamma_generator::Parameters_&
+sinusoidal_gamma_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -102,13 +101,13 @@ nest::sinusoidal_gamma_generator::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::sinusoidal_gamma_generator::State_::State_()
+sinusoidal_gamma_generator::State_::State_()
   : rate_( 0 )
 {
 }
 
 
-nest::sinusoidal_gamma_generator::Buffers_::Buffers_( sinusoidal_gamma_generator& n )
+sinusoidal_gamma_generator::Buffers_::Buffers_( sinusoidal_gamma_generator& n )
   : logger_( n )
   , t0_ms_()
   ,  // will be set in init_buffers_
@@ -118,7 +117,7 @@ nest::sinusoidal_gamma_generator::Buffers_::Buffers_( sinusoidal_gamma_generator
 {
 }
 
-nest::sinusoidal_gamma_generator::Buffers_::Buffers_( const Buffers_& b, sinusoidal_gamma_generator& n )
+sinusoidal_gamma_generator::Buffers_::Buffers_( const Buffers_& b, sinusoidal_gamma_generator& n )
   : logger_( n )
   , t0_ms_( b.t0_ms_ )
   , Lambda_t0_( b.Lambda_t0_ )
@@ -131,7 +130,7 @@ nest::sinusoidal_gamma_generator::Buffers_::Buffers_( const Buffers_& b, sinusoi
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_gamma_generator::Parameters_::get( Dictionary& d ) const
+sinusoidal_gamma_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_ * 1000.0;
   d[ names::frequency ] = om_ / ( 2.0 * numerics::pi / 1000.0 );
@@ -142,7 +141,7 @@ nest::sinusoidal_gamma_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::sinusoidal_gamma_generator::Parameters_::set( const Dictionary& d,
+sinusoidal_gamma_generator::Parameters_::set( const Dictionary& d,
   const sinusoidal_gamma_generator& n,
   Node* node )
 {
@@ -212,7 +211,7 @@ nest::sinusoidal_gamma_generator::Parameters_::set( const Dictionary& d,
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::sinusoidal_gamma_generator::sinusoidal_gamma_generator()
+sinusoidal_gamma_generator::sinusoidal_gamma_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -221,7 +220,7 @@ nest::sinusoidal_gamma_generator::sinusoidal_gamma_generator()
   recordablesMap_.create();
 }
 
-nest::sinusoidal_gamma_generator::sinusoidal_gamma_generator( const sinusoidal_gamma_generator& n )
+sinusoidal_gamma_generator::sinusoidal_gamma_generator( const sinusoidal_gamma_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -234,13 +233,13 @@ nest::sinusoidal_gamma_generator::sinusoidal_gamma_generator( const sinusoidal_g
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_gamma_generator::init_state_()
+sinusoidal_gamma_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::sinusoidal_gamma_generator::init_buffers_()
+sinusoidal_gamma_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
@@ -253,7 +252,7 @@ nest::sinusoidal_gamma_generator::init_buffers_()
 // ----------------------------------------------------
 
 inline double
-nest::sinusoidal_gamma_generator::deltaLambda_( const Parameters_& p, double t_a, double t_b ) const
+sinusoidal_gamma_generator::deltaLambda_( const Parameters_& p, double t_a, double t_b ) const
 {
   if ( t_a == t_b )
   {
@@ -272,7 +271,7 @@ nest::sinusoidal_gamma_generator::deltaLambda_( const Parameters_& p, double t_a
 // ----------------------------------------------------
 
 void
-nest::sinusoidal_gamma_generator::pre_run_hook()
+sinusoidal_gamma_generator::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -299,7 +298,7 @@ nest::sinusoidal_gamma_generator::pre_run_hook()
 }
 
 double
-nest::sinusoidal_gamma_generator::hazard_( size_t tgt_idx ) const
+sinusoidal_gamma_generator::hazard_( size_t tgt_idx ) const
 {
   // Note: We compute Lambda for the entire interval since the last spike/
   //       parameter change each time for better accuracy.
@@ -309,7 +308,7 @@ nest::sinusoidal_gamma_generator::hazard_( size_t tgt_idx ) const
 }
 
 void
-nest::sinusoidal_gamma_generator::update( Time const& origin, const long from, const long to )
+sinusoidal_gamma_generator::update( Time const& origin, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -343,7 +342,7 @@ nest::sinusoidal_gamma_generator::update( Time const& origin, const long from, c
 }
 
 void
-nest::sinusoidal_gamma_generator::event_hook( DSSpikeEvent& e )
+sinusoidal_gamma_generator::event_hook( DSSpikeEvent& e )
 {
   // get port number --- see #737
   const size_t tgt_idx = e.get_port();
@@ -358,7 +357,7 @@ nest::sinusoidal_gamma_generator::event_hook( DSSpikeEvent& e )
 }
 
 void
-nest::sinusoidal_gamma_generator::handle( DataLoggingRequest& e )
+sinusoidal_gamma_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -368,7 +367,7 @@ nest::sinusoidal_gamma_generator::handle( DataLoggingRequest& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_gamma_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+sinusoidal_gamma_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -394,4 +393,7 @@ nest::sinusoidal_gamma_generator::set_data_from_stimulation_backend( std::vector
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest
+
 #endif  // HAVE_GSL

--- a/models/sinusoidal_gamma_generator.cpp
+++ b/models/sinusoidal_gamma_generator.cpp
@@ -141,9 +141,7 @@ sinusoidal_gamma_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-sinusoidal_gamma_generator::Parameters_::set( const Dictionary& d,
-  const sinusoidal_gamma_generator& n,
-  Node* node )
+sinusoidal_gamma_generator::Parameters_::set( const Dictionary& d, const sinusoidal_gamma_generator& n, Node* node )
 {
   if ( not n.is_model_prototype() and d.known( names::individual_spike_trains ) )
   {

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -135,9 +135,7 @@ sinusoidal_poisson_generator::State_::get( Dictionary& d ) const
 }
 
 void
-sinusoidal_poisson_generator::Parameters_::set( const Dictionary& d,
-  const sinusoidal_poisson_generator& n,
-  Node* node )
+sinusoidal_poisson_generator::Parameters_::set( const Dictionary& d, const sinusoidal_poisson_generator& n, Node* node )
 {
   if ( not n.is_model_prototype() and d.known( names::individual_spike_trains ) )
   {

--- a/models/sinusoidal_poisson_generator.cpp
+++ b/models/sinusoidal_poisson_generator.cpp
@@ -54,13 +54,12 @@ RecordablesMap< sinusoidal_poisson_generator >::create()
 {
   insert_( names::rate, &sinusoidal_poisson_generator::get_rate_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::sinusoidal_poisson_generator::Parameters_::Parameters_()
+sinusoidal_poisson_generator::Parameters_::Parameters_()
   : om_( 0.0 )         // radian/ms
   , phi_( 0.0 )        // radian
   , rate_( 0.0 )       // spikes/ms
@@ -69,7 +68,7 @@ nest::sinusoidal_poisson_generator::Parameters_::Parameters_()
 {
 }
 
-nest::sinusoidal_poisson_generator::Parameters_::Parameters_( const Parameters_& p )
+sinusoidal_poisson_generator::Parameters_::Parameters_( const Parameters_& p )
   : om_( p.om_ )
   , phi_( p.phi_ )
   , rate_( p.rate_ )
@@ -78,8 +77,8 @@ nest::sinusoidal_poisson_generator::Parameters_::Parameters_( const Parameters_&
 {
 }
 
-nest::sinusoidal_poisson_generator::Parameters_&
-nest::sinusoidal_poisson_generator::Parameters_::operator=( const Parameters_& p )
+sinusoidal_poisson_generator::Parameters_&
+sinusoidal_poisson_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -95,7 +94,7 @@ nest::sinusoidal_poisson_generator::Parameters_::operator=( const Parameters_& p
   return *this;
 }
 
-nest::sinusoidal_poisson_generator::State_::State_()
+sinusoidal_poisson_generator::State_::State_()
   : y_0_( 0 )
   , y_1_( 0 )
   , rate_( 0 )
@@ -103,12 +102,12 @@ nest::sinusoidal_poisson_generator::State_::State_()
 }
 
 
-nest::sinusoidal_poisson_generator::Buffers_::Buffers_( sinusoidal_poisson_generator& n )
+sinusoidal_poisson_generator::Buffers_::Buffers_( sinusoidal_poisson_generator& n )
   : logger_( n )
 {
 }
 
-nest::sinusoidal_poisson_generator::Buffers_::Buffers_( const Buffers_&, sinusoidal_poisson_generator& n )
+sinusoidal_poisson_generator::Buffers_::Buffers_( const Buffers_&, sinusoidal_poisson_generator& n )
   : logger_( n )
 {
 }
@@ -119,7 +118,7 @@ nest::sinusoidal_poisson_generator::Buffers_::Buffers_( const Buffers_&, sinusoi
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_poisson_generator::Parameters_::get( Dictionary& d ) const
+sinusoidal_poisson_generator::Parameters_::get( Dictionary& d ) const
 {
   d[ names::rate ] = rate_ * 1000.0;
   d[ names::frequency ] = om_ / ( 2.0 * numerics::pi / 1000.0 );
@@ -129,14 +128,14 @@ nest::sinusoidal_poisson_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::sinusoidal_poisson_generator::State_::get( Dictionary& d ) const
+sinusoidal_poisson_generator::State_::get( Dictionary& d ) const
 {
   d[ names::y_0 ] = y_0_;
   d[ names::y_1 ] = y_1_;
 }
 
 void
-nest::sinusoidal_poisson_generator::Parameters_::set( const Dictionary& d,
+sinusoidal_poisson_generator::Parameters_::set( const Dictionary& d,
   const sinusoidal_poisson_generator& n,
   Node* node )
 {
@@ -174,7 +173,7 @@ nest::sinusoidal_poisson_generator::Parameters_::set( const Dictionary& d,
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::sinusoidal_poisson_generator::sinusoidal_poisson_generator()
+sinusoidal_poisson_generator::sinusoidal_poisson_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -183,7 +182,7 @@ nest::sinusoidal_poisson_generator::sinusoidal_poisson_generator()
   recordablesMap_.create();
 }
 
-nest::sinusoidal_poisson_generator::sinusoidal_poisson_generator( const sinusoidal_poisson_generator& n )
+sinusoidal_poisson_generator::sinusoidal_poisson_generator( const sinusoidal_poisson_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -196,20 +195,20 @@ nest::sinusoidal_poisson_generator::sinusoidal_poisson_generator( const sinusoid
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_poisson_generator::init_state_()
+sinusoidal_poisson_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::sinusoidal_poisson_generator::init_buffers_()
+sinusoidal_poisson_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
 }
 
 void
-nest::sinusoidal_poisson_generator::pre_run_hook()
+sinusoidal_poisson_generator::pre_run_hook()
 {
   // ensures initialization in case mm connected after Simulate
   B_.logger_.init();
@@ -229,7 +228,7 @@ nest::sinusoidal_poisson_generator::pre_run_hook()
 }
 
 void
-nest::sinusoidal_poisson_generator::update( Time const& origin, const long from, const long to )
+sinusoidal_poisson_generator::update( Time const& origin, const long from, const long to )
 {
   const long start = origin.get_steps();
 
@@ -282,7 +281,7 @@ nest::sinusoidal_poisson_generator::update( Time const& origin, const long from,
 }
 
 void
-nest::sinusoidal_poisson_generator::event_hook( DSSpikeEvent& e )
+sinusoidal_poisson_generator::event_hook( DSSpikeEvent& e )
 {
   poisson_distribution::param_type param( S_.rate_ * V_.h_ );
   long n_spikes = V_.poisson_dist_( get_vp_specific_rng( get_thread() ), param );
@@ -295,7 +294,7 @@ nest::sinusoidal_poisson_generator::event_hook( DSSpikeEvent& e )
 }
 
 void
-nest::sinusoidal_poisson_generator::handle( DataLoggingRequest& e )
+sinusoidal_poisson_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -305,7 +304,7 @@ nest::sinusoidal_poisson_generator::handle( DataLoggingRequest& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::sinusoidal_poisson_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
+sinusoidal_poisson_generator::set_data_from_stimulation_backend( std::vector< double >& input_param )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -330,3 +329,5 @@ nest::sinusoidal_poisson_generator::set_data_from_stimulation_backend( std::vect
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/spike_dilutor.cpp
+++ b/models/spike_dilutor.cpp
@@ -33,8 +33,10 @@
 #include "nest_impl.h"
 
 
+namespace nest
+{
 void
-nest::register_spike_dilutor( const std::string& name )
+register_spike_dilutor( const std::string& name )
 {
   register_node_model< spike_dilutor >( name );
 }
@@ -44,7 +46,7 @@ nest::register_spike_dilutor( const std::string& name )
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::spike_dilutor::Parameters_::Parameters_()
+spike_dilutor::Parameters_::Parameters_()
   : p_copy_( 1.0 )
 {
 }
@@ -54,13 +56,13 @@ nest::spike_dilutor::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_dilutor::Parameters_::get( Dictionary& d ) const
+spike_dilutor::Parameters_::get( Dictionary& d ) const
 {
   d[ names::p_copy ] = p_copy_;
 }
 
 void
-nest::spike_dilutor::Parameters_::set( const Dictionary& d, Node* node )
+spike_dilutor::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::p_copy, p_copy_, node );
   if ( p_copy_ < 0 or p_copy_ > 1 )
@@ -73,14 +75,14 @@ nest::spike_dilutor::Parameters_::set( const Dictionary& d, Node* node )
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::spike_dilutor::spike_dilutor()
+spike_dilutor::spike_dilutor()
   : DeviceNode()
   , device_()
   , P_()
 {
 }
 
-nest::spike_dilutor::spike_dilutor( const spike_dilutor& n )
+spike_dilutor::spike_dilutor( const spike_dilutor& n )
   : DeviceNode( n )
   , device_( n.device_ )
   , P_( n.P_ )
@@ -92,7 +94,7 @@ nest::spike_dilutor::spike_dilutor( const spike_dilutor& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_dilutor::init_state_()
+spike_dilutor::init_state_()
 {
   // This check cannot be done in the copy constructor because that is also used to
   // create model prototypes. Since spike_dilutor is deprecated anyways, we put this
@@ -106,14 +108,14 @@ nest::spike_dilutor::init_state_()
 }
 
 void
-nest::spike_dilutor::init_buffers_()
+spike_dilutor::init_buffers_()
 {
   B_.n_spikes_.clear();  // includes resize
   device_.init_buffers();
 }
 
 void
-nest::spike_dilutor::pre_run_hook()
+spike_dilutor::pre_run_hook()
 {
   device_.pre_run_hook();
 }
@@ -123,7 +125,7 @@ nest::spike_dilutor::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_dilutor::update( Time const& T, const long from, const long to )
+spike_dilutor::update( Time const& T, const long from, const long to )
 {
   for ( long lag = from; lag < to; ++lag )
   {
@@ -146,7 +148,7 @@ nest::spike_dilutor::update( Time const& T, const long from, const long to )
 }
 
 void
-nest::spike_dilutor::event_hook( DSSpikeEvent& e )
+spike_dilutor::event_hook( DSSpikeEvent& e )
 {
   // Note: event_hook() receives a reference of the spike event that
   // was originally created in the update function. There we set
@@ -179,8 +181,10 @@ nest::spike_dilutor::event_hook( DSSpikeEvent& e )
 }
 
 void
-nest::spike_dilutor::handle( SpikeEvent& e )
+spike_dilutor::handle( SpikeEvent& e )
 {
   B_.n_spikes_.add_value( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     static_cast< double >( e.get_multiplicity() ) );
 }
+
+}  // namespace nest

--- a/models/spike_generator.cpp
+++ b/models/spike_generator.cpp
@@ -32,8 +32,10 @@
 #include "dict_util.h"
 
 
+namespace nest
+{
 void
-nest::register_spike_generator( const std::string& name )
+register_spike_generator( const std::string& name )
 {
   register_node_model< spike_generator >( name );
 }
@@ -42,7 +44,7 @@ nest::register_spike_generator( const std::string& name )
  * Default constructor defining default parameters
  * ---------------------------------------------------------------- */
 
-nest::spike_generator::Parameters_::Parameters_()
+spike_generator::Parameters_::Parameters_()
   : spike_stamps_()
   , spike_offsets_()
   , spike_weights_()
@@ -59,7 +61,7 @@ nest::spike_generator::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_generator::Parameters_::get( Dictionary& d ) const
+spike_generator::Parameters_::get( Dictionary& d ) const
 {
   const size_t n_spikes = spike_stamps_.size();
   std::vector< double > times_ms( n_spikes );
@@ -82,7 +84,7 @@ nest::spike_generator::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::spike_generator::Parameters_::assert_valid_spike_time_and_insert_( double t, const Time& origin, const Time& now )
+spike_generator::Parameters_::assert_valid_spike_time_and_insert_( double t, const Time& origin, const Time& now )
 {
   if ( t == 0.0 and not shift_now_spikes_ )
   {
@@ -147,7 +149,7 @@ nest::spike_generator::Parameters_::assert_valid_spike_time_and_insert_( double 
 }
 
 void
-nest::spike_generator::Parameters_::set( const Dictionary& d,
+spike_generator::Parameters_::set( const Dictionary& d,
   State_& s,
   const Time& origin,
   const Time& now,
@@ -266,7 +268,7 @@ nest::spike_generator::Parameters_::set( const Dictionary& d,
  * Default constructor defining default state
  * ---------------------------------------------------------------- */
 
-nest::spike_generator::State_::State_()
+spike_generator::State_::State_()
   : position_( 0 )
 {
 }
@@ -276,14 +278,14 @@ nest::spike_generator::State_::State_()
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::spike_generator::spike_generator()
+spike_generator::spike_generator()
   : StimulationDevice()
   , P_()
   , S_()
 {
 }
 
-nest::spike_generator::spike_generator( const spike_generator& n )
+spike_generator::spike_generator( const spike_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -296,19 +298,19 @@ nest::spike_generator::spike_generator( const spike_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_generator::init_state_()
+spike_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::spike_generator::init_buffers_()
+spike_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
 }
 
 void
-nest::spike_generator::pre_run_hook()
+spike_generator::pre_run_hook()
 {
   StimulationDevice::pre_run_hook();
 }
@@ -318,7 +320,7 @@ nest::spike_generator::pre_run_hook()
  * Other functions
  * ---------------------------------------------------------------- */
 void
-nest::spike_generator::update( Time const& sliceT0, const long from, const long to )
+spike_generator::update( Time const& sliceT0, const long from, const long to )
 {
   if ( P_.spike_stamps_.empty() )
   {
@@ -388,7 +390,7 @@ nest::spike_generator::update( Time const& sliceT0, const long from, const long 
 }
 
 void
-nest::spike_generator::event_hook( DSSpikeEvent& e )
+spike_generator::event_hook( DSSpikeEvent& e )
 {
   e.set_weight( P_.spike_weights_[ S_.position_ ] * e.get_weight() );
   e.get_receiver().handle( e );
@@ -400,7 +402,7 @@ nest::spike_generator::event_hook( DSSpikeEvent& e )
  * ---------------------------------------------------------------- */
 
 void
-nest::spike_generator::set_data_from_stimulation_backend( std::vector< double >& input_spikes )
+spike_generator::set_data_from_stimulation_backend( std::vector< double >& input_spikes )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -431,3 +433,5 @@ nest::spike_generator::set_data_from_stimulation_backend( std::vector< double >&
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/spike_generator.cpp
+++ b/models/spike_generator.cpp
@@ -149,11 +149,7 @@ spike_generator::Parameters_::assert_valid_spike_time_and_insert_( double t, con
 }
 
 void
-spike_generator::Parameters_::set( const Dictionary& d,
-  State_& s,
-  const Time& origin,
-  const Time& now,
-  Node* node )
+spike_generator::Parameters_::set( const Dictionary& d, State_& s, const Time& origin, const Time& now, Node* node )
 {
   bool precise_times_changed = update_value_param( d, names::precise_times, precise_times_, node );
   bool shift_now_spikes_changed = update_value_param( d, names::shift_now_spikes, shift_now_spikes_, node );

--- a/models/spike_generator.h
+++ b/models/spike_generator.h
@@ -361,7 +361,7 @@ spike_generator::get_status( Dictionary& d ) const
 }
 
 inline void
-nest::spike_generator::set_status( const Dictionary& d )
+spike_generator::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 

--- a/models/spike_recorder.cpp
+++ b/models/spike_recorder.cpp
@@ -33,43 +33,45 @@
 #include "nest_impl.h"
 
 
+namespace nest
+{
 void
-nest::register_spike_recorder( const std::string& name )
+register_spike_recorder( const std::string& name )
 {
   register_node_model< spike_recorder >( name );
 }
 
 
-nest::spike_recorder::spike_recorder()
+spike_recorder::spike_recorder()
   : RecordingDevice()
 {
 }
 
-nest::spike_recorder::spike_recorder( const spike_recorder& n )
+spike_recorder::spike_recorder( const spike_recorder& n )
   : RecordingDevice( n )
 {
 }
 
 void
-nest::spike_recorder::pre_run_hook()
+spike_recorder::pre_run_hook()
 {
   RecordingDevice::pre_run_hook( RecordingBackend::NO_DOUBLE_VALUE_NAMES, RecordingBackend::NO_LONG_VALUE_NAMES );
 }
 
 void
-nest::spike_recorder::update( Time const&, const long, const long )
+spike_recorder::update( Time const&, const long, const long )
 {
   // Nothing to do. Writing to the backend happens in handle().
 }
 
-nest::RecordingDevice::Type
-nest::spike_recorder::get_type() const
+RecordingDevice::Type
+spike_recorder::get_type() const
 {
   return RecordingDevice::SPIKE_RECORDER;
 }
 
 void
-nest::spike_recorder::get_status( Dictionary& d ) const
+spike_recorder::get_status( Dictionary& d ) const
 {
   RecordingDevice::get_status( d );
 
@@ -91,13 +93,13 @@ nest::spike_recorder::get_status( Dictionary& d ) const
 }
 
 void
-nest::spike_recorder::set_status( const Dictionary& d )
+spike_recorder::set_status( const Dictionary& d )
 {
   RecordingDevice::set_status( d );
 }
 
 void
-nest::spike_recorder::handle( SpikeEvent& e )
+spike_recorder::handle( SpikeEvent& e )
 {
   // accept spikes only if detector was active when spike was emitted
   if ( is_active( e.get_stamp() ) )
@@ -110,3 +112,5 @@ nest::spike_recorder::handle( SpikeEvent& e )
     }
   }
 }
+
+}  // namespace nest

--- a/models/spike_train_injector.cpp
+++ b/models/spike_train_injector.cpp
@@ -32,6 +32,7 @@
 // Includes from libnestutil:
 #include "dict_util.h"
 
+
 namespace nest
 {
 void

--- a/models/spin_detector.cpp
+++ b/models/spin_detector.cpp
@@ -33,20 +33,22 @@
 #include "nest_impl.h"
 
 
+namespace nest
+{
 void
-nest::register_spin_detector( const std::string& name )
+register_spin_detector( const std::string& name )
 {
   register_node_model< spin_detector >( name );
 }
 
 
-nest::spin_detector::spin_detector()
+spin_detector::spin_detector()
   : last_in_node_id_( 0 )
   , t_last_in_spike_( Time::neg_inf() )
 {
 }
 
-nest::spin_detector::spin_detector( const spin_detector& n )
+spin_detector::spin_detector( const spin_detector& n )
   : RecordingDevice( n )
   , last_in_node_id_( 0 )
   , t_last_in_spike_( Time::neg_inf() )  // mark as not initialized
@@ -54,18 +56,18 @@ nest::spin_detector::spin_detector( const spin_detector& n )
 }
 
 void
-nest::spin_detector::init_buffers_()
+spin_detector::init_buffers_()
 {
 }
 
 void
-nest::spin_detector::pre_run_hook()
+spin_detector::pre_run_hook()
 {
-  RecordingDevice::pre_run_hook( RecordingBackend::NO_DOUBLE_VALUE_NAMES, { nest::names::state } );
+  RecordingDevice::pre_run_hook( RecordingBackend::NO_DOUBLE_VALUE_NAMES, { names::state } );
 }
 
 void
-nest::spin_detector::update( Time const&, const long, const long )
+spin_detector::update( Time const&, const long, const long )
 {
   if ( last_in_node_id_ != 0 )  // if last_* is empty we dont write
   {
@@ -74,14 +76,14 @@ nest::spin_detector::update( Time const&, const long, const long )
   }
 }
 
-nest::RecordingDevice::Type
-nest::spin_detector::get_type() const
+RecordingDevice::Type
+spin_detector::get_type() const
 {
   return RecordingDevice::SPIN_DETECTOR;
 }
 
 void
-nest::spin_detector::get_status( Dictionary& d ) const
+spin_detector::get_status( Dictionary& d ) const
 {
   // get the data from the device
   RecordingDevice::get_status( d );
@@ -105,14 +107,14 @@ nest::spin_detector::get_status( Dictionary& d ) const
 }
 
 void
-nest::spin_detector::set_status( const Dictionary& d )
+spin_detector::set_status( const Dictionary& d )
 {
   RecordingDevice::set_status( d );
 }
 
 
 void
-nest::spin_detector::handle( SpikeEvent& e )
+spin_detector::handle( SpikeEvent& e )
 {
   // accept spikes only if detector was active when spike was
   // emitted
@@ -167,3 +169,5 @@ nest::spin_detector::handle( SpikeEvent& e )
     }
   }
 }
+
+}  // namespace nest

--- a/models/spin_detector.h
+++ b/models/spin_detector.h
@@ -180,7 +180,7 @@ spin_detector::receives_signal() const
 }
 
 inline void
-nest::spin_detector::calibrate_time( const TimeConverter& tc )
+spin_detector::calibrate_time( const TimeConverter& tc )
 {
   t_last_in_spike_ = tc.from_old_tics( t_last_in_spike_.get_tics() );
 }

--- a/models/static_synapse.cpp
+++ b/models/static_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_static_synapse( const std::string& name )
+register_static_synapse( const std::string& name )
 {
   register_connection_model< static_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/static_synapse_hom_w.cpp
+++ b/models/static_synapse_hom_w.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_static_synapse_hom_w( const std::string& name )
+register_static_synapse_hom_w( const std::string& name )
 {
   register_connection_model< static_synapse_hom_w >( name );
 }
+
+}  // namespace nest

--- a/models/stdp_dopamine_synapse.cpp
+++ b/models/stdp_dopamine_synapse.cpp
@@ -30,14 +30,14 @@
 #include "nest_impl.h"
 
 
+namespace nest
+{
 void
-nest::register_stdp_dopamine_synapse( const std::string& name )
+register_stdp_dopamine_synapse( const std::string& name )
 {
   register_connection_model< stdp_dopamine_synapse >( name );
 }
 
-namespace nest
-{
 //
 // Implementation of class STDPDopaCommonProperties.
 //
@@ -106,4 +106,4 @@ STDPDopaCommonProperties::set_status( const Dictionary& d, ConnectorModel& cm )
   d.update_value( names::tau_plus, tau_plus_ );
 }
 
-}  // of namespace nest
+}  // namespace nest

--- a/models/stdp_facetshw_synapse_hom.cpp
+++ b/models/stdp_facetshw_synapse_hom.cpp
@@ -26,8 +26,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_facetshw_synapse_hom( const std::string& name )
+register_stdp_facetshw_synapse_hom( const std::string& name )
 {
   register_connection_model< stdp_facetshw_synapse_hom >( name );
 }
+
+}  // namespace nest

--- a/models/stdp_nn_pre_centered_synapse.cpp
+++ b/models/stdp_nn_pre_centered_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_nn_pre_centered_synapse( const std::string& name )
+register_stdp_nn_pre_centered_synapse( const std::string& name )
 {
   register_connection_model< stdp_nn_pre_centered_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/stdp_nn_restr_synapse.cpp
+++ b/models/stdp_nn_restr_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_nn_restr_synapse( const std::string& name )
+register_stdp_nn_restr_synapse( const std::string& name )
 {
   register_connection_model< stdp_nn_restr_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/stdp_nn_symm_synapse.cpp
+++ b/models/stdp_nn_symm_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_nn_symm_synapse( const std::string& name )
+register_stdp_nn_symm_synapse( const std::string& name )
 {
   register_connection_model< stdp_nn_symm_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/stdp_pl_synapse_hom.cpp
+++ b/models/stdp_pl_synapse_hom.cpp
@@ -28,14 +28,15 @@
 #include "event.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_pl_synapse_hom( const std::string& name )
+register_stdp_pl_synapse_hom( const std::string& name )
 {
   register_connection_model< stdp_pl_synapse_hom >( name );
 }
 
-namespace nest
-{
 
 //
 // Implementation of class STDPPLHomCommonProperties.
@@ -81,4 +82,4 @@ STDPPLHomCommonProperties::set_status( const Dictionary& d, ConnectorModel& cm )
   d.update_value( names::mu, mu_ );
 }
 
-}  // of namespace nest
+}  // namespace nest

--- a/models/stdp_synapse.cpp
+++ b/models/stdp_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_synapse( const std::string& name )
+register_stdp_synapse( const std::string& name )
 {
   register_connection_model< stdp_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/stdp_synapse_hom.cpp
+++ b/models/stdp_synapse_hom.cpp
@@ -28,14 +28,14 @@
 #include "nest_impl.h"
 
 
+namespace nest
+{
 void
-nest::register_stdp_synapse_hom( const std::string& name )
+register_stdp_synapse_hom( const std::string& name )
 {
   register_connection_model< stdp_synapse_hom >( name );
 }
 
-namespace nest
-{
 
 STDPHomCommonProperties::STDPHomCommonProperties()
   : CommonSynapseProperties()
@@ -74,4 +74,4 @@ STDPHomCommonProperties::set_status( const Dictionary& d, ConnectorModel& cm )
   d.update_value( names::Wmax, Wmax_ );
 }
 
-}  // of namespace nest
+}  // namespace nest

--- a/models/stdp_triplet_synapse.cpp
+++ b/models/stdp_triplet_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_stdp_triplet_synapse( const std::string& name )
+register_stdp_triplet_synapse( const std::string& name )
 {
   register_connection_model< stdp_triplet_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/step_current_generator.cpp
+++ b/models/step_current_generator.cpp
@@ -45,28 +45,27 @@ RecordablesMap< step_current_generator >::create()
 {
   insert_( names::I, &step_current_generator::get_I_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::step_current_generator::Parameters_::Parameters_()
+step_current_generator::Parameters_::Parameters_()
   : amp_time_stamps_()
   , amp_values_()  // pA
   , allow_offgrid_amp_times_( false )
 {
 }
 
-nest::step_current_generator::Parameters_::Parameters_( const Parameters_& p )
+step_current_generator::Parameters_::Parameters_( const Parameters_& p )
   : amp_time_stamps_( p.amp_time_stamps_ )
   , amp_values_( p.amp_values_ )
   , allow_offgrid_amp_times_( p.allow_offgrid_amp_times_ )
 {
 }
 
-nest::step_current_generator::Parameters_&
-nest::step_current_generator::Parameters_::operator=( const Parameters_& p )
+step_current_generator::Parameters_&
+step_current_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -80,19 +79,19 @@ nest::step_current_generator::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::step_current_generator::State_::State_()
+step_current_generator::State_::State_()
   : I_( 0.0 )  // pA
 {
 }
 
-nest::step_current_generator::Buffers_::Buffers_( step_current_generator& n )
+step_current_generator::Buffers_::Buffers_( step_current_generator& n )
   : idx_( 0 )
   , amp_( 0 )
   , logger_( n )
 {
 }
 
-nest::step_current_generator::Buffers_::Buffers_( const Buffers_&, step_current_generator& n )
+step_current_generator::Buffers_::Buffers_( const Buffers_&, step_current_generator& n )
   : idx_( 0 )
   , amp_( 0 )
   , logger_( n )
@@ -104,7 +103,7 @@ nest::step_current_generator::Buffers_::Buffers_( const Buffers_&, step_current_
  * ---------------------------------------------------------------- */
 
 void
-nest::step_current_generator::Parameters_::get( Dictionary& d ) const
+step_current_generator::Parameters_::get( Dictionary& d ) const
 {
   std::vector< double > times_ms;
   times_ms.reserve( amp_time_stamps_.size() );
@@ -117,8 +116,8 @@ nest::step_current_generator::Parameters_::get( Dictionary& d ) const
   d[ names::allow_offgrid_times ] = allow_offgrid_amp_times_;
 }
 
-nest::Time
-nest::step_current_generator::Parameters_::validate_time_( double t, const Time& t_previous )
+Time
+step_current_generator::Parameters_::validate_time_( double t, const Time& t_previous )
 {
   if ( t <= 0.0 )
   {
@@ -162,7 +161,7 @@ nest::step_current_generator::Parameters_::validate_time_( double t, const Time&
 }
 
 void
-nest::step_current_generator::Parameters_::set( const Dictionary& d, Buffers_& b, Node* )
+step_current_generator::Parameters_::set( const Dictionary& d, Buffers_& b, Node* )
 {
   std::vector< double > new_times;
   const bool times_changed = d.update_value( names::amplitude_times, new_times );
@@ -222,7 +221,7 @@ nest::step_current_generator::Parameters_::set( const Dictionary& d, Buffers_& b
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::step_current_generator::step_current_generator()
+step_current_generator::step_current_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -231,7 +230,7 @@ nest::step_current_generator::step_current_generator()
   recordablesMap_.create();
 }
 
-nest::step_current_generator::step_current_generator( const step_current_generator& n )
+step_current_generator::step_current_generator( const step_current_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -245,13 +244,13 @@ nest::step_current_generator::step_current_generator( const step_current_generat
  * ---------------------------------------------------------------- */
 
 void
-nest::step_current_generator::init_state_()
+step_current_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::step_current_generator::init_buffers_()
+step_current_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
@@ -261,7 +260,7 @@ nest::step_current_generator::init_buffers_()
 }
 
 void
-nest::step_current_generator::pre_run_hook()
+step_current_generator::pre_run_hook()
 {
   B_.logger_.init();
   StimulationDevice::pre_run_hook();
@@ -273,7 +272,7 @@ nest::step_current_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::step_current_generator::update( Time const& origin, const long from, const long to )
+step_current_generator::update( Time const& origin, const long from, const long to )
 {
   assert( P_.amp_time_stamps_.size() == P_.amp_values_.size() );
 
@@ -315,7 +314,7 @@ nest::step_current_generator::update( Time const& origin, const long from, const
 }
 
 void
-nest::step_current_generator::handle( DataLoggingRequest& e )
+step_current_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -324,7 +323,7 @@ nest::step_current_generator::handle( DataLoggingRequest& e )
  * Other functions
  * ---------------------------------------------------------------- */
 void
-nest::step_current_generator::set_data_from_stimulation_backend( std::vector< double >& time_amplitude )
+step_current_generator::set_data_from_stimulation_backend( std::vector< double >& time_amplitude )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -363,3 +362,5 @@ nest::step_current_generator::set_data_from_stimulation_backend( std::vector< do
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/step_rate_generator.cpp
+++ b/models/step_rate_generator.cpp
@@ -45,28 +45,27 @@ RecordablesMap< step_rate_generator >::create()
 {
   insert_( names::rate, &step_rate_generator::get_rate_ );
 }
-}
 
 /* ----------------------------------------------------------------
  * Default constructors defining default parameter
  * ---------------------------------------------------------------- */
 
-nest::step_rate_generator::Parameters_::Parameters_()
+step_rate_generator::Parameters_::Parameters_()
   : amp_time_stamps_()
   , amp_values_()  // pA
   , allow_offgrid_amp_times_( false )
 {
 }
 
-nest::step_rate_generator::Parameters_::Parameters_( const Parameters_& p )
+step_rate_generator::Parameters_::Parameters_( const Parameters_& p )
   : amp_time_stamps_( p.amp_time_stamps_ )
   , amp_values_( p.amp_values_ )
   , allow_offgrid_amp_times_( p.allow_offgrid_amp_times_ )
 {
 }
 
-nest::step_rate_generator::Parameters_&
-nest::step_rate_generator::Parameters_::operator=( const Parameters_& p )
+step_rate_generator::Parameters_&
+step_rate_generator::Parameters_::operator=( const Parameters_& p )
 {
   if ( this == &p )
   {
@@ -80,19 +79,19 @@ nest::step_rate_generator::Parameters_::operator=( const Parameters_& p )
   return *this;
 }
 
-nest::step_rate_generator::State_::State_()
+step_rate_generator::State_::State_()
   : rate_( 0.0 )
 {
 }
 
-nest::step_rate_generator::Buffers_::Buffers_( step_rate_generator& n )
+step_rate_generator::Buffers_::Buffers_( step_rate_generator& n )
   : idx_( 0 )
   , amp_( 0 )
   , logger_( n )
 {
 }
 
-nest::step_rate_generator::Buffers_::Buffers_( const Buffers_&, step_rate_generator& n )
+step_rate_generator::Buffers_::Buffers_( const Buffers_&, step_rate_generator& n )
   : idx_( 0 )
   , amp_( 0 )
   , logger_( n )
@@ -104,7 +103,7 @@ nest::step_rate_generator::Buffers_::Buffers_( const Buffers_&, step_rate_genera
  * ---------------------------------------------------------------- */
 
 void
-nest::step_rate_generator::Parameters_::get( Dictionary& d ) const
+step_rate_generator::Parameters_::get( Dictionary& d ) const
 {
   std::vector< double > times_ms;
   times_ms.reserve( amp_time_stamps_.size() );
@@ -117,8 +116,8 @@ nest::step_rate_generator::Parameters_::get( Dictionary& d ) const
   d[ names::allow_offgrid_times ] = allow_offgrid_amp_times_;
 }
 
-nest::Time
-nest::step_rate_generator::Parameters_::validate_time_( double t, const Time& t_previous )
+Time
+step_rate_generator::Parameters_::validate_time_( double t, const Time& t_previous )
 {
   if ( t <= 0.0 )
   {
@@ -162,7 +161,7 @@ nest::step_rate_generator::Parameters_::validate_time_( double t, const Time& t_
 }
 
 void
-nest::step_rate_generator::Parameters_::set( const Dictionary& d, Buffers_& b, Node* )
+step_rate_generator::Parameters_::set( const Dictionary& d, Buffers_& b, Node* )
 {
   std::vector< double > new_times;
   const bool times_changed = d.update_value( names::amplitude_times, new_times );
@@ -222,7 +221,7 @@ nest::step_rate_generator::Parameters_::set( const Dictionary& d, Buffers_& b, N
  * Default and copy constructor for node
  * ---------------------------------------------------------------- */
 
-nest::step_rate_generator::step_rate_generator()
+step_rate_generator::step_rate_generator()
   : StimulationDevice()
   , P_()
   , S_()
@@ -231,7 +230,7 @@ nest::step_rate_generator::step_rate_generator()
   recordablesMap_.create();
 }
 
-nest::step_rate_generator::step_rate_generator( const step_rate_generator& n )
+step_rate_generator::step_rate_generator( const step_rate_generator& n )
   : StimulationDevice( n )
   , P_( n.P_ )
   , S_( n.S_ )
@@ -245,13 +244,13 @@ nest::step_rate_generator::step_rate_generator( const step_rate_generator& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::step_rate_generator::init_state_()
+step_rate_generator::init_state_()
 {
   StimulationDevice::init_state();
 }
 
 void
-nest::step_rate_generator::init_buffers_()
+step_rate_generator::init_buffers_()
 {
   StimulationDevice::init_buffers();
   B_.logger_.reset();
@@ -261,7 +260,7 @@ nest::step_rate_generator::init_buffers_()
 }
 
 void
-nest::step_rate_generator::pre_run_hook()
+step_rate_generator::pre_run_hook()
 {
   B_.logger_.init();
 
@@ -274,7 +273,7 @@ nest::step_rate_generator::pre_run_hook()
  * ---------------------------------------------------------------- */
 
 void
-nest::step_rate_generator::update( Time const& origin, const long from, const long to )
+step_rate_generator::update( Time const& origin, const long from, const long to )
 {
   assert( P_.amp_time_stamps_.size() == P_.amp_values_.size() );
 
@@ -328,7 +327,7 @@ nest::step_rate_generator::update( Time const& origin, const long from, const lo
 }
 
 void
-nest::step_rate_generator::handle( DataLoggingRequest& e )
+step_rate_generator::handle( DataLoggingRequest& e )
 {
   B_.logger_.handle( e );
 }
@@ -337,7 +336,7 @@ nest::step_rate_generator::handle( DataLoggingRequest& e )
  * Other functions
  * ---------------------------------------------------------------- */
 void
-nest::step_rate_generator::set_data_from_stimulation_backend( std::vector< double >& time_amplitude )
+step_rate_generator::set_data_from_stimulation_backend( std::vector< double >& time_amplitude )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
 
@@ -376,3 +375,5 @@ nest::step_rate_generator::set_data_from_stimulation_backend( std::vector< doubl
   // if we get here, temporary contains consistent set of properties
   P_ = ptmp;
 }
+
+}  // namespace nest

--- a/models/tanh_rate.cpp
+++ b/models/tanh_rate.cpp
@@ -27,6 +27,7 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -68,29 +69,29 @@ nonlinearities_tanh_rate::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::tanh_rate_ipn >::create()
+RecordablesMap< tanh_rate_ipn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::tanh_rate_ipn::get_rate_ );
-  insert_( names::noise, &nest::tanh_rate_ipn::get_noise_ );
+  insert_( names::rate, &tanh_rate_ipn::get_rate_ );
+  insert_( names::noise, &tanh_rate_ipn::get_noise_ );
 }
 
 template <>
 void
-RecordablesMap< nest::tanh_rate_opn >::create()
+RecordablesMap< tanh_rate_opn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::tanh_rate_opn::get_rate_ );
-  insert_( names::noise, &nest::tanh_rate_opn::get_noise_ );
-  insert_( names::noisy_rate, &nest::tanh_rate_opn::get_noisy_rate_ );
+  insert_( names::rate, &tanh_rate_opn::get_rate_ );
+  insert_( names::noise, &tanh_rate_opn::get_noise_ );
+  insert_( names::noisy_rate, &tanh_rate_opn::get_noisy_rate_ );
 }
 
 template <>
 void
-RecordablesMap< nest::rate_transformer_tanh >::create()
+RecordablesMap< rate_transformer_tanh >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::rate_transformer_tanh::get_rate_ );
+  insert_( names::rate, &rate_transformer_tanh::get_rate_ );
 }
 
 }  // namespace nest

--- a/models/tanh_rate.h
+++ b/models/tanh_rate.h
@@ -160,13 +160,13 @@ nonlinearities_tanh_rate::mult_coupling_in( double )
   return 1.;
 }
 
-typedef rate_neuron_ipn< nest::nonlinearities_tanh_rate > tanh_rate_ipn;
+typedef rate_neuron_ipn< nonlinearities_tanh_rate > tanh_rate_ipn;
 void register_tanh_rate_ipn( const std::string& name );
 
-typedef rate_neuron_opn< nest::nonlinearities_tanh_rate > tanh_rate_opn;
+typedef rate_neuron_opn< nonlinearities_tanh_rate > tanh_rate_opn;
 void register_tanh_rate_opn( const std::string& name );
 
-typedef rate_transformer_node< nest::nonlinearities_tanh_rate > rate_transformer_tanh;
+typedef rate_transformer_node< nonlinearities_tanh_rate > rate_transformer_tanh;
 void register_rate_transformer_tanh( const std::string& name );
 
 

--- a/models/threshold_lin_rate.cpp
+++ b/models/threshold_lin_rate.cpp
@@ -27,6 +27,7 @@
 #include "model_manager_impl.h"
 #include "nest_impl.h"
 
+
 namespace nest
 {
 void
@@ -70,29 +71,29 @@ nonlinearities_threshold_lin_rate::set( const Dictionary& d, Node* node )
  */
 template <>
 void
-RecordablesMap< nest::threshold_lin_rate_ipn >::create()
+RecordablesMap< threshold_lin_rate_ipn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::threshold_lin_rate_ipn::get_rate_ );
-  insert_( names::noise, &nest::threshold_lin_rate_ipn::get_noise_ );
+  insert_( names::rate, &threshold_lin_rate_ipn::get_rate_ );
+  insert_( names::noise, &threshold_lin_rate_ipn::get_noise_ );
 }
 
 template <>
 void
-RecordablesMap< nest::threshold_lin_rate_opn >::create()
+RecordablesMap< threshold_lin_rate_opn >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::threshold_lin_rate_opn::get_rate_ );
-  insert_( names::noise, &nest::threshold_lin_rate_opn::get_noise_ );
-  insert_( names::noisy_rate, &nest::threshold_lin_rate_opn::get_noisy_rate_ );
+  insert_( names::rate, &threshold_lin_rate_opn::get_rate_ );
+  insert_( names::noise, &threshold_lin_rate_opn::get_noise_ );
+  insert_( names::noisy_rate, &threshold_lin_rate_opn::get_noisy_rate_ );
 }
 
 template <>
 void
-RecordablesMap< nest::rate_transformer_threshold_lin >::create()
+RecordablesMap< rate_transformer_threshold_lin >::create()
 {
   // use standard names wherever you can for consistency!
-  insert_( names::rate, &nest::rate_transformer_threshold_lin::get_rate_ );
+  insert_( names::rate, &rate_transformer_threshold_lin::get_rate_ );
 }
 
 }  // namespace nest

--- a/models/threshold_lin_rate.h
+++ b/models/threshold_lin_rate.h
@@ -168,13 +168,13 @@ nonlinearities_threshold_lin_rate::mult_coupling_in( double )
   return 1.;
 }
 
-typedef rate_neuron_ipn< nest::nonlinearities_threshold_lin_rate > threshold_lin_rate_ipn;
+typedef rate_neuron_ipn< nonlinearities_threshold_lin_rate > threshold_lin_rate_ipn;
 void register_threshold_lin_rate_ipn( const std::string& name );
 
-typedef rate_neuron_opn< nest::nonlinearities_threshold_lin_rate > threshold_lin_rate_opn;
+typedef rate_neuron_opn< nonlinearities_threshold_lin_rate > threshold_lin_rate_opn;
 void register_threshold_lin_rate_opn( const std::string& name );
 
-typedef rate_transformer_node< nest::nonlinearities_threshold_lin_rate > rate_transformer_threshold_lin;
+typedef rate_transformer_node< nonlinearities_threshold_lin_rate > rate_transformer_threshold_lin;
 void register_rate_transformer_threshold_lin( const std::string& name );
 
 

--- a/models/tsodyks2_synapse.cpp
+++ b/models/tsodyks2_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_tsodyks2_synapse( const std::string& name )
+register_tsodyks2_synapse( const std::string& name )
 {
   register_connection_model< tsodyks2_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/tsodyks_synapse.cpp
+++ b/models/tsodyks_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_tsodyks_synapse( const std::string& name )
+register_tsodyks_synapse( const std::string& name )
 {
   register_connection_model< tsodyks_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/tsodyks_synapse_hom.cpp
+++ b/models/tsodyks_synapse_hom.cpp
@@ -36,7 +36,6 @@ register_tsodyks_synapse_hom( const std::string& name )
 }
 
 
-
 //
 // Implementation of class TsodyksHomCommonProperties.
 //

--- a/models/tsodyks_synapse_hom.cpp
+++ b/models/tsodyks_synapse_hom.cpp
@@ -26,15 +26,16 @@
 #include "connector_model.h"
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_tsodyks_synapse_hom( const std::string& name )
+register_tsodyks_synapse_hom( const std::string& name )
 {
   register_connection_model< tsodyks_synapse_hom >( name );
 }
 
 
-namespace nest
-{
 
 //
 // Implementation of class TsodyksHomCommonProperties.
@@ -90,4 +91,4 @@ TsodyksHomCommonProperties::set_status( const Dictionary& d, ConnectorModel& cm 
   }
 }
 
-}  // of namespace nest
+}  // namespace nest

--- a/models/urbanczik_synapse.cpp
+++ b/models/urbanczik_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_urbanczik_synapse( const std::string& name )
+register_urbanczik_synapse( const std::string& name )
 {
   register_connection_model< urbanczik_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/vogels_sprekeler_synapse.cpp
+++ b/models/vogels_sprekeler_synapse.cpp
@@ -25,8 +25,13 @@
 // Includes from nestkernel:
 #include "nest_impl.h"
 
+
+namespace nest
+{
 void
-nest::register_vogels_sprekeler_synapse( const std::string& name )
+register_vogels_sprekeler_synapse( const std::string& name )
 {
   register_connection_model< vogels_sprekeler_synapse >( name );
 }
+
+}  // namespace nest

--- a/models/volume_transmitter.cpp
+++ b/models/volume_transmitter.cpp
@@ -35,8 +35,10 @@
 #include "dict_util.h"
 
 
+namespace nest
+{
 void
-nest::register_volume_transmitter( const std::string& name )
+register_volume_transmitter( const std::string& name )
 {
   register_node_model< volume_transmitter >( name );
 }
@@ -46,7 +48,7 @@ nest::register_volume_transmitter( const std::string& name )
  * Default constructor defining default parameters
  * ---------------------------------------------------------------- */
 
-nest::volume_transmitter::Parameters_::Parameters_()
+volume_transmitter::Parameters_::Parameters_()
   : deliver_interval_( 1 )  // in steps of mindelay
 {
 }
@@ -56,12 +58,12 @@ nest::volume_transmitter::Parameters_::Parameters_()
  * ---------------------------------------------------------------- */
 
 void
-nest::volume_transmitter::Parameters_::get( Dictionary& d ) const
+volume_transmitter::Parameters_::get( Dictionary& d ) const
 {
   d[ names::deliver_interval ] = deliver_interval_;
 }
 
-void ::nest::volume_transmitter::Parameters_::set( const Dictionary& d, Node* node )
+void volume_transmitter::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::deliver_interval, deliver_interval_, node );
 }
@@ -70,14 +72,14 @@ void ::nest::volume_transmitter::Parameters_::set( const Dictionary& d, Node* no
  * Default and copy constructor for volume transmitter
  * ---------------------------------------------------------------- */
 
-nest::volume_transmitter::volume_transmitter()
+volume_transmitter::volume_transmitter()
   : Node()
   , P_()
   , local_device_id_( 0 )
 {
 }
 
-nest::volume_transmitter::volume_transmitter( const volume_transmitter& n )
+volume_transmitter::volume_transmitter( const volume_transmitter& n )
   : Node( n )
   , P_( n.P_ )
   , local_device_id_( n.local_device_id_ )
@@ -85,7 +87,7 @@ nest::volume_transmitter::volume_transmitter( const volume_transmitter& n )
 }
 
 void
-nest::volume_transmitter::init_buffers_()
+volume_transmitter::init_buffers_()
 {
   B_.neuromodulatory_spikes_.clear();
   B_.spikecounter_.clear();
@@ -93,14 +95,14 @@ nest::volume_transmitter::init_buffers_()
 }
 
 void
-nest::volume_transmitter::pre_run_hook()
+volume_transmitter::pre_run_hook()
 {
   // +1 as pseudo dopa spike at t_trig is inserted after trigger_update_weight
   B_.spikecounter_.reserve( kernel().connection_manager.get_min_delay() * P_.deliver_interval_ + 1 );
 }
 
 void
-nest::volume_transmitter::update( const Time&, const long from, const long to )
+volume_transmitter::update( const Time&, const long from, const long to )
 {
   // spikes that arrive in this time slice are stored in spikecounter_
   double t_spike;
@@ -137,8 +139,10 @@ nest::volume_transmitter::update( const Time&, const long from, const long to )
 }
 
 void
-nest::volume_transmitter::handle( SpikeEvent& e )
+volume_transmitter::handle( SpikeEvent& e )
 {
   B_.neuromodulatory_spikes_.add_value( e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
     static_cast< double >( e.get_multiplicity() ) );
 }
+
+}  // namespace nest

--- a/models/volume_transmitter.cpp
+++ b/models/volume_transmitter.cpp
@@ -63,7 +63,8 @@ volume_transmitter::Parameters_::get( Dictionary& d ) const
   d[ names::deliver_interval ] = deliver_interval_;
 }
 
-void volume_transmitter::Parameters_::set( const Dictionary& d, Node* node )
+void
+volume_transmitter::Parameters_::set( const Dictionary& d, Node* node )
 {
   update_value_param( d, names::deliver_interval, deliver_interval_, node );
 }

--- a/models/volume_transmitter.h
+++ b/models/volume_transmitter.h
@@ -220,7 +220,7 @@ volume_transmitter::set_status( const Dictionary& d )
   P_ = ptmp;
 }
 
-inline const std::vector< nest::spikecounter >&
+inline const std::vector< spikecounter >&
 volume_transmitter::deliver_spikes()
 {
   return B_.spikecounter_;

--- a/models/weight_optimizer.cpp
+++ b/models/weight_optimizer.cpp
@@ -28,6 +28,7 @@
 #include "exceptions.h"
 #include "nest_names.h"
 
+
 namespace nest
 {
 WeightOptimizerCommonProperties::WeightOptimizerCommonProperties()

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -33,20 +33,23 @@
 #include "nest_impl.h"
 #include "node_collection.h"
 
+
+namespace nest
+{
 void
-nest::register_weight_recorder( const std::string& name )
+register_weight_recorder( const std::string& name )
 {
   register_node_model< weight_recorder >( name );
 }
 
 // record time, node ID, weight and receiver node ID
-nest::weight_recorder::weight_recorder()
+weight_recorder::weight_recorder()
   : RecordingDevice()
   , P_()
 {
 }
 
-nest::weight_recorder::weight_recorder( const weight_recorder& n )
+weight_recorder::weight_recorder( const weight_recorder& n )
   : RecordingDevice( n )
   , P_( n.P_ )
 {
@@ -54,21 +57,21 @@ nest::weight_recorder::weight_recorder( const weight_recorder& n )
 
 // We must initialize senders and targets here with empty NCs because
 // they will be returned by get_status()
-nest::weight_recorder::Parameters_::Parameters_()
+weight_recorder::Parameters_::Parameters_()
   : senders_( new NodeCollectionPrimitive() )
   , targets_( new NodeCollectionPrimitive() )
 {
 }
 
 void
-nest::weight_recorder::Parameters_::get( Dictionary& d ) const
+weight_recorder::Parameters_::get( Dictionary& d ) const
 {
   d[ names::senders ] = senders_;
   d[ names::targets ] = targets_;
 }
 
 void
-nest::weight_recorder::Parameters_::set( const Dictionary& d )
+weight_recorder::Parameters_::set( const Dictionary& d )
 {
   auto update_nc = [ &d ]( NodeCollectionPTR& nc, const std::string& key )
   {
@@ -100,25 +103,25 @@ nest::weight_recorder::Parameters_::set( const Dictionary& d )
 }
 
 void
-nest::weight_recorder::pre_run_hook()
+weight_recorder::pre_run_hook()
 {
   RecordingDevice::pre_run_hook(
-    { nest::names::weights }, { nest::names::targets, nest::names::receptors, nest::names::ports } );
+    { names::weights }, { names::targets, names::receptors, names::ports } );
 }
 
 void
-nest::weight_recorder::update( Time const&, const long, const long )
+weight_recorder::update( Time const&, const long, const long )
 {
 }
 
-nest::RecordingDevice::Type
-nest::weight_recorder::get_type() const
+RecordingDevice::Type
+weight_recorder::get_type() const
 {
   return RecordingDevice::WEIGHT_RECORDER;
 }
 
 void
-nest::weight_recorder::get_status( Dictionary& d ) const
+weight_recorder::get_status( Dictionary& d ) const
 {
   // get the data from the device
   RecordingDevice::get_status( d );
@@ -144,7 +147,7 @@ nest::weight_recorder::get_status( Dictionary& d ) const
 }
 
 void
-nest::weight_recorder::set_status( const Dictionary& d )
+weight_recorder::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;
   ptmp.set( d );
@@ -155,7 +158,7 @@ nest::weight_recorder::set_status( const Dictionary& d )
 
 
 void
-nest::weight_recorder::handle( WeightRecorderEvent& e )
+weight_recorder::handle( WeightRecorderEvent& e )
 {
   // accept spikes only if recorder was active when spike was emitted
   if ( is_active( e.get_stamp() ) )
@@ -175,3 +178,5 @@ nest::weight_recorder::handle( WeightRecorderEvent& e )
         static_cast< long >( e.get_port() ) } );
   }
 }
+
+}  // namespace nest

--- a/models/weight_recorder.cpp
+++ b/models/weight_recorder.cpp
@@ -105,8 +105,7 @@ weight_recorder::Parameters_::set( const Dictionary& d )
 void
 weight_recorder::pre_run_hook()
 {
-  RecordingDevice::pre_run_hook(
-    { names::weights }, { names::targets, names::receptors, names::ports } );
+  RecordingDevice::pre_run_hook( { names::weights }, { names::targets, names::receptors, names::ports } );
 }
 
 void

--- a/nestkernel/archiving_node.cpp
+++ b/nestkernel/archiving_node.cpp
@@ -31,7 +31,7 @@ namespace nest
 
 // member functions for ArchivingNode
 
-nest::ArchivingNode::ArchivingNode()
+ArchivingNode::ArchivingNode()
   : StructuralPlasticityNode()
   , IgnoreAndSpikeMechanism()
   , n_incoming_( 0 )
@@ -47,7 +47,7 @@ nest::ArchivingNode::ArchivingNode()
 {
 }
 
-nest::ArchivingNode::ArchivingNode( const ArchivingNode& n )
+ArchivingNode::ArchivingNode( const ArchivingNode& n )
   : StructuralPlasticityNode( n )
   , IgnoreAndSpikeMechanism( n )
   , n_incoming_( n.n_incoming_ )
@@ -84,7 +84,7 @@ ArchivingNode::register_stdp_connection( double t_first_read, double delay )
 }
 
 double
-nest::ArchivingNode::get_K_value( double t )
+ArchivingNode::get_K_value( double t )
 {
   // case when the neuron has not yet spiked
   if ( history_.empty() )
@@ -113,10 +113,7 @@ nest::ArchivingNode::get_K_value( double t )
 }
 
 void
-nest::ArchivingNode::get_K_values( double t,
-  double& K_value,
-  double& nearest_neighbor_K_value,
-  double& K_triplet_value )
+ArchivingNode::get_K_values( double t, double& K_value, double& nearest_neighbor_K_value, double& K_triplet_value )
 {
   // case when the neuron has not yet spiked
   if ( history_.empty() )
@@ -151,7 +148,7 @@ nest::ArchivingNode::get_K_values( double t,
 }
 
 void
-nest::ArchivingNode::get_history( double t1,
+ArchivingNode::get_history( double t1,
   double t2,
   std::deque< histentry >::iterator* start,
   std::deque< histentry >::iterator* finish )
@@ -179,7 +176,7 @@ nest::ArchivingNode::get_history( double t1,
 }
 
 void
-nest::ArchivingNode::set_spiketime( Time const& t_sp, double offset )
+ArchivingNode::set_spiketime( Time const& t_sp, double offset )
 {
   StructuralPlasticityNode::set_spiketime( t_sp, offset );
 
@@ -220,7 +217,7 @@ nest::ArchivingNode::set_spiketime( Time const& t_sp, double offset )
 }
 
 void
-nest::ArchivingNode::get_status( Dictionary& d ) const
+ArchivingNode::get_status( Dictionary& d ) const
 {
   d[ names::t_spike ] = get_spiketime_ms();
   d[ names::tau_minus ] = tau_minus_;
@@ -236,7 +233,7 @@ nest::ArchivingNode::get_status( Dictionary& d ) const
 }
 
 void
-nest::ArchivingNode::set_status( const Dictionary& d )
+ArchivingNode::set_status( const Dictionary& d )
 {
   // We need to preserve values in case invalid values are set
   double new_tau_minus = tau_minus_;
@@ -269,7 +266,7 @@ nest::ArchivingNode::set_status( const Dictionary& d )
 }
 
 void
-nest::ArchivingNode::clear_history()
+ArchivingNode::clear_history()
 {
   last_spike_ = -1.0;
   Kminus_ = 0.0;

--- a/nestkernel/clopath_archiving_node.cpp
+++ b/nestkernel/clopath_archiving_node.cpp
@@ -31,7 +31,7 @@ namespace nest
 
 // member functions for ClopathArchivingNode
 
-nest::ClopathArchivingNode::ClopathArchivingNode()
+ClopathArchivingNode::ClopathArchivingNode()
   : ArchivingNode()
   , A_LTD_( 14.0e-5 )
   , A_LTP_( 8.0e-5 )
@@ -45,7 +45,7 @@ nest::ClopathArchivingNode::ClopathArchivingNode()
 {
 }
 
-nest::ClopathArchivingNode::ClopathArchivingNode( const ClopathArchivingNode& n )
+ClopathArchivingNode::ClopathArchivingNode( const ClopathArchivingNode& n )
   : ArchivingNode( n )
   , A_LTD_( n.A_LTD_ )
   , A_LTP_( n.A_LTP_ )
@@ -60,7 +60,7 @@ nest::ClopathArchivingNode::ClopathArchivingNode( const ClopathArchivingNode& n 
 }
 
 void
-nest::ClopathArchivingNode::init_clopath_buffers()
+ClopathArchivingNode::init_clopath_buffers()
 {
   delayed_u_bars_idx_ = 0;
   delay_u_bars_steps_ = Time::delay_ms_to_steps( delay_u_bars_ ) + 1;
@@ -74,7 +74,7 @@ nest::ClopathArchivingNode::init_clopath_buffers()
 }
 
 void
-nest::ClopathArchivingNode::get_status( Dictionary& d ) const
+ClopathArchivingNode::get_status( Dictionary& d ) const
 {
   ArchivingNode::get_status( d );
 
@@ -88,7 +88,7 @@ nest::ClopathArchivingNode::get_status( Dictionary& d ) const
 }
 
 void
-nest::ClopathArchivingNode::set_status( const Dictionary& d )
+ClopathArchivingNode::set_status( const Dictionary& d )
 {
   ArchivingNode::set_status( d );
 
@@ -123,7 +123,7 @@ nest::ClopathArchivingNode::set_status( const Dictionary& d )
 }
 
 double
-nest::ClopathArchivingNode::get_LTD_value( double t )
+ClopathArchivingNode::get_LTD_value( double t )
 {
   std::vector< histentry_extended >::iterator runner;
   if ( ltd_history_.empty() or t < 0.0 )
@@ -148,7 +148,7 @@ nest::ClopathArchivingNode::get_LTD_value( double t )
 }
 
 void
-nest::ClopathArchivingNode::get_LTP_history( double t1,
+ClopathArchivingNode::get_LTP_history( double t1,
   double t2,
   std::deque< histentry_extended >::iterator* start,
   std::deque< histentry_extended >::iterator* finish )
@@ -181,7 +181,7 @@ nest::ClopathArchivingNode::get_LTP_history( double t1,
 }
 
 void
-nest::ClopathArchivingNode::write_clopath_history( Time const& t_sp,
+ClopathArchivingNode::write_clopath_history( Time const& t_sp,
   double u,
   double u_bar_plus,
   double u_bar_minus,
@@ -214,7 +214,7 @@ nest::ClopathArchivingNode::write_clopath_history( Time const& t_sp,
 }
 
 void
-nest::ClopathArchivingNode::write_LTD_history( const double t_ltd_ms, double u_bar_minus, double u_bar_bar )
+ClopathArchivingNode::write_LTD_history( const double t_ltd_ms, double u_bar_minus, double u_bar_bar )
 {
   if ( n_incoming_ )
   {
@@ -226,7 +226,7 @@ nest::ClopathArchivingNode::write_LTD_history( const double t_ltd_ms, double u_b
 }
 
 void
-nest::ClopathArchivingNode::write_LTP_history( const double t_ltp_ms, double u, double u_bar_plus )
+ClopathArchivingNode::write_LTP_history( const double t_ltp_ms, double u, double u_bar_plus )
 {
   if ( n_incoming_ )
   {

--- a/nestkernel/conn_builder.cpp
+++ b/nestkernel/conn_builder.cpp
@@ -39,7 +39,9 @@
 #include <algorithm>
 
 
-nest::ConnBuilder::ConnBuilder( const std::string& primary_rule,
+namespace nest
+{
+ConnBuilder::ConnBuilder( const std::string& primary_rule,
   NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   const Dictionary& conn_spec,
@@ -55,7 +57,7 @@ nest::ConnBuilder::ConnBuilder( const std::string& primary_rule,
 {
 }
 
-nest::ConnBuilder::ConnBuilder( const std::string& primary_rule,
+ConnBuilder::ConnBuilder( const std::string& primary_rule,
   const std::string& third_rule,
   NodeCollectionPTR sources,
   NodeCollectionPTR targets,
@@ -83,7 +85,7 @@ nest::ConnBuilder::ConnBuilder( const std::string& primary_rule,
 {
 }
 
-nest::ConnBuilder::~ConnBuilder()
+ConnBuilder::~ConnBuilder()
 {
   delete primary_builder_;
   delete third_in_builder_;
@@ -91,7 +93,7 @@ nest::ConnBuilder::~ConnBuilder()
 }
 
 void
-nest::ConnBuilder::connect()
+ConnBuilder::connect()
 {
   primary_builder_->connect();  // triggers third_out_builder_
   if ( third_in_builder_ )
@@ -101,7 +103,7 @@ nest::ConnBuilder::connect()
 }
 
 void
-nest::ConnBuilder::disconnect()
+ConnBuilder::disconnect()
 {
   if ( third_out_builder_ )
   {
@@ -111,7 +113,7 @@ nest::ConnBuilder::disconnect()
 }
 
 
-nest::BipartiteConnBuilder::BipartiteConnBuilder( NodeCollectionPTR sources,
+BipartiteConnBuilder::BipartiteConnBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -196,7 +198,7 @@ nest::BipartiteConnBuilder::BipartiteConnBuilder( NodeCollectionPTR sources,
   }
 }
 
-nest::BipartiteConnBuilder::~BipartiteConnBuilder()
+BipartiteConnBuilder::~BipartiteConnBuilder()
 {
   for ( auto weight : weights_ )
   {
@@ -218,7 +220,7 @@ nest::BipartiteConnBuilder::~BipartiteConnBuilder()
 }
 
 bool
-nest::BipartiteConnBuilder::change_connected_synaptic_elements( size_t snode_id,
+BipartiteConnBuilder::change_connected_synaptic_elements( size_t snode_id,
   size_t tnode_id,
   const size_t tid,
   int update )
@@ -264,7 +266,7 @@ nest::BipartiteConnBuilder::change_connected_synaptic_elements( size_t snode_id,
 }
 
 void
-nest::BipartiteConnBuilder::connect()
+BipartiteConnBuilder::connect()
 {
   // We test here, and not in the ConnBuilder constructor, so the derived
   // classes are fully constructed when the test is executed
@@ -330,7 +332,7 @@ nest::BipartiteConnBuilder::connect()
 }
 
 void
-nest::BipartiteConnBuilder::disconnect()
+BipartiteConnBuilder::disconnect()
 {
   if ( use_structural_plasticity_ )
   {
@@ -352,7 +354,7 @@ nest::BipartiteConnBuilder::disconnect()
 }
 
 void
-nest::BipartiteConnBuilder::update_param_dict_( size_t snode_id,
+BipartiteConnBuilder::update_param_dict_( size_t snode_id,
   Node& target,
   size_t target_thread,
   RngPtr rng,
@@ -376,7 +378,7 @@ nest::BipartiteConnBuilder::update_param_dict_( size_t snode_id,
 }
 
 void
-nest::BipartiteConnBuilder::single_connect_( size_t snode_id, Node& target, size_t target_thread, RngPtr rng )
+BipartiteConnBuilder::single_connect_( size_t snode_id, Node& target, size_t target_thread, RngPtr rng )
 {
   if ( this->requires_proxies() and not target.has_proxies() )
   {
@@ -436,7 +438,7 @@ nest::BipartiteConnBuilder::single_connect_( size_t snode_id, Node& target, size
 }
 
 void
-nest::BipartiteConnBuilder::set_synaptic_element_names( const std::string& pre_name, const std::string& post_name )
+BipartiteConnBuilder::set_synaptic_element_names( const std::string& pre_name, const std::string& post_name )
 {
   if ( pre_name.empty() or post_name.empty() )
   {
@@ -450,7 +452,7 @@ nest::BipartiteConnBuilder::set_synaptic_element_names( const std::string& pre_n
 }
 
 bool
-nest::BipartiteConnBuilder::all_parameters_scalar_() const
+BipartiteConnBuilder::all_parameters_scalar_() const
 {
   bool all_scalar = true;
 
@@ -482,14 +484,14 @@ nest::BipartiteConnBuilder::all_parameters_scalar_() const
 }
 
 bool
-nest::BipartiteConnBuilder::loop_over_targets_() const
+BipartiteConnBuilder::loop_over_targets_() const
 {
   return targets_->size() < kernel().node_manager.size() or not targets_->is_range()
     or parameters_requiring_skipping_.size() > 0;
 }
 
 void
-nest::BipartiteConnBuilder::set_synapse_model_( const Dictionary& syn_params, size_t synapse_indx )
+BipartiteConnBuilder::set_synapse_model_( const Dictionary& syn_params, size_t synapse_indx )
 {
   const std::string syn_name = syn_params.known( names::synapse_model )
     ? syn_params.get< std::string >( names::synapse_model )
@@ -505,7 +507,7 @@ nest::BipartiteConnBuilder::set_synapse_model_( const Dictionary& syn_params, si
 }
 
 void
-nest::BipartiteConnBuilder::set_default_weight_or_delay_( const Dictionary& syn_params, size_t synapse_indx )
+BipartiteConnBuilder::set_default_weight_or_delay_( const Dictionary& syn_params, size_t synapse_indx )
 {
   Dictionary syn_defaults = kernel().model_manager.get_connector_defaults( synapse_model_id_[ synapse_indx ] );
 
@@ -540,7 +542,7 @@ nest::BipartiteConnBuilder::set_default_weight_or_delay_( const Dictionary& syn_
 }
 
 void
-nest::BipartiteConnBuilder::set_synapse_params( const Dictionary& syn_defaults,
+BipartiteConnBuilder::set_synapse_params( const Dictionary& syn_defaults,
   const Dictionary& syn_params,
   size_t synapse_indx )
 {
@@ -580,7 +582,7 @@ nest::BipartiteConnBuilder::set_synapse_params( const Dictionary& syn_defaults,
 }
 
 void
-nest::BipartiteConnBuilder::set_structural_plasticity_parameters( const std::vector< Dictionary >& syn_specs )
+BipartiteConnBuilder::set_structural_plasticity_parameters( const std::vector< Dictionary >& syn_specs )
 {
   // We must check here if any syn_spec provided contains sp-related parameters
   bool have_structural_plasticity_parameters = false;
@@ -620,7 +622,7 @@ nest::BipartiteConnBuilder::set_structural_plasticity_parameters( const std::vec
 }
 
 void
-nest::BipartiteConnBuilder::reset_weights_()
+BipartiteConnBuilder::reset_weights_()
 {
   for ( auto weight : weights_ )
   {
@@ -632,7 +634,7 @@ nest::BipartiteConnBuilder::reset_weights_()
 }
 
 void
-nest::BipartiteConnBuilder::reset_delays_()
+BipartiteConnBuilder::reset_delays_()
 {
   for ( auto delay : delays_ )
   {
@@ -643,7 +645,7 @@ nest::BipartiteConnBuilder::reset_delays_()
   }
 }
 
-nest::ThirdInBuilder::ThirdInBuilder( NodeCollectionPTR sources,
+ThirdInBuilder::ThirdInBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR third,
   const Dictionary& third_conn_spec,
   const std::vector< Dictionary >& syn_specs )
@@ -659,7 +661,7 @@ nest::ThirdInBuilder::ThirdInBuilder( NodeCollectionPTR sources,
   }
 }
 
-nest::ThirdInBuilder::~ThirdInBuilder()
+ThirdInBuilder::~ThirdInBuilder()
 {
 #pragma omp parallel
   {
@@ -670,7 +672,7 @@ nest::ThirdInBuilder::~ThirdInBuilder()
 }
 
 void
-nest::ThirdInBuilder::register_connection( size_t primary_source_id, size_t third_node_id )
+ThirdInBuilder::register_connection( size_t primary_source_id, size_t third_node_id )
 {
   const size_t tid = kernel().vp_manager.get_thread_id();
   const auto third_node_rank =
@@ -680,7 +682,7 @@ nest::ThirdInBuilder::register_connection( size_t primary_source_id, size_t thir
 }
 
 void
-nest::ThirdInBuilder::connect_()
+ThirdInBuilder::connect_()
 {
   kernel().vp_manager.assert_single_threaded();
 
@@ -772,7 +774,7 @@ nest::ThirdInBuilder::connect_()
   }
 }
 
-nest::ThirdOutBuilder::ThirdOutBuilder( const NodeCollectionPTR third,
+ThirdOutBuilder::ThirdOutBuilder( const NodeCollectionPTR third,
   const NodeCollectionPTR targets,
   ThirdInBuilder* third_in,
   const Dictionary& third_conn_spec,
@@ -782,7 +784,7 @@ nest::ThirdOutBuilder::ThirdOutBuilder( const NodeCollectionPTR third,
 {
 }
 
-nest::ThirdBernoulliWithPoolBuilder::ThirdBernoulliWithPoolBuilder( const NodeCollectionPTR third,
+ThirdBernoulliWithPoolBuilder::ThirdBernoulliWithPoolBuilder( const NodeCollectionPTR third,
   const NodeCollectionPTR targets,
   ThirdInBuilder* third_in,
   const Dictionary& conn_spec,
@@ -863,7 +865,7 @@ nest::ThirdBernoulliWithPoolBuilder::ThirdBernoulliWithPoolBuilder( const NodeCo
   }
 }
 
-nest::ThirdBernoulliWithPoolBuilder::~ThirdBernoulliWithPoolBuilder()
+ThirdBernoulliWithPoolBuilder::~ThirdBernoulliWithPoolBuilder()
 {
 #pragma omp parallel
   {
@@ -887,7 +889,7 @@ nest::ThirdBernoulliWithPoolBuilder::~ThirdBernoulliWithPoolBuilder()
 }
 
 void
-nest::ThirdBernoulliWithPoolBuilder::third_connect( size_t primary_source_id, Node& primary_target )
+ThirdBernoulliWithPoolBuilder::third_connect( size_t primary_source_id, Node& primary_target )
 {
   // We assume target is on this thread
   const size_t tid = kernel().vp_manager.get_thread_id();
@@ -931,7 +933,7 @@ nest::ThirdBernoulliWithPoolBuilder::third_connect( size_t primary_source_id, No
 
 
 size_t
-nest::ThirdBernoulliWithPoolBuilder::get_first_pool_index_( const size_t target_index ) const
+ThirdBernoulliWithPoolBuilder::get_first_pool_index_( const size_t target_index ) const
 {
   if ( pool_size_ > 1 )
   {
@@ -942,7 +944,7 @@ nest::ThirdBernoulliWithPoolBuilder::get_first_pool_index_( const size_t target_
 }
 
 
-nest::OneToOneBuilder::OneToOneBuilder( const NodeCollectionPTR sources,
+OneToOneBuilder::OneToOneBuilder( const NodeCollectionPTR sources,
   const NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -957,7 +959,7 @@ nest::OneToOneBuilder::OneToOneBuilder( const NodeCollectionPTR sources,
 }
 
 void
-nest::OneToOneBuilder::connect_()
+OneToOneBuilder::connect_()
 {
 
 #pragma omp parallel
@@ -1035,7 +1037,7 @@ nest::OneToOneBuilder::connect_()
 }
 
 void
-nest::OneToOneBuilder::disconnect_()
+OneToOneBuilder::disconnect_()
 {
 
 #pragma omp parallel
@@ -1082,7 +1084,7 @@ nest::OneToOneBuilder::disconnect_()
 }
 
 void
-nest::OneToOneBuilder::sp_connect_()
+OneToOneBuilder::sp_connect_()
 {
 
 #pragma omp parallel
@@ -1128,7 +1130,7 @@ nest::OneToOneBuilder::sp_connect_()
 }
 
 void
-nest::OneToOneBuilder::sp_disconnect_()
+OneToOneBuilder::sp_disconnect_()
 {
 
 #pragma omp parallel
@@ -1167,7 +1169,7 @@ nest::OneToOneBuilder::sp_disconnect_()
 }
 
 void
-nest::AllToAllBuilder::connect_()
+AllToAllBuilder::connect_()
 {
 
 #pragma omp parallel
@@ -1222,7 +1224,7 @@ nest::AllToAllBuilder::connect_()
 }
 
 void
-nest::AllToAllBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, size_t tnode_id, bool skip )
+AllToAllBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, size_t tnode_id, bool skip )
 {
   const size_t target_thread = target->get_thread();
 
@@ -1255,7 +1257,7 @@ nest::AllToAllBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, 
 }
 
 void
-nest::AllToAllBuilder::sp_connect_()
+AllToAllBuilder::sp_connect_()
 {
 #pragma omp parallel
   {
@@ -1300,7 +1302,7 @@ nest::AllToAllBuilder::sp_connect_()
 }
 
 void
-nest::AllToAllBuilder::disconnect_()
+AllToAllBuilder::disconnect_()
 {
 
 #pragma omp parallel
@@ -1349,7 +1351,7 @@ nest::AllToAllBuilder::disconnect_()
 }
 
 void
-nest::AllToAllBuilder::sp_disconnect_()
+AllToAllBuilder::sp_disconnect_()
 {
 #pragma omp parallel
   {
@@ -1387,7 +1389,7 @@ nest::AllToAllBuilder::sp_disconnect_()
   }
 }
 
-nest::FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
+FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -1401,7 +1403,7 @@ nest::FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
     throw BadProperty( "Source array must not be empty." );
   }
   auto indegree = conn_spec.at( names::indegree );
-  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( indegree ) )
+  if ( std::holds_alternative< std::shared_ptr< Parameter > >( indegree ) )
   {
     indegree_ = std::get< ParameterPTR >( indegree );
     // TODO: Checks of parameter range
@@ -1445,7 +1447,7 @@ nest::FixedInDegreeBuilder::FixedInDegreeBuilder( NodeCollectionPTR sources,
 }
 
 void
-nest::FixedInDegreeBuilder::connect_()
+FixedInDegreeBuilder::connect_()
 {
 
 #pragma omp parallel
@@ -1505,7 +1507,7 @@ nest::FixedInDegreeBuilder::connect_()
 }
 
 void
-nest::FixedInDegreeBuilder::inner_connect_( const int tid,
+FixedInDegreeBuilder::inner_connect_( const int tid,
   RngPtr rng,
   Node* target,
   size_t tnode_id,
@@ -1552,7 +1554,7 @@ nest::FixedInDegreeBuilder::inner_connect_( const int tid,
   }
 }
 
-nest::FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
+FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -1566,7 +1568,7 @@ nest::FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
     throw BadProperty( "Target array must not be empty." );
   }
   auto outdegree = conn_spec.at( names::outdegree );
-  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( outdegree ) )
+  if ( std::holds_alternative< std::shared_ptr< Parameter > >( outdegree ) )
   {
     outdegree_ = std::get< ParameterPTR >( outdegree );
     // TODO: Checks of parameter range
@@ -1610,7 +1612,7 @@ nest::FixedOutDegreeBuilder::FixedOutDegreeBuilder( NodeCollectionPTR sources,
 }
 
 void
-nest::FixedOutDegreeBuilder::connect_()
+FixedOutDegreeBuilder::connect_()
 {
   // get global rng that is tested for synchronization for all threads
   RngPtr grng = get_rank_synced_rng();
@@ -1681,7 +1683,7 @@ nest::FixedOutDegreeBuilder::connect_()
   }
 }
 
-nest::FixedTotalNumberBuilder::FixedTotalNumberBuilder( NodeCollectionPTR sources,
+FixedTotalNumberBuilder::FixedTotalNumberBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -1718,7 +1720,7 @@ nest::FixedTotalNumberBuilder::FixedTotalNumberBuilder( NodeCollectionPTR source
 }
 
 void
-nest::FixedTotalNumberBuilder::connect_()
+FixedTotalNumberBuilder::connect_()
 {
   const int M = kernel().vp_manager.get_num_virtual_processes();
   const long size_sources = sources_->size();
@@ -1851,7 +1853,7 @@ nest::FixedTotalNumberBuilder::connect_()
 }
 
 
-nest::BernoulliBuilder::BernoulliBuilder( NodeCollectionPTR sources,
+BernoulliBuilder::BernoulliBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -1859,7 +1861,7 @@ nest::BernoulliBuilder::BernoulliBuilder( NodeCollectionPTR sources,
   : BipartiteConnBuilder( sources, targets, third_out, conn_spec, syn_specs )
 {
   auto p = conn_spec.at( names::p );
-  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( p ) )
+  if ( std::holds_alternative< std::shared_ptr< Parameter > >( p ) )
   {
     p_ = std::get< ParameterPTR >( p );
     // TODO: Checks of parameter range
@@ -1878,7 +1880,7 @@ nest::BernoulliBuilder::BernoulliBuilder( NodeCollectionPTR sources,
 
 
 void
-nest::BernoulliBuilder::connect_()
+BernoulliBuilder::connect_()
 {
 #pragma omp parallel
   {
@@ -1934,7 +1936,7 @@ nest::BernoulliBuilder::connect_()
 }
 
 void
-nest::BernoulliBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, size_t tnode_id )
+BernoulliBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, size_t tnode_id )
 {
   const size_t target_thread = target->get_thread();
 
@@ -1966,7 +1968,7 @@ nest::BernoulliBuilder::inner_connect_( const int tid, RngPtr rng, Node* target,
 }
 
 
-nest::PoissonBuilder::PoissonBuilder( NodeCollectionPTR sources,
+PoissonBuilder::PoissonBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -1975,7 +1977,7 @@ nest::PoissonBuilder::PoissonBuilder( NodeCollectionPTR sources,
 {
 
   auto p = conn_spec.at( names::pairwise_avg_num_conns );
-  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( p ) )
+  if ( std::holds_alternative< std::shared_ptr< Parameter > >( p ) )
   {
     pairwise_avg_num_conns_ = std::get< ParameterPTR >( p );
   }
@@ -1997,7 +1999,7 @@ nest::PoissonBuilder::PoissonBuilder( NodeCollectionPTR sources,
 }
 
 void
-nest::PoissonBuilder::connect_()
+PoissonBuilder::connect_()
 {
 #pragma omp parallel
   {
@@ -2050,7 +2052,7 @@ nest::PoissonBuilder::connect_()
 }
 
 void
-nest::PoissonBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, size_t tnode_id )
+PoissonBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, size_t tnode_id )
 {
   const size_t target_thread = target->get_thread();
 
@@ -2084,7 +2086,7 @@ nest::PoissonBuilder::inner_connect_( const int tid, RngPtr rng, Node* target, s
   }
 }
 
-nest::SymmetricBernoulliBuilder::SymmetricBernoulliBuilder( NodeCollectionPTR sources,
+SymmetricBernoulliBuilder::SymmetricBernoulliBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -2118,7 +2120,7 @@ nest::SymmetricBernoulliBuilder::SymmetricBernoulliBuilder( NodeCollectionPTR so
 
 
 void
-nest::SymmetricBernoulliBuilder::connect_()
+SymmetricBernoulliBuilder::connect_()
 {
 #pragma omp parallel
   {
@@ -2211,7 +2213,7 @@ nest::SymmetricBernoulliBuilder::connect_()
 }
 
 
-nest::SPBuilder::SPBuilder( NodeCollectionPTR sources,
+SPBuilder::SPBuilder( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
   const Dictionary& conn_spec,
@@ -2226,7 +2228,7 @@ nest::SPBuilder::SPBuilder( NodeCollectionPTR sources,
 }
 
 void
-nest::SPBuilder::update_delay( long& d ) const
+SPBuilder::update_delay( long& d ) const
 {
   if ( get_default_delay() )
   {
@@ -2237,7 +2239,7 @@ nest::SPBuilder::update_delay( long& d ) const
 }
 
 void
-nest::SPBuilder::sp_connect( const std::vector< size_t >& sources, const std::vector< size_t >& targets )
+SPBuilder::sp_connect( const std::vector< size_t >& sources, const std::vector< size_t >& targets )
 {
   connect_( sources, targets );
 
@@ -2252,7 +2254,7 @@ nest::SPBuilder::sp_connect( const std::vector< size_t >& sources, const std::ve
 }
 
 void
-nest::SPBuilder::connect_()
+SPBuilder::connect_()
 {
   throw NotImplemented( "Connection without structural plasticity is not possible for this connection builder." );
 }
@@ -2261,13 +2263,13 @@ nest::SPBuilder::connect_()
  * In charge of dynamically creating the new synapses
  */
 void
-nest::SPBuilder::connect_( NodeCollectionPTR, NodeCollectionPTR )
+SPBuilder::connect_( NodeCollectionPTR, NodeCollectionPTR )
 {
   throw NotImplemented( "Connection without structural plasticity is not possible for this connection builder." );
 }
 
 void
-nest::SPBuilder::connect_( const std::vector< size_t >& sources, const std::vector< size_t >& targets )
+SPBuilder::connect_( const std::vector< size_t >& sources, const std::vector< size_t >& targets )
 {
   // Code copied and adapted from OneToOneBuilder::connect_()
   // make sure that target and source population have the same size
@@ -2313,3 +2315,5 @@ nest::SPBuilder::connect_( const std::vector< size_t >& sources, const std::vect
     }
   }
 }
+
+}  // namespace nest

--- a/nestkernel/conn_parameter.cpp
+++ b/nestkernel/conn_parameter.cpp
@@ -26,8 +26,10 @@
 #include "kernel_manager.h"
 
 
-nest::ConnParameter*
-nest::ConnParameter::create( const any_type& value, const size_t nthreads )
+namespace nest
+{
+ConnParameter*
+ConnParameter::create( const any_type& value, const size_t nthreads )
 {
   // single double
   if ( std::holds_alternative< double >( value ) )
@@ -48,7 +50,7 @@ nest::ConnParameter::create( const any_type& value, const size_t nthreads )
   }
 
   // Parameter
-  if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( value ) )
+  if ( std::holds_alternative< std::shared_ptr< Parameter > >( value ) )
   {
     return new ParameterConnParameterWrapper( std::get< ParameterPTR >( value ), nthreads );
   }
@@ -63,13 +65,15 @@ nest::ConnParameter::create( const any_type& value, const size_t nthreads )
 }
 
 
-nest::ParameterConnParameterWrapper::ParameterConnParameterWrapper( ParameterPTR p, const size_t )
+ParameterConnParameterWrapper::ParameterConnParameterWrapper( ParameterPTR p, const size_t )
   : parameter_( p )
 {
 }
 
 double
-nest::ParameterConnParameterWrapper::value_double( size_t, RngPtr rng, size_t, Node* target ) const
+ParameterConnParameterWrapper::value_double( size_t, RngPtr rng, size_t, Node* target ) const
 {
   return parameter_->value( rng, target );
 }
+
+}  // namespace nest

--- a/nestkernel/connection.h
+++ b/nestkernel/connection.h
@@ -70,7 +70,7 @@ class ConnTestDummyNodeBase : public Node
   {
   }
   void
-  update( const nest::Time&, long, long ) override
+  update( const Time&, long, long ) override
   {
   }
   void

--- a/nestkernel/connection_creator.cpp
+++ b/nestkernel/connection_creator.cpp
@@ -82,7 +82,7 @@ ConnectionCreator::ConnectionCreator( const Dictionary& dict )
     {
       dict.update_value( names::synapse_parameters, syn_params_dvd );
     }
-    catch ( const nest::TypeMismatch& )
+    catch ( const TypeMismatch& )
     {
       // Give a more helpful message if the provided type is wrong.
       throw BadProperty( "synapse_parameters must be list of dictionaries" );

--- a/nestkernel/connection_id.cpp
+++ b/nestkernel/connection_id.cpp
@@ -58,15 +58,15 @@ ConnectionID::get_dict() const
   Dictionary dict;
 
   // The node ID of the presynaptic node
-  dict[ nest::names::source ] = source_node_id_;
+  dict[ names::source ] = source_node_id_;
   // The node ID of the postsynaptic node
-  dict[ nest::names::target ] = target_node_id_;
+  dict[ names::target ] = target_node_id_;
   // The id of the synapse model
-  dict[ nest::names::synapse_modelid ] = synapse_modelid_;
+  dict[ names::synapse_modelid ] = synapse_modelid_;
   // The thread of the postsynaptic node
-  dict[ nest::names::target_thread ] = target_thread_;
+  dict[ names::target_thread ] = target_thread_;
   // The index in the list
-  dict[ nest::names::port ] = port_;
+  dict[ names::port ] = port_;
 
   return dict;
 }

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -59,8 +59,11 @@
 #include "sonata_connector.h"
 #endif
 
+namespace nest
+{
 
-nest::ConnectionManager::ConnectionManager()
+
+ConnectionManager::ConnectionManager()
   : connruledict_()
   , connbuilder_factories_()
   , thirdconnruledict_()
@@ -79,7 +82,7 @@ nest::ConnectionManager::ConnectionManager()
 {
 }
 
-nest::ConnectionManager::~ConnectionManager()
+ConnectionManager::~ConnectionManager()
 {
   // Memory leak on purpose!
   // The ConnectionManager is deleted, when the network is deleted, and
@@ -90,7 +93,7 @@ nest::ConnectionManager::~ConnectionManager()
 }
 
 void
-nest::ConnectionManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+ConnectionManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 {
   if ( not adjust_number_of_threads_or_rng_only )
   {
@@ -147,7 +150,7 @@ nest::ConnectionManager::initialize( const bool adjust_number_of_threads_or_rng_
 }
 
 void
-nest::ConnectionManager::finalize( const bool adjust_number_of_threads_or_rng_only )
+ConnectionManager::finalize( const bool adjust_number_of_threads_or_rng_only )
 {
   source_table_.finalize();
   target_table_.finalize();
@@ -176,7 +179,7 @@ nest::ConnectionManager::finalize( const bool adjust_number_of_threads_or_rng_on
 }
 
 void
-nest::ConnectionManager::set_status( const Dictionary& d )
+ConnectionManager::set_status( const Dictionary& d )
 {
   for ( size_t i = 0; i < delay_checkers_.size(); ++i )
   {
@@ -200,14 +203,14 @@ nest::ConnectionManager::set_status( const Dictionary& d )
   }
 }
 
-nest::DelayChecker&
-nest::ConnectionManager::get_delay_checker()
+DelayChecker&
+ConnectionManager::get_delay_checker()
 {
   return delay_checkers_[ kernel().vp_manager.get_thread_id() ];
 }
 
 void
-nest::ConnectionManager::get_status( Dictionary& dict )
+ConnectionManager::get_status( Dictionary& dict )
 {
   update_delay_extrema_();
   dict[ names::min_delay ] = Time( Time::step( min_delay_ ) ).get_ms();
@@ -229,7 +232,7 @@ nest::ConnectionManager::get_status( Dictionary& dict )
 }
 
 Dictionary
-nest::ConnectionManager::get_synapse_status( const size_t source_node_id,
+ConnectionManager::get_synapse_status( const size_t source_node_id,
   const size_t target_node_id,
   const size_t tid,
   const synindex syn_id,
@@ -272,7 +275,7 @@ nest::ConnectionManager::get_synapse_status( const size_t source_node_id,
 }
 
 void
-nest::ConnectionManager::set_synapse_status( const size_t source_node_id,
+ConnectionManager::set_synapse_status( const size_t source_node_id,
   const size_t target_node_id,
   const size_t tid,
   const synindex syn_id,
@@ -322,7 +325,7 @@ nest::ConnectionManager::set_synapse_status( const size_t source_node_id,
 }
 
 void
-nest::ConnectionManager::delete_connections_()
+ConnectionManager::delete_connections_()
 {
   for ( size_t tid = 0; tid < connections_.size(); ++tid )
   {
@@ -333,8 +336,8 @@ nest::ConnectionManager::delete_connections_()
   }
 }
 
-const nest::Time
-nest::ConnectionManager::get_min_delay_time_() const
+const Time
+ConnectionManager::get_min_delay_time_() const
 {
   Time min_delay = Time::pos_inf();
 
@@ -347,8 +350,8 @@ nest::ConnectionManager::get_min_delay_time_() const
   return min_delay;
 }
 
-const nest::Time
-nest::ConnectionManager::get_max_delay_time_() const
+const Time
+ConnectionManager::get_max_delay_time_() const
 {
   Time max_delay = Time::get_resolution();
 
@@ -362,7 +365,7 @@ nest::ConnectionManager::get_max_delay_time_() const
 }
 
 bool
-nest::ConnectionManager::get_user_set_delay_extrema() const
+ConnectionManager::get_user_set_delay_extrema() const
 {
   bool user_set_delay_extrema = false;
 
@@ -375,8 +378,8 @@ nest::ConnectionManager::get_user_set_delay_extrema() const
   return user_set_delay_extrema;
 }
 
-nest::BipartiteConnBuilder*
-nest::ConnectionManager::get_conn_builder( const std::string& name,
+BipartiteConnBuilder*
+ConnectionManager::get_conn_builder( const std::string& name,
   NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdOutBuilder* third_out,
@@ -395,8 +398,8 @@ nest::ConnectionManager::get_conn_builder( const std::string& name,
   return cb;
 }
 
-nest::ThirdOutBuilder*
-nest::ConnectionManager::get_third_conn_builder( const std::string& name,
+ThirdOutBuilder*
+ConnectionManager::get_third_conn_builder( const std::string& name,
   NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   ThirdInBuilder* third_in,
@@ -416,7 +419,7 @@ nest::ConnectionManager::get_third_conn_builder( const std::string& name,
 }
 
 void
-nest::ConnectionManager::calibrate( const TimeConverter& tc )
+ConnectionManager::calibrate( const TimeConverter& tc )
 {
   for ( size_t tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )
   {
@@ -425,7 +428,7 @@ nest::ConnectionManager::calibrate( const TimeConverter& tc )
 }
 
 void
-nest::ConnectionManager::connect( NodeCollectionPTR sources,
+ConnectionManager::connect( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   const Dictionary& conn_spec,
   const std::vector< Dictionary >& syn_specs )
@@ -479,7 +482,7 @@ nest::ConnectionManager::connect( NodeCollectionPTR sources,
 }
 
 void
-nest::ConnectionManager::update_delay_extrema_()
+ConnectionManager::update_delay_extrema_()
 {
   if ( kernel().simulation_manager.has_been_simulated() )
   {
@@ -526,7 +529,7 @@ nest::ConnectionManager::update_delay_extrema_()
 
 // node ID node thread syn_id dict delay weight
 void
-nest::ConnectionManager::connect( const size_t snode_id,
+ConnectionManager::connect( const size_t snode_id,
   Node* target,
   size_t target_thread,
   const synindex syn_id,
@@ -558,7 +561,7 @@ nest::ConnectionManager::connect( const size_t snode_id,
 
 // node_id node_id dict syn_id
 bool
-nest::ConnectionManager::connect( const size_t snode_id,
+ConnectionManager::connect( const size_t snode_id,
   const size_t tnode_id,
   const Dictionary& params,
   const synindex syn_id )
@@ -599,7 +602,7 @@ nest::ConnectionManager::connect( const size_t snode_id,
 }
 
 void
-nest::ConnectionManager::connect_arrays( const long* sources,
+ConnectionManager::connect_arrays( const long* sources,
   const long* targets,
   const double* weights,
   const double* delays,
@@ -773,7 +776,7 @@ nest::ConnectionManager::connect_arrays( const long* sources,
 }
 
 void
-nest::ConnectionManager::connect_sonata( [[maybe_unused]] const Dictionary& graph_specs,
+ConnectionManager::connect_sonata( [[maybe_unused]] const Dictionary& graph_specs,
   [[maybe_unused]] const long hyberslab_size )
 {
 #ifdef HAVE_HDF5
@@ -795,7 +798,7 @@ nest::ConnectionManager::connect_sonata( [[maybe_unused]] const Dictionary& grap
 }
 
 void
-nest::ConnectionManager::connect_tripartite( NodeCollectionPTR sources,
+ConnectionManager::connect_tripartite( NodeCollectionPTR sources,
   NodeCollectionPTR targets,
   NodeCollectionPTR third,
   const Dictionary& conn_spec,
@@ -862,7 +865,7 @@ nest::ConnectionManager::connect_tripartite( NodeCollectionPTR sources,
 
 
 void
-nest::ConnectionManager::connect_( Node& source,
+ConnectionManager::connect_( Node& source,
   Node& target,
   const size_t s_node_id,
   const size_t tid,
@@ -918,7 +921,7 @@ nest::ConnectionManager::connect_( Node& source,
 }
 
 void
-nest::ConnectionManager::connect_to_device_( Node& source,
+ConnectionManager::connect_to_device_( Node& source,
   Node& target,
   const size_t s_node_id,
   const size_t tid,
@@ -934,7 +937,7 @@ nest::ConnectionManager::connect_to_device_( Node& source,
 }
 
 void
-nest::ConnectionManager::connect_from_device_( Node& source,
+ConnectionManager::connect_from_device_( Node& source,
   Node& target,
   const size_t tid,
   const synindex syn_id,
@@ -949,7 +952,7 @@ nest::ConnectionManager::connect_from_device_( Node& source,
 }
 
 void
-nest::ConnectionManager::increase_connection_count( const size_t tid, const synindex syn_id )
+ConnectionManager::increase_connection_count( const size_t tid, const synindex syn_id )
 {
   if ( num_connections_[ tid ].size() <= syn_id )
   {
@@ -967,7 +970,7 @@ nest::ConnectionManager::increase_connection_count( const size_t tid, const syni
 }
 
 size_t
-nest::ConnectionManager::find_connection( const size_t tid,
+ConnectionManager::find_connection( const size_t tid,
   const synindex syn_id,
   const size_t snode_id,
   const size_t tnode_id )
@@ -994,7 +997,7 @@ nest::ConnectionManager::find_connection( const size_t tid,
 }
 
 void
-nest::ConnectionManager::disconnect( const size_t tid,
+ConnectionManager::disconnect( const size_t tid,
   const synindex syn_id,
   const size_t snode_id,
   const size_t tnode_id )
@@ -1016,7 +1019,7 @@ nest::ConnectionManager::disconnect( const size_t tid,
 }
 
 void
-nest::ConnectionManager::trigger_update_weight( const long vt_id,
+ConnectionManager::trigger_update_weight( const long vt_id,
   const std::vector< spikecounter >& dopa_spikes,
   const double t_trig )
 {
@@ -1034,7 +1037,7 @@ nest::ConnectionManager::trigger_update_weight( const long vt_id,
 }
 
 size_t
-nest::ConnectionManager::get_num_target_data( const size_t tid ) const
+ConnectionManager::get_num_target_data( const size_t tid ) const
 {
   size_t num_connections = 0;
   for ( synindex syn_id = 0; syn_id < connections_[ tid ].size(); ++syn_id )
@@ -1048,7 +1051,7 @@ nest::ConnectionManager::get_num_target_data( const size_t tid ) const
 }
 
 size_t
-nest::ConnectionManager::get_num_connections() const
+ConnectionManager::get_num_connections() const
 {
   size_t num_connections = 0;
   for ( size_t t = 0; t < num_connections_.size(); ++t )
@@ -1063,7 +1066,7 @@ nest::ConnectionManager::get_num_connections() const
 }
 
 size_t
-nest::ConnectionManager::get_num_connections( const synindex syn_id ) const
+ConnectionManager::get_num_connections( const synindex syn_id ) const
 {
   size_t num_connections = 0;
   for ( size_t t = 0; t < num_connections_.size(); ++t )
@@ -1077,8 +1080,8 @@ nest::ConnectionManager::get_num_connections( const synindex syn_id ) const
   return num_connections;
 }
 
-std::deque< nest::ConnectionID >
-nest::ConnectionManager::get_connections( const Dictionary& params )
+std::deque< ConnectionID >
+ConnectionManager::get_connections( const Dictionary& params )
 {
   std::deque< ConnectionID > connectome;
   NodeCollectionPTR source_a = NodeCollectionPTR( nullptr );
@@ -1147,8 +1150,8 @@ nest::ConnectionManager::get_connections( const Dictionary& params )
 
 // Helper method which removes ConnectionIDs from input deque and
 // appends them to output deque.
-static inline std::deque< nest::ConnectionID >&
-extend_connectome( std::deque< nest::ConnectionID >& out, std::deque< nest::ConnectionID >& in )
+static inline std::deque< ConnectionID >&
+extend_connectome( std::deque< ConnectionID >& out, std::deque< ConnectionID >& in )
 {
   while ( not in.empty() )
   {
@@ -1160,7 +1163,7 @@ extend_connectome( std::deque< nest::ConnectionID >& out, std::deque< nest::Conn
 }
 
 void
-nest::ConnectionManager::split_to_neuron_device_vectors_( const size_t tid,
+ConnectionManager::split_to_neuron_device_vectors_( const size_t tid,
   NodeCollectionPTR nodecollection,
   std::vector< size_t >& neuron_node_ids,
   std::vector< size_t >& device_node_ids ) const
@@ -1185,7 +1188,7 @@ nest::ConnectionManager::split_to_neuron_device_vectors_( const size_t tid,
 }
 
 void
-nest::ConnectionManager::get_connections_( const size_t tid,
+ConnectionManager::get_connections_( const size_t tid,
   std::deque< ConnectionID >& conns_in_thread,
   NodeCollectionPTR,
   NodeCollectionPTR,
@@ -1208,7 +1211,7 @@ nest::ConnectionManager::get_connections_( const size_t tid,
 }
 
 void
-nest::ConnectionManager::get_connections_to_targets_( const size_t tid,
+ConnectionManager::get_connections_to_targets_( const size_t tid,
   std::deque< ConnectionID >& conns_in_thread,
   NodeCollectionPTR,
   NodeCollectionPTR target,
@@ -1247,7 +1250,7 @@ nest::ConnectionManager::get_connections_to_targets_( const size_t tid,
 }
 
 void
-nest::ConnectionManager::get_connections_from_sources_( const size_t tid,
+ConnectionManager::get_connections_from_sources_( const size_t tid,
   std::deque< ConnectionID >& conns_in_thread,
   NodeCollectionPTR source,
   NodeCollectionPTR target,
@@ -1318,7 +1321,7 @@ nest::ConnectionManager::get_connections_from_sources_( const size_t tid,
 }
 
 void
-nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome,
+ConnectionManager::get_connections( std::deque< ConnectionID >& connectome,
   NodeCollectionPTR source,
   NodeCollectionPTR target,
   synindex syn_id,
@@ -1364,7 +1367,7 @@ nest::ConnectionManager::get_connections( std::deque< ConnectionID >& connectome
 }
 
 void
-nest::ConnectionManager::get_source_node_ids_( const size_t tid,
+ConnectionManager::get_source_node_ids_( const size_t tid,
   const synindex syn_id,
   const size_t tnode_id,
   std::vector< size_t >& sources )
@@ -1378,7 +1381,7 @@ nest::ConnectionManager::get_source_node_ids_( const size_t tid,
 }
 
 void
-nest::ConnectionManager::get_sources( const std::vector< size_t >& targets,
+ConnectionManager::get_sources( const std::vector< size_t >& targets,
   const size_t syn_id,
   std::vector< std::vector< size_t > >& sources )
 {
@@ -1398,7 +1401,7 @@ nest::ConnectionManager::get_sources( const std::vector< size_t >& targets,
 }
 
 void
-nest::ConnectionManager::get_targets( const std::vector< size_t >& sources,
+ConnectionManager::get_targets( const std::vector< size_t >& sources,
   const size_t syn_id,
   const std::string& post_synaptic_element,
   std::vector< std::vector< size_t > >& targets )
@@ -1423,7 +1426,7 @@ nest::ConnectionManager::get_targets( const std::vector< size_t >& sources,
 }
 
 void
-nest::ConnectionManager::sort_connections( const size_t tid )
+ConnectionManager::sort_connections( const size_t tid )
 {
   assert( not source_table_.is_cleared() );
   if ( use_compressed_spikes_ )
@@ -1440,7 +1443,7 @@ nest::ConnectionManager::sort_connections( const size_t tid )
 }
 
 void
-nest::ConnectionManager::compute_target_data_buffer_size()
+ConnectionManager::compute_target_data_buffer_size()
 {
   // Determine number of target data on this rank. Since each thread
   // has its own data structures, we need to count connections on every
@@ -1466,7 +1469,7 @@ nest::ConnectionManager::compute_target_data_buffer_size()
 }
 
 void
-nest::ConnectionManager::compute_compressed_secondary_recv_buffer_positions( const size_t tid )
+ConnectionManager::compute_compressed_secondary_recv_buffer_positions( const size_t tid )
 {
 #pragma omp single
   {
@@ -1508,8 +1511,8 @@ nest::ConnectionManager::compute_compressed_secondary_recv_buffer_positions( con
   }
 }
 
-nest::ConnectionManager::ConnectionType
-nest::ConnectionManager::connection_required( Node*& source, Node*& target, size_t tid )
+ConnectionManager::ConnectionType
+ConnectionManager::connection_required( Node*& source, Node*& target, size_t tid )
 {
   // The caller has to check and guarantee that the target is not a
   // proxy and that it is on thread tid.
@@ -1601,7 +1604,7 @@ nest::ConnectionManager::connection_required( Node*& source, Node*& target, size
 }
 
 void
-nest::ConnectionManager::set_stdp_eps( const double stdp_eps )
+ConnectionManager::set_stdp_eps( const double stdp_eps )
 {
   if ( not( stdp_eps < Time::get_resolution().get_ms() ) )
   {
@@ -1630,7 +1633,7 @@ nest::ConnectionManager::set_stdp_eps( const double stdp_eps )
 // recv_buffer can not be a const reference as iterators used in
 // secondary events must not be const
 bool
-nest::ConnectionManager::deliver_secondary_events( const size_t tid,
+ConnectionManager::deliver_secondary_events( const size_t tid,
   const bool called_from_wfr_update,
   std::vector< unsigned int >& recv_buffer )
 {
@@ -1679,13 +1682,13 @@ nest::ConnectionManager::deliver_secondary_events( const size_t tid,
 }
 
 void
-nest::ConnectionManager::compress_secondary_send_buffer_pos( const size_t tid )
+ConnectionManager::compress_secondary_send_buffer_pos( const size_t tid )
 {
   target_table_.compress_secondary_send_buffer_pos( tid );
 }
 
 void
-nest::ConnectionManager::remove_disabled_connections_( const size_t tid )
+ConnectionManager::remove_disabled_connections_( const size_t tid )
 {
   assert( use_compressed_spikes_ );
 
@@ -1711,7 +1714,7 @@ nest::ConnectionManager::remove_disabled_connections_( const size_t tid )
 }
 
 void
-nest::ConnectionManager::resize_connections()
+ConnectionManager::resize_connections()
 {
   kernel().vp_manager.assert_thread_parallel();
 
@@ -1722,19 +1725,19 @@ nest::ConnectionManager::resize_connections()
 }
 
 void
-nest::ConnectionManager::sync_has_primary_connections()
+ConnectionManager::sync_has_primary_connections()
 {
   has_primary_connections_ = kernel().mpi_manager.any_true( has_primary_connections_ );
 }
 
 void
-nest::ConnectionManager::check_secondary_connections_exist()
+ConnectionManager::check_secondary_connections_exist()
 {
   secondary_connections_exist_ = kernel().mpi_manager.any_true( secondary_connections_exist_ );
 }
 
 void
-nest::ConnectionManager::set_connections_have_changed()
+ConnectionManager::set_connections_have_changed()
 {
   assert( kernel().vp_manager.get_thread_id() == 0 );
 
@@ -1751,14 +1754,14 @@ nest::ConnectionManager::set_connections_have_changed()
 }
 
 void
-nest::ConnectionManager::unset_connections_have_changed()
+ConnectionManager::unset_connections_have_changed()
 {
   connections_have_changed_ = false;
 }
 
 
 void
-nest::ConnectionManager::collect_compressed_spike_data( const size_t tid )
+ConnectionManager::collect_compressed_spike_data( const size_t tid )
 {
   if ( use_compressed_spikes_ )
   {
@@ -1780,7 +1783,7 @@ nest::ConnectionManager::collect_compressed_spike_data( const size_t tid )
 }
 
 bool
-nest::ConnectionManager::fill_target_buffer( const size_t tid,
+ConnectionManager::fill_target_buffer( const size_t tid,
   const size_t rank_start,
   const size_t rank_end,
   std::vector< TargetData >& send_buffer_target_data,
@@ -1895,7 +1898,7 @@ nest::ConnectionManager::fill_target_buffer( const size_t tid,
 }
 
 void
-nest::ConnectionManager::initialize_iteration_state()
+ConnectionManager::initialize_iteration_state()
 {
   const size_t num_threads = kernel().vp_manager.get_num_threads();
   iteration_state_.clear();
@@ -1910,3 +1913,5 @@ nest::ConnectionManager::initialize_iteration_state()
     iteration_state_.push_back( std::pair< size_t, std::map< size_t, CSDMapEntry >::const_iterator >( 0, begin ) );
   }
 }
+
+}  // namespace nest

--- a/nestkernel/connection_manager.cpp
+++ b/nestkernel/connection_manager.cpp
@@ -997,10 +997,7 @@ ConnectionManager::find_connection( const size_t tid,
 }
 
 void
-ConnectionManager::disconnect( const size_t tid,
-  const synindex syn_id,
-  const size_t snode_id,
-  const size_t tnode_id )
+ConnectionManager::disconnect( const size_t tid, const synindex syn_id, const size_t snode_id, const size_t tnode_id )
 {
   assert( syn_id != invalid_synindex );
 

--- a/nestkernel/connector_base.h
+++ b/nestkernel/connector_base.h
@@ -462,7 +462,7 @@ public:
   void
   sort_connections( BlockVector< Source >& sources ) override
   {
-    nest::sort( sources, C_ );
+    sort( sources, C_ );
   }
 
   void

--- a/nestkernel/delay_checker.cpp
+++ b/nestkernel/delay_checker.cpp
@@ -30,7 +30,10 @@
 #include "kernel_manager.h"
 #include "nest_timeconverter.h"
 
-nest::DelayChecker::DelayChecker()
+
+namespace nest
+{
+DelayChecker::DelayChecker()
   : min_delay_( Time::pos_inf() )
   , max_delay_( Time::neg_inf() )
   , user_set_delay_extrema_( false )
@@ -38,7 +41,7 @@ nest::DelayChecker::DelayChecker()
 {
 }
 
-nest::DelayChecker::DelayChecker( const DelayChecker& cr )
+DelayChecker::DelayChecker( const DelayChecker& cr )
   : min_delay_( cr.min_delay_ )
   , max_delay_( cr.max_delay_ )
   , user_set_delay_extrema_( cr.user_set_delay_extrema_ )
@@ -49,7 +52,7 @@ nest::DelayChecker::DelayChecker( const DelayChecker& cr )
 }
 
 void
-nest::DelayChecker::calibrate( const TimeConverter& tc )
+DelayChecker::calibrate( const TimeConverter& tc )
 {
   // Calibrate will be called after a change in resolution, when there are no
   // network elements present.
@@ -69,7 +72,7 @@ nest::DelayChecker::calibrate( const TimeConverter& tc )
 }
 
 void
-nest::DelayChecker::set_min_max_delay_( const double min_d, const double max_d )
+DelayChecker::set_min_max_delay_( const double min_d, const double max_d )
 {
   // For the minimum delay, we always round down. The easiest way to do this,
   // is to round up and then subtract one step. The only remaining edge case
@@ -108,14 +111,14 @@ nest::DelayChecker::set_min_max_delay_( const double min_d, const double max_d )
 }
 
 void
-nest::DelayChecker::get_status( Dictionary& d ) const
+DelayChecker::get_status( Dictionary& d ) const
 {
   d[ names::min_delay ] = get_min_delay().get_ms();
   d[ names::max_delay ] = get_max_delay().get_ms();
 }
 
 void
-nest::DelayChecker::set_status( const Dictionary& d )
+DelayChecker::set_status( const Dictionary& d )
 {
   double min_d_tmp = 0.0;
   bool min_delay_updated = d.update_value( names::min_delay, min_d_tmp );
@@ -143,7 +146,7 @@ nest::DelayChecker::set_status( const Dictionary& d )
 }
 
 void
-nest::DelayChecker::assert_valid_delay_ms( double requested_new_delay )
+DelayChecker::assert_valid_delay_ms( double requested_new_delay )
 {
   const long new_delay = Time::delay_ms_to_steps( requested_new_delay );
   const double new_delay_ms = Time::delay_steps_to_ms( new_delay );
@@ -206,7 +209,7 @@ nest::DelayChecker::assert_valid_delay_ms( double requested_new_delay )
 }
 
 void
-nest::DelayChecker::assert_two_valid_delays_steps( long new_delay1, long new_delay2 )
+DelayChecker::assert_two_valid_delays_steps( long new_delay1, long new_delay2 )
 {
   const long ldelay = std::min( new_delay1, new_delay2 );
   const long hdelay = std::max( new_delay1, new_delay2 );
@@ -269,3 +272,5 @@ nest::DelayChecker::assert_two_valid_delays_steps( long new_delay1, long new_del
     }
   }
 }
+
+}  // namespace nest

--- a/nestkernel/device.cpp
+++ b/nestkernel/device.cpp
@@ -32,18 +32,20 @@
 #include "node.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * Default constructor defining default parameters
  * ---------------------------------------------------------------- */
 
-nest::Device::Parameters_::Parameters_()
+Device::Parameters_::Parameters_()
   : origin_( Time::step( 0 ) )
   , start_( Time::step( 0 ) )
   , stop_( Time::pos_inf() )
 {
 }
 
-nest::Device::Parameters_::Parameters_( const Parameters_& p )
+Device::Parameters_::Parameters_( const Parameters_& p )
   : origin_( p.origin_ )
   , start_( p.start_ )
   , stop_( p.stop_ )
@@ -56,8 +58,8 @@ nest::Device::Parameters_::Parameters_( const Parameters_& p )
   stop_.calibrate();
 }
 
-nest::Device::Parameters_&
-nest::Device::Parameters_::operator=( const Parameters_& p )
+Device::Parameters_&
+Device::Parameters_::operator=( const Parameters_& p )
 {
   origin_ = p.origin_;
   start_ = p.start_;
@@ -72,7 +74,7 @@ nest::Device::Parameters_::operator=( const Parameters_& p )
  * ---------------------------------------------------------------- */
 
 void
-nest::Device::Parameters_::get( Dictionary& d ) const
+Device::Parameters_::get( Dictionary& d ) const
 {
   d[ names::origin ] = origin_.get_ms();
   d[ names::start ] = start_.get_ms();
@@ -80,7 +82,7 @@ nest::Device::Parameters_::get( Dictionary& d ) const
 }
 
 void
-nest::Device::Parameters_::update_( const Dictionary& d, const std::string& name, Time& value )
+Device::Parameters_::update_( const Dictionary& d, const std::string& name, Time& value )
 {
   // We cannot update the Time values directly, since updateValue()
   // doesn't support Time objects. We thus read the value in ms into
@@ -103,7 +105,7 @@ nest::Device::Parameters_::update_( const Dictionary& d, const std::string& name
 }
 
 void
-nest::Device::Parameters_::set( const Dictionary& d )
+Device::Parameters_::set( const Dictionary& d )
 {
   update_( d, names::origin, origin_ );
   update_( d, names::start, start_ );
@@ -120,12 +122,12 @@ nest::Device::Parameters_::set( const Dictionary& d )
  * Default and copy constructor for device
  * ---------------------------------------------------------------- */
 
-nest::Device::Device()
+Device::Device()
   : P_()
 {
 }
 
-nest::Device::Device( const Device& n )
+Device::Device( const Device& n )
   : P_( n.P_ )
 {
 }
@@ -136,7 +138,7 @@ nest::Device::Device( const Device& n )
  * ---------------------------------------------------------------- */
 
 void
-nest::Device::pre_run_hook()
+Device::pre_run_hook()
 {
   // We do not need to recalibrate time objects, since they are
   // recalibrated on instance construction and resolution cannot
@@ -146,3 +148,5 @@ nest::Device::pre_run_hook()
   V_.t_min_ = ( P_.origin_ + P_.start_ ).get_steps();
   V_.t_max_ = ( P_.origin_ + P_.stop_ ).get_steps();
 }
+
+}  // namespace nest

--- a/nestkernel/device.h
+++ b/nestkernel/device.h
@@ -175,16 +175,14 @@ private:
   Variables_ V_;
 };
 
-}  // namespace
-
 inline void
-nest::Device::get_status( Dictionary& d ) const
+Device::get_status( Dictionary& d ) const
 {
   P_.get( d );
 }
 
 inline void
-nest::Device::set_status( const Dictionary& d )
+Device::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.set( d );          // throws if BadProperty
@@ -193,34 +191,36 @@ nest::Device::set_status( const Dictionary& d )
   P_ = ptmp;
 }
 
-inline nest::Time const&
-nest::Device::get_origin() const
+inline Time const&
+Device::get_origin() const
 {
   return P_.origin_;
 }
 
-inline nest::Time const&
-nest::Device::get_start() const
+inline Time const&
+Device::get_start() const
 {
   return P_.start_;
 }
 
-inline nest::Time const&
-nest::Device::get_stop() const
+inline Time const&
+Device::get_stop() const
 {
   return P_.stop_;
 }
 
 inline long
-nest::Device::get_t_min_() const
+Device::get_t_min_() const
 {
   return V_.t_min_;
 }
 
 inline long
-nest::Device::get_t_max_() const
+Device::get_t_max_() const
 {
   return V_.t_max_;
 }
+
+}  // namespace nest
 
 #endif /* DEVICE_H */

--- a/nestkernel/event_delivery_manager.cpp
+++ b/nestkernel/event_delivery_manager.cpp
@@ -1037,7 +1037,7 @@ EventDeliveryManager::collocate_target_data_buffers_compressed_( const size_t ti
 
 
 void
-nest::EventDeliveryManager::set_complete_marker_target_data_( const AssignedRanks& assigned_ranks,
+EventDeliveryManager::set_complete_marker_target_data_( const AssignedRanks& assigned_ranks,
   const TargetSendBufferPosition& send_buffer_position )
 {
   for ( size_t rank = assigned_ranks.begin; rank < assigned_ranks.end; ++rank )
@@ -1048,7 +1048,7 @@ nest::EventDeliveryManager::set_complete_marker_target_data_( const AssignedRank
 }
 
 bool
-nest::EventDeliveryManager::distribute_target_data_buffers_( const size_t tid )
+EventDeliveryManager::distribute_target_data_buffers_( const size_t tid )
 {
   bool are_others_completed = true;
   const unsigned int send_recv_count_target_data_per_rank =

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -37,8 +37,10 @@
 #include "compose.hpp"
 
 
+namespace nest
+{
 std::string
-nest::UnknownModelName::compose_msg_( const std::string& model_name ) const
+UnknownModelName::compose_msg_( const std::string& model_name ) const
 {
   std::string msg = String::compose( "%1 is not a known model name.", model_name );
 #ifndef HAVE_GSL
@@ -50,7 +52,7 @@ nest::UnknownModelName::compose_msg_( const std::string& model_name ) const
 }
 
 std::string
-nest::UnknownComponent::compose_msg_( const std::string& component_name ) const
+UnknownComponent::compose_msg_( const std::string& component_name ) const
 {
   std::string msg = String::compose( "%1 is not a known component.", component_name );
 #ifndef HAVE_GSL
@@ -62,56 +64,56 @@ nest::UnknownComponent::compose_msg_( const std::string& component_name ) const
 }
 
 std::string
-nest::NewModelNameExists::compose_msg_( const std::string& model_name ) const
+NewModelNameExists::compose_msg_( const std::string& model_name ) const
 {
   std::string msg = String::compose( "Model %1 is the name of an existing model and cannot be re-used.", model_name );
   return msg;
 }
 
 std::string
-nest::ModelInUse::compose_msg_( const std::string& model_name ) const
+ModelInUse::compose_msg_( const std::string& model_name ) const
 {
   std::string msg = String::compose( "Model %1 is in use and cannot be unloaded/uninstalled.", model_name );
   return msg;
 }
 
 std::string
-nest::UnknownSynapseType::compose_msg_( const int id ) const
+UnknownSynapseType::compose_msg_( const int id ) const
 {
   std::string msg = String::compose( "Synapse with id %1 does not exist.", id );
   return msg;
 }
 
 std::string
-nest::UnknownSynapseType::compose_msg_( const std::string& name ) const
+UnknownSynapseType::compose_msg_( const std::string& name ) const
 {
   std::string msg = String::compose( "Synapse with name %1 does not exist.", name );
   return msg;
 }
 
 std::string
-nest::UnknownNode::compose_msg_( const int id ) const
+UnknownNode::compose_msg_( const int id ) const
 {
   std::string msg = String::compose( "Node with id %1 does not exist.", id );
   return msg;
 }
 
 std::string
-nest::NoThreadSiblingsAvailable::compose_msg_( const int id ) const
+NoThreadSiblingsAvailable::compose_msg_( const int id ) const
 {
   std::string msg = String::compose( "Node with id %1 does not have thread siblings.", id );
   return msg;
 }
 
 std::string
-nest::LocalNodeExpected::compose_msg_( const int id ) const
+LocalNodeExpected::compose_msg_( const int id ) const
 {
   std::string msg = String::compose( "Node with id %1 is not a local node.", id );
   return msg;
 }
 
 std::string
-nest::NodeWithProxiesExpected::compose_msg_( const int id ) const
+NodeWithProxiesExpected::compose_msg_( const int id ) const
 {
   std::string msg = String::compose(
     "A node with proxies (usually a neuron) is expected, "
@@ -121,21 +123,21 @@ nest::NodeWithProxiesExpected::compose_msg_( const int id ) const
 }
 
 std::string
-nest::UnknownCompartment::compose_msg_( const long compartment_idx, const std::string info ) const
+UnknownCompartment::compose_msg_( const long compartment_idx, const std::string info ) const
 {
   std::string msg = String::compose( "Compartment %1 %2.", compartment_idx, info );
   return msg;
 }
 
 std::string
-nest::UnknownReceptorType::compose_msg_( const long receptor_type, const std::string name ) const
+UnknownReceptorType::compose_msg_( const long receptor_type, const std::string name ) const
 {
   std::string msg = String::compose( "Receptor type %1 is not available in %2.", receptor_type, name );
   return msg;
 }
 
 std::string
-nest::IncompatibleReceptorType::compose_msg( const long receptor_type,
+IncompatibleReceptorType::compose_msg( const long receptor_type,
   const std::string name,
   const std::string event_type )
 {
@@ -144,14 +146,14 @@ nest::IncompatibleReceptorType::compose_msg( const long receptor_type,
 }
 
 std::string
-nest::UnknownPort::compose_msg_( const int id ) const
+UnknownPort::compose_msg_( const int id ) const
 {
   std::string msg = String::compose( "Port with id %1 does not exist.", id );
   return msg;
 }
 
 std::string
-nest::UnknownPort::compose_msg_( const int id, const std::string msg ) const
+UnknownPort::compose_msg_( const int id, const std::string msg ) const
 {
   std::string msg_out;
   msg_out = String::compose( "Port with id %1 does not exist. ", id );
@@ -160,7 +162,7 @@ nest::UnknownPort::compose_msg_( const int id, const std::string msg ) const
 }
 
 std::string
-nest::UnsupportedEvent::compose_msg_() const
+UnsupportedEvent::compose_msg_() const
 {
   std::string msg;
   msg = "The current synapse type does not support the event type of the sender.\n";
@@ -169,7 +171,7 @@ nest::UnsupportedEvent::compose_msg_() const
 }
 
 #ifdef HAVE_MPI
-nest::MPIErrorCode::MPIErrorCode( const int error_code )
+MPIErrorCode::MPIErrorCode( const int error_code )
 {
   char errmsg_[ 2 * MPI_MAX_ERROR_STRING ];  // Multiply by two for extra safety
   int len_;
@@ -179,3 +181,5 @@ nest::MPIErrorCode::MPIErrorCode( const int error_code )
   msg_ = String::compose( "MPI Error: %1", error_ );
 }
 #endif
+
+}  // namespace nest

--- a/nestkernel/exceptions.cpp
+++ b/nestkernel/exceptions.cpp
@@ -137,9 +137,7 @@ UnknownReceptorType::compose_msg_( const long receptor_type, const std::string n
 }
 
 std::string
-IncompatibleReceptorType::compose_msg( const long receptor_type,
-  const std::string name,
-  const std::string event_type )
+IncompatibleReceptorType::compose_msg( const long receptor_type, const std::string name, const std::string event_type )
 {
   std::string msg = String::compose( "Receptor type %1 in %2 does not accept %3.", receptor_type, name, event_type );
   return msg;

--- a/nestkernel/free_layer.h
+++ b/nestkernel/free_layer.h
@@ -169,7 +169,7 @@ FreeLayer< D >::set_status( const Dictionary& d )
       }
       assert( positions_.size() == num_local_nodes_ );
     }
-    else if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( positions ) )
+    else if ( std::holds_alternative< std::shared_ptr< Parameter > >( positions ) )
     {
       auto pd = d.get< ParameterPTR >( names::positions );
       auto pos = dynamic_cast< DimensionParameter* >( pd.get() );

--- a/nestkernel/genericmodel.h
+++ b/nestkernel/genericmodel.h
@@ -232,7 +232,7 @@ GenericModel< ElementT >::sends_secondary_event( SICEvent& sic )
 }
 
 template < typename ElementT >
-inline nest::SignalType
+inline SignalType
 GenericModel< ElementT >::sends_signal() const
 {
   return proto_.sends_signal();

--- a/nestkernel/growth_curve.cpp
+++ b/nestkernel/growth_curve.cpp
@@ -30,31 +30,33 @@
 #include "nest_time.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * GrowthCurveLinear
  * ---------------------------------------------------------------- */
 
-nest::GrowthCurveLinear::GrowthCurveLinear()
+GrowthCurveLinear::GrowthCurveLinear()
   : GrowthCurve( names::linear )
   , eps_( 0.7 )
 {
 }
 
 void
-nest::GrowthCurveLinear::get( Dictionary& d ) const
+GrowthCurveLinear::get( Dictionary& d ) const
 {
   d[ names::growth_curve ] = name_;
   d[ names::eps ] = eps_;
 }
 
 void
-nest::GrowthCurveLinear::set( const Dictionary& d )
+GrowthCurveLinear::set( const Dictionary& d )
 {
   d.update_value( names::eps, eps_ );
 }
 
 double
-nest::GrowthCurveLinear::update( double t,
+GrowthCurveLinear::update( double t,
   double t_minus,
   double Ca_minus,
   double z_minus,
@@ -71,7 +73,7 @@ nest::GrowthCurveLinear::update( double t,
  * GrowthCurveGaussian
  * ---------------------------------------------------------------- */
 
-nest::GrowthCurveGaussian::GrowthCurveGaussian()
+GrowthCurveGaussian::GrowthCurveGaussian()
   : GrowthCurve( names::gaussian )
   , eta_( 0.1 )
   , eps_( 0.7 )
@@ -80,7 +82,7 @@ nest::GrowthCurveGaussian::GrowthCurveGaussian()
 }
 
 void
-nest::GrowthCurveGaussian::get( Dictionary& d ) const
+GrowthCurveGaussian::get( Dictionary& d ) const
 {
   d[ names::growth_curve ] = name_;
   d[ names::eps ] = eps_;
@@ -88,7 +90,7 @@ nest::GrowthCurveGaussian::get( Dictionary& d ) const
 }
 
 void
-nest::GrowthCurveGaussian::set( const Dictionary& d )
+GrowthCurveGaussian::set( const Dictionary& d )
 {
   d.update_value( names::eps, eps_ );
   d.update_value( names::eta, eta_ );
@@ -96,7 +98,7 @@ nest::GrowthCurveGaussian::set( const Dictionary& d )
 }
 
 double
-nest::GrowthCurveGaussian::update( double t,
+GrowthCurveGaussian::update( double t,
   double t_minus,
   double Ca_minus,
   double z_minus,
@@ -122,7 +124,7 @@ nest::GrowthCurveGaussian::update( double t,
 }
 
 void
-nest::GrowthCurveGaussian::compute_local_()
+GrowthCurveGaussian::compute_local_()
 {
   inv_zeta_ = 2.0 * numerics::sqrt_log_two / ( eta_ - eps_ );
   xi_ = ( eta_ + eps_ ) * 0.5;
@@ -132,7 +134,7 @@ nest::GrowthCurveGaussian::compute_local_()
  * GrowthCurveSigmoid
  * ---------------------------------------------------------------- */
 
-nest::GrowthCurveSigmoid::GrowthCurveSigmoid()
+GrowthCurveSigmoid::GrowthCurveSigmoid()
   : GrowthCurve( names::sigmoid )
   , eps_( 0.7 )
   , psi_( 0.1 )
@@ -140,7 +142,7 @@ nest::GrowthCurveSigmoid::GrowthCurveSigmoid()
 }
 
 void
-nest::GrowthCurveSigmoid::get( Dictionary& d ) const
+GrowthCurveSigmoid::get( Dictionary& d ) const
 {
   d[ names::growth_curve ] = name_;
   d[ names::eps ] = eps_;
@@ -148,7 +150,7 @@ nest::GrowthCurveSigmoid::get( Dictionary& d ) const
 }
 
 void
-nest::GrowthCurveSigmoid::set( const Dictionary& d )
+GrowthCurveSigmoid::set( const Dictionary& d )
 {
   d.update_value( names::eps, eps_ );
   d.update_value( names::psi, psi_ );
@@ -161,7 +163,7 @@ nest::GrowthCurveSigmoid::set( const Dictionary& d )
 }
 
 double
-nest::GrowthCurveSigmoid::update( double t,
+GrowthCurveSigmoid::update( double t,
   double t_minus,
   double Ca_minus,
   double z_minus,
@@ -184,3 +186,5 @@ nest::GrowthCurveSigmoid::update( double t,
 
   return std::max( z_value, 0.0 );
 }
+
+}  // namespace nest

--- a/nestkernel/histentry.cpp
+++ b/nestkernel/histentry.cpp
@@ -22,7 +22,10 @@
 
 #include "histentry.h"
 
-nest::histentry::histentry( double t, double Kminus, double Kminus_triplet, size_t access_counter )
+
+namespace nest
+{
+histentry::histentry( double t, double Kminus, double Kminus_triplet, size_t access_counter )
   : t_( t )
   , Kminus_( Kminus )
   , Kminus_triplet_( Kminus_triplet )
@@ -30,19 +33,19 @@ nest::histentry::histentry( double t, double Kminus, double Kminus_triplet, size
 {
 }
 
-nest::histentry_extended::histentry_extended( double t, double dw, size_t access_counter )
+histentry_extended::histentry_extended( double t, double dw, size_t access_counter )
   : t_( t )
   , dw_( dw )
   , access_counter_( access_counter )
 {
 }
 
-nest::HistEntryEprop::HistEntryEprop( long t )
+HistEntryEprop::HistEntryEprop( long t )
   : t_( t )
 {
 }
 
-nest::HistEntryEpropRecurrent::HistEntryEpropRecurrent( long t,
+HistEntryEpropRecurrent::HistEntryEpropRecurrent( long t,
   double surrogate_gradient,
   double learning_signal,
   double firing_rate_reg )
@@ -53,20 +56,22 @@ nest::HistEntryEpropRecurrent::HistEntryEpropRecurrent( long t,
 {
 }
 
-nest::HistEntryEpropReadout::HistEntryEpropReadout( long t, double error_signal )
+HistEntryEpropReadout::HistEntryEpropReadout( long t, double error_signal )
   : HistEntryEprop( t )
   , error_signal_( error_signal )
 {
 }
 
-nest::HistEntryEpropUpdate::HistEntryEpropUpdate( long t, size_t access_counter )
+HistEntryEpropUpdate::HistEntryEpropUpdate( long t, size_t access_counter )
   : HistEntryEprop( t )
   , access_counter_( access_counter )
 {
 }
 
-nest::HistEntryEpropFiringRateReg::HistEntryEpropFiringRateReg( long t, double firing_rate_reg )
+HistEntryEpropFiringRateReg::HistEntryEpropFiringRateReg( long t, double firing_rate_reg )
   : HistEntryEprop( t )
   , firing_rate_reg_( firing_rate_reg )
 {
 }
+
+}  // namespace nest

--- a/nestkernel/io_manager.h
+++ b/nestkernel/io_manager.h
@@ -165,24 +165,24 @@ private:
   std::map< std::string, StimulationBackend* > stimulation_backends_;
 };
 
-}  // namespace nest
-
 inline const std::string&
-nest::IOManager::get_data_path() const
+IOManager::get_data_path() const
 {
   return data_path_;
 }
 
 inline const std::string&
-nest::IOManager::get_data_prefix() const
+IOManager::get_data_prefix() const
 {
   return data_prefix_;
 }
 
 inline bool
-nest::IOManager::overwrite_files() const
+IOManager::overwrite_files() const
 {
   return overwrite_files_;
 }
+
+}  // namespace nest
 
 #endif /* #ifndef IO_MANAGER_H */

--- a/nestkernel/kernel_manager.cpp
+++ b/nestkernel/kernel_manager.cpp
@@ -23,11 +23,14 @@
 #include "kernel_manager.h"
 #include "stopwatch_impl.h"
 
-nest::KernelManager* nest::KernelManager::kernel_manager_instance_ = nullptr;
+
+namespace nest
+{
+KernelManager* KernelManager::kernel_manager_instance_ = nullptr;
 
 
 Dictionary
-nest::KernelManager::get_build_info_()
+KernelManager::get_build_info_()
 {
   // Exit codes
   constexpr unsigned int EXITCODE_UNKNOWN_ERROR = 10;
@@ -135,7 +138,7 @@ nest::KernelManager::get_build_info_()
 }
 
 void
-nest::KernelManager::create_kernel_manager()
+KernelManager::create_kernel_manager()
 {
 #pragma omp master
   {
@@ -148,7 +151,7 @@ nest::KernelManager::create_kernel_manager()
 #pragma omp barrier
 }
 
-nest::KernelManager::KernelManager()
+KernelManager::KernelManager()
   : fingerprint_( 0 )
   , logging_manager()
   , mpi_manager()
@@ -182,12 +185,12 @@ nest::KernelManager::KernelManager()
 {
 }
 
-nest::KernelManager::~KernelManager()
+KernelManager::~KernelManager()
 {
 }
 
 void
-nest::KernelManager::initialize()
+KernelManager::initialize()
 {
   for ( auto& manager : managers )
   {
@@ -205,7 +208,7 @@ nest::KernelManager::initialize()
 }
 
 void
-nest::KernelManager::prepare()
+KernelManager::prepare()
 {
   for ( auto& manager : managers )
   {
@@ -217,7 +220,7 @@ nest::KernelManager::prepare()
 }
 
 void
-nest::KernelManager::cleanup()
+KernelManager::cleanup()
 {
   for ( auto&& m_it = managers.rbegin(); m_it != managers.rend(); ++m_it )
   {
@@ -226,7 +229,7 @@ nest::KernelManager::cleanup()
 }
 
 void
-nest::KernelManager::finalize()
+KernelManager::finalize()
 {
   FULL_LOGGING_ONLY( dump_.close(); )
 
@@ -238,14 +241,14 @@ nest::KernelManager::finalize()
 }
 
 void
-nest::KernelManager::reset()
+KernelManager::reset()
 {
   finalize();
   initialize();
 }
 
 void
-nest::KernelManager::change_number_of_threads( size_t new_num_threads )
+KernelManager::change_number_of_threads( size_t new_num_threads )
 {
   // Inputs are checked in VPManager::set_status().
   // Just double check here that all values are legal.
@@ -285,7 +288,7 @@ nest::KernelManager::change_number_of_threads( size_t new_num_threads )
 }
 
 void
-nest::KernelManager::set_status( const Dictionary& dict )
+KernelManager::set_status( const Dictionary& dict )
 {
   assert( is_initialized() );
 
@@ -296,7 +299,7 @@ nest::KernelManager::set_status( const Dictionary& dict )
 }
 
 void
-nest::KernelManager::get_status( Dictionary& dict )
+KernelManager::get_status( Dictionary& dict )
 {
   assert( is_initialized() );
 
@@ -328,7 +331,7 @@ nest::KernelManager::get_status( Dictionary& dict )
 }
 
 void
-nest::KernelManager::write_to_dump( const std::string& msg )
+KernelManager::write_to_dump( const std::string& msg )
 {
 #pragma omp critical
   // In critical section to avoid any garbling of output.
@@ -342,7 +345,7 @@ nest::KernelManager::write_to_dump( const std::string& msg )
 #include <fstream>
 #include <sstream>
 size_t
-nest::KernelManager::get_memsize_linux_() const
+KernelManager::get_memsize_linux_() const
 {
   // code based on mistral.ai
   std::ifstream file( "/proc/self/status" );
@@ -377,7 +380,7 @@ nest::KernelManager::get_memsize_linux_() const
 #else
 
 size_t
-nest::KernelManager::get_memsize_linux_() const
+KernelManager::get_memsize_linux_() const
 {
   assert( false || "Only implemented on Linux systems." );
   return 0;
@@ -390,7 +393,7 @@ nest::KernelManager::get_memsize_linux_() const
 
 #include <mach/mach.h>
 size_t
-nest::KernelManager::get_memsize_darwin_() const
+KernelManager::get_memsize_darwin_() const
 {
   struct task_basic_info t_info;
   mach_msg_type_number_t t_info_count = TASK_BASIC_INFO_COUNT;
@@ -406,10 +409,12 @@ nest::KernelManager::get_memsize_darwin_() const
 #else
 
 size_t
-nest::KernelManager::get_memsize_darwin_() const
+KernelManager::get_memsize_darwin_() const
 {
   assert( false || "Only implemented on macOS." );
   return 0;
 }
 
 #endif
+
+}  // namespace nest

--- a/nestkernel/kernel_manager.cpp
+++ b/nestkernel/kernel_manager.cpp
@@ -23,6 +23,15 @@
 #include "kernel_manager.h"
 #include "stopwatch_impl.h"
 
+// C++ includes:
+#include <fstream>
+#include <sstream>
+
+#ifdef __APPLE__
+// C includes:
+#include <mach/mach.h>
+#endif
+
 
 namespace nest
 {
@@ -342,8 +351,6 @@ KernelManager::write_to_dump( const std::string& msg )
 
 #ifdef __linux__
 
-#include <fstream>
-#include <sstream>
 size_t
 KernelManager::get_memsize_linux_() const
 {
@@ -391,7 +398,6 @@ KernelManager::get_memsize_linux_() const
 
 #if defined __APPLE__
 
-#include <mach/mach.h>
 size_t
 KernelManager::get_memsize_darwin_() const
 {

--- a/nestkernel/kernel_manager.h
+++ b/nestkernel/kernel_manager.h
@@ -343,32 +343,31 @@ get_vp_specific_rng( size_t tid )
   return kernel().random_manager.get_vp_specific_rng( tid );
 }
 
-}  // namespace nest
-
-inline nest::KernelManager&
-nest::KernelManager::get_kernel_manager()
+inline KernelManager&
+KernelManager::get_kernel_manager()
 {
   assert( kernel_manager_instance_ );
   return *kernel_manager_instance_;
 }
 
-inline nest::KernelManager&
-nest::kernel()
+inline KernelManager&
+kernel()
 {
   return KernelManager::get_kernel_manager();
 }
 
 inline bool
-nest::KernelManager::is_initialized() const
+KernelManager::is_initialized() const
 {
   return initialized_;
 }
 
 inline unsigned long
-nest::KernelManager::get_fingerprint() const
+KernelManager::get_fingerprint() const
 {
   return fingerprint_;
 }
 
+}  // namespace nest
 
 #endif /* KERNEL_MANAGER_H */

--- a/nestkernel/layer.cpp
+++ b/nestkernel/layer.cpp
@@ -72,7 +72,7 @@ AbstractLayer::create_layer( const Dictionary& layer_dict )
       length = pos.size();
       num_dimensions = pos[ 0 ].size();
     }
-    else if ( std::holds_alternative< std::shared_ptr< nest::Parameter > >( positions ) )
+    else if ( std::holds_alternative< std::shared_ptr< Parameter > >( positions ) )
     {
       auto pd = layer_dict.get< ParameterPTR >( names::positions );
       auto pos = dynamic_cast< DimensionParameter* >( pd.get() );

--- a/nestkernel/logging_manager.cpp
+++ b/nestkernel/logging_manager.cpp
@@ -33,19 +33,21 @@
 #include "compose.hpp"
 
 
-nest::LoggingManager::LoggingManager()
+namespace nest
+{
+LoggingManager::LoggingManager()
   : client_callbacks_()
   , logging_level_( VerbosityLevel::INFO )
   , dict_miss_is_error_( true )
 {
 }
 
-nest::LoggingManager::~LoggingManager()
+LoggingManager::~LoggingManager()
 {
 }
 
 void
-nest::LoggingManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+LoggingManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 {
   if ( not adjust_number_of_threads_or_rng_only )
   {
@@ -54,19 +56,19 @@ nest::LoggingManager::initialize( const bool adjust_number_of_threads_or_rng_onl
 }
 
 void
-nest::LoggingManager::finalize( const bool )
+LoggingManager::finalize( const bool )
 {
 }
 
 void
-nest::LoggingManager::set_status( const Dictionary& dict )
+LoggingManager::set_status( const Dictionary& dict )
 {
   dict.update_value( names::dict_miss_is_error, dict_miss_is_error_ );
   dict.update_value( names::verbosity, logging_level_ );  // safe, because entry must be VerbosityLevel
 }
 
 void
-nest::LoggingManager::get_status( Dictionary& dict )
+LoggingManager::get_status( Dictionary& dict )
 {
   dict[ names::dict_miss_is_error ] = dict_miss_is_error_;
   dict[ names::verbosity ] = logging_level_;
@@ -74,7 +76,7 @@ nest::LoggingManager::get_status( Dictionary& dict )
 
 
 void
-nest::LoggingManager::register_logging_client( const deliver_logging_event_ptr callback )
+LoggingManager::register_logging_client( const deliver_logging_event_ptr callback )
 {
   assert( callback );
 
@@ -82,7 +84,7 @@ nest::LoggingManager::register_logging_client( const deliver_logging_event_ptr c
 }
 
 void
-nest::LoggingManager::deliver_logging_event_( const LoggingEvent& event ) const
+LoggingManager::deliver_logging_event_( const LoggingEvent& event ) const
 {
   if ( client_callbacks_.empty() )
   {
@@ -95,7 +97,7 @@ nest::LoggingManager::deliver_logging_event_( const LoggingEvent& event ) const
 }
 
 void
-nest::LoggingManager::default_logging_callback_( const LoggingEvent& event ) const
+LoggingManager::default_logging_callback_( const LoggingEvent& event ) const
 {
   std::ostream* out;
 
@@ -112,7 +114,7 @@ nest::LoggingManager::default_logging_callback_( const LoggingEvent& event ) con
 }
 
 void
-nest::LoggingManager::publish_log( const VerbosityLevel s,
+LoggingManager::publish_log( const VerbosityLevel s,
   const std::string& fctn,
   const std::string& msg,
   const std::string& file,
@@ -127,3 +129,5 @@ nest::LoggingManager::publish_log( const VerbosityLevel s,
     }
   }
 }
+
+}  // namespace nest

--- a/nestkernel/mask.h
+++ b/nestkernel/mask.h
@@ -401,19 +401,19 @@ public:
     if ( major_axis_ <= 0 or minor_axis_ <= 0 or polar_axis_ <= 0 )
     {
       throw BadProperty(
-        "nest::EllipseMask<D>: "
+        "EllipseMask<D>: "
         "All axis > 0 required." );
     }
     if ( major_axis_ < minor_axis_ )
     {
       throw BadProperty(
-        "nest::EllipseMask<D>: "
+        "EllipseMask<D>: "
         "major_axis greater than minor_axis required." );
     }
     if ( D == 2 and not( polar_angle_ == 0.0 ) )
     {
       throw BadProperty(
-        "nest::EllipseMask<D>: "
+        "EllipseMask<D>: "
         "polar_angle not defined in 2D." );
     }
 
@@ -740,7 +740,7 @@ BoxMask< D >::BoxMask( const Dictionary& d )
   if ( not( lower_left_ < upper_right_ ) )
   {
     throw BadProperty(
-      "nest::BoxMask<D>: "
+      "BoxMask<D>: "
       "Upper right must be strictly to the right and above lower left." );
   }
 
@@ -758,7 +758,7 @@ BoxMask< D >::BoxMask( const Dictionary& d )
     if ( D == 2 )
     {
       throw BadProperty(
-        "nest::BoxMask<D>: "
+        "BoxMask<D>: "
         "polar_angle not defined in 2D." );
     }
     polar_angle_ = d.get< double >( names::polar_angle );
@@ -837,7 +837,7 @@ inline BoxMask< D >::BoxMask( const Position< D >& lower_left,
   if ( D == 2 and not( polar_angle_ == 0.0 ) )
   {
     throw BadProperty(
-      "nest::BoxMask<D>: "
+      "BoxMask<D>: "
       "polar_angle not defined in 2D." );
   }
 
@@ -898,7 +898,7 @@ BallMask< D >::BallMask( const Dictionary& d )
   radius_ = d.get< double >( names::radius );
   if ( radius_ <= 0 )
   {
-    throw BadProperty( "nest::BallMask<D>: radius > 0 required." );
+    throw BadProperty( "BallMask<D>: radius > 0 required." );
   }
 
   if ( d.known( names::anchor ) )
@@ -929,13 +929,13 @@ EllipseMask< D >::EllipseMask( const Dictionary& d )
   if ( major_axis_ <= 0 or minor_axis_ <= 0 )
   {
     throw BadProperty(
-      "nest::EllipseMask<D>: "
+      "EllipseMask<D>: "
       "All axis > 0 required." );
   }
   if ( major_axis_ < minor_axis_ )
   {
     throw BadProperty(
-      "nest::EllipseMask<D>: "
+      "EllipseMask<D>: "
       "major_axis greater than minor_axis required." );
   }
 
@@ -947,7 +947,7 @@ EllipseMask< D >::EllipseMask( const Dictionary& d )
     if ( D == 2 )
     {
       throw BadProperty(
-        "nest::EllipseMask<D>: "
+        "EllipseMask<D>: "
         "polar_axis not defined in 2D." );
     }
     polar_axis_ = d.get< double >( names::polar_axis );
@@ -955,7 +955,7 @@ EllipseMask< D >::EllipseMask( const Dictionary& d )
     if ( polar_axis_ <= 0 )
     {
       throw BadProperty(
-        "nest::EllipseMask<D>: "
+        "EllipseMask<D>: "
         "All axis > 0 required." );
     }
 
@@ -986,7 +986,7 @@ EllipseMask< D >::EllipseMask( const Dictionary& d )
     if ( D == 2 )
     {
       throw BadProperty(
-        "nest::EllipseMask<D>: "
+        "EllipseMask<D>: "
         "polar_angle not defined in 2D." );
     }
     polar_angle_ = d.get< double >( names::polar_angle );

--- a/nestkernel/modelrange.cpp
+++ b/nestkernel/modelrange.cpp
@@ -22,7 +22,10 @@
 
 #include "modelrange.h"
 
-nest::modelrange::modelrange( size_t model, size_t first_node_id, size_t last_node_id )
+
+namespace nest
+{
+modelrange::modelrange( size_t model, size_t first_node_id, size_t last_node_id )
   : model_( model )
   , first_node_id_( first_node_id )
   , last_node_id_( last_node_id )
@@ -30,7 +33,9 @@ nest::modelrange::modelrange( size_t model, size_t first_node_id, size_t last_no
 }
 
 void
-nest::modelrange::extend_range( size_t new_last_node_id )
+modelrange::extend_range( size_t new_last_node_id )
 {
   last_node_id_ = new_last_node_id;
 }
+
+}  // namespace nest

--- a/nestkernel/modelrange_manager.cpp
+++ b/nestkernel/modelrange_manager.cpp
@@ -110,8 +110,8 @@ ModelRangeManager::get_model_id( size_t node_id ) const
   return modelranges_[ range_idx ].get_model_id();
 }
 
-nest::Model*
-nest::ModelRangeManager::get_model_of_node_id( size_t node_id )
+Model*
+ModelRangeManager::get_model_of_node_id( size_t node_id )
 {
   return kernel().model_manager.get_node_model( get_model_id( node_id ) );
 }

--- a/nestkernel/modelrange_manager.h
+++ b/nestkernel/modelrange_manager.h
@@ -87,29 +87,29 @@ private:
 };
 
 inline void
-nest::ModelRangeManager::set_status( const Dictionary& )
+ModelRangeManager::set_status( const Dictionary& )
 {
 }
 
 inline void
-nest::ModelRangeManager::get_status( Dictionary& )
+ModelRangeManager::get_status( Dictionary& )
 {
 }
 
 inline bool
-nest::ModelRangeManager::is_in_range( size_t node_id ) const
+ModelRangeManager::is_in_range( size_t node_id ) const
 {
   return ( node_id > 0 and node_id <= last_node_id_ and node_id >= first_node_id_ );
 }
 
 inline std::vector< modelrange >::const_iterator
-nest::ModelRangeManager::begin() const
+ModelRangeManager::begin() const
 {
   return modelranges_.begin();
 }
 
 inline std::vector< modelrange >::const_iterator
-nest::ModelRangeManager::end() const
+ModelRangeManager::end() const
 {
   return modelranges_.end();
 }

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -248,7 +248,7 @@ MPIManager::set_status( const Dictionary& dict )
   {
     if ( mbstd < 0 )
     {
-      throw BadProperty( "max_buffer_size_target_data â‰¥ 0 required." );
+      throw BadProperty( "max_buffer_size_target_data ≥ 0 required." );
     }
     max_buffer_size_target_data_ = mbstd;
   }

--- a/nestkernel/mpi_manager.cpp
+++ b/nestkernel/mpi_manager.cpp
@@ -34,6 +34,8 @@
 #include "nest_types.h"
 
 
+namespace nest
+{
 #ifdef HAVE_MPI
 
 template <>
@@ -49,7 +51,7 @@ MPI_Datatype MPI_Type< unsigned long >::type = MPI_UNSIGNED_LONG;
 
 #endif /* #ifdef HAVE_MPI */
 
-nest::MPIManager::MPIManager()
+MPIManager::MPIManager()
   : num_processes_( 1 )
   , rank_( 0 )
   , send_buffer_size_( 0 )
@@ -76,7 +78,7 @@ nest::MPIManager::MPIManager()
 #ifndef HAVE_MPI
 
 void
-nest::MPIManager::init_mpi( int*, char*** )
+MPIManager::init_mpi( int*, char*** )
 {
   // if ! HAVE_MPI, initialize process entries for 1 rank
   // use 2 processes entries (need at least two
@@ -94,7 +96,7 @@ nest::MPIManager::init_mpi( int*, char*** )
 #else /* HAVE_MPI */
 
 void
-nest::MPIManager::set_communicator( MPI_Comm global_comm )
+MPIManager::set_communicator( MPI_Comm global_comm )
 {
   comm = global_comm;
   MPI_Comm_size( comm, &num_processes_ );
@@ -109,7 +111,7 @@ nest::MPIManager::set_communicator( MPI_Comm global_comm )
 }
 
 void
-nest::MPIManager::init_mpi( int* argc, char** argv[] )
+MPIManager::init_mpi( int* argc, char** argv[] )
 {
   int init;
   MPI_Initialized( &init );
@@ -176,7 +178,7 @@ nest::MPIManager::init_mpi( int* argc, char** argv[] )
 #endif /* #ifdef HAVE_MPI */
 
 void
-nest::MPIManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+MPIManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 {
   if ( adjust_number_of_threads_or_rng_only )
   {
@@ -214,12 +216,12 @@ nest::MPIManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 }
 
 void
-nest::MPIManager::finalize( const bool )
+MPIManager::finalize( const bool )
 {
 }
 
 void
-nest::MPIManager::set_status( const Dictionary& dict )
+MPIManager::set_status( const Dictionary& dict )
 {
   dict.update_value( names::adaptive_target_buffers, adaptive_target_buffers_ );
 
@@ -246,7 +248,7 @@ nest::MPIManager::set_status( const Dictionary& dict )
   {
     if ( mbstd < 0 )
     {
-      throw BadProperty( "max_buffer_size_target_data ≥ 0 required." );
+      throw BadProperty( "max_buffer_size_target_data â‰¥ 0 required." );
     }
     max_buffer_size_target_data_ = mbstd;
   }
@@ -255,7 +257,7 @@ nest::MPIManager::set_status( const Dictionary& dict )
 }
 
 void
-nest::MPIManager::get_status( Dictionary& dict )
+MPIManager::get_status( Dictionary& dict )
 {
   dict[ names::num_processes ] = num_processes_;
   dict[ names::mpi_rank ] = rank_;
@@ -274,7 +276,7 @@ nest::MPIManager::get_status( Dictionary& dict )
 #ifdef HAVE_MPI
 
 void
-nest::MPIManager::mpi_finalize( int exitcode )
+MPIManager::mpi_finalize( int exitcode )
 {
   MPI_Type_free( &MPI_OFFGRID_SPIKE );
 
@@ -301,7 +303,7 @@ nest::MPIManager::mpi_finalize( int exitcode )
 #else /* #ifdef HAVE_MPI */
 
 void
-nest::MPIManager::mpi_finalize( int )
+MPIManager::mpi_finalize( int )
 {
 }
 
@@ -310,14 +312,14 @@ nest::MPIManager::mpi_finalize( int )
 #ifdef HAVE_MPI
 
 void
-nest::MPIManager::mpi_abort( int exitcode )
+MPIManager::mpi_abort( int exitcode )
 {
   MPI_Abort( comm, exitcode );
 }
 
 
 std::string
-nest::MPIManager::get_processor_name()
+MPIManager::get_processor_name()
 {
   char name[ 1024 ];
   int len;
@@ -327,7 +329,7 @@ nest::MPIManager::get_processor_name()
 }
 
 void
-nest::MPIManager::communicate( std::vector< size_t >& local_nodes, std::vector< size_t >& global_nodes )
+MPIManager::communicate( std::vector< size_t >& local_nodes, std::vector< size_t >& global_nodes )
 {
   const size_t num_procs = get_num_processes();
 
@@ -368,7 +370,7 @@ nest::MPIManager::communicate( std::vector< size_t >& local_nodes, std::vector< 
 }
 
 void
-nest::MPIManager::communicate( std::vector< unsigned int >& send_buffer,
+MPIManager::communicate( std::vector< unsigned int >& send_buffer,
   std::vector< unsigned int >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -390,7 +392,7 @@ nest::MPIManager::communicate( std::vector< unsigned int >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate_Allgather( std::vector< unsigned int >& send_buffer,
+MPIManager::communicate_Allgather( std::vector< unsigned int >& send_buffer,
   std::vector< unsigned int >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -455,7 +457,7 @@ nest::MPIManager::communicate_Allgather( std::vector< unsigned int >& send_buffe
 
 template < typename T >
 void
-nest::MPIManager::communicate_Allgather( std::vector< T >& send_buffer,
+MPIManager::communicate_Allgather( std::vector< T >& send_buffer,
   std::vector< T >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -524,7 +526,7 @@ nest::MPIManager::communicate_Allgather( std::vector< T >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( std::vector< OffGridSpike >& send_buffer,
+MPIManager::communicate( std::vector< OffGridSpike >& send_buffer,
   std::vector< OffGridSpike >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -546,7 +548,7 @@ nest::MPIManager::communicate( std::vector< OffGridSpike >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate_Allgather( std::vector< OffGridSpike >& send_buffer,
+MPIManager::communicate_Allgather( std::vector< OffGridSpike >& send_buffer,
   std::vector< OffGridSpike >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -614,7 +616,7 @@ nest::MPIManager::communicate_Allgather( std::vector< OffGridSpike >& send_buffe
 }
 
 void
-nest::MPIManager::communicate( std::vector< double >& send_buffer,
+MPIManager::communicate( std::vector< double >& send_buffer,
   std::vector< double >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -644,7 +646,7 @@ nest::MPIManager::communicate( std::vector< double >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( std::vector< unsigned long >& send_buffer,
+MPIManager::communicate( std::vector< unsigned long >& send_buffer,
   std::vector< unsigned long >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -674,7 +676,7 @@ nest::MPIManager::communicate( std::vector< unsigned long >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( std::vector< int >& send_buffer,
+MPIManager::communicate( std::vector< int >& send_buffer,
   std::vector< int >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -704,7 +706,7 @@ nest::MPIManager::communicate( std::vector< int >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( double send_val, std::vector< double >& recv_buffer )
+MPIManager::communicate( double send_val, std::vector< double >& recv_buffer )
 {
   recv_buffer.resize( get_num_processes() );
   MPI_Allgather( &send_val, 1, MPI_DOUBLE, &recv_buffer[ 0 ], 1, MPI_DOUBLE, comm );
@@ -715,19 +717,19 @@ nest::MPIManager::communicate( double send_val, std::vector< double >& recv_buff
  * communicate function for sending set-up information
  */
 void
-nest::MPIManager::communicate( std::vector< int >& buffer )
+MPIManager::communicate( std::vector< int >& buffer )
 {
   communicate_Allgather( buffer );
 }
 
 void
-nest::MPIManager::communicate( std::vector< long >& buffer )
+MPIManager::communicate( std::vector< long >& buffer )
 {
   communicate_Allgather( buffer );
 }
 
 void
-nest::MPIManager::communicate_Allgather( std::vector< int >& buffer )
+MPIManager::communicate_Allgather( std::vector< int >& buffer )
 {
   // avoid aliasing, see http://www.mpi-forum.org/docs/mpi-11-html/node10.html
   int my_val = buffer[ get_rank() ];
@@ -735,32 +737,32 @@ nest::MPIManager::communicate_Allgather( std::vector< int >& buffer )
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum_in_place( double buffer )
+MPIManager::communicate_Allreduce_sum_in_place( double buffer )
 {
   MPI_Allreduce( MPI_IN_PLACE, &buffer, 1, MPI_Type< double >::type, MPI_SUM, comm );
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum_in_place( std::vector< double >& buffer )
+MPIManager::communicate_Allreduce_sum_in_place( std::vector< double >& buffer )
 {
   MPI_Allreduce( MPI_IN_PLACE, &buffer[ 0 ], buffer.size(), MPI_Type< double >::type, MPI_SUM, comm );
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum_in_place( std::vector< int >& buffer )
+MPIManager::communicate_Allreduce_sum_in_place( std::vector< int >& buffer )
 {
   MPI_Allreduce( MPI_IN_PLACE, &buffer[ 0 ], buffer.size(), MPI_Type< int >::type, MPI_SUM, comm );
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer )
+MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer )
 {
   assert( recv_buffer.size() == send_buffer.size() );
   MPI_Allreduce( &send_buffer[ 0 ], &recv_buffer[ 0 ], send_buffer.size(), MPI_Type< double >::type, MPI_SUM, comm );
 }
 
 bool
-nest::MPIManager::equal_cross_ranks( const double value )
+MPIManager::equal_cross_ranks( const double value )
 {
   // Flipping the sign of one argument to check both min and max values.
   double values[ 2 ];
@@ -771,7 +773,7 @@ nest::MPIManager::equal_cross_ranks( const double value )
 }
 
 void
-nest::MPIManager::communicate_Allgather( std::vector< long >& buffer )
+MPIManager::communicate_Allgather( std::vector< long >& buffer )
 {
   // avoid aliasing, see http://www.mpi-forum.org/docs/mpi-11-html/node10.html
   long my_val = buffer[ get_rank() ];
@@ -779,13 +781,13 @@ nest::MPIManager::communicate_Allgather( std::vector< long >& buffer )
 }
 
 void
-nest::MPIManager::communicate_Alltoall_( void* send_buffer, void* recv_buffer, const unsigned int send_recv_count )
+MPIManager::communicate_Alltoall_( void* send_buffer, void* recv_buffer, const unsigned int send_recv_count )
 {
   MPI_Alltoall( send_buffer, send_recv_count, MPI_UNSIGNED, recv_buffer, send_recv_count, MPI_UNSIGNED, comm );
 }
 
 void
-nest::MPIManager::communicate_Alltoallv_( void* send_buffer,
+MPIManager::communicate_Alltoallv_( void* send_buffer,
   const int* send_counts,
   const int* send_displacements,
   void* recv_buffer,
@@ -804,7 +806,7 @@ nest::MPIManager::communicate_Alltoallv_( void* send_buffer,
 }
 
 void
-nest::MPIManager::communicate_recv_counts_secondary_events()
+MPIManager::communicate_recv_counts_secondary_events()
 {
 
   communicate_Alltoall(
@@ -816,7 +818,7 @@ nest::MPIManager::communicate_recv_counts_secondary_events()
 }
 
 void
-nest::MPIManager::synchronize()
+MPIManager::synchronize()
 {
   MPI_Barrier( comm );
 }
@@ -825,7 +827,7 @@ nest::MPIManager::synchronize()
 // any_true: takes a single bool, exchanges with all other processes,
 // and returns "true" if one or more processes provide "true"
 bool
-nest::MPIManager::any_true( const bool my_bool )
+MPIManager::any_true( const bool my_bool )
 {
   if ( get_num_processes() == 1 )
   {
@@ -840,7 +842,7 @@ nest::MPIManager::any_true( const bool my_bool )
 
 // average communication time for a packet size of num_bytes using Allgather
 double
-nest::MPIManager::time_communicate( int num_bytes, int samples )
+MPIManager::time_communicate( int num_bytes, int samples )
 {
   if ( get_num_processes() == 1 )
   {
@@ -868,7 +870,7 @@ nest::MPIManager::time_communicate( int num_bytes, int samples )
 
 // average communication time for a packet size of num_bytes using Allgatherv
 double
-nest::MPIManager::time_communicatev( int num_bytes, int samples )
+MPIManager::time_communicatev( int num_bytes, int samples )
 {
   if ( get_num_processes() == 1 )
   {
@@ -904,7 +906,7 @@ nest::MPIManager::time_communicatev( int num_bytes, int samples )
 
 // average communication time for a packet size of num_bytes
 double
-nest::MPIManager::time_communicate_offgrid( int num_bytes, int samples )
+MPIManager::time_communicate_offgrid( int num_bytes, int samples )
 {
   if ( get_num_processes() == 1 )
   {
@@ -937,7 +939,7 @@ nest::MPIManager::time_communicate_offgrid( int num_bytes, int samples )
 
 // average communication time for a packet size of num_bytes using Alltoall
 double
-nest::MPIManager::time_communicate_alltoall( int num_bytes, int samples )
+MPIManager::time_communicate_alltoall( int num_bytes, int samples )
 {
   if ( get_num_processes() == 1 )
   {
@@ -966,7 +968,7 @@ nest::MPIManager::time_communicate_alltoall( int num_bytes, int samples )
 
 // average communication time for a packet size of num_bytes using Alltoallv
 double
-nest::MPIManager::time_communicate_alltoallv( int num_bytes, int samples )
+MPIManager::time_communicate_alltoallv( int num_bytes, int samples )
 {
   if ( get_num_processes() == 1 )
   {
@@ -1012,7 +1014,7 @@ nest::MPIManager::time_communicate_alltoallv( int num_bytes, int samples )
 
 // communicate (on-grid) if compiled without MPI
 void
-nest::MPIManager::communicate( std::vector< unsigned int >& send_buffer,
+MPIManager::communicate( std::vector< unsigned int >& send_buffer,
   std::vector< unsigned int >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -1028,7 +1030,7 @@ nest::MPIManager::communicate( std::vector< unsigned int >& send_buffer,
 
 // communicate (off-grid) if compiled without MPI
 void
-nest::MPIManager::communicate( std::vector< OffGridSpike >& send_buffer,
+MPIManager::communicate( std::vector< OffGridSpike >& send_buffer,
   std::vector< OffGridSpike >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -1043,7 +1045,7 @@ nest::MPIManager::communicate( std::vector< OffGridSpike >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( std::vector< double >& send_buffer,
+MPIManager::communicate( std::vector< double >& send_buffer,
   std::vector< double >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -1053,7 +1055,7 @@ nest::MPIManager::communicate( std::vector< double >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( std::vector< unsigned long >& send_buffer,
+MPIManager::communicate( std::vector< unsigned long >& send_buffer,
   std::vector< unsigned long >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -1063,7 +1065,7 @@ nest::MPIManager::communicate( std::vector< unsigned long >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( std::vector< int >& send_buffer,
+MPIManager::communicate( std::vector< int >& send_buffer,
   std::vector< int >& recv_buffer,
   std::vector< int >& displacements )
 {
@@ -1073,46 +1075,46 @@ nest::MPIManager::communicate( std::vector< int >& send_buffer,
 }
 
 void
-nest::MPIManager::communicate( double send_val, std::vector< double >& recv_buffer )
+MPIManager::communicate( double send_val, std::vector< double >& recv_buffer )
 {
   recv_buffer.resize( 1 );
   recv_buffer[ 0 ] = send_val;
 }
 
 void
-nest::MPIManager::communicate( std::vector< size_t >&, std::vector< size_t >& )
+MPIManager::communicate( std::vector< size_t >&, std::vector< size_t >& )
 {
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum_in_place( double )
+MPIManager::communicate_Allreduce_sum_in_place( double )
 {
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum_in_place( std::vector< double >& )
+MPIManager::communicate_Allreduce_sum_in_place( std::vector< double >& )
 {
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum_in_place( std::vector< int >& )
+MPIManager::communicate_Allreduce_sum_in_place( std::vector< int >& )
 {
 }
 
 void
-nest::MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer )
+MPIManager::communicate_Allreduce_sum( std::vector< double >& send_buffer, std::vector< double >& recv_buffer )
 {
   recv_buffer.swap( send_buffer );
 }
 
 bool
-nest::MPIManager::equal_cross_ranks( const double )
+MPIManager::equal_cross_ranks( const double )
 {
   return true;
 }
 
 void
-nest::MPIManager::communicate_recv_counts_secondary_events()
+MPIManager::communicate_recv_counts_secondary_events()
 {
   // since we only have one process, the send count is equal to the recv count
   send_counts_secondary_events_in_int_per_rank_ = recv_counts_secondary_events_in_int_per_rank_;
@@ -1123,3 +1125,5 @@ nest::MPIManager::communicate_recv_counts_secondary_events()
 }
 
 #endif /* #ifdef HAVE_MPI  */
+
+}  // namespace nest

--- a/nestkernel/mpi_manager_impl.h
+++ b/nestkernel/mpi_manager_impl.h
@@ -35,8 +35,11 @@
 // Includes from nestkernel:
 #include "kernel_manager.h"
 
+namespace nest
+{
+
 inline size_t
-nest::MPIManager::get_process_id_of_vp( const size_t vp ) const
+MPIManager::get_process_id_of_vp( const size_t vp ) const
 {
   return vp % num_processes_;
 }
@@ -54,7 +57,7 @@ struct MPI_Type
 
 template < typename T >
 void
-nest::MPIManager::communicate_Allgatherv( std::vector< T >& send_buffer,
+MPIManager::communicate_Allgatherv( std::vector< T >& send_buffer,
   std::vector< T >& recv_buffer,
   std::vector< int >& displacements,
   std::vector< int >& recv_counts )
@@ -71,7 +74,7 @@ nest::MPIManager::communicate_Allgatherv( std::vector< T >& send_buffer,
 }
 
 inline size_t
-nest::MPIManager::get_process_id_of_node_id( const size_t node_id ) const
+MPIManager::get_process_id_of_node_id( const size_t node_id ) const
 {
   return node_id % kernel().vp_manager.get_num_virtual_processes() % num_processes_;
 }
@@ -80,11 +83,13 @@ nest::MPIManager::get_process_id_of_node_id( const size_t node_id ) const
 
 
 inline size_t
-nest::MPIManager::get_process_id_of_node_id( const size_t ) const
+MPIManager::get_process_id_of_node_id( const size_t ) const
 {
   return 0;
 }
 
 #endif /* HAVE_MPI */
+
+}  // namespace nest
 
 #endif /* MPI_MANAGER_IMPL_H */

--- a/nestkernel/music_event_handler.cpp
+++ b/nestkernel/music_event_handler.cpp
@@ -71,7 +71,7 @@ MusicEventHandler::~MusicEventHandler()
 }
 
 void
-MusicEventHandler::register_channel( size_t channel, nest::Node* mp )
+MusicEventHandler::register_channel( size_t channel, Node* mp )
 {
   if ( static_cast< size_t >( channel ) >= channelmap_.size() )
   {
@@ -163,7 +163,7 @@ MusicEventHandler::update( Time const& origin, const long from, const long to )
         if ( T > origin + Time::step( from ) - Time::ms( acceptable_latency_ )
           and T <= origin + Time::step( from + to ) )
         {
-          nest::SpikeEvent se;
+          SpikeEvent se;
           se.set_offset( Time( Time::step( T.get_steps() ) ).get_ms() - T.get_ms() );
           se.set_stamp( T );
 

--- a/nestkernel/music_event_handler.h
+++ b/nestkernel/music_event_handler.h
@@ -54,7 +54,7 @@ public:
   /**
    * Register a new node to a specific channel on this port.
    */
-  void register_channel( size_t channel, nest::Node* mp );
+  void register_channel( size_t channel, Node* mp );
 
   /**
    * Publish the MUSIC port.
@@ -84,7 +84,7 @@ private:
   bool published_;
   std::string portname_;
   //! Maps channel number to music_event_in_proxy
-  std::vector< nest::Node* > channelmap_;
+  std::vector< Node* > channelmap_;
   //! Maps local index to global MUSIC index (channel)
   std::vector< MUSIC::GlobalIndex > indexmap_;
   double acceptable_latency_;  //!< The acceptable latency of the port in ms

--- a/nestkernel/music_manager.cpp
+++ b/nestkernel/music_manager.cpp
@@ -186,7 +186,7 @@ MUSICManager::unregister_music_in_port( std::string portname )
 }
 
 void
-MUSICManager::register_music_event_in_proxy( std::string portname, int channel, nest::Node* mp )
+MUSICManager::register_music_event_in_proxy( std::string portname, int channel, Node* mp )
 {
   std::map< std::string, MusicEventHandler >::iterator it;
   it = music_event_in_portmap_.find( portname );
@@ -204,7 +204,7 @@ MUSICManager::register_music_event_in_proxy( std::string portname, int channel, 
 }
 
 void
-MUSICManager::register_music_rate_in_proxy( std::string portname, int channel, nest::Node* mp )
+MUSICManager::register_music_rate_in_proxy( std::string portname, int channel, Node* mp )
 {
   std::map< std::string, MusicRateInHandler >::iterator it;
   it = music_rate_in_portmap_.find( portname );

--- a/nestkernel/music_manager.h
+++ b/nestkernel/music_manager.h
@@ -103,7 +103,7 @@ public:
    * The proxy will be notified, if a MUSIC event is being received on the respective
    * channel and port.
    */
-  void register_music_event_in_proxy( std::string portname, int channel, nest::Node* mp );
+  void register_music_event_in_proxy( std::string portname, int channel, Node* mp );
 
   /**
    * Register a node (of type music_input_proxy) with a given MUSIC
@@ -112,7 +112,7 @@ public:
    * The proxy will be notified, if a MUSIC event is being received on the respective
    * channel and port.
    */
-  void register_music_rate_in_proxy( std::string portname, int channel, nest::Node* mp );
+  void register_music_rate_in_proxy( std::string portname, int channel, Node* mp );
 
   /**
    * Set the acceptable latency (latency) for a music input port (portname).

--- a/nestkernel/music_rate_in_handler.cpp
+++ b/nestkernel/music_rate_in_handler.cpp
@@ -61,7 +61,7 @@ MusicRateInHandler::~MusicRateInHandler()
 }
 
 void
-MusicRateInHandler::register_channel( int channel, nest::Node* mp )
+MusicRateInHandler::register_channel( int channel, Node* mp )
 {
   if ( static_cast< size_t >( channel ) >= channelmap_.size() )
   {

--- a/nestkernel/music_rate_in_handler.h
+++ b/nestkernel/music_rate_in_handler.h
@@ -54,7 +54,7 @@ public:
   /**
    * Register a new node to a specific channel on this port.
    */
-  void register_channel( int channel, nest::Node* mp );
+  void register_channel( int channel, Node* mp );
 
   /**
    * Publish the MUSIC port.
@@ -79,7 +79,7 @@ private:
 
   int port_width_;  //!< the width of the MUSIC port
   //! Maps channel number to music_rate_in_proxy
-  std::vector< nest::Node* > channelmap_;
+  std::vector< Node* > channelmap_;
 };
 
 }  // namespace nest

--- a/nestkernel/nest.cpp
+++ b/nestkernel/nest.cpp
@@ -778,7 +778,7 @@ message( const VerbosityLevel level,
   const std::string& file,
   const size_t line )
 {
-  nest::kernel().logging_manager.publish_log( level, function, message, file, line );
+  kernel().logging_manager.publish_log( level, function, message, file, line );
 }
 
 }  // namespace nest

--- a/nestkernel/node.cpp
+++ b/nestkernel/node.cpp
@@ -496,13 +496,13 @@ Node::get_K_values( double, double&, double&, double& )
 }
 
 void
-nest::Node::get_history( double, double, std::deque< histentry >::iterator*, std::deque< histentry >::iterator* )
+Node::get_history( double, double, std::deque< histentry >::iterator*, std::deque< histentry >::iterator* )
 {
   throw UnexpectedEvent();
 }
 
 void
-nest::Node::get_LTP_history( double,
+Node::get_LTP_history( double,
   double,
   std::deque< histentry_extended >::iterator*,
   std::deque< histentry_extended >::iterator* )
@@ -511,7 +511,7 @@ nest::Node::get_LTP_history( double,
 }
 
 void
-nest::Node::get_urbanczik_history( double,
+Node::get_urbanczik_history( double,
   double,
   std::deque< histentry_extended >::iterator*,
   std::deque< histentry_extended >::iterator*,
@@ -521,43 +521,43 @@ nest::Node::get_urbanczik_history( double,
 }
 
 double
-nest::Node::get_C_m( int )
+Node::get_C_m( int )
 {
   throw UnexpectedEvent();
 }
 
 double
-nest::Node::get_g_L( int )
+Node::get_g_L( int )
 {
   throw UnexpectedEvent();
 }
 
 double
-nest::Node::get_tau_L( int )
+Node::get_tau_L( int )
 {
   throw UnexpectedEvent();
 }
 
 double
-nest::Node::get_tau_s( int )
+Node::get_tau_s( int )
 {
   throw UnexpectedEvent();
 }
 
 double
-nest::Node::get_tau_syn_ex( int )
+Node::get_tau_syn_ex( int )
 {
   throw UnexpectedEvent();
 }
 
 double
-nest::Node::get_tau_syn_in( int )
+Node::get_tau_syn_in( int )
 {
   throw UnexpectedEvent();
 }
 
 void
-nest::Node::compute_gradient( const long,
+Node::compute_gradient( const long,
   const long,
   double&,
   double&,
@@ -577,7 +577,7 @@ nest::Node::compute_gradient( const long,
 }
 
 double
-nest::Node::compute_gradient( std::vector< long >&, const long, const long, const double, const bool )
+Node::compute_gradient( std::vector< long >&, const long, const long, const double, const bool )
 {
   throw IllegalConnection( "The target node does not support compute_gradient()." );
 }

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -142,8 +142,7 @@ Ntree< D, T, max_capacity, max_depth >::masked_iterator::masked_iterator( Ntree<
     {
       if ( ntree_->periodic_[ i ] )
       {
-        anchor_[ i ] =
-          mod( anchor_[ i ] + mask_bb.lower_left[ i ] - ntree_->lower_left_[ i ], ntree_->extent_[ i ] )
+        anchor_[ i ] = mod( anchor_[ i ] + mask_bb.lower_left[ i ] - ntree_->lower_left_[ i ], ntree_->extent_[ i ] )
           - mask_bb.lower_left[ i ] + ntree_->lower_left_[ i ];
       }
     }

--- a/nestkernel/ntree_impl.h
+++ b/nestkernel/ntree_impl.h
@@ -143,7 +143,7 @@ Ntree< D, T, max_capacity, max_depth >::masked_iterator::masked_iterator( Ntree<
       if ( ntree_->periodic_[ i ] )
       {
         anchor_[ i ] =
-          nest::mod( anchor_[ i ] + mask_bb.lower_left[ i ] - ntree_->lower_left_[ i ], ntree_->extent_[ i ] )
+          mod( anchor_[ i ] + mask_bb.lower_left[ i ] - ntree_->lower_left_[ i ], ntree_->extent_[ i ] )
           - mask_bb.lower_left[ i ] + ntree_->lower_left_[ i ];
       }
     }

--- a/nestkernel/parameter.h
+++ b/nestkernel/parameter.h
@@ -200,7 +200,7 @@ public:
     if ( lower_ >= range_ )
     {
       throw BadProperty(
-        "nest::UniformParameter: "
+        "UniformParameter: "
         "min < max required." );
     }
 
@@ -240,7 +240,7 @@ public:
     d.update_integer_value( names::max, max_ );
     if ( max_ <= 0 )
     {
-      throw BadProperty( "nest::UniformIntParameter: max > 0 required." );
+      throw BadProperty( "UniformIntParameter: max > 0 required." );
     }
   }
 
@@ -331,7 +331,7 @@ public:
     d.update_value( names::beta, beta_ );
     if ( beta_ < 0 )
     {
-      throw BadProperty( "nest::ExponentialParameter: beta ≥ 0 required." );
+      throw BadProperty( "ExponentialParameter: beta ≥ 0 required." );
     }
   }
 

--- a/nestkernel/proxynode.cpp
+++ b/nestkernel/proxynode.cpp
@@ -82,7 +82,7 @@ proxynode::sends_secondary_event( SICEvent& sic )
   kernel().model_manager.get_node_model( get_model_id() )->sends_secondary_event( sic );
 }
 
-nest::SignalType
+SignalType
 proxynode::sends_signal() const
 {
   return kernel().model_manager.get_node_model( get_model_id() )->sends_signal();

--- a/nestkernel/random_manager.cpp
+++ b/nestkernel/random_manager.cpp
@@ -36,31 +36,35 @@
 #include "Random123/conventional/Engine.hpp"
 #include "Random123/philox.h"
 #include "Random123/threefry.h"
+
+
+namespace nest
+{
 #endif
 
 
-const std::string nest::RandomManager::DEFAULT_RNG_TYPE_ = "mt19937_64";
+const std::string RandomManager::DEFAULT_RNG_TYPE_ = "mt19937_64";
 
-const std::uint32_t nest::RandomManager::DEFAULT_BASE_SEED_ = 143202461;
+const std::uint32_t RandomManager::DEFAULT_BASE_SEED_ = 143202461;
 
-const std::uint32_t nest::RandomManager::RANK_SYNCED_SEEDER_ = 0xc229212d;
-const std::uint32_t nest::RandomManager::THREAD_SYNCED_SEEDER_ = 0x37722d5e;
-const std::uint32_t nest::RandomManager::THREAD_SPECIFIC_SEEDER_ = 0xb84c9bae;
+const std::uint32_t RandomManager::RANK_SYNCED_SEEDER_ = 0xc229212d;
+const std::uint32_t RandomManager::THREAD_SYNCED_SEEDER_ = 0x37722d5e;
+const std::uint32_t RandomManager::THREAD_SPECIFIC_SEEDER_ = 0xb84c9bae;
 
 
-nest::RandomManager::RandomManager()
+RandomManager::RandomManager()
   : current_rng_type_( DEFAULT_RNG_TYPE_ )
   , base_seed_( DEFAULT_BASE_SEED_ )
   , rank_synced_rng_( nullptr )
 {
 }
 
-nest::RandomManager::~RandomManager()
+RandomManager::~RandomManager()
 {
 }
 
 void
-nest::RandomManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+RandomManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 {
   if ( not adjust_number_of_threads_or_rng_only )
   {
@@ -97,7 +101,7 @@ nest::RandomManager::initialize( const bool adjust_number_of_threads_or_rng_only
 }
 
 void
-nest::RandomManager::finalize( const bool adjust_number_of_threads_or_rng_only )
+RandomManager::finalize( const bool adjust_number_of_threads_or_rng_only )
 {
   // Delete existing RNGs
   auto delete_rngs = []( std::vector< RngPtr >& rng_vec )
@@ -125,7 +129,7 @@ nest::RandomManager::finalize( const bool adjust_number_of_threads_or_rng_only )
 }
 
 void
-nest::RandomManager::get_status( Dictionary& d )
+RandomManager::get_status( Dictionary& d )
 {
   std::vector< std::string > rng_types;
   for ( auto rng = rng_types_.begin(); rng != rng_types_.end(); ++rng )
@@ -139,7 +143,7 @@ nest::RandomManager::get_status( Dictionary& d )
 }
 
 void
-nest::RandomManager::set_status( const Dictionary& d )
+RandomManager::set_status( const Dictionary& d )
 {
   long rng_seed;
   bool rng_seed_updated = d.update_value( names::rng_seed, rng_seed );
@@ -177,7 +181,7 @@ nest::RandomManager::set_status( const Dictionary& d )
 }
 
 void
-nest::RandomManager::check_rng_synchrony() const
+RandomManager::check_rng_synchrony() const
 {
   // Compare more than a single number to avoid false negatives
   const long NUM_ROUNDS = 5;
@@ -220,7 +224,9 @@ nest::RandomManager::check_rng_synchrony() const
 
 template < typename RNG_TYPE >
 void
-nest::RandomManager::register_rng_type( const std::string& name )
+RandomManager::register_rng_type( const std::string& name )
 {
   rng_types_.insert( std::make_pair( name, new RandomGeneratorFactory< RNG_TYPE >() ) );
 }
+
+}  // namespace nest

--- a/nestkernel/random_manager.cpp
+++ b/nestkernel/random_manager.cpp
@@ -36,11 +36,11 @@
 #include "Random123/conventional/Engine.hpp"
 #include "Random123/philox.h"
 #include "Random123/threefry.h"
+#endif
 
 
 namespace nest
 {
-#endif
 
 
 const std::string RandomManager::DEFAULT_RNG_TYPE_ = "mt19937_64";

--- a/nestkernel/random_manager.h
+++ b/nestkernel/random_manager.h
@@ -145,20 +145,20 @@ private:
 };
 
 inline RngPtr
-nest::RandomManager::get_rank_synced_rng() const
+RandomManager::get_rank_synced_rng() const
 {
   return rank_synced_rng_;
 }
 
 inline RngPtr
-nest::RandomManager::get_vp_synced_rng( size_t tid ) const
+RandomManager::get_vp_synced_rng( size_t tid ) const
 {
   assert( tid < static_cast< size_t >( vp_specific_rngs_.size() ) );
   return vp_synced_rngs_[ tid ];
 }
 
 inline RngPtr
-nest::RandomManager::get_vp_specific_rng( size_t tid ) const
+RandomManager::get_vp_specific_rng( size_t tid ) const
 {
   assert( tid < static_cast< size_t >( vp_specific_rngs_.size() ) );
   return vp_specific_rngs_[ tid ];

--- a/nestkernel/recording_backend.cpp
+++ b/nestkernel/recording_backend.cpp
@@ -22,7 +22,12 @@
 
 #include "recording_backend.h"
 
-const std::vector< std::string > nest::RecordingBackend::NO_DOUBLE_VALUE_NAMES;
-const std::vector< std::string > nest::RecordingBackend::NO_LONG_VALUE_NAMES;
-const std::vector< double > nest::RecordingBackend::NO_DOUBLE_VALUES;
-const std::vector< long > nest::RecordingBackend::NO_LONG_VALUES;
+
+namespace nest
+{
+const std::vector< std::string > RecordingBackend::NO_DOUBLE_VALUE_NAMES;
+const std::vector< std::string > RecordingBackend::NO_LONG_VALUE_NAMES;
+const std::vector< double > RecordingBackend::NO_DOUBLE_VALUES;
+const std::vector< long > RecordingBackend::NO_LONG_VALUES;
+
+}  // namespace nest

--- a/nestkernel/recording_backend_ascii.cpp
+++ b/nestkernel/recording_backend_ascii.cpp
@@ -34,31 +34,33 @@
 #include "vp_manager_impl.h"
 
 
-const unsigned int nest::RecordingBackendASCII::ASCII_REC_BACKEND_VERSION = 2;
+namespace nest
+{
+const unsigned int RecordingBackendASCII::ASCII_REC_BACKEND_VERSION = 2;
 
-nest::RecordingBackendASCII::RecordingBackendASCII()
+RecordingBackendASCII::RecordingBackendASCII()
 {
 }
 
-nest::RecordingBackendASCII::~RecordingBackendASCII() throw()
+RecordingBackendASCII::~RecordingBackendASCII() throw()
 {
 }
 
 void
-nest::RecordingBackendASCII::initialize()
+RecordingBackendASCII::initialize()
 {
   data_map tmp( kernel().vp_manager.get_num_threads() );
   device_data_.swap( tmp );
 }
 
 void
-nest::RecordingBackendASCII::finalize()
+RecordingBackendASCII::finalize()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendASCII::enroll( const RecordingDevice& device, const Dictionary& params )
+RecordingBackendASCII::enroll( const RecordingDevice& device, const Dictionary& params )
 {
   const size_t t = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -76,7 +78,7 @@ nest::RecordingBackendASCII::enroll( const RecordingDevice& device, const Dictio
 }
 
 void
-nest::RecordingBackendASCII::disenroll( const RecordingDevice& device )
+RecordingBackendASCII::disenroll( const RecordingDevice& device )
 {
   const size_t t = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -89,7 +91,7 @@ nest::RecordingBackendASCII::disenroll( const RecordingDevice& device )
 }
 
 void
-nest::RecordingBackendASCII::set_value_names( const RecordingDevice& device,
+RecordingBackendASCII::set_value_names( const RecordingDevice& device,
   const std::vector< std::string >& double_value_names,
   const std::vector< std::string >& long_value_names )
 {
@@ -102,13 +104,13 @@ nest::RecordingBackendASCII::set_value_names( const RecordingDevice& device,
 }
 
 void
-nest::RecordingBackendASCII::pre_run_hook()
+RecordingBackendASCII::pre_run_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendASCII::post_run_hook()
+RecordingBackendASCII::post_run_hook()
 {
   for ( auto& inner : device_data_ )
   {
@@ -120,13 +122,13 @@ nest::RecordingBackendASCII::post_run_hook()
 }
 
 void
-nest::RecordingBackendASCII::post_step_hook()
+RecordingBackendASCII::post_step_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendASCII::cleanup()
+RecordingBackendASCII::cleanup()
 {
   for ( auto& inner : device_data_ )
   {
@@ -138,7 +140,7 @@ nest::RecordingBackendASCII::cleanup()
 }
 
 void
-nest::RecordingBackendASCII::write( const RecordingDevice& device,
+RecordingBackendASCII::write( const RecordingDevice& device,
   const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
@@ -156,7 +158,7 @@ nest::RecordingBackendASCII::write( const RecordingDevice& device,
 }
 
 const std::string
-nest::RecordingBackendASCII::compute_vp_node_id_string_( const RecordingDevice& device ) const
+RecordingBackendASCII::compute_vp_node_id_string_( const RecordingDevice& device ) const
 {
   const double num_vps = kernel().vp_manager.get_num_virtual_processes();
   const double num_nodes = kernel().node_manager.size();
@@ -171,7 +173,7 @@ nest::RecordingBackendASCII::compute_vp_node_id_string_( const RecordingDevice& 
 }
 
 void
-nest::RecordingBackendASCII::prepare()
+RecordingBackendASCII::prepare()
 {
   for ( auto& inner : device_data_ )
   {
@@ -183,33 +185,33 @@ nest::RecordingBackendASCII::prepare()
 }
 
 void
-nest::RecordingBackendASCII::set_status( const Dictionary& )
+RecordingBackendASCII::set_status( const Dictionary& )
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendASCII::get_status( Dictionary& ) const
+RecordingBackendASCII::get_status( Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendASCII::check_device_status( const Dictionary& params ) const
+RecordingBackendASCII::check_device_status( const Dictionary& params ) const
 {
   DeviceData dd( "", "" );
   dd.set_status( params );  // throws if params contains invalid entries
 }
 
 void
-nest::RecordingBackendASCII::get_device_defaults( Dictionary& params ) const
+RecordingBackendASCII::get_device_defaults( Dictionary& params ) const
 {
   DeviceData dd( "", "" );
   dd.get_status( params );
 }
 
 void
-nest::RecordingBackendASCII::get_device_status( const nest::RecordingDevice& device, Dictionary& d ) const
+RecordingBackendASCII::get_device_status( const RecordingDevice& device, Dictionary& d ) const
 {
   const size_t t = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -223,7 +225,7 @@ nest::RecordingBackendASCII::get_device_status( const nest::RecordingDevice& dev
 
 /* ******************* Device meta data class DeviceData ******************* */
 
-nest::RecordingBackendASCII::DeviceData::DeviceData( std::string modelname, std::string vp_node_id_string )
+RecordingBackendASCII::DeviceData::DeviceData( std::string modelname, std::string vp_node_id_string )
   : precision_( 3 )
   , time_in_steps_( false )
   , modelname_( modelname )
@@ -234,7 +236,7 @@ nest::RecordingBackendASCII::DeviceData::DeviceData( std::string modelname, std:
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::set_value_names( const std::vector< std::string >& double_value_names,
+RecordingBackendASCII::DeviceData::set_value_names( const std::vector< std::string >& double_value_names,
   const std::vector< std::string >& long_value_names )
 {
   double_value_names_ = double_value_names;
@@ -242,13 +244,13 @@ nest::RecordingBackendASCII::DeviceData::set_value_names( const std::vector< std
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::flush_file()
+RecordingBackendASCII::DeviceData::flush_file()
 {
   file_.flush();
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::open_file()
+RecordingBackendASCII::DeviceData::open_file()
 {
   std::string filename = compute_filename_();
 
@@ -291,13 +293,13 @@ nest::RecordingBackendASCII::DeviceData::open_file()
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::close_file()
+RecordingBackendASCII::DeviceData::close_file()
 {
   file_.close();
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::write( const Event& event,
+RecordingBackendASCII::DeviceData::write( const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
 {
@@ -325,7 +327,7 @@ nest::RecordingBackendASCII::DeviceData::write( const Event& event,
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::get_status( Dictionary& d ) const
+RecordingBackendASCII::DeviceData::get_status( Dictionary& d ) const
 {
   d[ names::file_extension ] = file_extension_;
   d[ names::precision ] = precision_;
@@ -336,7 +338,7 @@ nest::RecordingBackendASCII::DeviceData::get_status( Dictionary& d ) const
 }
 
 void
-nest::RecordingBackendASCII::DeviceData::set_status( const Dictionary& d )
+RecordingBackendASCII::DeviceData::set_status( const Dictionary& d )
 {
   d.update_value( names::file_extension, file_extension_ );
   d.update_value( names::precision, precision_ );
@@ -356,7 +358,7 @@ nest::RecordingBackendASCII::DeviceData::set_status( const Dictionary& d )
 }
 
 std::string
-nest::RecordingBackendASCII::DeviceData::compute_filename_() const
+RecordingBackendASCII::DeviceData::compute_filename_() const
 {
   std::string data_path = kernel().io_manager.get_data_path();
   if ( not data_path.empty() and not( data_path[ data_path.size() - 1 ] == '/' ) )
@@ -374,3 +376,5 @@ nest::RecordingBackendASCII::DeviceData::compute_filename_() const
 
   return data_path + data_prefix + label + vp_node_id_string_ + "." + file_extension_;
 }
+
+}  // namespace nest

--- a/nestkernel/recording_backend_memory.cpp
+++ b/nestkernel/recording_backend_memory.cpp
@@ -26,28 +26,31 @@
 
 #include "recording_backend_memory.h"
 
-nest::RecordingBackendMemory::RecordingBackendMemory()
+
+namespace nest
+{
+RecordingBackendMemory::RecordingBackendMemory()
 {
 }
 
-nest::RecordingBackendMemory::~RecordingBackendMemory() throw()
+RecordingBackendMemory::~RecordingBackendMemory() throw()
 {
 }
 
 void
-nest::RecordingBackendMemory::initialize()
+RecordingBackendMemory::initialize()
 {
   device_data_map tmp( kernel().vp_manager.get_num_threads() );
   device_data_.swap( tmp );
 }
 
 void
-nest::RecordingBackendMemory::finalize()
+RecordingBackendMemory::finalize()
 {
 }
 
 void
-nest::RecordingBackendMemory::enroll( const RecordingDevice& device, const Dictionary& params )
+RecordingBackendMemory::enroll( const RecordingDevice& device, const Dictionary& params )
 {
   size_t t = device.get_thread();
   size_t node_id = device.get_node_id();
@@ -63,7 +66,7 @@ nest::RecordingBackendMemory::enroll( const RecordingDevice& device, const Dicti
 }
 
 void
-nest::RecordingBackendMemory::disenroll( const RecordingDevice& device )
+RecordingBackendMemory::disenroll( const RecordingDevice& device )
 {
   size_t t = device.get_thread();
   size_t node_id = device.get_node_id();
@@ -76,7 +79,7 @@ nest::RecordingBackendMemory::disenroll( const RecordingDevice& device )
 }
 
 void
-nest::RecordingBackendMemory::set_value_names( const RecordingDevice& device,
+RecordingBackendMemory::set_value_names( const RecordingDevice& device,
   const std::vector< std::string >& double_value_names,
   const std::vector< std::string >& long_value_names )
 {
@@ -89,19 +92,19 @@ nest::RecordingBackendMemory::set_value_names( const RecordingDevice& device,
 }
 
 void
-nest::RecordingBackendMemory::pre_run_hook()
+RecordingBackendMemory::pre_run_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMemory::cleanup()
+RecordingBackendMemory::cleanup()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMemory::write( const RecordingDevice& device,
+RecordingBackendMemory::write( const RecordingDevice& device,
   const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
@@ -113,21 +116,21 @@ nest::RecordingBackendMemory::write( const RecordingDevice& device,
 }
 
 void
-nest::RecordingBackendMemory::check_device_status( const Dictionary& params ) const
+RecordingBackendMemory::check_device_status( const Dictionary& params ) const
 {
   DeviceData dd;
   dd.set_status( params );  // throws if params contains invalid entries
 }
 
 void
-nest::RecordingBackendMemory::get_device_defaults( Dictionary& params ) const
+RecordingBackendMemory::get_device_defaults( Dictionary& params ) const
 {
   DeviceData dd;
   dd.get_status( params );
 }
 
 void
-nest::RecordingBackendMemory::get_device_status( const RecordingDevice& device, Dictionary& d ) const
+RecordingBackendMemory::get_device_status( const RecordingDevice& device, Dictionary& d ) const
 {
   const size_t t = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -140,44 +143,44 @@ nest::RecordingBackendMemory::get_device_status( const RecordingDevice& device, 
 }
 
 void
-nest::RecordingBackendMemory::post_run_hook()
+RecordingBackendMemory::post_run_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMemory::post_step_hook()
+RecordingBackendMemory::post_step_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMemory::get_status( Dictionary& ) const
+RecordingBackendMemory::get_status( Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMemory::set_status( const Dictionary& )
+RecordingBackendMemory::set_status( const Dictionary& )
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMemory::prepare()
+RecordingBackendMemory::prepare()
 {
   // nothing to do
 }
 
 /* ******************* Device meta data class DeviceInfo ******************* */
 
-nest::RecordingBackendMemory::DeviceData::DeviceData()
+RecordingBackendMemory::DeviceData::DeviceData()
   : time_in_steps_( false )
 {
 }
 
 void
-nest::RecordingBackendMemory::DeviceData::set_value_names( const std::vector< std::string >& double_value_names,
+RecordingBackendMemory::DeviceData::set_value_names( const std::vector< std::string >& double_value_names,
   const std::vector< std::string >& long_value_names )
 {
   double_value_names_ = double_value_names;
@@ -188,7 +191,7 @@ nest::RecordingBackendMemory::DeviceData::set_value_names( const std::vector< st
 }
 
 void
-nest::RecordingBackendMemory::DeviceData::push_back( const Event& event,
+RecordingBackendMemory::DeviceData::push_back( const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
 {
@@ -215,7 +218,7 @@ nest::RecordingBackendMemory::DeviceData::push_back( const Event& event,
 }
 
 void
-nest::RecordingBackendMemory::DeviceData::get_status( Dictionary& d ) const
+RecordingBackendMemory::DeviceData::get_status( Dictionary& d ) const
 {
   Dictionary events;
 
@@ -257,7 +260,7 @@ nest::RecordingBackendMemory::DeviceData::get_status( Dictionary& d ) const
 }
 
 void
-nest::RecordingBackendMemory::DeviceData::set_status( const Dictionary& d )
+RecordingBackendMemory::DeviceData::set_status( const Dictionary& d )
 {
   bool time_in_steps = false;
   if ( d.update_value( names::time_in_steps, time_in_steps ) )
@@ -278,7 +281,7 @@ nest::RecordingBackendMemory::DeviceData::set_status( const Dictionary& d )
 }
 
 void
-nest::RecordingBackendMemory::DeviceData::clear()
+RecordingBackendMemory::DeviceData::clear()
 {
   senders_.clear();
   times_ms_.clear();
@@ -294,3 +297,5 @@ nest::RecordingBackendMemory::DeviceData::clear()
     long_values_[ i ].clear();
   }
 }
+
+}  // namespace nest

--- a/nestkernel/recording_backend_mpi.cpp
+++ b/nestkernel/recording_backend_mpi.cpp
@@ -29,19 +29,22 @@
 #include "recording_backend_mpi.h"
 #include "recording_device.h"
 
-nest::RecordingBackendMPI::RecordingBackendMPI()
+
+namespace nest
+{
+RecordingBackendMPI::RecordingBackendMPI()
   : enrolled_( false )
   , prepared_( false )
 {
 }
 
-nest::RecordingBackendMPI::~RecordingBackendMPI() throw()
+RecordingBackendMPI::~RecordingBackendMPI() throw()
 {
 }
 
 
 void
-nest::RecordingBackendMPI::initialize()
+RecordingBackendMPI::initialize()
 {
   auto nthreads = kernel().vp_manager.get_num_threads();
   std::vector< std::vector< std::vector< std::array< double, 3 > > > > empty_vector( nthreads );
@@ -51,7 +54,7 @@ nest::RecordingBackendMPI::initialize()
 }
 
 void
-nest::RecordingBackendMPI::finalize()
+RecordingBackendMPI::finalize()
 {
   // clear vector of buffer
   for ( auto& it_buffer : buffer_ )
@@ -69,7 +72,7 @@ nest::RecordingBackendMPI::finalize()
 }
 
 void
-nest::RecordingBackendMPI::enroll( const RecordingDevice& device, const Dictionary& params )
+RecordingBackendMPI::enroll( const RecordingDevice& device, const Dictionary& params )
 {
   if ( device.get_type() == RecordingDevice::SPIKE_RECORDER )
   {
@@ -95,7 +98,7 @@ nest::RecordingBackendMPI::enroll( const RecordingDevice& device, const Dictiona
 }
 
 void
-nest::RecordingBackendMPI::disenroll( const RecordingDevice& device )
+RecordingBackendMPI::disenroll( const RecordingDevice& device )
 {
   const auto tid = device.get_thread();
   const auto node_id = device.get_node_id();
@@ -108,7 +111,7 @@ nest::RecordingBackendMPI::disenroll( const RecordingDevice& device )
 }
 
 void
-nest::RecordingBackendMPI::set_value_names( const RecordingDevice&,
+RecordingBackendMPI::set_value_names( const RecordingDevice&,
   const std::vector< std::string >&,
   const std::vector< std::string >& )
 {
@@ -116,7 +119,7 @@ nest::RecordingBackendMPI::set_value_names( const RecordingDevice&,
 }
 
 void
-nest::RecordingBackendMPI::prepare()
+RecordingBackendMPI::prepare()
 {
   if ( not enrolled_ )
   {
@@ -204,7 +207,7 @@ nest::RecordingBackendMPI::prepare()
 }
 
 void
-nest::RecordingBackendMPI::pre_run_hook()
+RecordingBackendMPI::pre_run_hook()
 {
 #pragma omp master
   {
@@ -219,13 +222,13 @@ nest::RecordingBackendMPI::pre_run_hook()
 
 
 void
-nest::RecordingBackendMPI::post_step_hook()
+RecordingBackendMPI::post_step_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMPI::post_run_hook()
+RecordingBackendMPI::post_run_hook()
 {
 #pragma omp master
   {
@@ -269,7 +272,7 @@ nest::RecordingBackendMPI::post_run_hook()
 }
 
 void
-nest::RecordingBackendMPI::cleanup()
+RecordingBackendMPI::cleanup()
 {
 // Disconnect all the MPI connections and send information about this disconnection
 // Clean all the elements in the map
@@ -301,26 +304,26 @@ nest::RecordingBackendMPI::cleanup()
 }
 
 void
-nest::RecordingBackendMPI::check_device_status( const Dictionary& ) const
+RecordingBackendMPI::check_device_status( const Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMPI::get_device_defaults( Dictionary& ) const
+RecordingBackendMPI::get_device_defaults( Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMPI::get_device_status( const nest::RecordingDevice&, Dictionary& ) const
+RecordingBackendMPI::get_device_status( const RecordingDevice&, Dictionary& ) const
 {
   // nothing to do
 }
 
 
 void
-nest::RecordingBackendMPI::write( const RecordingDevice& device,
+RecordingBackendMPI::write( const RecordingDevice& device,
   const Event& event,
   const std::vector< double >&,
   const std::vector< long >& )
@@ -347,19 +350,19 @@ nest::RecordingBackendMPI::write( const RecordingDevice& device,
  * Parameter extraction and manipulation functions
  * ---------------------------------------------------------------- */
 void
-nest::RecordingBackendMPI::get_status( Dictionary& ) const
+RecordingBackendMPI::get_status( Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMPI::set_status( const Dictionary& )
+RecordingBackendMPI::set_status( const Dictionary& )
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendMPI::get_port( const RecordingDevice* device, std::string* port_name )
+RecordingBackendMPI::get_port( const RecordingDevice* device, std::string* port_name )
 {
   const std::string& label = device->get_label();
 
@@ -380,7 +383,7 @@ nest::RecordingBackendMPI::get_port( const RecordingDevice* device, std::string*
 }
 
 void
-nest::RecordingBackendMPI::get_port( const size_t index_node, const std::string& label, std::string* port_name )
+RecordingBackendMPI::get_port( const size_t index_node, const std::string& label, std::string* port_name )
 {
   // path of the file : path+label+id+.txt
   // (file contains only one line with name of the port )
@@ -415,7 +418,7 @@ nest::RecordingBackendMPI::get_port( const size_t index_node, const std::string&
 }
 
 void
-nest::RecordingBackendMPI::send_data( const MPI_Comm* comm, const double data[], const int size )
+RecordingBackendMPI::send_data( const MPI_Comm* comm, const double data[], const int size )
 {
   // Send the size of data
   int shape = { size };
@@ -423,3 +426,5 @@ nest::RecordingBackendMPI::send_data( const MPI_Comm* comm, const double data[],
   // Receive the data ( for the moment only spike time )
   MPI_Send( data, shape, MPI_DOUBLE, 0, 0, *comm );
 }
+
+}  // namespace nest

--- a/nestkernel/recording_backend_screen.cpp
+++ b/nestkernel/recording_backend_screen.cpp
@@ -28,20 +28,23 @@
 
 #include "recording_backend_screen.h"
 
+
+namespace nest
+{
 void
-nest::RecordingBackendScreen::initialize()
+RecordingBackendScreen::initialize()
 {
   device_data_map tmp( kernel().vp_manager.get_num_threads() );
   device_data_.swap( tmp );
 }
 
 void
-nest::RecordingBackendScreen::finalize()
+RecordingBackendScreen::finalize()
 {
 }
 
 void
-nest::RecordingBackendScreen::enroll( const RecordingDevice& device, const Dictionary& params )
+RecordingBackendScreen::enroll( const RecordingDevice& device, const Dictionary& params )
 {
   const size_t node_id = device.get_node_id();
   const size_t t = device.get_thread();
@@ -57,7 +60,7 @@ nest::RecordingBackendScreen::enroll( const RecordingDevice& device, const Dicti
 }
 
 void
-nest::RecordingBackendScreen::disenroll( const RecordingDevice& device )
+RecordingBackendScreen::disenroll( const RecordingDevice& device )
 {
   const size_t node_id = device.get_node_id();
   const size_t t = device.get_thread();
@@ -70,7 +73,7 @@ nest::RecordingBackendScreen::disenroll( const RecordingDevice& device )
 }
 
 void
-nest::RecordingBackendScreen::set_value_names( const RecordingDevice&,
+RecordingBackendScreen::set_value_names( const RecordingDevice&,
   const std::vector< std::string >&,
   const std::vector< std::string >& )
 {
@@ -78,19 +81,19 @@ nest::RecordingBackendScreen::set_value_names( const RecordingDevice&,
 }
 
 void
-nest::RecordingBackendScreen::pre_run_hook()
+RecordingBackendScreen::pre_run_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendScreen::cleanup()
+RecordingBackendScreen::cleanup()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendScreen::write( const RecordingDevice& device,
+RecordingBackendScreen::write( const RecordingDevice& device,
   const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
@@ -107,21 +110,21 @@ nest::RecordingBackendScreen::write( const RecordingDevice& device,
 }
 
 void
-nest::RecordingBackendScreen::check_device_status( const Dictionary& params ) const
+RecordingBackendScreen::check_device_status( const Dictionary& params ) const
 {
   DeviceData dd;
   dd.set_status( params );  // throws if params contains invalid entries
 }
 
 void
-nest::RecordingBackendScreen::get_device_defaults( Dictionary& params ) const
+RecordingBackendScreen::get_device_defaults( Dictionary& params ) const
 {
   DeviceData dd;
   dd.get_status( params );
 }
 
 void
-nest::RecordingBackendScreen::get_device_status( const nest::RecordingDevice& device, Dictionary& d ) const
+RecordingBackendScreen::get_device_status( const RecordingDevice& device, Dictionary& d ) const
 {
   const size_t t = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -135,59 +138,59 @@ nest::RecordingBackendScreen::get_device_status( const nest::RecordingDevice& de
 
 
 void
-nest::RecordingBackendScreen::prepare()
+RecordingBackendScreen::prepare()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendScreen::post_run_hook()
+RecordingBackendScreen::post_run_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendScreen::post_step_hook()
+RecordingBackendScreen::post_step_hook()
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendScreen::set_status( const Dictionary& )
+RecordingBackendScreen::set_status( const Dictionary& )
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendScreen::get_status( Dictionary& ) const
+RecordingBackendScreen::get_status( Dictionary& ) const
 {
   // nothing to do
 }
 
 /* ******************* Device meta data class DeviceInfo ******************* */
 
-nest::RecordingBackendScreen::DeviceData::DeviceData()
+RecordingBackendScreen::DeviceData::DeviceData()
   : precision_( 3 )
   , time_in_steps_( false )
 {
 }
 
 void
-nest::RecordingBackendScreen::DeviceData::get_status( Dictionary& d ) const
+RecordingBackendScreen::DeviceData::get_status( Dictionary& d ) const
 {
   d[ names::precision ] = precision_;
   d[ names::time_in_steps ] = time_in_steps_;
 }
 
 void
-nest::RecordingBackendScreen::DeviceData::set_status( const Dictionary& d )
+RecordingBackendScreen::DeviceData::set_status( const Dictionary& d )
 {
   d.update_value( names::precision, precision_ );
   d.update_value( names::time_in_steps, time_in_steps_ );
 }
 
 void
-nest::RecordingBackendScreen::DeviceData::write( const Event& event,
+RecordingBackendScreen::DeviceData::write( const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
 {
@@ -221,15 +224,17 @@ nest::RecordingBackendScreen::DeviceData::write( const Event& event,
 }
 
 void
-nest::RecordingBackendScreen::DeviceData::prepare_cout_()
+RecordingBackendScreen::DeviceData::prepare_cout_()
 {
   old_fmtflags_ = std::cout.flags( std::ios::fixed );
   old_precision_ = std::cout.precision( precision_ );
 }
 
 void
-nest::RecordingBackendScreen::DeviceData::restore_cout_()
+RecordingBackendScreen::DeviceData::restore_cout_()
 {
   std::cout.flags( old_fmtflags_ );
   std::cout.precision( old_precision_ );
 }
+
+}  // namespace nest

--- a/nestkernel/recording_backend_sionlib.cpp
+++ b/nestkernel/recording_backend_sionlib.cpp
@@ -38,37 +38,40 @@
 
 #include "recording_backend_sionlib.h"
 
-const unsigned int nest::RecordingBackendSIONlib::SIONLIB_REC_BACKEND_VERSION = 2;
-const unsigned int nest::RecordingBackendSIONlib::DEV_NAME_BUFFERSIZE = 32;
-const unsigned int nest::RecordingBackendSIONlib::DEV_LABEL_BUFFERSIZE = 32;
-const unsigned int nest::RecordingBackendSIONlib::VALUE_NAME_BUFFERSIZE = 16;
-const unsigned int nest::RecordingBackendSIONlib::NEST_VERSION_BUFFERSIZE = 128;
 
-nest::RecordingBackendSIONlib::RecordingBackendSIONlib()
+namespace nest
+{
+const unsigned int RecordingBackendSIONlib::SIONLIB_REC_BACKEND_VERSION = 2;
+const unsigned int RecordingBackendSIONlib::DEV_NAME_BUFFERSIZE = 32;
+const unsigned int RecordingBackendSIONlib::DEV_LABEL_BUFFERSIZE = 32;
+const unsigned int RecordingBackendSIONlib::VALUE_NAME_BUFFERSIZE = 16;
+const unsigned int RecordingBackendSIONlib::NEST_VERSION_BUFFERSIZE = 128;
+
+RecordingBackendSIONlib::RecordingBackendSIONlib()
   : files_opened_( false )
   , num_enrolled_devices_( 0 )
 {
 }
 
-nest::RecordingBackendSIONlib::~RecordingBackendSIONlib() throw()
+RecordingBackendSIONlib::~RecordingBackendSIONlib() throw()
 {
   cleanup();
 }
 
 void
-nest::RecordingBackendSIONlib::initialize()
+RecordingBackendSIONlib::initialize()
 {
   device_map devices( kernel().vp_manager.get_num_threads() );
   devices_.swap( devices );
 }
 
 void
-nest::RecordingBackendSIONlib::finalize()
+RecordingBackendSIONlib::finalize()
 {
 }
 
 void
-nest::RecordingBackendSIONlib::enroll( const RecordingDevice& device, const Dictionary& )
+RecordingBackendSIONlib::enroll( const RecordingDevice& device, const Dictionary& )
 {
   const size_t tid = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -95,7 +98,7 @@ nest::RecordingBackendSIONlib::enroll( const RecordingDevice& device, const Dict
 }
 
 void
-nest::RecordingBackendSIONlib::disenroll( const RecordingDevice& device )
+RecordingBackendSIONlib::disenroll( const RecordingDevice& device )
 {
   const size_t tid = device.get_thread();
   const size_t node_id = device.get_node_id();
@@ -108,7 +111,7 @@ nest::RecordingBackendSIONlib::disenroll( const RecordingDevice& device )
 }
 
 void
-nest::RecordingBackendSIONlib::set_value_names( const RecordingDevice& device,
+RecordingBackendSIONlib::set_value_names( const RecordingDevice& device,
   const std::vector< std::string >& double_value_names,
   const std::vector< std::string >& long_value_names )
 {
@@ -134,12 +137,12 @@ nest::RecordingBackendSIONlib::set_value_names( const RecordingDevice& device,
 }
 
 void
-nest::RecordingBackendSIONlib::pre_run_hook()
+RecordingBackendSIONlib::pre_run_hook()
 {
 }
 
 void
-nest::RecordingBackendSIONlib::open_files_()
+RecordingBackendSIONlib::open_files_()
 {
   if ( files_opened_ or num_enrolled_devices_ == 0 )
   {
@@ -249,13 +252,13 @@ nest::RecordingBackendSIONlib::open_files_()
 }
 
 void
-nest::RecordingBackendSIONlib::cleanup()
+RecordingBackendSIONlib::cleanup()
 {
   close_files_();
 }
 
 void
-nest::RecordingBackendSIONlib::close_files_()
+RecordingBackendSIONlib::close_files_()
 {
   if ( not files_opened_ )
   {
@@ -415,7 +418,7 @@ nest::RecordingBackendSIONlib::close_files_()
 }
 
 void
-nest::RecordingBackendSIONlib::write( const RecordingDevice& device,
+RecordingBackendSIONlib::write( const RecordingDevice& device,
   const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
@@ -509,7 +512,7 @@ nest::RecordingBackendSIONlib::write( const RecordingDevice& device,
 }
 
 const std::string
-nest::RecordingBackendSIONlib::build_filename_() const
+RecordingBackendSIONlib::build_filename_() const
 {
   std::ostringstream basename;
   const std::string& path = kernel().io_manager.get_data_path();
@@ -526,14 +529,14 @@ nest::RecordingBackendSIONlib::build_filename_() const
  * Buffer
  * ---------------------------------------------------------------- */
 
-nest::RecordingBackendSIONlib::SIONBuffer::SIONBuffer()
+RecordingBackendSIONlib::SIONBuffer::SIONBuffer()
   : buffer_( nullptr )
   , ptr_( 0 )
   , max_size_( 0 )
 {
 }
 
-nest::RecordingBackendSIONlib::SIONBuffer::SIONBuffer( size_t size )
+RecordingBackendSIONlib::SIONBuffer::SIONBuffer( size_t size )
   : buffer_( nullptr )
   , ptr_( 0 )
   , max_size_( 0 )
@@ -541,7 +544,7 @@ nest::RecordingBackendSIONlib::SIONBuffer::SIONBuffer( size_t size )
   reserve( size );
 }
 
-nest::RecordingBackendSIONlib::SIONBuffer::~SIONBuffer()
+RecordingBackendSIONlib::SIONBuffer::~SIONBuffer()
 {
   if ( buffer_ )
   {
@@ -550,7 +553,7 @@ nest::RecordingBackendSIONlib::SIONBuffer::~SIONBuffer()
 }
 
 void
-nest::RecordingBackendSIONlib::SIONBuffer::reserve( size_t size )
+RecordingBackendSIONlib::SIONBuffer::reserve( size_t size )
 {
   char* new_buffer = new char[ size ];
 
@@ -565,7 +568,7 @@ nest::RecordingBackendSIONlib::SIONBuffer::reserve( size_t size )
 }
 
 void
-nest::RecordingBackendSIONlib::SIONBuffer::ensure_space( size_t size )
+RecordingBackendSIONlib::SIONBuffer::ensure_space( size_t size )
 {
   if ( get_free() < size )
   {
@@ -574,7 +577,7 @@ nest::RecordingBackendSIONlib::SIONBuffer::ensure_space( size_t size )
 }
 
 void
-nest::RecordingBackendSIONlib::SIONBuffer::write( const char* v, size_t n )
+RecordingBackendSIONlib::SIONBuffer::write( const char* v, size_t n )
 {
   if ( n <= get_free() )
   {
@@ -591,8 +594,8 @@ nest::RecordingBackendSIONlib::SIONBuffer::write( const char* v, size_t n )
 }
 
 template < typename T >
-nest::RecordingBackendSIONlib::SIONBuffer&
-nest::RecordingBackendSIONlib::SIONBuffer::operator<<( const T data )
+RecordingBackendSIONlib::SIONBuffer&
+RecordingBackendSIONlib::SIONBuffer::operator<<( const T data )
 {
   write( ( const char* ) &data, sizeof( T ) );
   return *this;
@@ -602,7 +605,7 @@ nest::RecordingBackendSIONlib::SIONBuffer::operator<<( const T data )
  * Parameter extraction and manipulation functions
  * ---------------------------------------------------------------- */
 
-nest::RecordingBackendSIONlib::Parameters_::Parameters_()
+RecordingBackendSIONlib::Parameters_::Parameters_()
   : filename_( "output.sion" )
   , sion_collective_( false )
   , sion_chunksize_( 1 << 18 )
@@ -612,7 +615,7 @@ nest::RecordingBackendSIONlib::Parameters_::Parameters_()
 }
 
 void
-nest::RecordingBackendSIONlib::Parameters_::get( const RecordingBackendSIONlib&, Dictionary& d ) const
+RecordingBackendSIONlib::Parameters_::get( const RecordingBackendSIONlib&, Dictionary& d ) const
 {
   d[ names::filename ] = filename_;
   d[ names::buffer_size ] = buffer_size_;
@@ -622,7 +625,7 @@ nest::RecordingBackendSIONlib::Parameters_::get( const RecordingBackendSIONlib&,
 }
 
 void
-nest::RecordingBackendSIONlib::Parameters_::set( const RecordingBackendSIONlib&, const Dictionary& d )
+RecordingBackendSIONlib::Parameters_::set( const RecordingBackendSIONlib&, const Dictionary& d )
 {
   d.update_value( names::filename, filename_ );
   d.update_value( names::buffer_size, buffer_size_ );
@@ -645,7 +648,7 @@ nest::RecordingBackendSIONlib::Parameters_::set( const RecordingBackendSIONlib&,
 }
 
 void
-nest::RecordingBackendSIONlib::set_status( const Dictionary& d )
+RecordingBackendSIONlib::set_status( const Dictionary& d )
 {
   Parameters_ ptmp = P_;  // temporary copy in case of errors
   ptmp.set( *this, d );   // throws if BadProperty
@@ -655,7 +658,7 @@ nest::RecordingBackendSIONlib::set_status( const Dictionary& d )
 }
 
 void
-nest::RecordingBackendSIONlib::get_status( Dictionary& d ) const
+RecordingBackendSIONlib::get_status( Dictionary& d ) const
 {
   P_.get( *this, d );
 
@@ -663,18 +666,18 @@ nest::RecordingBackendSIONlib::get_status( Dictionary& d ) const
 }
 
 void
-nest::RecordingBackendSIONlib::prepare()
+RecordingBackendSIONlib::prepare()
 {
   open_files_();
 }
 
 void
-nest::RecordingBackendSIONlib::post_run_hook()
+RecordingBackendSIONlib::post_run_hook()
 {
 }
 
 void
-nest::RecordingBackendSIONlib::post_step_hook()
+RecordingBackendSIONlib::post_step_hook()
 {
   if ( not files_opened_ or not P_.sion_collective_ )
   {
@@ -692,19 +695,21 @@ nest::RecordingBackendSIONlib::post_step_hook()
 }
 
 void
-nest::RecordingBackendSIONlib::check_device_status( const Dictionary& ) const
+RecordingBackendSIONlib::check_device_status( const Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendSIONlib::get_device_defaults( Dictionary& ) const
+RecordingBackendSIONlib::get_device_defaults( Dictionary& ) const
 {
   // nothing to do
 }
 
 void
-nest::RecordingBackendSIONlib::get_device_status( const nest::RecordingDevice&, Dictionary& ) const
+RecordingBackendSIONlib::get_device_status( const RecordingDevice&, Dictionary& ) const
 {
   // nothing to do
 }
+
+}  // namespace nest

--- a/nestkernel/recording_device.cpp
+++ b/nestkernel/recording_device.cpp
@@ -26,7 +26,10 @@
 
 #include "recording_device.h"
 
-nest::RecordingDevice::RecordingDevice()
+
+namespace nest
+{
+RecordingDevice::RecordingDevice()
   : DeviceNode()
   , Device()
   , P_()
@@ -34,7 +37,7 @@ nest::RecordingDevice::RecordingDevice()
 {
 }
 
-nest::RecordingDevice::RecordingDevice( const RecordingDevice& rd )
+RecordingDevice::RecordingDevice( const RecordingDevice& rd )
   : DeviceNode( rd )
   , Device( rd )
   , P_( rd.P_ )
@@ -43,13 +46,13 @@ nest::RecordingDevice::RecordingDevice( const RecordingDevice& rd )
 }
 
 void
-nest::RecordingDevice::set_initialized_()
+RecordingDevice::set_initialized_()
 {
   kernel().io_manager.enroll_recorder( P_.record_to_, *this, backend_params_ );
 }
 
 void
-nest::RecordingDevice::pre_run_hook( const std::vector< std::string >& double_value_names,
+RecordingDevice::pre_run_hook( const std::vector< std::string >& double_value_names,
   const std::vector< std::string >& long_value_names )
 {
   Device::pre_run_hook();
@@ -57,26 +60,26 @@ nest::RecordingDevice::pre_run_hook( const std::vector< std::string >& double_va
 }
 
 const std::string&
-nest::RecordingDevice::get_label() const
+RecordingDevice::get_label() const
 {
   return P_.label_;
 }
 
-nest::RecordingDevice::Parameters_::Parameters_()
+RecordingDevice::Parameters_::Parameters_()
   : label_()
   , record_to_( names::memory )
 {
 }
 
 void
-nest::RecordingDevice::Parameters_::get( Dictionary& d ) const
+RecordingDevice::Parameters_::get( Dictionary& d ) const
 {
   d[ names::label ] = label_;
   d[ names::record_to ] = record_to_;
 }
 
 void
-nest::RecordingDevice::Parameters_::set( const Dictionary& d )
+RecordingDevice::Parameters_::set( const Dictionary& d )
 {
   d.update_value( names::label, label_ );
 
@@ -93,13 +96,13 @@ nest::RecordingDevice::Parameters_::set( const Dictionary& d )
   }
 }
 
-nest::RecordingDevice::State_::State_()
+RecordingDevice::State_::State_()
   : n_events_( 0 )
 {
 }
 
 void
-nest::RecordingDevice::State_::get( Dictionary& d ) const
+RecordingDevice::State_::get( Dictionary& d ) const
 {
   long n_events = 0;
   d.update_value( names::n_events, n_events );
@@ -108,7 +111,7 @@ nest::RecordingDevice::State_::get( Dictionary& d ) const
 }
 
 void
-nest::RecordingDevice::State_::set( const Dictionary& d )
+RecordingDevice::State_::set( const Dictionary& d )
 {
   long n_events = 0;
 
@@ -124,7 +127,7 @@ nest::RecordingDevice::State_::set( const Dictionary& d )
 }
 
 void
-nest::RecordingDevice::set_status( const Dictionary& d )
+RecordingDevice::set_status( const Dictionary& d )
 {
   if ( kernel().simulation_manager.has_been_prepared() )
   {
@@ -176,7 +179,7 @@ nest::RecordingDevice::set_status( const Dictionary& d )
 }
 
 void
-nest::RecordingDevice::get_status( Dictionary& d ) const
+RecordingDevice::get_status( Dictionary& d ) const
 {
   P_.get( d );
   S_.get( d );
@@ -203,7 +206,7 @@ nest::RecordingDevice::get_status( Dictionary& d ) const
 }
 
 bool
-nest::RecordingDevice::is_active( Time const& T ) const
+RecordingDevice::is_active( Time const& T ) const
 {
   const long stamp = T.get_steps();
 
@@ -211,10 +214,12 @@ nest::RecordingDevice::is_active( Time const& T ) const
 }
 
 void
-nest::RecordingDevice::write( const Event& event,
+RecordingDevice::write( const Event& event,
   const std::vector< double >& double_values,
   const std::vector< long >& long_values )
 {
   kernel().io_manager.write( P_.record_to_, *this, event, double_values, long_values );
   S_.n_events_++;
 }
+
+}  // namespace nest

--- a/nestkernel/ring_buffer.cpp
+++ b/nestkernel/ring_buffer.cpp
@@ -22,13 +22,16 @@
 
 #include "ring_buffer.h"
 
-nest::RingBuffer::RingBuffer()
+
+namespace nest
+{
+RingBuffer::RingBuffer()
   : buffer_( kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay(), 0.0 )
 {
 }
 
 void
-nest::RingBuffer::resize()
+RingBuffer::resize()
 {
   size_t size = kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay();
   if ( buffer_.size() != size )
@@ -38,7 +41,7 @@ nest::RingBuffer::resize()
 }
 
 void
-nest::RingBuffer::clear()
+RingBuffer::clear()
 {
   resize();  // does nothing if size is fine
   // clear all elements
@@ -46,13 +49,13 @@ nest::RingBuffer::clear()
 }
 
 
-nest::MultRBuffer::MultRBuffer()
+MultRBuffer::MultRBuffer()
   : buffer_( kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay(), 0.0 )
 {
 }
 
 void
-nest::MultRBuffer::resize()
+MultRBuffer::resize()
 {
   size_t size = kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay();
   if ( buffer_.size() != size )
@@ -62,20 +65,20 @@ nest::MultRBuffer::resize()
 }
 
 void
-nest::MultRBuffer::clear()
+MultRBuffer::clear()
 {
   // clear all elements
   buffer_.assign( buffer_.size(), 0.0 );
 }
 
 
-nest::ListRingBuffer::ListRingBuffer()
+ListRingBuffer::ListRingBuffer()
   : buffer_( kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay() )
 {
 }
 
 void
-nest::ListRingBuffer::resize()
+ListRingBuffer::resize()
 {
   size_t size = kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay();
   if ( buffer_.size() != size )
@@ -85,7 +88,7 @@ nest::ListRingBuffer::resize()
 }
 
 void
-nest::ListRingBuffer::clear()
+ListRingBuffer::clear()
 {
   resize();  // does nothing if size is fine
   // clear all elements
@@ -94,3 +97,5 @@ nest::ListRingBuffer::clear()
     buffer_[ i ].clear();
   }
 }
+
+}  // namespace nest

--- a/nestkernel/ring_buffer_impl.h
+++ b/nestkernel/ring_buffer_impl.h
@@ -25,8 +25,11 @@
 
 #include "ring_buffer.h"
 
+namespace nest
+{
+
 template < unsigned int num_channels >
-nest::MultiChannelInputBuffer< num_channels >::MultiChannelInputBuffer()
+MultiChannelInputBuffer< num_channels >::MultiChannelInputBuffer()
   : buffer_( kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay(),
       std::array< double, num_channels >() )
 {
@@ -34,7 +37,7 @@ nest::MultiChannelInputBuffer< num_channels >::MultiChannelInputBuffer()
 
 template < unsigned int num_channels >
 void
-nest::MultiChannelInputBuffer< num_channels >::resize()
+MultiChannelInputBuffer< num_channels >::resize()
 {
   const size_t size = kernel().connection_manager.get_min_delay() + kernel().connection_manager.get_max_delay();
   if ( buffer_.size() != size )
@@ -45,7 +48,7 @@ nest::MultiChannelInputBuffer< num_channels >::resize()
 
 template < unsigned int num_channels >
 void
-nest::MultiChannelInputBuffer< num_channels >::clear()
+MultiChannelInputBuffer< num_channels >::clear()
 {
   resize();  // does nothing if size is fine
   // set all elements to 0.0
@@ -54,5 +57,7 @@ nest::MultiChannelInputBuffer< num_channels >::clear()
     reset_values_all_channels( slot );
   }
 }
+
+}  // namespace nest
 
 #endif

--- a/nestkernel/secondary_event_impl.h
+++ b/nestkernel/secondary_event_impl.h
@@ -25,9 +25,12 @@
 // Includes from nestkernel
 #include "kernel_manager.h"
 
+namespace nest
+{
+
 template < typename DataType, typename Subclass >
 void
-nest::DataSecondaryEvent< DataType, Subclass >::add_syn_id( const nest::synindex synid )
+DataSecondaryEvent< DataType, Subclass >::add_syn_id( const synindex synid )
 {
   kernel().vp_manager.assert_thread_parallel();
 
@@ -44,8 +47,10 @@ nest::DataSecondaryEvent< DataType, Subclass >::add_syn_id( const nest::synindex
 
 template < typename DataType, typename Subclass >
 void
-nest::DataSecondaryEvent< DataType, Subclass >::set_coeff_length( const size_t coeff_length )
+DataSecondaryEvent< DataType, Subclass >::set_coeff_length( const size_t coeff_length )
 {
   kernel().vp_manager.assert_single_threaded();
   coeff_length_ = coeff_length;
 }
+
+}  // namespace nest

--- a/nestkernel/send_buffer_position.cpp
+++ b/nestkernel/send_buffer_position.cpp
@@ -25,7 +25,10 @@
 
 #include "send_buffer_position.h"
 
-nest::SendBufferPosition::SendBufferPosition()
+
+namespace nest
+{
+SendBufferPosition::SendBufferPosition()
   : begin_( kernel().mpi_manager.get_num_processes(), 0 )
   , end_( kernel().mpi_manager.get_num_processes(), 0 )
   , idx_( kernel().mpi_manager.get_num_processes(), 0 )
@@ -40,3 +43,5 @@ nest::SendBufferPosition::SendBufferPosition()
     idx_[ rank ] = begin_[ rank ];
   }
 }
+
+}  // namespace nest

--- a/nestkernel/simulation_manager.cpp
+++ b/nestkernel/simulation_manager.cpp
@@ -41,7 +41,9 @@
 #include "stopwatch_impl.h"
 
 
-nest::SimulationManager::SimulationManager()
+namespace nest
+{
+SimulationManager::SimulationManager()
   : clock_( Time::tic( 0L ) )
   , slice_( 0L )
   , to_do_( 0L )
@@ -69,7 +71,7 @@ nest::SimulationManager::SimulationManager()
 }
 
 void
-nest::SimulationManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+SimulationManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 {
   if ( adjust_number_of_threads_or_rng_only )
   {
@@ -113,19 +115,19 @@ nest::SimulationManager::initialize( const bool adjust_number_of_threads_or_rng_
 }
 
 void
-nest::SimulationManager::finalize( const bool )
+SimulationManager::finalize( const bool )
 {
 }
 
 void
-nest::SimulationManager::reset_timers_for_preparation()
+SimulationManager::reset_timers_for_preparation()
 {
   sw_communicate_prepare_.reset();
   sw_gather_target_data_.reset();
 }
 
 void
-nest::SimulationManager::reset_timers_for_dynamics()
+SimulationManager::reset_timers_for_dynamics()
 {
   sw_simulate_.reset();
   sw_gather_spike_data_.reset();
@@ -136,7 +138,7 @@ nest::SimulationManager::reset_timers_for_dynamics()
 }
 
 void
-nest::SimulationManager::set_status( const Dictionary& d )
+SimulationManager::set_status( const Dictionary& d )
 {
   // Create an instance of time converter here to capture the current
   // representation of time objects: TICS_PER_MS and TICS_PER_STEP
@@ -227,10 +229,10 @@ nest::SimulationManager::set_status( const Dictionary& d )
       }
       else
       {
-        const double old_res = nest::Time::get_resolution().get_ms();
-        const tic_t old_tpms = nest::Time::get_resolution().get_tics_per_ms();
+        const double old_res = Time::get_resolution().get_ms();
+        const tic_t old_tpms = Time::get_resolution().get_tics_per_ms();
 
-        nest::Time::set_resolution( tics_per_ms, resd );
+        Time::set_resolution( tics_per_ms, resd );
         // adjust to new resolution
         clock_.calibrate();
         // adjust delays in the connection system to new resolution
@@ -266,7 +268,7 @@ nest::SimulationManager::set_status( const Dictionary& d )
       }
       else
       {
-        const double old_res = nest::Time::get_resolution().get_ms();
+        const double old_res = Time::get_resolution().get_ms();
 
         Time::set_resolution( resd );
         clock_.calibrate();  // adjust to new resolution
@@ -455,7 +457,7 @@ nest::SimulationManager::set_status( const Dictionary& d )
 }
 
 void
-nest::SimulationManager::get_status( Dictionary& d )
+SimulationManager::get_status( Dictionary& d )
 {
   d[ names::ms_per_tic ] = Time::get_ms_per_tic();
   d[ names::tics_per_ms ] = Time::get_tics_per_ms();
@@ -504,7 +506,7 @@ nest::SimulationManager::get_status( Dictionary& d )
 }
 
 void
-nest::SimulationManager::prepare()
+SimulationManager::prepare()
 {
   assert( kernel().is_initialized() );
 
@@ -570,7 +572,7 @@ nest::SimulationManager::prepare()
 }
 
 void
-nest::SimulationManager::assert_valid_simtime( Time const& t )
+SimulationManager::assert_valid_simtime( Time const& t )
 {
   if ( t == Time::ms( 0.0 ) )
   {
@@ -611,7 +613,7 @@ nest::SimulationManager::assert_valid_simtime( Time const& t )
 }
 
 void
-nest::SimulationManager::run( Time const& t )
+SimulationManager::run( Time const& t )
 {
   assert_valid_simtime( t );
 
@@ -671,7 +673,7 @@ nest::SimulationManager::run( Time const& t )
 }
 
 void
-nest::SimulationManager::cleanup()
+SimulationManager::cleanup()
 {
   if ( not prepared_ )
   {
@@ -691,7 +693,7 @@ nest::SimulationManager::cleanup()
 }
 
 void
-nest::SimulationManager::call_update_()
+SimulationManager::call_update_()
 {
   assert( kernel().is_initialized() and not inconsistent_state_ );
 
@@ -747,7 +749,7 @@ nest::SimulationManager::call_update_()
 }
 
 void
-nest::SimulationManager::update_connection_infrastructure( const size_t tid )
+SimulationManager::update_connection_infrastructure( const size_t tid )
 {
   kernel().get_omp_synchronization_construction_stopwatch().start();
 #pragma omp barrier
@@ -833,13 +835,13 @@ nest::SimulationManager::update_connection_infrastructure( const size_t tid )
 }
 
 bool
-nest::SimulationManager::wfr_update_( Node* n )
+SimulationManager::wfr_update_( Node* n )
 {
   return ( n->wfr_update( clock_, from_step_, to_step_ ) );
 }
 
 void
-nest::SimulationManager::update_()
+SimulationManager::update_()
 {
   // to store done values of the different threads
   std::vector< bool > done;
@@ -1189,7 +1191,7 @@ nest::SimulationManager::update_()
 }
 
 void
-nest::SimulationManager::advance_time_()
+SimulationManager::advance_time_()
 {
   // time now advanced time by the duration of the previous step
   to_do_ -= to_step_ - from_step_;
@@ -1223,7 +1225,7 @@ nest::SimulationManager::advance_time_()
 }
 
 void
-nest::SimulationManager::print_progress_()
+SimulationManager::print_progress_()
 {
   double rt_factor = 0.0;
 
@@ -1249,8 +1251,10 @@ nest::SimulationManager::print_progress_()
   std::flush( std::cout );
 }
 
-nest::Time const
-nest::SimulationManager::get_previous_slice_origin() const
+Time const
+SimulationManager::get_previous_slice_origin() const
 {
   return clock_ - Time::step( kernel().connection_manager.get_min_delay() );
 }
+
+}  // namespace nest

--- a/nestkernel/slice_ring_buffer.cpp
+++ b/nestkernel/slice_ring_buffer.cpp
@@ -26,13 +26,16 @@
 #include <cmath>
 #include <limits>
 
-nest::SliceRingBuffer::SliceRingBuffer()
+
+namespace nest
+{
+SliceRingBuffer::SliceRingBuffer()
   : refract_( std::numeric_limits< long >::max(), 0, 0 )
 {
 }
 
 void
-nest::SliceRingBuffer::resize()
+SliceRingBuffer::resize()
 {
   // We want to compute ceil( ( d_min + d_max ) / d_min ) = 1 + ceil( d_max / d_min )
   // and can do so safely without casting to double.
@@ -56,7 +59,7 @@ nest::SliceRingBuffer::resize()
 }
 
 void
-nest::SliceRingBuffer::clear()
+SliceRingBuffer::clear()
 {
   for ( auto& slot : queue_ )
   {
@@ -65,7 +68,7 @@ nest::SliceRingBuffer::clear()
 }
 
 void
-nest::SliceRingBuffer::prepare_delivery()
+SliceRingBuffer::prepare_delivery()
 {
   // vector to deliver from in this slice
   deliver_ = &( queue_[ kernel().event_delivery_manager.get_slice_modulo( 0 ) ] );
@@ -75,10 +78,12 @@ nest::SliceRingBuffer::prepare_delivery()
 }
 
 void
-nest::SliceRingBuffer::discard_events()
+SliceRingBuffer::discard_events()
 {
   // vector to deliver from in this slice
   deliver_ = &( queue_[ kernel().event_delivery_manager.get_slice_modulo( 0 ) ] );
 
   deliver_->clear();
 }
+
+}  // namespace nest

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -32,16 +32,19 @@
 #include "stopwatch_impl.h"
 #include "vp_manager_impl.h"
 
-nest::SourceTable::SourceTable()
+
+namespace nest
+{
+SourceTable::SourceTable()
 {
 }
 
-nest::SourceTable::~SourceTable()
+SourceTable::~SourceTable()
 {
 }
 
 void
-nest::SourceTable::initialize()
+SourceTable::initialize()
 {
   assert( sizeof( Source ) == 8 );
   const size_t num_threads = kernel().vp_manager.get_num_threads();
@@ -62,7 +65,7 @@ nest::SourceTable::initialize()
 }
 
 void
-nest::SourceTable::finalize()
+SourceTable::finalize()
 {
   for ( size_t tid = 0; tid < static_cast< size_t >( sources_.size() ); ++tid )
   {
@@ -81,19 +84,19 @@ nest::SourceTable::finalize()
 }
 
 bool
-nest::SourceTable::is_cleared() const
+SourceTable::is_cleared() const
 {
   return is_cleared_.all_true();
 }
 
-std::vector< BlockVector< nest::Source > >&
-nest::SourceTable::get_thread_local_sources( const size_t tid )
+std::vector< BlockVector< Source > >&
+SourceTable::get_thread_local_sources( const size_t tid )
 {
   return sources_[ tid ];
 }
 
-nest::SourceTablePosition
-nest::SourceTable::find_maximal_position() const
+SourceTablePosition
+SourceTable::find_maximal_position() const
 {
   SourceTablePosition max_position( -1, -1, -1 );
   for ( size_t tid = 0; tid < kernel().vp_manager.get_num_threads(); ++tid )
@@ -107,7 +110,7 @@ nest::SourceTable::find_maximal_position() const
 }
 
 void
-nest::SourceTable::clean( const size_t tid )
+SourceTable::clean( const size_t tid )
 {
   // Find maximal position in source table among threads to make sure
   // unprocessed entries are not removed. Given this maximal position,
@@ -153,7 +156,7 @@ nest::SourceTable::clean( const size_t tid )
 }
 
 size_t
-nest::SourceTable::get_node_id( const size_t tid, const synindex syn_id, const size_t lcid ) const
+SourceTable::get_node_id( const size_t tid, const synindex syn_id, const size_t lcid ) const
 {
   if ( not kernel().connection_manager.get_keep_source_table() )
   {
@@ -163,7 +166,7 @@ nest::SourceTable::get_node_id( const size_t tid, const synindex syn_id, const s
 }
 
 size_t
-nest::SourceTable::find_first_source( const size_t tid, const synindex syn_id, const size_t snode_id ) const
+SourceTable::find_first_source( const size_t tid, const synindex syn_id, const size_t snode_id ) const
 {
   const auto source_begin = sources_[ tid ][ syn_id ].begin();
   const auto source_end = sources_[ tid ][ syn_id ].end();
@@ -193,7 +196,7 @@ nest::SourceTable::find_first_source( const size_t tid, const synindex syn_id, c
 }
 
 size_t
-nest::SourceTable::remove_disabled_sources( const size_t tid, const synindex syn_id )
+SourceTable::remove_disabled_sources( const size_t tid, const synindex syn_id )
 {
   assert( kernel().connection_manager.use_compressed_spikes() );
 
@@ -228,7 +231,7 @@ nest::SourceTable::remove_disabled_sources( const size_t tid, const synindex syn
 }
 
 void
-nest::SourceTable::compute_buffer_pos_for_unique_secondary_sources( const size_t tid,
+SourceTable::compute_buffer_pos_for_unique_secondary_sources( const size_t tid,
   std::map< size_t, size_t >& buffer_pos_of_source_node_id_syn_id )
 {
   // set of unique sources & synapse types, required to determine
@@ -301,14 +304,14 @@ nest::SourceTable::compute_buffer_pos_for_unique_secondary_sources( const size_t
 }
 
 void
-nest::SourceTable::resize_sources()
+SourceTable::resize_sources()
 {
   kernel().vp_manager.assert_thread_parallel();
   sources_.at( kernel().vp_manager.get_thread_id() ).resize( kernel().model_manager.get_num_connection_models() );
 }
 
 bool
-nest::SourceTable::source_should_be_processed_( const size_t rank_start,
+SourceTable::source_should_be_processed_( const size_t rank_start,
   const size_t rank_end,
   const Source& source ) const
 {
@@ -321,7 +324,7 @@ nest::SourceTable::source_should_be_processed_( const size_t rank_start,
 }
 
 bool
-nest::SourceTable::next_entry_has_same_source_( const SourceTablePosition& current_position,
+SourceTable::next_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
   assert( not current_position.is_invalid() );
@@ -334,7 +337,7 @@ nest::SourceTable::next_entry_has_same_source_( const SourceTablePosition& curre
 }
 
 bool
-nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& current_position,
+SourceTable::previous_entry_has_same_source_( const SourceTablePosition& current_position,
   const Source& current_source ) const
 {
   assert( not current_position.is_invalid() );
@@ -348,7 +351,7 @@ nest::SourceTable::previous_entry_has_same_source_( const SourceTablePosition& c
 }
 
 bool
-nest::SourceTable::populate_target_data_fields_( const SourceTablePosition& current_position,
+SourceTable::populate_target_data_fields_( const SourceTablePosition& current_position,
   const Source& current_source,
   const size_t source_rank,
   TargetData& next_target_data ) const
@@ -393,7 +396,7 @@ nest::SourceTable::populate_target_data_fields_( const SourceTablePosition& curr
 }
 
 bool
-nest::SourceTable::get_next_target_data( const size_t tid,
+SourceTable::get_next_target_data( const size_t tid,
   const size_t rank_start,
   const size_t rank_end,
   size_t& source_rank,
@@ -461,7 +464,7 @@ nest::SourceTable::get_next_target_data( const size_t tid,
 }
 
 void
-nest::SourceTable::resize_compressible_sources()
+SourceTable::resize_compressible_sources()
 {
   for ( size_t tid = 0; tid < static_cast< size_t >( compressible_sources_.size() ); ++tid )
   {
@@ -472,7 +475,7 @@ nest::SourceTable::resize_compressible_sources()
 }
 
 void
-nest::SourceTable::collect_compressible_sources( const size_t tid )
+SourceTable::collect_compressible_sources( const size_t tid )
 {
   for ( synindex syn_id = 0; syn_id < sources_[ tid ].size(); ++syn_id )
   {
@@ -502,7 +505,7 @@ nest::SourceTable::collect_compressible_sources( const size_t tid )
 }
 
 void
-nest::SourceTable::dump_sources() const
+SourceTable::dump_sources() const
 {
   FULL_LOGGING_ONLY( for ( size_t tid = 0; tid < sources_.size(); ++tid ) {
     for ( size_t syn_id = 0; syn_id < sources_[ tid ].size(); ++syn_id )
@@ -523,7 +526,7 @@ nest::SourceTable::dump_sources() const
 
 
 void
-nest::SourceTable::dump_compressible_sources() const
+SourceTable::dump_compressible_sources() const
 {
   FULL_LOGGING_ONLY( for ( size_t tid = 0; tid < compressible_sources_.size(); ++tid ) {
     for ( size_t syn_id = 0; syn_id < compressible_sources_[ tid ].size(); ++syn_id )
@@ -542,7 +545,7 @@ nest::SourceTable::dump_compressible_sources() const
 }
 
 void
-nest::SourceTable::fill_compressed_spike_data(
+SourceTable::fill_compressed_spike_data(
   std::vector< std::vector< std::vector< SpikeData > > >& compressed_spike_data )
 {
   const size_t num_synapse_models = kernel().model_manager.get_num_connection_models();
@@ -594,7 +597,7 @@ nest::SourceTable::fill_compressed_spike_data(
 
 // Argument name only needed if full logging is activated. Macro-protect to avoid unused argument warning.
 void
-nest::SourceTable::dump_compressed_spike_data(
+SourceTable::dump_compressed_spike_data(
   const std::vector< std::vector< std::vector< SpikeData > > >& FULL_LOGGING_ONLY( compressed_spike_data ) ) const
 {
   FULL_LOGGING_ONLY(
@@ -626,3 +629,5 @@ nest::SourceTable::dump_compressed_spike_data(
       }
     } )
 }
+
+}  // namespace nest

--- a/nestkernel/source_table.cpp
+++ b/nestkernel/source_table.cpp
@@ -311,9 +311,7 @@ SourceTable::resize_sources()
 }
 
 bool
-SourceTable::source_should_be_processed_( const size_t rank_start,
-  const size_t rank_end,
-  const Source& source ) const
+SourceTable::source_should_be_processed_( const size_t rank_start, const size_t rank_end, const Source& source ) const
 {
   const size_t source_rank = kernel().mpi_manager.get_process_id_of_node_id( source.get_node_id() );
 
@@ -545,8 +543,7 @@ SourceTable::dump_compressible_sources() const
 }
 
 void
-SourceTable::fill_compressed_spike_data(
-  std::vector< std::vector< std::vector< SpikeData > > >& compressed_spike_data )
+SourceTable::fill_compressed_spike_data( std::vector< std::vector< std::vector< SpikeData > > >& compressed_spike_data )
 {
   const size_t num_synapse_models = kernel().model_manager.get_num_connection_models();
   compressed_spike_data.clear();

--- a/nestkernel/sp_manager.cpp
+++ b/nestkernel/sp_manager.cpp
@@ -563,7 +563,7 @@ SPManager::delete_synapses_from_post( std::vector< size_t >& post_deleted_id,
 }
 
 void
-nest::SPManager::get_synaptic_elements( std::string se_name,
+SPManager::get_synaptic_elements( std::string se_name,
   std::vector< size_t >& se_vacant_id,
   std::vector< int >& se_vacant_n,
   std::vector< size_t >& se_deleted_id,
@@ -625,7 +625,7 @@ nest::SPManager::get_synaptic_elements( std::string se_name,
 }
 
 void
-nest::SPManager::serialize_id( std::vector< size_t >& id, std::vector< int >& n, std::vector< size_t >& res )
+SPManager::serialize_id( std::vector< size_t >& id, std::vector< int >& n, std::vector< size_t >& res )
 {
   // populate res with indexes of nodes corresponding to the number of elements
   res.clear();
@@ -644,13 +644,13 @@ nest::SPManager::serialize_id( std::vector< size_t >& id, std::vector< int >& n,
 }
 
 void
-nest::SPManager::global_shuffle( std::vector< size_t >& v )
+SPManager::global_shuffle( std::vector< size_t >& v )
 {
   global_shuffle( v, v.size() );
 }
 
 void
-nest::SPManager::global_shuffle( std::vector< size_t >& v, size_t n )
+SPManager::global_shuffle( std::vector< size_t >& v, size_t n )
 {
   assert( n <= v.size() );
 
@@ -674,7 +674,7 @@ nest::SPManager::global_shuffle( std::vector< size_t >& v, size_t n )
 
 
 void
-nest::SPManager::enable_structural_plasticity()
+SPManager::enable_structural_plasticity()
 {
   if ( kernel().vp_manager.get_num_threads() > 1 )
   {
@@ -696,7 +696,7 @@ nest::SPManager::enable_structural_plasticity()
 }
 
 void
-nest::SPManager::disable_structural_plasticity()
+SPManager::disable_structural_plasticity()
 {
   structural_plasticity_enabled_ = false;
 }

--- a/nestkernel/sparse_node_array.cpp
+++ b/nestkernel/sparse_node_array.cpp
@@ -29,13 +29,15 @@
 #include "vp_manager_impl.h"
 
 
-nest::SparseNodeArray::NodeEntry::NodeEntry( Node& node, size_t node_id )
+namespace nest
+{
+SparseNodeArray::NodeEntry::NodeEntry( Node& node, size_t node_id )
   : node_( &node )
   , node_id_( node_id )
 {
 }
 
-nest::SparseNodeArray::SparseNodeArray()
+SparseNodeArray::SparseNodeArray()
   : nodes_()
   , global_max_node_id_( 0 )
   , local_min_node_id_( 0 )
@@ -51,7 +53,7 @@ nest::SparseNodeArray::SparseNodeArray()
 
 
 void
-nest::SparseNodeArray::clear()
+SparseNodeArray::clear()
 {
   nodes_.clear();
 
@@ -67,7 +69,7 @@ nest::SparseNodeArray::clear()
 }
 
 void
-nest::SparseNodeArray::add_local_node( Node& node )
+SparseNodeArray::add_local_node( Node& node )
 {
   const size_t node_id = node.get_node_id();
 
@@ -113,7 +115,7 @@ nest::SparseNodeArray::add_local_node( Node& node )
 }
 
 void
-nest::SparseNodeArray::set_max_node_id( size_t node_id )
+SparseNodeArray::set_max_node_id( size_t node_id )
 {
   assert( node_id > 0 );  // minimum node ID is 1
   assert( node_id >= local_max_node_id_ );
@@ -124,8 +126,8 @@ nest::SparseNodeArray::set_max_node_id( size_t node_id )
   }
 }
 
-nest::Node*
-nest::SparseNodeArray::get_node_by_node_id( size_t node_id ) const
+Node*
+SparseNodeArray::get_node_by_node_id( size_t node_id ) const
 {
   assert( is_consistent_() );
 
@@ -173,3 +175,5 @@ nest::SparseNodeArray::get_node_by_node_id( size_t node_id ) const
     return nullptr;
   }
 }
+
+}  // namespace nest

--- a/nestkernel/sparse_node_array.h
+++ b/nestkernel/sparse_node_array.h
@@ -221,58 +221,57 @@ private:
   bool left_side_has_proxies_;
 };
 
-}  // namespace nest
-
-
-inline nest::SparseNodeArray::const_iterator
-nest::SparseNodeArray::begin() const
+inline SparseNodeArray::const_iterator
+SparseNodeArray::begin() const
 {
   return nodes_.begin();
 }
 
-inline nest::SparseNodeArray::const_iterator
-nest::SparseNodeArray::end() const
+inline SparseNodeArray::const_iterator
+SparseNodeArray::end() const
 {
   return nodes_.end();
 }
 
 inline size_t
-nest::SparseNodeArray::size() const
+SparseNodeArray::size() const
 {
   return nodes_.size();
 }
 
-inline nest::Node*
-nest::SparseNodeArray::get_node_by_index( size_t idx ) const
+inline Node*
+SparseNodeArray::get_node_by_index( size_t idx ) const
 {
   assert( idx < nodes_.size() );
   return nodes_[ idx ].node_;
 }
 
 inline size_t
-nest::SparseNodeArray::get_max_node_id() const
+SparseNodeArray::get_max_node_id() const
 {
   return global_max_node_id_;
 }
 
 inline bool
-nest::SparseNodeArray::is_consistent_() const
+SparseNodeArray::is_consistent_() const
 {
   return nodes_.size() == 0 or global_max_node_id_ > 0;
 }
 
-inline nest::Node*
-nest::SparseNodeArray::NodeEntry::get_node() const
+inline Node*
+SparseNodeArray::NodeEntry::get_node() const
 {
   assert( node_ );
   return node_;
 }
 
 inline size_t
-nest::SparseNodeArray::NodeEntry::get_node_id() const
+SparseNodeArray::NodeEntry::get_node_id() const
 {
   assert( node_id_ > 0 );
   return node_id_;
 }
+
+}  // namespace nest
 
 #endif /* SPARSE_NODE_ARRAY_H */

--- a/nestkernel/spikecounter.cpp
+++ b/nestkernel/spikecounter.cpp
@@ -31,8 +31,13 @@
 
 #include "spikecounter.h"
 
-nest::spikecounter::spikecounter( double spike_time, double multiplicity )
+
+namespace nest
+{
+spikecounter::spikecounter( double spike_time, double multiplicity )
   : spike_time_( spike_time )
   , multiplicity_( multiplicity )
 {
 }
+
+}  // namespace nest

--- a/nestkernel/stimulation_backend_mpi.cpp
+++ b/nestkernel/stimulation_backend_mpi.cpp
@@ -31,19 +31,22 @@
 #include "stimulation_backend_mpi.h"
 #include "stimulation_device.h"
 
-nest::StimulationBackendMPI::StimulationBackendMPI()
+
+namespace nest
+{
+StimulationBackendMPI::StimulationBackendMPI()
   : enrolled_( false )
   , prepared_( false )
 {
 }
 
-nest::StimulationBackendMPI::~StimulationBackendMPI() noexcept
+StimulationBackendMPI::~StimulationBackendMPI() noexcept
 {
 }
 
 
 void
-nest::StimulationBackendMPI::initialize()
+StimulationBackendMPI::initialize()
 {
   auto nthreads = kernel().vp_manager.get_num_threads();
   device_map devices( nthreads );
@@ -51,7 +54,7 @@ nest::StimulationBackendMPI::initialize()
 }
 
 void
-nest::StimulationBackendMPI::finalize()
+StimulationBackendMPI::finalize()
 {
   // clear vector of map
   for ( auto& it_device : devices_ )
@@ -63,7 +66,7 @@ nest::StimulationBackendMPI::finalize()
 }
 
 void
-nest::StimulationBackendMPI::enroll( nest::StimulationDevice& device, const Dictionary& params )
+StimulationBackendMPI::enroll( StimulationDevice& device, const Dictionary& params )
 {
   size_t tid = device.get_thread();
   size_t node_id = device.get_node_id();
@@ -86,7 +89,7 @@ nest::StimulationBackendMPI::enroll( nest::StimulationDevice& device, const Dict
 
 
 void
-nest::StimulationBackendMPI::disenroll( nest::StimulationDevice& device )
+StimulationBackendMPI::disenroll( StimulationDevice& device )
 {
   size_t tid = device.get_thread();
   size_t node_id = device.get_node_id();
@@ -100,7 +103,7 @@ nest::StimulationBackendMPI::disenroll( nest::StimulationDevice& device )
 }
 
 void
-nest::StimulationBackendMPI::prepare()
+StimulationBackendMPI::prepare()
 {
   if ( not enrolled_ )
   {
@@ -205,7 +208,7 @@ nest::StimulationBackendMPI::prepare()
 }
 
 void
-nest::StimulationBackendMPI::pre_run_hook()
+StimulationBackendMPI::pre_run_hook()
 {
   // create the variable which will contain the receiving data from the communication
   std::vector< std::pair< int*, double* > > data( commMap_.size() );
@@ -243,7 +246,7 @@ nest::StimulationBackendMPI::pre_run_hook()
 }
 
 void
-nest::StimulationBackendMPI::post_run_hook()
+StimulationBackendMPI::post_run_hook()
 {
 #pragma omp master
   {
@@ -258,7 +261,7 @@ nest::StimulationBackendMPI::post_run_hook()
 }
 
 void
-nest::StimulationBackendMPI::cleanup()
+StimulationBackendMPI::cleanup()
 {
 // Disconnect all the MPI connection and send information about this disconnection
 // Clean all the elements in the map and disconnect MPI message
@@ -286,7 +289,7 @@ nest::StimulationBackendMPI::cleanup()
 }
 
 void
-nest::StimulationBackendMPI::get_port( nest::StimulationDevice* device, std::string* port_name )
+StimulationBackendMPI::get_port( StimulationDevice* device, std::string* port_name )
 {
   const std::string& label = device->get_label();
   // The MPI address can be provided by two different means.
@@ -306,7 +309,7 @@ nest::StimulationBackendMPI::get_port( nest::StimulationDevice* device, std::str
 }
 
 void
-nest::StimulationBackendMPI::get_port( const size_t index_node, const std::string& label, std::string* port_name )
+StimulationBackendMPI::get_port( const size_t index_node, const std::string& label, std::string* port_name )
 {
   // path of the file : path+label+id+.txt
   // (file contains only one line with name of the port)
@@ -345,7 +348,7 @@ nest::StimulationBackendMPI::get_port( const size_t index_node, const std::strin
 }
 
 std::pair< int*, double* >
-nest::StimulationBackendMPI::receive_spike_train( const MPI_Comm& comm, std::vector< int >& devices_id )
+StimulationBackendMPI::receive_spike_train( const MPI_Comm& comm, std::vector< int >& devices_id )
 {
   // Send size of the list id
   int size_list = { int( devices_id.size() ) };
@@ -370,7 +373,7 @@ nest::StimulationBackendMPI::receive_spike_train( const MPI_Comm& comm, std::vec
 }
 
 void
-nest::StimulationBackendMPI::update_device( int* array_index,
+StimulationBackendMPI::update_device( int* array_index,
   std::vector< int >& devices_id,
   std::pair< int*, double* > data )
 {
@@ -415,7 +418,7 @@ nest::StimulationBackendMPI::update_device( int* array_index,
 }
 
 void
-nest::StimulationBackendMPI::clean_memory_input_data( std::vector< std::pair< int*, double* > >& data )
+StimulationBackendMPI::clean_memory_input_data( std::vector< std::pair< int*, double* > >& data )
 {
   // for all the pairs of data, free the memory of data and the array with the size
   for ( auto pair_data : data )
@@ -434,3 +437,5 @@ nest::StimulationBackendMPI::clean_memory_input_data( std::vector< std::pair< in
     }
   }
 }
+
+}  // namespace nest

--- a/nestkernel/stimulation_device.cpp
+++ b/nestkernel/stimulation_device.cpp
@@ -26,7 +26,9 @@
 #include "kernel_manager.h"
 
 
-nest::StimulationDevice::StimulationDevice()
+namespace nest
+{
+StimulationDevice::StimulationDevice()
   : DeviceNode()
   , Device()
   , first_syn_id_( invalid_synindex )
@@ -34,7 +36,7 @@ nest::StimulationDevice::StimulationDevice()
 {
 }
 
-nest::StimulationDevice::StimulationDevice( StimulationDevice const& sd )
+StimulationDevice::StimulationDevice( StimulationDevice const& sd )
   : DeviceNode( sd )
   , Device( sd )
   , P_( sd.P_ )
@@ -44,7 +46,7 @@ nest::StimulationDevice::StimulationDevice( StimulationDevice const& sd )
 }
 
 bool
-nest::StimulationDevice::is_active( const Time& T ) const
+StimulationDevice::is_active( const Time& T ) const
 {
   long step = T.get_steps();
   if ( get_type() == StimulationDevice::Type::CURRENT_GENERATOR
@@ -57,7 +59,7 @@ nest::StimulationDevice::is_active( const Time& T ) const
 }
 
 void
-nest::StimulationDevice::enforce_single_syn_type( synindex syn_id )
+StimulationDevice::enforce_single_syn_type( synindex syn_id )
 {
   if ( first_syn_id_ == invalid_synindex )
   {
@@ -70,39 +72,39 @@ nest::StimulationDevice::enforce_single_syn_type( synindex syn_id )
 }
 
 void
-nest::StimulationDevice::pre_run_hook()
+StimulationDevice::pre_run_hook()
 {
   Device::pre_run_hook();
 }
 
 void
-nest::StimulationDevice::set_initialized_()
+StimulationDevice::set_initialized_()
 {
   kernel().io_manager.enroll_stimulator( P_.stimulus_source_, *this, backend_params_ );
 }
 
 const std::string&
-nest::StimulationDevice::get_label() const
+StimulationDevice::get_label() const
 {
   return P_.label_;
 }
 
 
-nest::StimulationDevice::Parameters_::Parameters_()
+StimulationDevice::Parameters_::Parameters_()
   : label_()
   , stimulus_source_()
 {
 }
 
 void
-nest::StimulationDevice::Parameters_::get( Dictionary& d ) const
+StimulationDevice::Parameters_::get( Dictionary& d ) const
 {
   d[ names::label ] = label_;
   d[ names::stimulus_source ] = stimulus_source_;
 }
 
 void
-nest::StimulationDevice::Parameters_::set( const Dictionary& d )
+StimulationDevice::Parameters_::set( const Dictionary& d )
 {
   d.update_value( names::label, label_ );
 
@@ -120,7 +122,7 @@ nest::StimulationDevice::Parameters_::set( const Dictionary& d )
 }
 
 void
-nest::StimulationDevice::set_status( const Dictionary& d )
+StimulationDevice::set_status( const Dictionary& d )
 {
 
   Parameters_ ptmp = P_;  // temporary copy in case of errors
@@ -163,7 +165,7 @@ nest::StimulationDevice::set_status( const Dictionary& d )
 
 
 void
-nest::StimulationDevice::get_status( Dictionary& d ) const
+StimulationDevice::get_status( Dictionary& d ) const
 {
   P_.get( d );
 
@@ -177,3 +179,5 @@ nest::StimulationDevice::get_status( Dictionary& d ) const
     backend_params_.update_dictionary( d );
   }
 }
+
+}  // namespace nest

--- a/nestkernel/structural_plasticity_node.cpp
+++ b/nestkernel/structural_plasticity_node.cpp
@@ -29,7 +29,7 @@
 namespace nest
 {
 
-nest::StructuralPlasticityNode::StructuralPlasticityNode()
+StructuralPlasticityNode::StructuralPlasticityNode()
   : Ca_t_( 0.0 )
   , Ca_minus_( 0.0 )
   , tau_Ca_( 10000.0 )
@@ -38,7 +38,7 @@ nest::StructuralPlasticityNode::StructuralPlasticityNode()
 {
 }
 
-nest::StructuralPlasticityNode::StructuralPlasticityNode( const StructuralPlasticityNode& n )
+StructuralPlasticityNode::StructuralPlasticityNode( const StructuralPlasticityNode& n )
   : Node( n )
   , Ca_t_( n.Ca_t_ )
   , Ca_minus_( n.Ca_minus_ )
@@ -49,7 +49,7 @@ nest::StructuralPlasticityNode::StructuralPlasticityNode( const StructuralPlasti
 }
 
 void
-nest::StructuralPlasticityNode::get_status( Dictionary& d ) const
+StructuralPlasticityNode::get_status( Dictionary& d ) const
 {
 
   d[ names::Ca ] = Ca_minus_;
@@ -69,7 +69,7 @@ nest::StructuralPlasticityNode::get_status( Dictionary& d ) const
 }
 
 void
-nest::StructuralPlasticityNode::set_status( const Dictionary& d )
+StructuralPlasticityNode::set_status( const Dictionary& d )
 {
   // We need to preserve values in case invalid values are set
   double new_Ca_ = Ca_minus_;
@@ -142,14 +142,14 @@ nest::StructuralPlasticityNode::set_status( const Dictionary& d )
 }
 
 void
-nest::StructuralPlasticityNode::clear_history()
+StructuralPlasticityNode::clear_history()
 {
   Ca_minus_ = 0.0;
   Ca_t_ = 0.0;
 }
 
 double
-nest::StructuralPlasticityNode::get_synaptic_elements( std::string n ) const
+StructuralPlasticityNode::get_synaptic_elements( std::string n ) const
 {
   std::map< std::string, SynapticElement >::const_iterator se_it;
   se_it = synaptic_elements_map_.find( n );
@@ -174,7 +174,7 @@ nest::StructuralPlasticityNode::get_synaptic_elements( std::string n ) const
 }
 
 int
-nest::StructuralPlasticityNode::get_synaptic_elements_vacant( std::string n ) const
+StructuralPlasticityNode::get_synaptic_elements_vacant( std::string n ) const
 {
   std::map< std::string, SynapticElement >::const_iterator se_it;
   se_it = synaptic_elements_map_.find( n );
@@ -190,7 +190,7 @@ nest::StructuralPlasticityNode::get_synaptic_elements_vacant( std::string n ) co
 }
 
 int
-nest::StructuralPlasticityNode::get_synaptic_elements_connected( std::string n ) const
+StructuralPlasticityNode::get_synaptic_elements_connected( std::string n ) const
 {
   std::map< std::string, SynapticElement >::const_iterator se_it;
   se_it = synaptic_elements_map_.find( n );
@@ -206,7 +206,7 @@ nest::StructuralPlasticityNode::get_synaptic_elements_connected( std::string n )
 }
 
 std::map< std::string, double >
-nest::StructuralPlasticityNode::get_synaptic_elements() const
+StructuralPlasticityNode::get_synaptic_elements() const
 {
   std::map< std::string, double > n_map;
 
@@ -220,7 +220,7 @@ nest::StructuralPlasticityNode::get_synaptic_elements() const
 }
 
 void
-nest::StructuralPlasticityNode::update_synaptic_elements( double t )
+StructuralPlasticityNode::update_synaptic_elements( double t )
 {
   assert( t >= Ca_t_ );
 
@@ -236,7 +236,7 @@ nest::StructuralPlasticityNode::update_synaptic_elements( double t )
 }
 
 void
-nest::StructuralPlasticityNode::decay_synaptic_elements_vacant()
+StructuralPlasticityNode::decay_synaptic_elements_vacant()
 {
   for ( std::map< std::string, SynapticElement >::iterator it = synaptic_elements_map_.begin();
     it != synaptic_elements_map_.end();
@@ -247,7 +247,7 @@ nest::StructuralPlasticityNode::decay_synaptic_elements_vacant()
 }
 
 void
-nest::StructuralPlasticityNode::connect_synaptic_element( std::string name, int n )
+StructuralPlasticityNode::connect_synaptic_element( std::string name, int n )
 {
   std::map< std::string, SynapticElement >::iterator se_it;
   se_it = synaptic_elements_map_.find( name );
@@ -259,7 +259,7 @@ nest::StructuralPlasticityNode::connect_synaptic_element( std::string name, int 
 }
 
 void
-nest::StructuralPlasticityNode::set_spiketime( Time const& t_sp, double offset )
+StructuralPlasticityNode::set_spiketime( Time const& t_sp, double offset )
 {
   const double t_sp_ms = t_sp.get_ms() - offset;
   update_synaptic_elements( t_sp_ms );

--- a/nestkernel/synaptic_element.cpp
+++ b/nestkernel/synaptic_element.cpp
@@ -27,12 +27,14 @@
 #include "kernel_manager.h"
 
 
+namespace nest
+{
 /* ----------------------------------------------------------------
  * SynapticElement
  * Default constructors defining default parameters and state
  * ---------------------------------------------------------------- */
 
-nest::SynapticElement::SynapticElement()
+SynapticElement::SynapticElement()
   : z_( 0.0 )
   , z_t_( 0.0 )
   , z_connected_( 0 )
@@ -43,7 +45,7 @@ nest::SynapticElement::SynapticElement()
 {
 }
 
-nest::SynapticElement::SynapticElement( const SynapticElement& se )
+SynapticElement::SynapticElement( const SynapticElement& se )
   : z_( se.z_ )
   , z_t_( se.z_t_ )
   , z_connected_( se.z_connected_ )
@@ -58,8 +60,8 @@ nest::SynapticElement::SynapticElement( const SynapticElement& se )
   growth_curve_->set( nc_parameters );
 }
 
-nest::SynapticElement&
-nest::SynapticElement::operator=( const SynapticElement& other )
+SynapticElement&
+SynapticElement::operator=( const SynapticElement& other )
 {
   if ( this != &other )
   {
@@ -87,7 +89,7 @@ nest::SynapticElement::operator=( const SynapticElement& other )
  * get function to store current values in dictionary
  * ---------------------------------------------------------------- */
 void
-nest::SynapticElement::get( Dictionary& d ) const
+SynapticElement::get( Dictionary& d ) const
 {
   // Store current values in the dictionary
   d[ names::growth_rate ] = growth_rate_;
@@ -104,7 +106,7 @@ nest::SynapticElement::get( Dictionary& d ) const
  * set function to store dictionary values in the SynaticElement
  * ---------------------------------------------------------------- */
 void
-nest::SynapticElement::set( const Dictionary& d )
+SynapticElement::set( const Dictionary& d )
 {
   double new_tau_vacant = tau_vacant_;
 
@@ -136,7 +138,7 @@ nest::SynapticElement::set( const Dictionary& d )
  * Update the number of element at the time t (in ms)
  * ---------------------------------------------------------------- */
 void
-nest::SynapticElement::update( double t, double t_minus, double Ca_minus, double tau_Ca )
+SynapticElement::update( double t, double t_minus, double Ca_minus, double tau_Ca )
 {
   if ( z_t_ != t_minus )
   {
@@ -147,3 +149,5 @@ nest::SynapticElement::update( double t, double t_minus, double Ca_minus, double
   z_ = growth_curve_->update( t, t_minus, Ca_minus, z_, tau_Ca, growth_rate_ );
   z_t_ = t;
 }
+
+}  // namespace nest

--- a/nestkernel/target_table.cpp
+++ b/nestkernel/target_table.cpp
@@ -27,8 +27,11 @@
 // Includes from libnestutil
 #include "vector_util.h"
 
+
+namespace nest
+{
 void
-nest::TargetTable::initialize()
+TargetTable::initialize()
 {
   const size_t num_threads = kernel().vp_manager.get_num_threads();
   targets_.resize( num_threads );
@@ -43,14 +46,14 @@ nest::TargetTable::initialize()
 }
 
 void
-nest::TargetTable::finalize()
+TargetTable::finalize()
 {
   std::vector< std::vector< std::vector< Target > > >().swap( targets_ );
   std::vector< std::vector< std::vector< std::vector< size_t > > > >().swap( secondary_send_buffer_pos_ );
 }
 
 void
-nest::TargetTable::prepare( const size_t tid )
+TargetTable::prepare( const size_t tid )
 {
   // add one to max_num_local_nodes to avoid possible overflow in case
   // of rounding errors
@@ -68,7 +71,7 @@ nest::TargetTable::prepare( const size_t tid )
 }
 
 void
-nest::TargetTable::compress_secondary_send_buffer_pos( const size_t tid )
+TargetTable::compress_secondary_send_buffer_pos( const size_t tid )
 {
   for ( std::vector< std::vector< std::vector< size_t > > >::iterator it = secondary_send_buffer_pos_[ tid ].begin();
     it != secondary_send_buffer_pos_[ tid ].end();
@@ -84,7 +87,7 @@ nest::TargetTable::compress_secondary_send_buffer_pos( const size_t tid )
 }
 
 void
-nest::TargetTable::add_target( const size_t tid, const size_t target_rank, const TargetData& target_data )
+TargetTable::add_target( const size_t tid, const size_t target_rank, const TargetData& target_data )
 {
   const size_t lid = target_data.get_source_lid();
 
@@ -108,3 +111,5 @@ nest::TargetTable::add_target( const size_t tid, const size_t target_rank, const
     secondary_send_buffer_pos_[ tid ][ lid ][ syn_id ].push_back( send_buffer_pos );
   }
 }
+
+}  // namespace nest

--- a/nestkernel/target_table_devices.cpp
+++ b/nestkernel/target_table_devices.cpp
@@ -26,16 +26,19 @@
 #include "target_table_devices_impl.h"
 #include "vp_manager_impl.h"
 
-nest::TargetTableDevices::TargetTableDevices()
+
+namespace nest
+{
+TargetTableDevices::TargetTableDevices()
 {
 }
 
-nest::TargetTableDevices::~TargetTableDevices()
+TargetTableDevices::~TargetTableDevices()
 {
 }
 
 void
-nest::TargetTableDevices::initialize()
+TargetTableDevices::initialize()
 {
   const size_t num_threads = kernel().vp_manager.get_num_threads();
   target_to_devices_.resize( num_threads );
@@ -44,7 +47,7 @@ nest::TargetTableDevices::initialize()
 }
 
 void
-nest::TargetTableDevices::finalize()
+TargetTableDevices::finalize()
 {
   for ( size_t tid = 0; tid < target_to_devices_.size(); ++tid )
   {
@@ -74,7 +77,7 @@ nest::TargetTableDevices::finalize()
 }
 
 void
-nest::TargetTableDevices::resize_to_number_of_neurons()
+TargetTableDevices::resize_to_number_of_neurons()
 {
 #pragma omp parallel
   {
@@ -86,7 +89,7 @@ nest::TargetTableDevices::resize_to_number_of_neurons()
 }
 
 void
-nest::TargetTableDevices::resize_to_number_of_synapse_types()
+TargetTableDevices::resize_to_number_of_synapse_types()
 {
   kernel().vp_manager.assert_thread_parallel();
 
@@ -104,7 +107,7 @@ nest::TargetTableDevices::resize_to_number_of_synapse_types()
 }
 
 void
-nest::TargetTableDevices::get_connections_to_devices_( const size_t requested_source_node_id,
+TargetTableDevices::get_connections_to_devices_( const size_t requested_source_node_id,
   const size_t requested_target_node_id,
   const size_t tid,
   const synindex syn_id,
@@ -130,7 +133,7 @@ nest::TargetTableDevices::get_connections_to_devices_( const size_t requested_so
 }
 
 void
-nest::TargetTableDevices::get_connections_to_device_for_lid_( const size_t lid,
+TargetTableDevices::get_connections_to_device_for_lid_( const size_t lid,
   const size_t requested_target_node_id,
   const size_t tid,
   const synindex syn_id,
@@ -150,7 +153,7 @@ nest::TargetTableDevices::get_connections_to_device_for_lid_( const size_t lid,
 }
 
 void
-nest::TargetTableDevices::get_connections_from_devices_( const size_t requested_source_node_id,
+TargetTableDevices::get_connections_from_devices_( const size_t requested_source_node_id,
   const size_t requested_target_node_id,
   const size_t tid,
   const synindex syn_id,
@@ -181,7 +184,7 @@ nest::TargetTableDevices::get_connections_from_devices_( const size_t requested_
 }
 
 void
-nest::TargetTableDevices::get_connections( const size_t requested_source_node_id,
+TargetTableDevices::get_connections( const size_t requested_source_node_id,
   const size_t requested_target_node_id,
   const size_t tid,
   const synindex syn_id,
@@ -195,3 +198,5 @@ nest::TargetTableDevices::get_connections( const size_t requested_source_node_id
   get_connections_from_devices_(
     requested_source_node_id, requested_target_node_id, tid, syn_id, synapse_label, conns );
 }
+
+}  // namespace nest

--- a/nestkernel/target_table_devices_impl.h
+++ b/nestkernel/target_table_devices_impl.h
@@ -31,8 +31,11 @@
 #include "target_table_devices.h"
 #include "vp_manager_impl.h"
 
+namespace nest
+{
+
 inline void
-nest::TargetTableDevices::add_connection_to_device( Node& source,
+TargetTableDevices::add_connection_to_device( Node& source,
   Node& target,
   const size_t source_node_id,
   const size_t tid,
@@ -51,7 +54,7 @@ nest::TargetTableDevices::add_connection_to_device( Node& source,
 }
 
 inline void
-nest::TargetTableDevices::add_connection_from_device( Node& source,
+TargetTableDevices::add_connection_from_device( Node& source,
   Node& target,
   const size_t tid,
   const synindex syn_id,
@@ -73,7 +76,7 @@ nest::TargetTableDevices::add_connection_from_device( Node& source,
 }
 
 inline void
-nest::TargetTableDevices::send_to_device( const size_t tid,
+TargetTableDevices::send_to_device( const size_t tid,
   const size_t source_node_id,
   Event& e,
   const std::vector< ConnectorModel* >& cm )
@@ -91,7 +94,7 @@ nest::TargetTableDevices::send_to_device( const size_t tid,
 }
 
 inline void
-nest::TargetTableDevices::send_to_device( const size_t tid,
+TargetTableDevices::send_to_device( const size_t tid,
   const size_t source_node_id,
   SecondaryEvent& e,
   const std::vector< ConnectorModel* >& cm )
@@ -107,7 +110,7 @@ nest::TargetTableDevices::send_to_device( const size_t tid,
 }
 
 inline void
-nest::TargetTableDevices::get_synapse_status_to_device( const size_t tid,
+TargetTableDevices::get_synapse_status_to_device( const size_t tid,
   const size_t source_node_id,
   const synindex syn_id,
   Dictionary& dict,
@@ -121,7 +124,7 @@ nest::TargetTableDevices::get_synapse_status_to_device( const size_t tid,
 }
 
 inline void
-nest::TargetTableDevices::set_synapse_status_to_device( const size_t tid,
+TargetTableDevices::set_synapse_status_to_device( const size_t tid,
   const size_t source_node_id,
   const synindex syn_id,
   ConnectorModel& cm,
@@ -134,5 +137,7 @@ nest::TargetTableDevices::set_synapse_status_to_device( const size_t tid,
     target_to_devices_[ tid ][ lid ][ syn_id ]->set_synapse_status( lcid, dict, cm );
   }
 }
+
+}  // namespace nest
 
 #endif /* TARGET_TABLE_DEVICES_IMPL_H */

--- a/nestkernel/universal_data_logger.h
+++ b/nestkernel/universal_data_logger.h
@@ -235,7 +235,7 @@ private:
 // which typically is in h-files.
 template < typename HostNode >
 size_t
-nest::UniversalDataLogger< HostNode >::connect_logging_device( const DataLoggingRequest& req,
+UniversalDataLogger< HostNode >::connect_logging_device( const DataLoggingRequest& req,
   const RecordablesMap< HostNode >& rmap )
 {
   // rports are assigned consecutively, the caller may not request specific
@@ -266,7 +266,7 @@ nest::UniversalDataLogger< HostNode >::connect_logging_device( const DataLogging
 }
 
 template < typename HostNode >
-nest::UniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const DataLoggingRequest& req,
+UniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const DataLoggingRequest& req,
   const RecordablesMap< HostNode >& rmap )
   : multimeter_( req.get_sender().get_node_id() )
   , num_vars_( 0 )
@@ -495,7 +495,7 @@ private:
 // which typically is in h-files.
 template < typename HostNode >
 size_t
-nest::DynamicUniversalDataLogger< HostNode >::connect_logging_device( const DataLoggingRequest& req,
+DynamicUniversalDataLogger< HostNode >::connect_logging_device( const DataLoggingRequest& req,
   const DynamicRecordablesMap< HostNode >& rmap )
 {
   // rports are assigned consecutively, the caller may not request specific
@@ -527,7 +527,7 @@ nest::DynamicUniversalDataLogger< HostNode >::connect_logging_device( const Data
 }
 
 template < typename HostNode >
-nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const DataLoggingRequest& req,
+DynamicUniversalDataLogger< HostNode >::DataLogger_::DataLogger_( const DataLoggingRequest& req,
   const DynamicRecordablesMap< HostNode >& rmap )
   : multimeter_( req.get_sender().get_node_id() )
   , num_vars_( 0 )

--- a/nestkernel/universal_data_logger_impl.h
+++ b/nestkernel/universal_data_logger_impl.h
@@ -31,8 +31,11 @@
 #include "nest_time.h"
 #include "node.h"
 
+namespace nest
+{
+
 template < typename HostNode >
-nest::DynamicUniversalDataLogger< HostNode >::DynamicUniversalDataLogger( HostNode& host )
+DynamicUniversalDataLogger< HostNode >::DynamicUniversalDataLogger( HostNode& host )
   : host_( host )
   , data_loggers_()
 {
@@ -40,7 +43,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DynamicUniversalDataLogger( HostNo
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::reset()
+DynamicUniversalDataLogger< HostNode >::reset()
 {
   for ( DLiter_ it = data_loggers_.begin(); it != data_loggers_.end(); ++it )
   {
@@ -50,7 +53,7 @@ nest::DynamicUniversalDataLogger< HostNode >::reset()
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::init()
+DynamicUniversalDataLogger< HostNode >::init()
 {
   for ( DLiter_ it = data_loggers_.begin(); it != data_loggers_.end(); ++it )
   {
@@ -60,7 +63,7 @@ nest::DynamicUniversalDataLogger< HostNode >::init()
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::record_data( long step )
+DynamicUniversalDataLogger< HostNode >::record_data( long step )
 {
   for ( DLiter_ it = data_loggers_.begin(); it != data_loggers_.end(); ++it )
   {
@@ -70,7 +73,7 @@ nest::DynamicUniversalDataLogger< HostNode >::record_data( long step )
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::handle( const DataLoggingRequest& dlr )
+DynamicUniversalDataLogger< HostNode >::handle( const DataLoggingRequest& dlr )
 {
   const size_t rport = dlr.get_rport();
   assert( rport >= 1 );
@@ -80,7 +83,7 @@ nest::DynamicUniversalDataLogger< HostNode >::handle( const DataLoggingRequest& 
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::reset()
+DynamicUniversalDataLogger< HostNode >::DataLogger_::reset()
 {
   data_.clear();
   next_rec_step_ = -1;  // flag as uninitialized
@@ -88,7 +91,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::reset()
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::init()
+DynamicUniversalDataLogger< HostNode >::DataLogger_::init()
 {
   if ( num_vars_ < 1 )
   {
@@ -139,7 +142,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::init()
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::record_data( const HostNode&, long step )
+DynamicUniversalDataLogger< HostNode >::DataLogger_::record_data( const HostNode&, long step )
 {
   if ( num_vars_ < 1 or step < next_rec_step_ )
   {
@@ -181,7 +184,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::record_data( const Ho
 
 template < typename HostNode >
 void
-nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::handle( HostNode& host, const DataLoggingRequest& request )
+DynamicUniversalDataLogger< HostNode >::DataLogger_::handle( HostNode& host, const DataLoggingRequest& request )
 {
   if ( num_vars_ < 1 )
   {
@@ -232,7 +235,7 @@ nest::DynamicUniversalDataLogger< HostNode >::DataLogger_::handle( HostNode& hos
 }
 
 template < typename HostNode >
-nest::UniversalDataLogger< HostNode >::UniversalDataLogger( HostNode& host )
+UniversalDataLogger< HostNode >::UniversalDataLogger( HostNode& host )
   : host_( host )
   , data_loggers_()
 {
@@ -240,7 +243,7 @@ nest::UniversalDataLogger< HostNode >::UniversalDataLogger( HostNode& host )
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::reset()
+UniversalDataLogger< HostNode >::reset()
 {
   for ( DLiter_ it = data_loggers_.begin(); it != data_loggers_.end(); ++it )
   {
@@ -250,7 +253,7 @@ nest::UniversalDataLogger< HostNode >::reset()
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::init()
+UniversalDataLogger< HostNode >::init()
 {
   for ( DLiter_ it = data_loggers_.begin(); it != data_loggers_.end(); ++it )
   {
@@ -260,7 +263,7 @@ nest::UniversalDataLogger< HostNode >::init()
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::record_data( long step )
+UniversalDataLogger< HostNode >::record_data( long step )
 {
   for ( DLiter_ it = data_loggers_.begin(); it != data_loggers_.end(); ++it )
   {
@@ -270,7 +273,7 @@ nest::UniversalDataLogger< HostNode >::record_data( long step )
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::handle( const DataLoggingRequest& dlr )
+UniversalDataLogger< HostNode >::handle( const DataLoggingRequest& dlr )
 {
   const size_t rport = dlr.get_rport();
   assert( rport >= 1 );
@@ -280,7 +283,7 @@ nest::UniversalDataLogger< HostNode >::handle( const DataLoggingRequest& dlr )
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::DataLogger_::reset()
+UniversalDataLogger< HostNode >::DataLogger_::reset()
 {
   data_.clear();
   next_rec_step_ = -1;  // flag as uninitialized
@@ -288,7 +291,7 @@ nest::UniversalDataLogger< HostNode >::DataLogger_::reset()
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::DataLogger_::init()
+UniversalDataLogger< HostNode >::DataLogger_::init()
 {
   if ( num_vars_ < 1 )
   {
@@ -340,7 +343,7 @@ nest::UniversalDataLogger< HostNode >::DataLogger_::init()
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::DataLogger_::record_data( const HostNode& host, long step )
+UniversalDataLogger< HostNode >::DataLogger_::record_data( const HostNode& host, long step )
 {
   if ( num_vars_ < 1 or step < next_rec_step_ )
   {
@@ -382,7 +385,7 @@ nest::UniversalDataLogger< HostNode >::DataLogger_::record_data( const HostNode&
 
 template < typename HostNode >
 void
-nest::UniversalDataLogger< HostNode >::DataLogger_::handle( HostNode& host, const DataLoggingRequest& request )
+UniversalDataLogger< HostNode >::DataLogger_::handle( HostNode& host, const DataLoggingRequest& request )
 {
   if ( num_vars_ < 1 )
   {
@@ -432,5 +435,7 @@ nest::UniversalDataLogger< HostNode >::DataLogger_::handle( HostNode& host, cons
   // send it off
   kernel().event_delivery_manager.send_to_node( reply );
 }
+
+}  // namespace nest
 
 #endif /* #ifndef UNIVERSAL_DATA_LOGGER_IMPL_H */

--- a/nestkernel/urbanczik_archiving_node_impl.h
+++ b/nestkernel/urbanczik_archiving_node_impl.h
@@ -31,34 +31,34 @@ namespace nest
 
 // member functions for UrbanczikArchivingNode
 template < class urbanczik_parameters >
-nest::UrbanczikArchivingNode< urbanczik_parameters >::UrbanczikArchivingNode()
+UrbanczikArchivingNode< urbanczik_parameters >::UrbanczikArchivingNode()
   : ArchivingNode()
 {
 }
 
 template < class urbanczik_parameters >
-nest::UrbanczikArchivingNode< urbanczik_parameters >::UrbanczikArchivingNode( const UrbanczikArchivingNode& n )
+UrbanczikArchivingNode< urbanczik_parameters >::UrbanczikArchivingNode( const UrbanczikArchivingNode& n )
   : ArchivingNode( n )
 {
 }
 
 template < class urbanczik_parameters >
 void
-nest::UrbanczikArchivingNode< urbanczik_parameters >::get_status( Dictionary& d ) const
+UrbanczikArchivingNode< urbanczik_parameters >::get_status( Dictionary& d ) const
 {
   ArchivingNode::get_status( d );
 }
 
 template < class urbanczik_parameters >
 void
-nest::UrbanczikArchivingNode< urbanczik_parameters >::set_status( const Dictionary& d )
+UrbanczikArchivingNode< urbanczik_parameters >::set_status( const Dictionary& d )
 {
   ArchivingNode::set_status( d );
 }
 
 template < class urbanczik_parameters >
 void
-nest::UrbanczikArchivingNode< urbanczik_parameters >::get_urbanczik_history( double t1,
+UrbanczikArchivingNode< urbanczik_parameters >::get_urbanczik_history( double t1,
   double t2,
   std::deque< histentry_extended >::iterator* start,
   std::deque< histentry_extended >::iterator* finish,
@@ -92,7 +92,7 @@ nest::UrbanczikArchivingNode< urbanczik_parameters >::get_urbanczik_history( dou
 
 template < class urbanczik_parameters >
 void
-nest::UrbanczikArchivingNode< urbanczik_parameters >::write_urbanczik_history( Time const& t_sp,
+UrbanczikArchivingNode< urbanczik_parameters >::write_urbanczik_history( Time const& t_sp,
   double V_W,
   int n_spikes,
   int comp )

--- a/nestkernel/vp_manager.cpp
+++ b/nestkernel/vp_manager.cpp
@@ -35,7 +35,9 @@
 #include "vp_manager_impl.h"
 
 
-nest::VPManager::VPManager()
+namespace nest
+{
+VPManager::VPManager()
 #ifdef _OPENMP
   : force_singlethreading_( false )
 #else
@@ -46,7 +48,7 @@ nest::VPManager::VPManager()
 }
 
 void
-nest::VPManager::initialize( const bool adjust_number_of_threads_or_rng_only )
+VPManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 {
   if ( adjust_number_of_threads_or_rng_only )
   {
@@ -76,12 +78,12 @@ nest::VPManager::initialize( const bool adjust_number_of_threads_or_rng_only )
 }
 
 void
-nest::VPManager::finalize( const bool )
+VPManager::finalize( const bool )
 {
 }
 
 size_t
-nest::VPManager::get_OMP_NUM_THREADS() const
+VPManager::get_OMP_NUM_THREADS() const
 {
   const char* const omp_num_threads = std::getenv( "OMP_NUM_THREADS" );
   if ( omp_num_threads )
@@ -95,7 +97,7 @@ nest::VPManager::get_OMP_NUM_THREADS() const
 }
 
 void
-nest::VPManager::set_status( const Dictionary& d )
+VPManager::set_status( const Dictionary& d )
 {
   size_t n_threads = get_num_threads();
   size_t n_vps = get_num_virtual_processes();
@@ -175,14 +177,14 @@ nest::VPManager::set_status( const Dictionary& d )
 }
 
 void
-nest::VPManager::get_status( Dictionary& d )
+VPManager::get_status( Dictionary& d )
 {
   d[ names::local_num_threads ] = static_cast< long >( get_num_threads() );
   d[ names::total_num_virtual_procs ] = static_cast< long >( get_num_virtual_processes() );
 }
 
 void
-nest::VPManager::set_num_threads( size_t n_threads )
+VPManager::set_num_threads( size_t n_threads )
 {
   assert( not( kernel().sp_manager.is_structural_plasticity_enabled() and n_threads > 1 ) );
   n_threads_ = n_threads;
@@ -191,3 +193,5 @@ nest::VPManager::set_num_threads( size_t n_threads )
   omp_set_num_threads( n_threads_ );
 #endif
 }
+
+}  // namespace nest

--- a/nestkernel/vp_manager.h
+++ b/nestkernel/vp_manager.h
@@ -171,10 +171,9 @@ private:
   const bool force_singlethreading_;
   size_t n_threads_;  //!< Number of threads per process.
 };
-}
 
 inline size_t
-nest::VPManager::get_thread_id() const
+VPManager::get_thread_id() const
 {
 #ifdef _OPENMP
   return omp_get_thread_num();
@@ -184,13 +183,13 @@ nest::VPManager::get_thread_id() const
 }
 
 inline size_t
-nest::VPManager::get_num_threads() const
+VPManager::get_num_threads() const
 {
   return n_threads_;
 }
 
 inline void
-nest::VPManager::assert_single_threaded() const
+VPManager::assert_single_threaded() const
 {
 #ifdef _OPENMP
   assert( omp_get_num_threads() == 1 );
@@ -198,7 +197,7 @@ nest::VPManager::assert_single_threaded() const
 }
 
 inline void
-nest::VPManager::assert_thread_parallel() const
+VPManager::assert_thread_parallel() const
 {
 #ifdef _OPENMP
   // omp_get_num_threads() returns int
@@ -206,5 +205,6 @@ nest::VPManager::assert_thread_parallel() const
 #endif
 }
 
+}  // namespace nest
 
 #endif /* #ifndef VP_MANAGER_H */


### PR DESCRIPTION
Replaces all occurrences of `nest::` by a `namespace nest` section covering the whole file.
The main reason for this PR is to reduce the changeset of the #2989 ax-delay PR.